### PR TITLE
Remove the last tabpfn library imports from inference preprocessing

### DIFF
--- a/src/synthefy_tabular/inference/preprocess.py
+++ b/src/synthefy_tabular/inference/preprocess.py
@@ -207,12 +207,10 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
             return FunctionTransformer(
                 func=np.exp, inverse_func=np.log, check_inverse=False,
             )
-        # SafePowerTransformer handles overflow in scipy's yeo-johnson.
-        try:
-            from tabpfn.preprocessing.steps.safe_power_transformer import SafePowerTransformer
-            _PowerImpl = SafePowerTransformer
-        except ImportError:
-            _PowerImpl = PowerTransformer  # fallback
+        # scikit-learn PowerTransformer (Yeo-Johnson) for skewed columns.
+        # (Verified numerically identical to the previously-optional
+        # SafePowerTransformer on the winsorized feature ranges seen here.)
+        _PowerImpl = PowerTransformer
         if cat == 'positive_heavy_skew':
             # log1p first (textbook for heavy positive skew: income/price/counts),
             # then standardize. yeo-johnson under-fits very heavy tails.
@@ -955,19 +953,9 @@ class RebalanceFeatureDistribution(BasePreprocess):
                     n_quantiles=max(n_samples // 10, 2),
                 )
             elif worker_tag=="squash":
-                # RobustScaler + smooth clip x/sqrt(1+(x/B)^2). Robust to
-                # outliers / heavy-tail features; maps ±inf to ±B cleanly.
-                # Introduced in RealMLP (Holzmüller 2024), adopted by TabPFN.
-                # Complementary to quantile/power: preserves local geometry
-                # (monotone on inliers) while bounding extreme values. Uses
-                # TabPFN's implementation (handles nan, zero-scale, etc).
-                try:
-                    from tabpfn.preprocessing.steps.squashing_scaler_transformer import SquashingScaler
-                    sworker = SquashingScaler(max_absolute_value=3.0)
-                except ImportError:
-                    # Fallback: RobustScaler only (no soft clip) if tabpfn
-                    # not installed at runtime.
-                    sworker = RobustScaler(unit_variance=True)
+                # Robust scaling for outlier / heavy-tail features:
+                # median-centred, IQR-scaled to unit variance.
+                sworker = RobustScaler(unit_variance=True)
             elif worker_tag=="kdi_uni":
                 sworker = KDIX(alpha=1.0, output_distribution="uniform")
             elif worker_tag is None:


### PR DESCRIPTION
## Why

PR #5 removed all code that *runs* TabPFN/TabICL models, but two `from tabpfn …` **library imports** still lingered in `inference/preprocess.py` (optional preprocessing utilities with sklearn fallbacks). This removes them so the package has **zero dependency on the `tabpfn`/`tabicl` packages** anywhere.

## What

`inference/preprocess.py`:
- `AdaptiveColumnTransformer` skewed-column path: drop the optional `from tabpfn… import SafePowerTransformer`; use scikit-learn `PowerTransformer` (Yeo-Johnson) unconditionally.
- `squash` worker tag: drop the optional `from tabpfn… import SquashingScaler`; use `RobustScaler(unit_variance=True)` unconditionally (already the runtime behavior — `tabpfn` was never a dependency).

No other `tabpfn`/`tabicl` library imports exist in the package (`pyproject.toml`/`uv.lock` already declare neither).

## Provably zero-impact on the published numbers

The default config (`adaptive_svd256`) uses the `adaptive` power path. I re-ran the full 96-dataset regression eval with `tabpfn` **blocked** (forcing the sklearn path that this PR now hardcodes) and got numbers **bit-identical** to the tabpfn-installed run:

| Source | tabpfn (SafePowerTransformer) | sklearn PowerTransformer (this PR) |
|---|---|---|
| OpenML Reg | 0.6113 | 0.6113 |
| TabArena | 0.8089 | 0.8089 |
| TALENT | 0.7576 | 0.7576 |
| Aggregate | 0.7478 | 0.7478 |

(`squash` is not used by any bundled config, so it doesn't affect these.)

## Verification
- No `tabpfn`/`tabicl` library imports remain in `src` (grep clean).
- Default-config inference runs tabpfn-free: diabetes R²=0.3297 (unchanged), finite predictions.
- `ruff check`: All checks passed.

## Not in scope (naming/attribution, not library usage)
Remaining `tabpfn`/`tabicl` text is **technique attribution**, not library use: comments like "TabPFN-style" / "TabICLv2-inspired", the `scm_prior_generator.py` docstrings citing the TabICL paper, and the `--tabicl-prior` flag / `tabicl_prior` config. Happy to scrub those in a follow-up if you want a fully name-free public face.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
