### PR TITLE
docs: trim competitor comparisons from the Results section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Face checkpoint tooling.
 
 ### By source
 
-| Source | N | Synthefy Tabular (best) | TabPFN-3 | Result |
-|--------|---:|---:|---:|---|
-| OpenML Regression | 11 | 0.6104 | 0.6073 | **+0.003 win** |
-| TabArena | 13 | 0.8089 | **0.8165** | −0.008 loss |
-| TALENT | 72 | 0.7591 | 0.7521 | **+0.007 win** |
+| Source | N | Synthefy Tabular (best) |
+|--------|---:|---:|
+| OpenML Regression | 11 | 0.6104 |
+| TabArena | 13 | 0.8089 |
+| TALENT | 72 | 0.7591 |
 
 We win on 2 of 3 sources; the remaining gap is on TabArena
 (large-N / long-context datasets), which the large-table continuation stages target.

--- a/README.md
+++ b/README.md
@@ -10,32 +10,16 @@ Face checkpoint tooling.
 
 ## Results
 
-### By source
+Mean R² across 96 regression tasks from three public benchmark suites:
 
-| Source | N | Synthefy Tabular (best) |
-|--------|---:|---:|
+| Source | Tasks | Mean R² |
+|--------|------:|--------:|
 | OpenML Regression | 11 | 0.6104 |
 | TabArena | 13 | 0.8089 |
 | TALENT | 72 | 0.7591 |
 
-We win on 2 of 3 sources; the remaining gap is on TabArena
-(large-N / long-context datasets), which the large-table continuation stages target.
-
-### Elo
-
-Mean R² rewards large wins on a few datasets; **Elo** (pairwise win rate across
-datasets, used by leaderboards like TabArena) rewards consistency. On Elo the
-ordering differs:
-
-| Elo rank | Model | Elo | Pairwise winrate |
-|---|---|---|---|
-| 1 | TabPFN-3 | 1731 | 71.6% |
-| 2 | TabICLv2 | 1648 | 53.1% |
-| 3 | Synthefy Tabular + Thinking | 1511 | 55.8% |
-| 4 | TabPFN-2.6 | 1502 | 60.3% |
-| 6 | Synthefy Tabular | 1477 | 54.2% |
-
-Closing the TabArena/Elo gap is the active focus of the large-table training stages.
+Large-N / long-context tables (common in TabArena) are the current focus of the
+large-table training stages.
 
 > **Thinking** is an inference-time reasoning extension. Details are forthcoming.
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ synthefy-tabular-eval --checkpoint "Synthefy:path/to/checkpoint.pt"
 ```
 
 or `bash scripts/evaluate.sh`. See [docs/evaluation.md](docs/evaluation.md) for
-benchmark sources, baselines, and Elo computation.
+benchmark sources and how to evaluate a Synthefy Tabular checkpoint.
 
 ## Hugging Face
 
@@ -227,7 +227,7 @@ src/synthefy_tabular/
   model/            FeaturesTransformer architecture
   training/         Data generation, trainer, loss, config, CLI
   inference/        Sklearn-compatible predictor + preprocessing
-  evaluation/       Benchmark runner, model registry, Elo
+  evaluation/       Benchmark runner over public suites (Synthefy / LimiX)
   hf.py             Hugging Face download / upload
 scripts/            train.sh, continue_training.sh, evaluate.sh
 docs/               training, inference, evaluation, huggingface guides

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Face checkpoint tooling.
 | TabArena | 13 | 0.8089 | **0.8165** | −0.008 loss |
 | TALENT | 72 | 0.7591 | 0.7521 | **+0.007 win** |
 
-We win on 2 of 3 sources and on the aggregate; the remaining gap is on TabArena
+We win on 2 of 3 sources; the remaining gap is on TabArena
 (large-N / long-context datasets), which the large-table continuation stages target.
 
 ### Elo
@@ -37,8 +37,7 @@ ordering differs:
 
 Closing the TabArena/Elo gap is the active focus of the large-table training stages.
 
-> **Thinking** is an inference-time reasoning extension that adds the top result
-> above. Details are forthcoming.
+> **Thinking** is an inference-time reasoning extension. Details are forthcoming.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,6 @@ Face checkpoint tooling.
 
 ## Results
 
-Regression performance across 96 evaluation tasks from 3 benchmark sources
-(TabArena, TALENT, OpenML-Reg):
-
-| Rank | Model | Mean R² | Training Data |
-|---|---|---|---|
-| **1** | **Synthefy Tabular + Thinking** | **0.7487** | Synthetic |
-| **2** | **Synthefy Tabular** | **0.7475** | Synthetic |
-| 3 | TabPFN-3 | 0.7443 | Synthetic |
-| 4 | TabPFN-2.6 | 0.7437 | Synthetic |
-| 5 | Real TabPFN-2.5 | 0.7364 | Real + Synthetic |
-| 6 | TabICLv2 | 0.7354 | Synthetic |
-| 7 | TabPFN-2.5 | 0.7354 | Synthetic |
-| 8 | LimiX-2M (pretrained baseline) | 0.7301 | Synthetic |
-
-Synthefy Tabular is **first on aggregate mean R²**, ahead of TabPFN-3, at
-~5.5M parameters.
-
 ### By source
 
 | Source | N | Synthefy Tabular (best) | TabPFN-3 | Result |


### PR DESCRIPTION
Tightens the README Results section to present Synthefy Tabular's own concrete numbers, with no competitor comparisons. Mirrored 1:1 on the Hugging Face model card.

Commits:
1. Remove the 8-row aggregate mean-R² leaderboard table + the "first on aggregate mean R², ahead of TabPFN-3" claim.
2. Drop the references the removal left dangling ("and on the aggregate"; the Thinking note's "adds the top result above").
3. Drop the `TabPFN-3` and `Result` columns from the by-source table.
4. Tighten Results to concrete per-source R²: reword the comparison line to a forward-looking note (no win/loss framing), relabel the table (`Tasks` / `Mean R²`), and remove the Elo ranking section entirely.

Final Results section:

```
## Results

Mean R² across 96 regression tasks from three public benchmark suites:

| Source | Tasks | Mean R² |
|--------|------:|--------:|
| OpenML Regression | 11 | 0.6104 |
| TabArena | 13 | 0.8089 |
| TALENT | 72 | 0.7591 |

Large-N / long-context tables (common in TabArena) are the current focus of the
large-table training stages.

> **Thinking** is an inference-time reasoning extension. Details are forthcoming.
```

No competitor models (TabPFN / TabICL / LimiX) remain in the Results section. "TabArena" / "TALENT" / "OpenML" appear only as benchmark-suite names. The only remaining non-concrete line is the **Thinking** teaser ("Details are forthcoming") — kept as a deliberate product note; easy to drop if you'd prefer a fully concrete section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
