### PR TITLE
Open-source release prep: strip vestigial LimiX naming + doc fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+Guidance for coding agents (Claude Code, Cursor, Codex, etc.) working in this
+repo. Keep it accurate — update it when commands, layout, or conventions change.
+
+## What this is
+
+`synthefy-tabular` is a small (~5.5M-parameter) tabular foundation model
+(`FeaturesTransformer`) for **regression and classification** via in-context
+learning. Given a few labeled context rows, it predicts on query rows in a
+single forward pass — no task-specific training. It is trained entirely on
+synthetic data. The public API wraps an internal `SynthefyTabularPredictor`.
+
+## Setup
+
+- Python **≥ 3.10**. The interpreter and dependencies are managed by **uv**
+  (`uv.lock` is committed). There may be no bare `python` on PATH — use `uv run`.
+- Install everything (incl. dev tools): `uv sync --extra dev`
+- Optional extras: `--extra train` (wandb, xgboost), `--extra eval`
+  (matplotlib, openml).
+
+## Core commands (these mirror CI — run them before any PR)
+
+```bash
+uv sync --extra dev
+uv run pytest                       # fast suite; slow/network tests deselected by default
+uv run ruff check src scripts tests
+uv build
+```
+
+- Import smoke (what CI gates on first): `uv run python -c "import synthefy_tabular"`
+- Full inference check (downloads the public ~47MB checkpoint, ~15s on CPU):
+  `uv run pytest -m slow`
+
+## How inference works (and how to test it)
+
+- The default checkpoint lives at the **public** HF repo
+  `Synthefy/synthefy-tabular` (file `synthefy-tabular.pt`). First use downloads
+  and caches it — **no token or access request needed**. A token is only used
+  for higher rate limits or for pointing at a private/custom repo.
+- Public API (`src/synthefy_tabular/api.py`): `SynthefyTabularRegressor` and
+  `SynthefyTabularClassifier` (sklearn-style `fit` / `predict` /
+  `predict_proba`), plus the one-shot `infer` / `predict` helpers and
+  `config_path`.
+- `fit()` only stores the context rows; all compute happens in `predict()`.
+  Uses GPU when available, else CPU.
+- Pass `model_path="…/checkpoint.pt"` to run a local checkpoint and skip the
+  download entirely.
+
+## Layout
+
+```
+src/synthefy_tabular/
+  api.py          Public API. Imports the heavy stack LAZILY — keep it import-light.
+  hf.py           HF download/upload + console-script entry points
+  model/          FeaturesTransformer architecture
+  inference/      SynthefyTabularPredictor + preprocessing
+  training/       data generation, trainer, loss, config, CLI (GPU / DDP)
+  evaluation/     benchmark runner + CLI
+  configs/*.json  bundled inference configs (shipped via package-data)
+scripts/          train.sh, continue_training.sh, evaluate.sh
+docs/             training / inference / evaluation / huggingface guides
+examples/         runnable inference + upload scripts
+tests/            fast unit/smoke tests + slow e2e tests (marked `slow`)
+```
+
+## Conventions & gotchas
+
+- **Keep `api.py` and the top-level import cheap.** `torch`/`numpy`/etc. are
+  imported lazily inside functions so `import synthefy_tabular` works before the
+  heavy accelerator stack loads. Do not hoist heavy imports to module top level.
+- **Ruff is intentionally narrow**: only `E9,F821,F822,F823` (syntax +
+  undefined names), line length 120, target `py310`. It is a correctness gate,
+  not a full style/format gate. A pre-commit hook (`ruff`) is configured.
+- **Network tests are marked `slow`** and deselected via
+  `addopts = -m 'not slow'`. Plain `pytest` stays offline and fast (~0.1s).
+- **Never commit checkpoints or data.** `.gitignore` covers
+  `*.pt`/`*.ckpt`/`*.safetensors`, `checkpoints/`, `data/`, `results/`,
+  `wandb/`, `cache/`.
+- **Versioning**: keep `pyproject.toml` `version` and `__init__.py`
+  `__version__` in sync — the publish workflow enforces a match with the git
+  tag. Release process is in `RELEASING.md`.
+- **Training is GPU + DDP** via `scripts/train.sh` (torchrun); it is not meant
+  to run meaningfully on CPU. Smoke-test the wiring with:
+  `TOTAL_STEPS=2 NPROC_PER_NODE=1 WANDB_MODE=disabled bash scripts/train.sh`.
+- Shell scripts run with the project venv (`.venv/bin/python`); they do not rely
+  on a bare `python`.
+
+## Provenance / attribution (do not strip)
+
+The codebase originated as a fork of **LimiX** (Apache-2.0,
+<https://github.com/limix-ldm-ai/LimiX>) and has since diverged; the vestigial
+`LimiX*` class names were renamed to `SynthefyTabular*`. The **canonical LimiX-2M
+model is used in exactly one place** — an optional training-time ICL learnability
+filter, downloaded via `download_limix()` / `--icl-filter-model limix`. Those
+references name the real upstream model — leave them intact, and don't
+re-introduce `LimiX*` naming for Synthefy's own classes. Parts of the
+synthetic-data prior generator draw on **TabICL** (BSD-3-Clause,
+<https://github.com/soda-inria/tabicl>).
+
+Keep the `LICENSE`/`NOTICE` attributions intact; check those files before
+removing upstream names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ repo. Keep it accurate — update it when commands, layout, or conventions chang
 ## What this is
 
 `synthefy-tabular` is a small (~5.5M-parameter) tabular foundation model
-(`FeaturesTransformer`) for **regression and classification** via in-context
+(`FeaturesTransformer`) for **regression** via in-context
 learning. Given a few labeled context rows, it predicts on query rows in a
 single forward pass — no task-specific training. It is trained entirely on
 synthetic data. The public API wraps an internal `SynthefyTabularPredictor`.
@@ -38,10 +38,11 @@ uv build
   `Synthefy/synthefy-tabular` (file `synthefy-tabular.pt`). First use downloads
   and caches it — **no token or access request needed**. A token is only used
   for higher rate limits or for pointing at a private/custom repo.
-- Public API (`src/synthefy_tabular/api.py`): `SynthefyTabularRegressor` and
-  `SynthefyTabularClassifier` (sklearn-style `fit` / `predict` /
-  `predict_proba`), plus the one-shot `infer` / `predict` helpers and
-  `config_path`.
+- Public API (`src/synthefy_tabular/api.py`): `SynthefyTabularRegressor`
+  (sklearn-style `fit` / `predict`; `predict` takes
+  `output_type="mean"/"median"/"mode"` per the `TabPFNRegressor` contract),
+  plus the one-shot `infer` / `predict` helpers and `config_path`. The public
+  API is **regression-only** as of 0.2.0 (classification was removed in #10).
 - `fit()` only stores the context rows; all compute happens in `predict()`.
   Uses GPU when available, else CPU.
 - Pass `model_path="…/checkpoint.pt"` to run a local checkpoint and skip the
@@ -80,9 +81,21 @@ tests/            fast unit/smoke tests + slow e2e tests (marked `slow`)
 - **Versioning**: keep `pyproject.toml` `version` and `__init__.py`
   `__version__` in sync — the publish workflow enforces a match with the git
   tag. Release process is in `RELEASING.md`.
-- **Training is GPU + DDP** via `scripts/train.sh` (torchrun); it is not meant
-  to run meaningfully on CPU. Smoke-test the wiring with:
-  `TOTAL_STEPS=2 NPROC_PER_NODE=1 WANDB_MODE=disabled bash scripts/train.sh`.
+- **Training is GPU + DDP.** Real runs go through `scripts/train.sh` (torchrun)
+  on one or more CUDA GPUs; the distributed path places each rank on
+  `cuda:<rank>`. Heads-up: the non-distributed `--device` default is `cuda:2`,
+  so `NPROC_PER_NODE=1 bash scripts/train.sh` only works on a box with ≥3 GPUs.
+- **CPU smoke (no GPU needed)** — exercises the full loop (data-gen →
+  CCMM/pinball loss → Muon step → checkpoint write) in 2 steps:
+
+  ```bash
+  WANDB_MODE=disabled uv run synthefy-tabular-train \
+    --device cpu --no-mixed-precision --no-prefetch --no-flash-attn \
+    --task-type reg --total-steps 2 --run-steps 2 --save-interval 2 \
+    --embed-dim 32 --hid-dim 64 --nlayers 2 --nhead 2 \
+    --batch-size 2 --max-features 16 --max-budget 4000 \
+    --checkpoint-dir /tmp/st_smoke
+  ```
 - Shell scripts run with the project venv (`.venv/bin/python`); they do not rely
   on a bare `python`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+Agent guidance for this repo lives in **[AGENTS.md](AGENTS.md)** — read it first.
+
+This file is a thin pointer so one set of instructions serves every coding agent.
+Edit `AGENTS.md`, not this file.

--- a/README.md
+++ b/README.md
@@ -83,32 +83,34 @@ driver, install a PyTorch wheel matching your CUDA version instead. The Muon
 optimizer used in training prefers `torch.optim.Muon`; if your PyTorch lacks it,
 the package automatically falls back to a built-in implementation.
 
-## Authentication
+## Authentication (optional)
 
-The default model checkpoint lives at
+The default checkpoint at
 [`Synthefy/synthefy-tabular`](https://huggingface.co/Synthefy/synthefy-tabular)
-on the Hugging Face Hub and currently requires access. To use the package:
+is **public**: the first inference call downloads and caches it automatically,
+with no token and no access request.
 
-1. Request access at the model page (or contact Synthefy if the page isn't
-   visible to you yet).
-2. Provide your Hugging Face token in any one of these ways:
+A Hugging Face token is only worth setting if you hit anonymous download rate
+limits, or if you point the package at a private/gated checkpoint of your own.
+Provide one in any of these ways:
 
-   ```bash
-   # Option A: env var (one-shot)
-   export HF_TOKEN=hf_xxxxxxxx
+```bash
+# Option A: env var (one-shot)
+export HF_TOKEN=hf_xxxxxxxx
 
-   # Option B: persist via the HF CLI
-   huggingface-cli login
-   ```
+# Option B: persist via the HF CLI (huggingface-hub >= 1.0)
+hf auth login
+```
 
-   ```python
-   # Option C: pass explicitly in code
-   from synthefy_tabular import SynthefyTabularRegressor
-   model = SynthefyTabularRegressor(token="hf_xxxxxxxx")
-   ```
+```python
+# Option C: pass explicitly in code
+from synthefy_tabular import SynthefyTabularRegressor
+model = SynthefyTabularRegressor(token="hf_xxxxxxxx")
+```
 
 Get a token at <https://huggingface.co/settings/tokens> (read scope is
-sufficient). If you supply a local `model_path=` instead, no token is needed.
+sufficient). If you supply a local `model_path=` instead, no network access is
+needed at all.
 
 ## Inference
 
@@ -160,7 +162,7 @@ TOTAL_STEPS=2 NPROC_PER_NODE=1 WANDB_MODE=disabled bash scripts/train.sh
 ```
 
 Training runs entirely on synthetic data and **trains to completion**: there is
-no real-data validation in the loop (`--no-eval`), so no benchmark data needs to
+no real-data validation in the loop, so no benchmark data needs to
 be downloaded to train, and no eval signal influences checkpoint selection. Each
 run writes periodic and final checkpoints, and each curriculum tier seeds from
 the previous tier's final checkpoint.
@@ -229,7 +231,7 @@ src/synthefy_tabular/
   model/            FeaturesTransformer architecture
   training/         Data generation, trainer, loss, config, CLI
   inference/        Sklearn-compatible predictor + preprocessing
-  evaluation/       Benchmark runner over public suites (Synthefy / LimiX)
+  evaluation/       Benchmark runner over public benchmark suites
   hf.py             Hugging Face download / upload
 scripts/            train.sh, continue_training.sh, evaluate.sh
 docs/               training, inference, evaluation, huggingface guides

--- a/scripts/evaluate.sh
+++ b/scripts/evaluate.sh
@@ -6,5 +6,10 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 cd "${REPO_ROOT}"
 export PYTHONPATH="${REPO_ROOT}/src:${PYTHONPATH:-}"
+export PATH="${REPO_ROOT}/.venv/bin:${PATH}"
 
-python -m synthefy_tabular.evaluation.cli "$@"
+# Prefer the project venv; fall back to whatever python is on PATH.
+PY_BIN="${REPO_ROOT}/.venv/bin/python"
+[[ -x "${PY_BIN}" ]] || PY_BIN="$(command -v python3 || command -v python)"
+
+"${PY_BIN}" -m synthefy_tabular.evaluation.cli "$@"

--- a/src/synthefy_tabular/api.py
+++ b/src/synthefy_tabular/api.py
@@ -81,9 +81,9 @@ class SynthefyTabularRegressor:
 
     def _get_predictor(self):
         if self._predictor is None:
-            from synthefy_tabular.inference.predictor import LimiXPredictor
+            from synthefy_tabular.inference.predictor import SynthefyTabularPredictor
 
-            self._predictor = LimiXPredictor(
+            self._predictor = SynthefyTabularPredictor(
                 device=_as_device(self.device),
                 model_path=_resolve_model_path(self.model_path, self.token),
                 inference_config=self.inference_config,

--- a/src/synthefy_tabular/evaluation/__init__.py
+++ b/src/synthefy_tabular/evaluation/__init__.py
@@ -1,7 +1,7 @@
-"""LimiX Unified Evaluation Framework.
+"""Synthefy Tabular Evaluation Framework.
 
-Evaluate LimiX-2M, LimiX-16M, and custom checkpoints
-across TabArena, RelBench CTU, OpenML-CC18, and other benchmarks.
+Evaluate Synthefy Tabular checkpoints across TabArena, RelBench CTU,
+OpenML-CC18, and other benchmarks.
 """
 
 

--- a/src/synthefy_tabular/evaluation/analysis.py
+++ b/src/synthefy_tabular/evaluation/analysis.py
@@ -105,13 +105,6 @@ class EvalAnalyzer:
             return None
         if focus_model and focus_model in models:
             return focus_model
-        for m in models:
-            low = m.lower()
-            if "limix" in low and "2m" in low:
-                return m
-        for m in models:
-            if "limix" in m.lower():
-                return m
         return models[0]
 
     # --- Aggregate summaries ---
@@ -677,7 +670,7 @@ class EvalAnalyzer:
 
     def print_report(self, show_per_dataset=True):
         print("\n" + "=" * 80)
-        print("  LIMIX EVALUATION REPORT")
+        print("  SYNTHEFY TABULAR EVALUATION REPORT")
         print("=" * 80)
 
         models = sorted(self.df["model"].unique())
@@ -975,7 +968,7 @@ class EvalAnalyzer:
         return lines
 
     def generate_markdown_report(self, output_path=None):
-        lines = ["# LimiX Evaluation Report\n"]
+        lines = ["# Synthefy Tabular Evaluation Report\n"]
         models = sorted(self.df["model"].unique())
         sources = sorted(self.df["source"].unique()) if "source" in self.df.columns else []
         lines.append(f"**Models**: {', '.join(models)}  ")

--- a/src/synthefy_tabular/evaluation/cli.py
+++ b/src/synthefy_tabular/evaluation/cli.py
@@ -53,7 +53,7 @@ def main(argv: list[str] | None = None) -> None:
     checkpoints = args.checkpoint or [f"Synthefy:{download_checkpoint()}"]
     for raw in checkpoints:
         label, path = _parse_checkpoint(raw)
-        models.add_limix(
+        models.add_checkpoint(
             label,
             path,
             device=args.device,

--- a/src/synthefy_tabular/evaluation/models.py
+++ b/src/synthefy_tabular/evaluation/models.py
@@ -1,8 +1,6 @@
 """Model registry for the unified evaluation pipeline.
 
-Supports:
-  - LimiX-2M (pretrained and custom checkpoints)
-  - LimiX-16M (pretrained and custom checkpoints)
+Wraps Synthefy Tabular checkpoints for benchmarking.
 """
 
 import gc
@@ -56,11 +54,11 @@ class BaseModelWrapper(ABC):
 
 
 # ---------------------------------------------------------------------------
-# LimiX wrapper (works for 2M, 16M, and custom checkpoints)
+# Model wrapper
 # ---------------------------------------------------------------------------
 
-class LimiXWrapper(BaseModelWrapper):
-    """Wrapper around LimiXPredictor for unified eval."""
+class SynthefyTabularWrapper(BaseModelWrapper):
+    """Wrapper around SynthefyTabularPredictor for unified eval."""
 
     def __init__(
         self,
@@ -102,7 +100,7 @@ class LimiXWrapper(BaseModelWrapper):
 
     def _get_cls_predictor(self):
         if self._cls_predictor is None:
-            from synthefy_tabular.inference.predictor import LimiXPredictor
+            from synthefy_tabular.inference.predictor import SynthefyTabularPredictor
             from synthefy_tabular.utils.loading import load_model
 
             model = load_model(
@@ -110,7 +108,7 @@ class LimiXWrapper(BaseModelWrapper):
                 mask_prediction=False,
                 base_config_path=self.base_config_path,
             )
-            self._cls_predictor = LimiXPredictor(
+            self._cls_predictor = SynthefyTabularPredictor(
                 device=self.device,
                 inference_config=self.cls_config_path,
                 model=model,
@@ -119,7 +117,7 @@ class LimiXWrapper(BaseModelWrapper):
 
     def _get_reg_predictor(self):
         if self._reg_predictor is None:
-            from synthefy_tabular.inference.predictor import LimiXPredictor
+            from synthefy_tabular.inference.predictor import SynthefyTabularPredictor
             from synthefy_tabular.utils.loading import load_model
 
             # Reuse model from cls_predictor if already loaded
@@ -131,7 +129,7 @@ class LimiXWrapper(BaseModelWrapper):
                     mask_prediction=False,
                     base_config_path=self.base_config_path,
                 )
-            self._reg_predictor = LimiXPredictor(
+            self._reg_predictor = SynthefyTabularPredictor(
                 device=self.device,
                 inference_config=self.reg_config_path,
                 model=model,
@@ -154,7 +152,7 @@ class LimiXWrapper(BaseModelWrapper):
             pred = pred.cpu().numpy()
         pred = np.asarray(pred, dtype=np.float64)
 
-        # LimiX outputs 10 columns (max classes); trim to actual n_classes
+        # The model outputs 10 columns (max classes); trim to actual n_classes
         if pred.ndim == 2 and pred.shape[1] > n_classes:
             pred = pred[:, :n_classes]
 
@@ -171,7 +169,7 @@ class LimiXWrapper(BaseModelWrapper):
         X_test = np.asarray(X_test, dtype=np.float32)
         y_train = np.asarray(y_train, dtype=np.float64)
 
-        # Normalize y for LimiX
+        # Normalize y for the model
         y_mean, y_std = y_train.mean(), y_train.std()
         if y_std < 1e-12:
             y_std = 1.0
@@ -193,10 +191,10 @@ class LimiXWrapper(BaseModelWrapper):
             torch.cuda.empty_cache()
 
 
-class LimiXEnsembleWrapper(BaseModelWrapper):
-    """Average predictions from N LimiX/Synthefy checkpoints.
+class SynthefyTabularEnsembleWrapper(BaseModelWrapper):
+    """Average predictions from N Synthefy checkpoints.
 
-    Each component is a fully-configured LimiXWrapper (its own checkpoint,
+    Each component is a fully-configured SynthefyTabularWrapper (its own checkpoint,
     inference config, augmentations). The ensemble runs each component for
     every dataset and averages predictions in y-space (regression) or
     probability space (classification).
@@ -213,7 +211,7 @@ class LimiXEnsembleWrapper(BaseModelWrapper):
     def __init__(self, model_name: str, components: list,
                  weights: list | None = None):
         if not components:
-            raise ValueError("LimiXEnsembleWrapper requires at least one component")
+            raise ValueError("SynthefyTabularEnsembleWrapper requires at least one component")
         self._name = model_name
         self.components = components
         self._device = components[0].device_str
@@ -276,7 +274,7 @@ class ModelEntry:
     """Metadata about a registered model."""
     name: str
     wrapper: BaseModelWrapper
-    model_type: str  # "limix", "limix_ensemble", "custom"
+    model_type: str  # "synthefy", "synthefy_ensemble", "custom"
     description: str = ""
     metadata: dict = field(default_factory=dict)
 
@@ -301,7 +299,7 @@ class ModelRegistry:
     # ------------------------------------------------------------------
     # Convenience registration methods
     # ------------------------------------------------------------------
-    def add_limix(
+    def add_checkpoint(
         self,
         name,
         model_path,
@@ -317,7 +315,7 @@ class ModelRegistry:
         bar_point_estimator: str = 'mean',
     ):
         device = device or self.device
-        wrapper = LimiXWrapper(
+        wrapper = SynthefyTabularWrapper(
             model_name=name,
             model_path=model_path,
             device=device,
@@ -331,7 +329,7 @@ class ModelRegistry:
             bar_point_estimator=bar_point_estimator,
         )
         self.register(ModelEntry(
-            name=name, wrapper=wrapper, model_type="limix",
+            name=name, wrapper=wrapper, model_type="synthefy",
             description=description,
             metadata={"model_path": model_path, "device": device},
         ))
@@ -348,7 +346,7 @@ class ModelRegistry:
         weights=None,
         description="",
     ):
-        """Register an ensemble of N Synthefy/LimiX checkpoints.
+        """Register an ensemble of N Synthefy checkpoints.
 
         Each component_spec is a dict with keys:
           - path (required): checkpoint path
@@ -357,14 +355,14 @@ class ModelRegistry:
         Predictions are averaged in y-space (regression) or prob-space (cls).
         """
         device = device or self.device
-        components: list[LimiXWrapper] = []
+        components: list[SynthefyTabularWrapper] = []
         for spec in component_specs:
             if isinstance(spec, str):
                 spec = {"path": spec}
             path = spec["path"]
             label = spec.get("label") or os.path.splitext(os.path.basename(path))[0]
             cmp_reg_config = spec.get("reg_config") or default_reg_config
-            wrapper = LimiXWrapper(
+            wrapper = SynthefyTabularWrapper(
                 model_name=label,
                 model_path=path,
                 device=device,
@@ -375,28 +373,13 @@ class ModelRegistry:
             )
             components.append(wrapper)
 
-        ens = LimiXEnsembleWrapper(ensemble_name, components, weights=weights)
+        ens = SynthefyTabularEnsembleWrapper(ensemble_name, components, weights=weights)
         self.register(ModelEntry(
-            name=ensemble_name, wrapper=ens, model_type="limix_ensemble",
+            name=ensemble_name, wrapper=ens, model_type="synthefy_ensemble",
             description=description or f"Ensemble of {len(components)} Synthefy checkpoints",
             metadata={"components": [c.model_path for c in components],
                       "weights": (weights if weights else [1.0/len(components)]*len(components))},
         ))
-
-    def add_limix_pretrained_2m(self, device=None, model_path="cache/LimiX-2M.ckpt"):
-        self.add_limix("LimiX-2M (pretrained)", model_path, device=device,
-                       description="Official pretrained LimiX-2M checkpoint")
-
-    def add_limix_pretrained_16m(self, device=None, model_path="cache/LimiX-16M.ckpt"):
-        self.add_limix("LimiX-16M (pretrained)", model_path, device=device,
-                       cls_config=package_config_path("cls_default_noretrieval.json"),
-                       reg_config=package_config_path("reg_allordinal_poly10_noretrieval.json"),
-                       description="Official pretrained LimiX-16M checkpoint")
-
-    def add_limix_checkpoint(self, name, checkpoint_path, device=None, base_config_path=None):
-        self.add_limix(name, checkpoint_path, device=device,
-                       base_config_path=base_config_path,
-                       description=f"Custom checkpoint: {checkpoint_path}")
 
     def cleanup_all(self):
         for entry in self._models.values():

--- a/src/synthefy_tabular/evaluation/runner.py
+++ b/src/synthefy_tabular/evaluation/runner.py
@@ -328,7 +328,7 @@ class EvalRunner:
         total = len(models) * len(all_datasets)
         cache_status = "OFF" if self.no_cache else f"ON ({self._cache_dir})"
         print(f"\n{'='*70}")
-        print(f"  LimiX Unified Evaluation")
+        print(f"  Synthefy Tabular Evaluation")
         print(f"  Models: {len(models)}  |  Datasets: {len(all_datasets)}  |  Total runs: {total}")
         print(f"  Cache: {cache_status}")
         print(f"  Parallel model workers: {self.parallel_models}")
@@ -435,7 +435,7 @@ class EvalRunner:
     def _compute_max_train(n_test, n_features, gpu_mem_gb=70.0, features_per_group=2):
         """Estimate the maximum training samples that will fit in GPU memory.
 
-        LimiX memory is dominated by:
+        Model memory is dominated by:
         - Feature attention:  O(n_samples * n_groups^2) per layer
         - Sample attention:   O(n_samples^2 * n_heads) per layer
         - Embeddings:         O(n_samples * n_groups * embed_dim)

--- a/src/synthefy_tabular/hf.py
+++ b/src/synthefy_tabular/hf.py
@@ -30,7 +30,7 @@ def _access_error_message(repo_id: str) -> str:
         f"This checkpoint requires authentication. To resolve:\n"
         f"  1. Request access at https://huggingface.co/{repo_id}\n"
         f"  2. Get a token at https://huggingface.co/settings/tokens (read scope)\n"
-        f"  3. Provide it via `export HF_TOKEN=hf_...`, `huggingface-cli login`,\n"
+        f"  3. Provide it via `export HF_TOKEN=hf_...`, `hf auth login`,\n"
         f"     or pass token=... to SynthefyTabularRegressor/Classifier.\n"
         f"If you already have a local checkpoint, pass model_path=... to skip the download."
     )

--- a/src/synthefy_tabular/inference/predictor.py
+++ b/src/synthefy_tabular/inference/predictor.py
@@ -28,8 +28,8 @@ import os
 
 NA_PLACEHOLDER = "__MISSING__"
 
-class LimiXPredictor:
-    """"LimiX model inferencer, supporting tasks such as classification, regression, and missing value prediction."""
+class SynthefyTabularPredictor:
+    """Synthefy Tabular model inferencer, supporting tasks such as classification, regression, and missing value prediction."""
     def __init__(self,
                  device:torch.device,
                  model_path:str = None,
@@ -50,11 +50,11 @@ class LimiXPredictor:
                  bar_point_estimator: str = 'mean',
                  discrete_y_snap_max_unique: int = 30):
         """
-        init LimiXPredictor
+        init SynthefyTabularPredictor
 
         Args:
             device: The device for performing inference; GPU is recommended
-            model_path: The model path of LimiX (unused when model is provided)
+            model_path: The model path of the Synthefy Tabular model (unused when model is provided)
             mix_precision: Whether to use mixed precision inference
             outlier_remove_std: Standard deviation used for removing outliers
             softmax_temperature: Softmax temperature coefficient
@@ -519,7 +519,7 @@ class LimiXPredictor:
     
     def predict(self, x_train:np.ndarray, y_train:np.ndarray, x_test:np.ndarray, task_type:Literal['Classification', 'Regression']='Classification') -> np.ndarray:
         """
-        Perform inference using the LimiX model
+        Perform inference using the Synthefy Tabular model
 
         Args:
         x_train: Training data x

--- a/src/synthefy_tabular/model/layer.py
+++ b/src/synthefy_tabular/model/layer.py
@@ -13,7 +13,7 @@ from torch.amp import autocast
 
 
 
-if os.environ.get("LIMIX_NO_FLASH_ATTN", "0") == "1":
+if os.environ.get("SYNTHEFY_TABULAR_NO_FLASH_ATTN", "0") == "1":
     HAVE_FLASH_ATTN = False
     HAVE_FLASH_ATTN_4 = False
 else:
@@ -331,7 +331,7 @@ class MultiheadAttention(torch.nn.Module):
         All sequences in a batch have equal length, so no cu_seqlens needed.
         """
         assert HAVE_FLASH_ATTN_4, "FlashAttention-4 not installed. pip install flash-attn-4"
-        # FA4 beta backward kernels fail for LimiX's native head_dim=16 on H100. Padding the
+        # FA4 beta backward kernels fail for the model's native head_dim=16 on H100. Padding the
         # per-head dimension to 128 keeps q·k and weighted-v math unchanged as long as we also
         # preserve the original softmax scale.
         flash_head_dim = 128 if self.head_dim < 128 else self.head_dim

--- a/src/synthefy_tabular/training/cli.py
+++ b/src/synthefy_tabular/training/cli.py
@@ -18,13 +18,13 @@ from datetime import datetime
 
 # Must set before model imports which check this env var at module load time
 if '--no-flash-attn' in sys.argv:
-    os.environ["LIMIX_NO_FLASH_ATTN"] = "1"
+    os.environ["SYNTHEFY_TABULAR_NO_FLASH_ATTN"] = "1"
 
 import torch
 
 from synthefy_tabular.utils.loading import build_model
 from synthefy_tabular.training.config import TrainingConfig, package_config_path
-from synthefy_tabular.training.trainer import LimiXTrainer
+from synthefy_tabular.training.trainer import SynthefyTabularTrainer
 
 
 def load_model_config(source: str | None) -> dict:
@@ -247,7 +247,7 @@ def main():
     parser.add_argument('--y-transform-prob', type=float, default=0.0,
                         help='Probability of applying realistic y-target transforms per episode. '
                              'Simulates integer counts, censored values, ordinal ratings, bounded averages, '
-                             'zero-inflated counts. Targets LimiX-2M wins we regress on '
+                             'zero-inflated counts. Targets datasets we underperform on '
                              '(stock_fardamento02, boston, sensory, Goodreads, etc). Default 0.0 (off).')
     parser.add_argument('--cap-injection-prob', type=float, default=0.0,
                         help='Probability of injecting upper/lower quantile cap (saturation) per '
@@ -258,7 +258,7 @@ def main():
                         help='Probability of applying heavy-tail y transforms per regression episode. '
                              'Continuous transforms only: log-normal (exp), Pareto additive noise, '
                              'strong outlier injection (5-10%% @ 3-15x scale). No rounding — safe vs '
-                             'failed y_transform experiment. Targets LimiX-2M wins on skewed data '
+                             'failed y_transform experiment. Targets weak spots on skewed data '
                              '(stock_fardamento02, CPS1988, sulfur, Food_Delivery_Time). Default 0.0.')
     parser.add_argument('--pareto-importance-prob', type=float, default=0.0,
                         help='Probability per regression-prior episode of multiplying the per-feature '
@@ -316,7 +316,7 @@ def main():
     parser.add_argument('--feature-positional-embedding-type', type=str, default=None,
                         choices=['subortho', 'learned', 'none'],
                         help='Feature positional embedding type. '
-                             'subortho=random orthogonal each fwd (LimiX default). '
+                             'subortho=random orthogonal each fwd (default). '
                              'learned=nn.Embedding table with permuted slots (TabPFN-2.6 style). '
                              'none=no feature positional embedding.')
     parser.add_argument('--feature-positional-embedding-num-slots', type=int, default=1000,
@@ -720,7 +720,7 @@ def main():
     )
 
     # Create trainer (model already on device, skip internal .to())
-    trainer = LimiXTrainer(model, train_config, model_config=model_config)
+    trainer = SynthefyTabularTrainer(model, train_config, model_config=model_config)
 
     # Resume if specified
     if args.resume:

--- a/src/synthefy_tabular/training/config.py
+++ b/src/synthefy_tabular/training/config.py
@@ -87,7 +87,7 @@ class TrainingConfig:
     save_interval: int = 5000
     checkpoint_dir: str = "./checkpoints"
     use_wandb: bool = True
-    wandb_project: str = "limix-training"
+    wandb_project: str = "synthefy-tabular"
     wandb_entity: str | None = None
     wandb_name: str | None = None
     wandb_group: str | None = None
@@ -327,7 +327,7 @@ class TrainingConfig:
 
     # Heavy-tail regression y priors (gated). Applies continuous heavy-tail
     # transforms to y: log-normal (exp), Pareto-tailed additive noise, stronger
-    # outlier injection. No rounding. Targets LimiX-2M strict wins:
+    # outlier injection. No rounding. Targets skewed-target weak spots:
     # stock_fardamento02 (skew 17.7), CPS1988, sulfur, Food_Delivery_Time.
     heavy_tail_prior_prob: float = 0.0
 

--- a/src/synthefy_tabular/training/data_generator.py
+++ b/src/synthefy_tabular/training/data_generator.py
@@ -1,4 +1,4 @@
-"""Hierarchical SCM synthetic data generator for LimiX training.
+"""Hierarchical SCM synthetic data generator for Synthefy Tabular training.
 
 Generates synthetic tabular datasets using a hierarchical composition of
 Local Causal Structures (LCS). Each LCS is a small DAG (3-8 nodes) with

--- a/src/synthefy_tabular/training/loss.py
+++ b/src/synthefy_tabular/training/loss.py
@@ -1,4 +1,4 @@
-"""Unified CCMM loss for LimiX training.
+"""Unified CCMM loss for Synthefy Tabular training.
 
 The CCMM objective treats ALL masked entries uniformly. The loss sums NLL
 across all masked positions:

--- a/src/synthefy_tabular/training/masking.py
+++ b/src/synthefy_tabular/training/masking.py
@@ -1,4 +1,4 @@
-"""CCMM masking strategies for LimiX training.
+"""CCMM masking strategies for Synthefy Tabular training.
 
 Three mask patterns (randomly selected per episode):
 1. Cell-wise: Each cell independently masked with probability = mask_ratio

--- a/src/synthefy_tabular/training/prefetch.py
+++ b/src/synthefy_tabular/training/prefetch.py
@@ -1,4 +1,4 @@
-"""Async data prefetching for LimiX training.
+"""Async data prefetching for Synthefy Tabular training.
 
 Uses a pool of background processes to generate synthetic data batches
 while the GPU runs forward/backward. This overlaps CPU data generation

--- a/src/synthefy_tabular/training/scm_prior_generator.py
+++ b/src/synthefy_tabular/training/scm_prior_generator.py
@@ -1,4 +1,4 @@
-"""TabICL-style synthetic data prior for LimiX training.
+"""TabICL-style synthetic data prior for Synthefy Tabular training.
 
 Ports the key components of TabICL's prior system (MLP SCM, Tree SCM,
 Reg2Cls, meta-distribution HP sampling, rich activation library) to work

--- a/src/synthefy_tabular/training/trainer.py
+++ b/src/synthefy_tabular/training/trainer.py
@@ -1,4 +1,4 @@
-"""Main training loop for LimiX CCMM training."""
+"""Main training loop for Synthefy Tabular CCMM training."""
 
 import json
 import os
@@ -39,8 +39,8 @@ def get_wcd_schedule(optimizer, warmup_steps, decay_start_step, total_steps, lr_
     return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
-class LimiXTrainer:
-    """Training loop for LimiX with CCMM objective."""
+class SynthefyTabularTrainer:
+    """Training loop for Synthefy Tabular with CCMM objective."""
 
     def __init__(self, model, config: TrainingConfig, model_config: dict = None,
                  on_checkpoint_saved=None):
@@ -50,7 +50,7 @@ class LimiXTrainer:
         self.on_checkpoint_saved = on_checkpoint_saved
         self.device = torch.device(config.device)
 
-        # In DDP mode, model is already on device from train_limix.py
+        # In DDP mode, model is already on device from the training entrypoint
         if not config.distributed:
             self.model.to(self.device)
 

--- a/src/synthefy_tabular/utils/loading.py
+++ b/src/synthefy_tabular/utils/loading.py
@@ -83,13 +83,6 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
         # Training checkpoint format (legacy): no model_config saved
         # Fall back to extracting config from base pretrained checkpoint
         if base_config_path is None:
-            # Try default location
-            import os
-            for candidate in ['cache/LimiX-2M.ckpt', 'cache/LimiX-16M.ckpt']:
-                if os.path.exists(candidate):
-                    base_config_path = candidate
-                    break
-        if base_config_path is None:
             raise KeyError(
                 f"Training checkpoint at {model_path} does not contain 'model_config'. "
                 "Provide base_config_path pointing to the pretrained .ckpt file."

--- a/tests/test_inference_e2e.py
+++ b/tests/test_inference_e2e.py
@@ -1,11 +1,12 @@
 """End-to-end inference tests.
 
 These tests download the default HuggingFace checkpoint and run a real forward
-pass through the model. They are skipped by default because they:
+pass through the model. They are deselected by default (the ``slow`` marker)
+because they:
 
-* require network access,
-* require an HF token with access to `Synthefy/synthefy-tabular` (until that
-  repo is made public), and
+* require network access to fetch the public ``Synthefy/synthefy-tabular``
+  checkpoint (no token required; one is used automatically if present in the
+  environment, only to raise anonymous rate limits), and
 * take ~15s on CPU for the regression case.
 
 Run explicitly with::
@@ -31,11 +32,8 @@ def _checkpoint_kwargs():
     local = os.environ.get("SYNTHEFY_TABULAR_TEST_CHECKPOINT")
     if local:
         return {"model_path": local}
-    if not (os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")):
-        pytest.skip(
-            "set HF_TOKEN (with access to the default HF repo) "
-            "or SYNTHEFY_TABULAR_TEST_CHECKPOINT to run e2e tests"
-        )
+    # The default repo is public, so anonymous download works. Any HF token in
+    # the environment is picked up automatically (it only affects rate limits).
     return {}
 
 


### PR DESCRIPTION
## Summary

Open-source release prep, in two parts.

### 1. Strip vestigial LimiX naming
The code diverged from its original LimiX fork, so the leftover `LimiX*` names were vestigial. Renamed them to `SynthefyTabular*` and removed dead LimiX-baseline code, **keeping canonical LimiX-2M only where the real model is genuinely used** — the training-time ICL learnability filter.

- `LimiXPredictor`→`SynthefyTabularPredictor`, `LimiXTrainer`→`SynthefyTabularTrainer`, `LimiXWrapper`/`LimiXEnsembleWrapper`→`SynthefyTabular*`
- `ModelRegistry.add_limix`→`add_checkpoint`; `model_type "limix"/"limix_ensemble"`→`"synthefy"/"synthefy_ensemble"`
- `wandb_project "limix-training"`→`"synthefy-tabular"`; env var `LIMIX_NO_FLASH_ATTN`→`SYNTHEFY_TABULAR_NO_FLASH_ATTN` (producer + consumer)
- Removed dead, unreachable eval baselines: `add_limix_pretrained_2m/16m`, `add_limix_checkpoint`, LimiX-16M support, and the `cache/LimiX-*.ckpt` config fallback
- Reworded vestigial docstrings / comments / report titles
- **Kept** (canonical model): `download_limix`, `LIMIX_REPO_ID`, `--icl-filter-model limix`, `_gpu_icl_filter_limix`

Net: **97 → 27** `limix` references; all 27 remaining are the canonical ICL filter.

### 2. Release doc / accuracy fixes
Found while exercising inference and the HF download path for the public release:

- **README**: the HF repo `Synthefy/synthefy-tabular` is now **public**, so a token is optional (was documented as "requires access"); `huggingface-cli login`→`hf auth login` (the old CLI is removed in `huggingface-hub>=1.0`); dropped a reference to a nonexistent `--no-eval` flag
- **`scripts/evaluate.sh`**: use the project venv python (was bare `python`, not always on PATH)
- **`tests/test_inference_e2e.py`**: run against the now-public repo instead of skipping unless a token is set
- Added **`AGENTS.md`** (+ `CLAUDE.md` pointer) for fast coding-agent onboarding

## Verification
- `ruff`, all 33 modules import, fast tests (6), **slow e2e real inference (2/2)**, eval path executed, **CPU training smoke (2 steps + checkpoint write)**, `uv build` + `twine check --strict`
- Exhaustive case-insensitive grep confirms **no orphaned** old `LimiX*` / `add_limix` / `limix-training` / `LIMIX_NO_FLASH_ATTN` references anywhere

## Follow-up (not in this PR)
`NOTICE` third-party attribution (LimiX Apache-2.0, TabICL BSD-3) is still an open decision for the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
