### PR TITLE
Return HTTP 400 on invalid predict input; add OpenAPI spec

### DIFF
--- a/baseten/model/model.py
+++ b/baseten/model/model.py
@@ -95,12 +95,15 @@ class Model:
     # --------------------------------------------------------------- predict
     def predict(self, model_input):
         import numpy as np
+        from fastapi import HTTPException
 
         task = str(model_input.get("task", "regression")).lower()
 
         for key in ("X_train", "y_train", "X_test"):
             if key not in model_input:
-                return {"error": f"Missing required field '{key}'."}
+                raise HTTPException(
+                    status_code=400, detail=f"Missing required field '{key}'."
+                )
 
         X_train = np.asarray(model_input["X_train"], dtype=np.float32)
         X_test = np.asarray(model_input["X_test"], dtype=np.float32)
@@ -127,4 +130,7 @@ class Model:
                 "classes": _to_jsonable(classes),
             }
 
-        return {"error": f"Unsupported task: {task!r}. Use 'regression' or 'classification'."}
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported task: {task!r}. Use 'regression' or 'classification'.",
+        )

--- a/baseten/openapi.yaml
+++ b/baseten/openapi.yaml
@@ -1,0 +1,188 @@
+openapi: 3.1.0
+info:
+  title: Synthefy Tabular Inference API
+  version: "1.0.0"
+  description: |
+    In-context learning model for tabular **regression** and **classification**,
+    served on Baseten. There is no offline training step: every request supplies
+    the context rows (`X_train`, `y_train`) and the query rows (`X_test`), and the
+    model conditions on the context and predicts labels for the queries in a
+    single forward pass.
+
+    Notes:
+    - The first request after a scale-to-zero idle triggers a checkpoint download +
+      warmup and can take ~90s; warm requests return in ~1-2s.
+    - Invalid requests (missing fields, unsupported task) return **HTTP 400** with
+      an object carrying an `error` key.
+servers:
+  - url: https://model-3m5j7y9w.api.baseten.co
+    description: Production deployment (model ID 3m5j7y9w)
+security:
+  - basetenApiKey: []
+paths:
+  /environments/production/predict:
+    post:
+      operationId: predict
+      summary: Run an in-context prediction
+      description: |
+        Submit context rows and query rows and receive predictions for the query
+        rows. The response shape depends on `task`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PredictRequest"
+            examples:
+              regression:
+                summary: Regression request
+                value:
+                  task: regression
+                  X_train: [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
+                  y_train: [0.1, 0.9, 0.5, 0.3]
+                  X_test: [[0.3, 0.7], [0.8, 0.2]]
+              classification:
+                summary: Classification request
+                value:
+                  task: classification
+                  X_train: [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
+                  y_train: [0, 1, 0, 1]
+                  X_test: [[0.3, 0.7], [0.8, 0.2]]
+      responses:
+        "200":
+          description: |
+            A successful prediction. The shape depends on `task`:
+            `RegressionResponse` or `ClassificationResponse`.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/RegressionResponse"
+                  - $ref: "#/components/schemas/ClassificationResponse"
+              examples:
+                regression:
+                  summary: Regression response (real output)
+                  value:
+                    task: regression
+                    predictions: [0.3699104921941226, 0.7807573902172393]
+                classification:
+                  summary: Classification response (real output)
+                  value:
+                    task: classification
+                    predictions: [0, 0]
+                    probabilities:
+                      - [0.5008668154219742, 0.4991331845780258]
+                      - [0.5013414770764553, 0.49865852292354473]
+                    classes: [0, 1]
+        "400":
+          description: |
+            Invalid request — a required field (`X_train`, `y_train`, `X_test`)
+            is missing, or `task` is not one of the supported values.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                missingField:
+                  summary: Missing required field
+                  value:
+                    error: "Missing required field 'X_test'."
+                badTask:
+                  summary: Unsupported task
+                  value:
+                    error: "Unsupported task: 'cluster'. Use 'regression' or 'classification'."
+        "401":
+          description: Missing or invalid API key.
+        "404":
+          description: Unknown model ID or environment in the path.
+components:
+  securitySchemes:
+    basetenApiKey:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: |
+        Baseten API key, sent as `Authorization: Api-Key <YOUR_KEY>`. The literal
+        `Api-Key ` prefix is required as part of the header value.
+  schemas:
+    Task:
+      type: string
+      description: Prediction task. Defaults to `regression` when omitted.
+      enum: [regression, reg, classification, cls]
+      default: regression
+    Label:
+      description: A target/class label; may be a number or a string.
+      oneOf:
+        - type: number
+        - type: string
+    PredictRequest:
+      type: object
+      required: [X_train, y_train, X_test]
+      properties:
+        task:
+          $ref: "#/components/schemas/Task"
+        X_train:
+          type: array
+          description: Context feature matrix, n_context x n_features.
+          items:
+            type: array
+            items:
+              type: number
+        y_train:
+          type: array
+          description: |
+            Context targets aligned with `X_train` rows. Numeric for regression;
+            ints or strings for classification.
+          items:
+            $ref: "#/components/schemas/Label"
+        X_test:
+          type: array
+          description: Query feature matrix, n_query x n_features.
+          items:
+            type: array
+            items:
+              type: number
+      additionalProperties: false
+    RegressionResponse:
+      type: object
+      required: [task, predictions]
+      properties:
+        task:
+          type: string
+          const: regression
+        predictions:
+          type: array
+          description: Predicted value per `X_test` row.
+          items:
+            type: number
+    ClassificationResponse:
+      type: object
+      required: [task, predictions, probabilities, classes]
+      properties:
+        task:
+          type: string
+          const: classification
+        predictions:
+          type: array
+          description: Predicted class label per `X_test` row (argmax over classes).
+          items:
+            $ref: "#/components/schemas/Label"
+        probabilities:
+          type: array
+          description: Per-class probabilities per `X_test` row; columns ordered by `classes`.
+          items:
+            type: array
+            items:
+              type: number
+        classes:
+          type: array
+          description: Class labels giving the column order of `probabilities`.
+          items:
+            $ref: "#/components/schemas/Label"
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+      additionalProperties: false


### PR DESCRIPTION
Stacked on top of #2 (Add Baseten Truss). Targets `add-baseten-deployment` since `baseten/` isn't on `main` yet.

## What & why
- **`model/model.py`**: `predict()` returned a `{"error": ...}` dict for missing fields / unsupported `task`. Truss serves a returned dict as **HTTP 200**, so malformed requests looked successful. Now raises `fastapi.HTTPException(status_code=400, ...)`, so bad input gets a real **400** (body still `{"error": ...}`). Success paths unchanged.
- **`openapi.yaml`** (new): OpenAPI 3.1 spec for `/environments/production/predict` — request/response schemas, `Api-Key` auth, `200` success (regression/classification), `400` errors.

## Verification
Validated against the **live production deployment** with a spec-driven contract test (drives the spec's own examples, validates responses against its schemas):

| Case | Expected | Result |
|---|---|---|
| regression | 200 | 200 ✓ matches `RegressionResponse` |
| classification | 200 | 200 ✓ matches `ClassificationResponse` |
| missing-field | 400 | 400 ✓ matches `ErrorResponse` |
| bad-task | 400 | 400 ✓ matches `ErrorResponse` |

Spec also passes `openapi-spec-validator`. The fix is already deployed and promoted to production (deployment `qe22j2p`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)