### PR TITLE
Make context-size budget configurable via SYNTHEFY_MAX_ELEMENTS_BUDGET

### DIFF
--- a/src/synthefy_tabular/inference/predictor.py
+++ b/src/synthefy_tabular/inference/predictor.py
@@ -827,9 +827,12 @@ class SynthefyTabularPredictor:
         n_samples_train = x_train.shape[0]
         n_samples_test = x_test.shape[0]
         
-        # If the number of elements is too large, we must chunk the test set to avoid OOM
-        # A conservative budget for 24GB GPUs is around 200,000 to 500,000 elements
-        MAX_ELEMENTS_BUDGET = 2_000_000
+        # If the number of elements is too large, we must chunk the test set to avoid OOM.
+        # The default (2M elements) is conservative for ~24GB GPUs. On larger GPUs
+        # (A100/H100/H200) raise it via SYNTHEFY_MAX_ELEMENTS_BUDGET so big tables use
+        # their full context instead of being silently subsampled — e.g. set
+        # SYNTHEFY_MAX_ELEMENTS_BUDGET=16000000 for large-context (50K-row) inference.
+        MAX_ELEMENTS_BUDGET = int(os.environ.get("SYNTHEFY_MAX_ELEMENTS_BUDGET", "2000000"))
         
         # Calculate elements for one full forward pass (train + 1 test row at
         # minimum). Use the post-HighDimFeatureSelector feature count — the
@@ -1187,9 +1190,12 @@ class SynthefyTabularPredictor:
         n_samples_train = x_train.shape[0]
         n_samples_test = x_test.shape[0]
         
-        # If the number of elements is too large, we must chunk the test set to avoid OOM
-        # A conservative budget for 24GB GPUs is around 200,000 to 500,000 elements
-        MAX_ELEMENTS_BUDGET = 2_000_000
+        # If the number of elements is too large, we must chunk the test set to avoid OOM.
+        # The default (2M elements) is conservative for ~24GB GPUs. On larger GPUs
+        # (A100/H100/H200) raise it via SYNTHEFY_MAX_ELEMENTS_BUDGET so big tables use
+        # their full context instead of being silently subsampled — e.g. set
+        # SYNTHEFY_MAX_ELEMENTS_BUDGET=16000000 for large-context (50K-row) inference.
+        MAX_ELEMENTS_BUDGET = int(os.environ.get("SYNTHEFY_MAX_ELEMENTS_BUDGET", "2000000"))
         
         # Calculate elements for one full forward pass (train + 1 test row at
         # minimum). Use the post-HighDimFeatureSelector feature count — the


### PR DESCRIPTION
## Summary

The OOM guard in `SynthefyTabularPredictor` hard-codes
`MAX_ELEMENTS_BUDGET = 2_000_000`. That budget is a sensible default for
~24 GB GPUs, but on larger GPUs it **silently subsamples the in-context
training rows** on big tables. For example, a 50K-row × 1K-feature table
(after the SVD feature reduction to 256) is cut from 50K context rows to
~3.9K — the model never sees most of the data, which costs accuracy on
exactly the large-context workloads the docs advertise for A100/H100/H200.

This makes the budget configurable via the `SYNTHEFY_MAX_ELEMENTS_BUDGET`
environment variable, in both the classification and regression paths.

## Behavior

- **Default unchanged** (`2_000_000`) → small-GPU behavior is byte-identical.
- On a larger GPU, opt into full context:
  ```bash
  SYNTHEFY_MAX_ELEMENTS_BUDGET=16000000 python your_script.py
  ```
  (~16M elements ≈ full context for 50K-row tables.)

## Why an env var

Keeps the safe default for the common case while letting power users on
big GPUs use the full table without code changes. No new dependencies, no
API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)