### PR TITLE
Make Baseten deployment regression-only

### DIFF
--- a/baseten/config.yaml
+++ b/baseten/config.yaml
@@ -25,8 +25,10 @@ resources:
   memory: 16Gi
   use_gpu: true
 
-# The default checkpoint (Synthefy/synthefy-tabular) is gated on the Hugging Face
-# Hub. Set this secret in the Baseten workspace (Settings -> Secrets) to a HF token
-# with read access, then reference it here. The value below is just a placeholder.
+# The default checkpoint (Synthefy/synthefy-tabular) is PUBLIC and un-gated on the
+# Hugging Face Hub (verified: private=false, gated=false), so no token is required —
+# warmup downloads it anonymously and this secret can stay null. Only set
+# hf_access_token (a HF token with read access, via the Baseten workspace:
+# Settings -> Secrets) if the repo is ever made private or re-gated.
 secrets:
   hf_access_token: null

--- a/baseten/model/model.py
+++ b/baseten/model/model.py
@@ -2,8 +2,10 @@
 
 Synthefy Tabular is an in-context learning model: there is no offline training
 step. Every request supplies the context rows (``X_train``, ``y_train``) and the
-query rows (``X_test``); the model conditions on the context and predicts labels
+query rows (``X_test``); the model conditions on the context and predicts targets
 for the queries in a single forward pass.
+
+This release is **regression-only**.
 
 Request body (POST /predict):
 
@@ -11,16 +13,12 @@ Request body (POST /predict):
         "X_train": [[...], ...],   # n_context x n_features
         "y_train": [...],          # n_context targets
         "X_test":  [[...], ...],   # n_query x n_features
-        "task":    "regression"    # or "classification" (default: regression)
+        "task":    "regression"    # optional; "regression"/"reg" only (default: regression)
     }
 
 Response:
 
-    regression     -> {"task": "regression", "predictions": [...]}
-    classification -> {"task": "classification",
-                       "predictions": [...],        # predicted class labels
-                       "probabilities": [[...], ...],  # per-class probabilities
-                       "classes": [...]}            # class label order for the cols
+    {"task": "regression", "predictions": [...]}   # one value per X_test row
 """
 
 from __future__ import annotations
@@ -45,34 +43,30 @@ class Model:
         # Baseten injects the declared secrets here at construction time.
         self._secrets = kwargs.get("secrets") or {}
         self._token = None
-        # Long-lived wrappers hold the loaded checkpoint weights in their cached
+        # The long-lived wrapper holds the loaded checkpoint weights in its cached
         # predictor, so weights are read from disk only once (during load()).
         self._regressor = None
-        self._classifier = None
         # The underlying predictor's preprocessing uses per-call RNG/shuffling
         # state, so serialize inference to stay correct under concurrent requests.
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------ load
     def load(self):
-        """Download the gated checkpoint and warm up both task heads once."""
-        from synthefy_tabular import (
-            SynthefyTabularClassifier,
-            SynthefyTabularRegressor,
-        )
+        """Download the checkpoint and warm up the regression head once."""
+        from synthefy_tabular import SynthefyTabularRegressor
 
+        # The default checkpoint is public; a token is only needed if the repo is
+        # gated. Honor an optional hf_access_token secret when present.
         token = self._secrets.get("hf_access_token")
         if token:
-            # Make the token visible to huggingface_hub for any indirect lookups.
             os.environ.setdefault("HF_TOKEN", token)
         self._token = token
 
         self._regressor = SynthefyTabularRegressor(token=token)
-        self._classifier = SynthefyTabularClassifier(token=token)
 
         # Trigger checkpoint download + weight load now (not on first request) by
-        # running a tiny in-context prediction through each head. The loaded
-        # predictor is cached on the wrapper and reused for real requests.
+        # running a tiny in-context prediction. The loaded predictor is cached on
+        # the wrapper and reused for real requests.
         self._warmup()
 
     def _warmup(self):
@@ -82,13 +76,11 @@ class Model:
         try:
             self._regressor.fit(x, np.array([0.0, 1.0, 0.5, 0.3], dtype=np.float64))
             self._regressor.predict(x[:1])
-            self._classifier.fit(x, np.array([0, 1, 0, 1], dtype=np.int64))
-            self._classifier.predict(x[:1])
         except Exception as exc:  # pragma: no cover - surfaced in deploy logs
             raise RuntimeError(
                 "Failed to load the Synthefy Tabular checkpoint during warmup. "
-                "If this is an auth error, ensure the 'hf_access_token' secret is "
-                "set in your Baseten workspace and has read access to "
+                "If this is an auth error, set the 'hf_access_token' secret in your "
+                "Baseten workspace to a Hugging Face token with read access to "
                 "'Synthefy/synthefy-tabular'."
             ) from exc
 
@@ -105,32 +97,21 @@ class Model:
                     status_code=400, detail=f"Missing required field '{key}'."
                 )
 
+        if task not in ("regression", "reg"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unsupported task: {task!r}. This deployment is "
+                    "regression-only; use 'regression'."
+                ),
+            )
+
         X_train = np.asarray(model_input["X_train"], dtype=np.float32)
         X_test = np.asarray(model_input["X_test"], dtype=np.float32)
-        y_train = model_input["y_train"]
+        y_train = np.asarray(model_input["y_train"], dtype=np.float64)
 
-        if task in ("regression", "reg"):
-            with self._lock:
-                self._regressor.fit(X_train, np.asarray(y_train, dtype=np.float64))
-                preds = self._regressor.predict(X_test)
-            preds = np.atleast_1d(preds)
-            return {"task": "regression", "predictions": _to_jsonable(preds)}
-
-        if task in ("classification", "cls"):
-            with self._lock:
-                self._classifier.fit(X_train, np.asarray(y_train))
-                proba = self._classifier.predict_proba(X_test)
-                classes = self._classifier.classes_
-            proba = np.atleast_2d(proba)
-            preds = classes[proba.argmax(axis=1)]
-            return {
-                "task": "classification",
-                "predictions": _to_jsonable(preds),
-                "probabilities": _to_jsonable(proba),
-                "classes": _to_jsonable(classes),
-            }
-
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported task: {task!r}. Use 'regression' or 'classification'.",
-        )
+        with self._lock:
+            self._regressor.fit(X_train, y_train)
+            preds = self._regressor.predict(X_test)
+        preds = np.atleast_1d(preds)
+        return {"task": "regression", "predictions": _to_jsonable(preds)}

--- a/baseten/openapi.yaml
+++ b/baseten/openapi.yaml
@@ -3,13 +3,13 @@ info:
   title: Synthefy Tabular Inference API
   version: "1.0.0"
   description: |
-    In-context learning model for tabular **regression** and **classification**,
-    served on Baseten. There is no offline training step: every request supplies
-    the context rows (`X_train`, `y_train`) and the query rows (`X_test`), and the
-    model conditions on the context and predicts labels for the queries in a
-    single forward pass.
+    In-context learning model for tabular **regression**, served on Baseten.
+    There is no offline training step: every request supplies the context rows
+    (`X_train`, `y_train`) and the query rows (`X_test`), and the model conditions
+    on the context and predicts targets for the queries in a single forward pass.
 
     Notes:
+    - This deployment is **regression-only**.
     - The first request after a scale-to-zero idle triggers a checkpoint download +
       warmup and can take ~90s; warm requests return in ~1-2s.
     - Invalid requests (missing fields, unsupported task) return **HTTP 400** with
@@ -23,10 +23,10 @@ paths:
   /environments/production/predict:
     post:
       operationId: predict
-      summary: Run an in-context prediction
+      summary: Run an in-context regression prediction
       description: |
-        Submit context rows and query rows and receive predictions for the query
-        rows. The response shape depends on `task`.
+        Submit context rows and query rows and receive a predicted value for each
+        query row.
       requestBody:
         required: true
         content:
@@ -41,43 +41,23 @@ paths:
                   X_train: [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
                   y_train: [0.1, 0.9, 0.5, 0.3]
                   X_test: [[0.3, 0.7], [0.8, 0.2]]
-              classification:
-                summary: Classification request
-                value:
-                  task: classification
-                  X_train: [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
-                  y_train: [0, 1, 0, 1]
-                  X_test: [[0.3, 0.7], [0.8, 0.2]]
       responses:
         "200":
-          description: |
-            A successful prediction. The shape depends on `task`:
-            `RegressionResponse` or `ClassificationResponse`.
+          description: A successful regression prediction.
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/RegressionResponse"
-                  - $ref: "#/components/schemas/ClassificationResponse"
+                $ref: "#/components/schemas/RegressionResponse"
               examples:
                 regression:
-                  summary: Regression response (real output)
+                  summary: Regression response (illustrative output)
                   value:
                     task: regression
                     predictions: [0.3699104921941226, 0.7807573902172393]
-                classification:
-                  summary: Classification response (real output)
-                  value:
-                    task: classification
-                    predictions: [0, 0]
-                    probabilities:
-                      - [0.5008668154219742, 0.4991331845780258]
-                      - [0.5013414770764553, 0.49865852292354473]
-                    classes: [0, 1]
         "400":
           description: |
             Invalid request — a required field (`X_train`, `y_train`, `X_test`)
-            is missing, or `task` is not one of the supported values.
+            is missing, or `task` is not a supported (regression) value.
           content:
             application/json:
               schema:
@@ -90,7 +70,7 @@ paths:
                 badTask:
                   summary: Unsupported task
                   value:
-                    error: "Unsupported task: 'cluster'. Use 'regression' or 'classification'."
+                    error: "Unsupported task: 'classification'. This deployment is regression-only; use 'regression'."
         "401":
           description: Missing or invalid API key.
         "404":
@@ -107,14 +87,9 @@ components:
   schemas:
     Task:
       type: string
-      description: Prediction task. Defaults to `regression` when omitted.
-      enum: [regression, reg, classification, cls]
+      description: Prediction task. Regression-only; defaults to `regression` when omitted.
+      enum: [regression, reg]
       default: regression
-    Label:
-      description: A target/class label; may be a number or a string.
-      oneOf:
-        - type: number
-        - type: string
     PredictRequest:
       type: object
       required: [X_train, y_train, X_test]
@@ -130,11 +105,9 @@ components:
               type: number
         y_train:
           type: array
-          description: |
-            Context targets aligned with `X_train` rows. Numeric for regression;
-            ints or strings for classification.
+          description: Context targets aligned with `X_train` rows (numeric).
           items:
-            $ref: "#/components/schemas/Label"
+            type: number
         X_test:
           type: array
           description: Query feature matrix, n_query x n_features.
@@ -155,30 +128,6 @@ components:
           description: Predicted value per `X_test` row.
           items:
             type: number
-    ClassificationResponse:
-      type: object
-      required: [task, predictions, probabilities, classes]
-      properties:
-        task:
-          type: string
-          const: classification
-        predictions:
-          type: array
-          description: Predicted class label per `X_test` row (argmax over classes).
-          items:
-            $ref: "#/components/schemas/Label"
-        probabilities:
-          type: array
-          description: Per-class probabilities per `X_test` row; columns ordered by `classes`.
-          items:
-            type: array
-            items:
-              type: number
-        classes:
-          type: array
-          description: Class labels giving the column order of `probabilities`.
-          items:
-            $ref: "#/components/schemas/Label"
     ErrorResponse:
       type: object
       required: [error]


### PR DESCRIPTION
## Summary
Aligns the Baseten Truss deployment with the **regression-only** `synthefy-tabular` package (0.2.0). Stacked on top of #2 (`add-baseten-deployment`); merge after/with that PR.

The deploy workflow re-vendors `packages/synthefy_tabular` from `src/` before `truss push`. Since `src/` no longer defines `SynthefyTabularClassifier`, the existing wrapper would `ImportError` at `load()`. This strips the classification path so the deployment matches the shipped package.

## Changes
- **`model/model.py`** — remove the `SynthefyTabularClassifier` import, the classifier warmup, and the `classification` branch in `predict()`. A non-regression `task` now returns **HTTP 400** ("regression-only"); the regression path is unchanged.
- **`openapi.yaml`** — regression-only request/response; drop the `Classification*` schemas/examples. Error body key is **`error`** (Truss reformats a raised `HTTPException(detail=...)` into `{"error": ...}`) — corrected to match the live model.
- **`config.yaml`** — the checkpoint `Synthefy/synthefy-tabular` is **public/un-gated** (verified `private=false`, `gated=false`), so `hf_access_token` stays `null` and warmup downloads anonymously. Comment corrected (previously said "gated").

## Deployment verification
Deployed via `truss push` and promoted to **production** — deployment **`qz44goe`** on model **`3m5j7y9w`** (`is_production: true`, `ACTIVE`). Warmup logs confirm anonymous HF download (HEAD 302 / xet-token 200).

Smoke tests against `…/environments/production/predict`:
| Request | Result |
|---|---|
| valid regression | `200` → `{"task":"regression","predictions":[…]}` (~1.3s warm) |
| missing `X_test` | `400` → `{"error":"Missing required field 'X_test'."}` |
| `task=classification` | `400` → `{"error":"…regression-only; use 'regression'."}` |
| `task` omitted | `200` (defaults to regression) |

## Notes
- `packages/synthefy_tabular/` stays git-ignored (regenerated from `src/` before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)