### PR TITLE
Default to adaptive_svd256 reg config (reproduces published numbers)

### DIFF
--- a/src/synthefy_tabular/api.py
+++ b/src/synthefy_tabular/api.py
@@ -60,7 +60,7 @@ class SynthefyTabularRegressor:
         self.device = device
         self.token = token
         self.inference_config = inference_config or config_path(
-            "reg_allordinal_poly10_noretrieval.json"
+            "reg_allordinal_poly10_adaptive_svd256.json"
         )
         self.augmentations = tuple(augmentations) if augmentations else ()
         self.yj_skew_threshold = float(yj_skew_threshold)

--- a/src/synthefy_tabular/configs/reg_allordinal_poly10_adaptive_svd256.json
+++ b/src/synthefy_tabular/configs/reg_allordinal_poly10_adaptive_svd256.json
@@ -1,0 +1,306 @@
+[
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "quantile_uniform_all_data"
+      ],
+      "discrete_flag": false,
+      "original_flag": true,
+      "svd_tag": "svd"
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "quantile_uniform_all_data"
+      ],
+      "discrete_flag": false,
+      "original_flag": true,
+      "svd_tag": "svd"
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "quantile_uniform_all_data"
+      ],
+      "discrete_flag": false,
+      "original_flag": true,
+      "svd_tag": "svd"
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "quantile_uniform_all_data"
+      ],
+      "discrete_flag": false,
+      "original_flag": true,
+      "svd_tag": "svd"
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "adaptive"
+      ],
+      "discrete_flag": false,
+      "original_flag": false,
+      "svd_tag": null
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "adaptive"
+      ],
+      "discrete_flag": false,
+      "original_flag": false,
+      "svd_tag": null
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "adaptive"
+      ],
+      "discrete_flag": false,
+      "original_flag": false,
+      "svd_tag": null
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  },
+  {
+    "MaxFeatureSubsampler": {
+      "max_features": 500
+    },
+    "PolynomialInteractionGenerator": {
+      "max_interaction_features": 10
+    },
+    "CategoricalFeatureEncoder": {
+      "encoding_strategy": "ordinal_strict_feature_shuffled"
+    },
+    "FeatureShuffler": {
+      "mode": "shuffle"
+    },
+    "RebalanceFeatureDistribution": {
+      "worker_tags": [
+        "adaptive"
+      ],
+      "discrete_flag": false,
+      "original_flag": false,
+      "svd_tag": null
+    },
+    "retrieval_config": {
+      "use_retrieval": false,
+      "retrieval_before_preprocessing": false,
+      "calculate_feature_attention": false,
+      "calculate_sample_attention": false,
+      "subsample_ratio": 0.7,
+      "subsample_type": "sample",
+      "use_type": "mixed"
+    },
+    "FingerprintFeatureEncoder": true,
+    "HighDimFeatureSelector": {
+      "strategy": "svd_all",
+      "svd_components": 256,
+      "n_features_threshold": 256,
+      "binary_threshold": 1.01
+    }
+  }
+]

--- a/src/synthefy_tabular/evaluation/cli.py
+++ b/src/synthefy_tabular/evaluation/cli.py
@@ -26,7 +26,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--custom-cls-dir", default=None)
     parser.add_argument("--custom-reg-dir", default=None)
     parser.add_argument("--cls-config", default=config_path("cls_default_noretrieval.json"))
-    parser.add_argument("--reg-config", default=config_path("reg_allordinal_poly10_noretrieval.json"))
+    parser.add_argument("--reg-config", default=config_path("reg_allordinal_poly10_adaptive_svd256.json"))
     parser.add_argument("--task-types", nargs="+", default=None,
                         choices=["classification", "regression"])
     parser.add_argument("--sources", nargs="+", default=None)

--- a/src/synthefy_tabular/evaluation/models.py
+++ b/src/synthefy_tabular/evaluation/models.py
@@ -85,7 +85,7 @@ class LimiXWrapper(BaseModelWrapper):
         self.device = torch.device(device)
         self.cls_config_path = cls_config_path or package_config_path("cls_default_noretrieval.json")
         self.reg_config_path = reg_config_path or package_config_path(
-            "reg_allordinal_poly10_noretrieval.json"
+            "reg_allordinal_poly10_adaptive_svd256.json"
         )
         self.base_config_path = base_config_path
         self.augmentations = tuple(augmentations) if augmentations else ()

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -12,4 +12,4 @@ def test_config_path_points_to_bundled_file():
 def test_regressor_uses_default_regression_config():
     model = SynthefyTabularRegressor(model_path="local.pt")
     assert model.model_path == "local.pt"
-    assert model.inference_config.endswith("reg_allordinal_poly10_noretrieval.json")
+    assert model.inference_config.endswith("reg_allordinal_poly10_adaptive_svd256.json")


### PR DESCRIPTION
## Why

A full R² reproduction of the published benchmark numbers (released HF checkpoint, all 96 regression datasets, GPU) showed the README/model-card numbers are produced by the **`reg_allordinal_poly10_adaptive_svd256`** config — which was **not bundled** in the package and **not the default**. The package defaulted to `noretrieval`, which is ~0.004 lower in aggregate (and ~0.009 lower on TabArena), so a user running the package out-of-the-box could not reproduce the published numbers.

Reproduction (released `best_reg_r2.pt` weights = the HF checkpoint, verified bit-identical):

| Source | N | Published | `noretrieval` (old default) | **`adaptive_svd256` (new default)** |
|---|---|---|---|---|
| OpenML Reg | 11 | 0.6104 | 0.6109 | 0.6113 |
| TabArena | 13 | 0.8089 | 0.7998 | **0.8089** (exact) |
| TALENT | 72 | 0.7591 | 0.7531 | 0.7576 |
| **Aggregate** | 96 | 0.7475 | 0.7431 | **0.7478** |

The SVD-256 step only activates at ≥256 features, so it lifts high-dimensional datasets (TabArena) while leaving low/mid-dim datasets unchanged.

## What

- Bundle `src/synthefy_tabular/configs/reg_allordinal_poly10_adaptive_svd256.json` (the `adaptive` config + a `HighDimFeatureSelector(strategy=svd_all, svd_components=256, n_features_threshold=256)` block per stage).
- Make it the default regression config in:
  - `api.py` — `SynthefyTabularRegressor` default `inference_config`
  - `evaluation/models.py` — `LimiXWrapper` default `reg_config_path`
  - `evaluation/cli.py` — `synthefy-tabular-eval` `--reg-config` default
- Update `tests/test_api_smoke.py` to assert the new default.
- `add_limix_pretrained_16m` (the LimiX-16M baseline) is left on `noretrieval` — unrelated to the Synthefy default.

## Verification (public package, CPU)
- Default config resolves to `…adaptive_svd256.json`.
- Low-dim (diabetes, 10 feat → svd no-op): R²=0.3297 — unchanged vs the prior default (no regression).
- High-dim (synthetic 300 feat → `svd_all` activates): R²=0.9973, finite predictions — the SVD path runs correctly in the public `preprocess.py` (`HighDimFeatureSelector`/`svd_all` already supported).
- `ruff check`: All checks passed.

With this change the shipped package reproduces the published per-source numbers out-of-the-box (TabArena bit-exact at 0.8089; aggregate 0.7478 vs published 0.7475 — within run-to-run noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
