### PR TITLE
Add OpenAI-compatible usage block to inference output

### DIFF
--- a/baseten/README.md
+++ b/baseten/README.md
@@ -64,7 +64,8 @@ curl -X POST https://model-{MODEL_ID}.api.baseten.co/development/predict \
     "y_train": [0.1, 0.9, 0.5, 0.3],
     "X_test":  [[0.3, 0.7], [0.8, 0.2]]
   }'
-# -> {"task": "regression", "predictions": [0.34, 0.81]}
+# -> {"task": "regression", "predictions": [0.34, 0.81],
+#     "usage": {"input_tokens": 16, "output_tokens": 2, "total_tokens": 18}}
 ```
 
 ### Classification
@@ -87,6 +88,12 @@ curl -X POST https://model-{MODEL_ID}.api.baseten.co/development/predict \
 `X_train`/`X_test` are `n_rows × n_features`; `y_train` aligns with `X_train`.
 For classification, `y_train` labels may be ints or strings, and `classes`
 gives the column order of `probabilities`.
+
+Every successful response carries an OpenAI-compatible `usage` block:
+`input_tokens` counts every real (non-null) value sent across `X_train`,
+`y_train` and `X_test` (null/`NaN` cells are imputed server-side and not
+counted), `output_tokens` is one predicted target per `X_test` row, and
+`total_tokens` is their sum.
 
 ## Notes
 

--- a/baseten/model/model.py
+++ b/baseten/model/model.py
@@ -18,7 +18,15 @@ Request body (POST /predict):
 
 Response:
 
-    {"task": "regression", "predictions": [...]}   # one value per X_test row
+    {
+        "task": "regression",
+        "predictions": [...],   # one value per X_test row
+        "usage": {              # OpenAI-compatible token accounting
+            "input_tokens": ...,   # real (non-null) values sent across the inputs
+            "output_tokens": ...,  # one predicted target per X_test row
+            "total_tokens": ...,   # input_tokens + output_tokens
+        },
+    }
 """
 
 from __future__ import annotations
@@ -36,6 +44,28 @@ def _to_jsonable(value):
     if isinstance(value, np.generic):
         return value.item()
     return value
+
+
+def _load_token_accounting():
+    """Import the sibling ``token_accounting`` module.
+
+    Works both in-repo, where it imports as ``baseten.token_accounting``, and on
+    the deployed Truss container, where ``model.py`` runs as a top-level module
+    and ``token_accounting.py`` sits one directory up. Import is deferred to call
+    time to keep ``model.py`` import-light (the module pulls in numpy).
+    """
+    try:
+        from baseten import token_accounting
+    except ImportError:
+        import sys
+        from pathlib import Path
+
+        root = str(Path(__file__).resolve().parents[1])
+        if root not in sys.path:
+            sys.path.insert(0, root)
+        import token_accounting
+
+    return token_accounting
 
 
 class Model:
@@ -114,4 +144,12 @@ class Model:
             self._regressor.fit(X_train, y_train)
             preds = self._regressor.predict(X_test)
         preds = np.atleast_1d(preds)
-        return {"task": "regression", "predictions": _to_jsonable(preds)}
+
+        # Token accounting is pure CPU counting and independent of the model, so
+        # it runs outside the inference lock.
+        usage = _load_token_accounting().usage(X_train, y_train, X_test)
+        return {
+            "task": "regression",
+            "predictions": _to_jsonable(preds),
+            "usage": usage,
+        }

--- a/baseten/openapi.yaml
+++ b/baseten/openapi.yaml
@@ -54,6 +54,10 @@ paths:
                   value:
                     task: regression
                     predictions: [0.3699104921941226, 0.7807573902172393]
+                    usage:
+                      input_tokens: 16
+                      output_tokens: 2
+                      total_tokens: 18
         "400":
           description: |
             Invalid request — a required field (`X_train`, `y_train`, `X_test`)
@@ -118,7 +122,7 @@ components:
       additionalProperties: false
     RegressionResponse:
       type: object
-      required: [task, predictions]
+      required: [task, predictions, usage]
       properties:
         task:
           type: string
@@ -128,6 +132,28 @@ components:
           description: Predicted value per `X_test` row.
           items:
             type: number
+        usage:
+          $ref: "#/components/schemas/Usage"
+    Usage:
+      type: object
+      description: |
+        OpenAI-compatible token accounting for the request. `input_tokens`
+        counts every real (non-null) value sent across `X_train`, `y_train` and
+        `X_test` — null/`NaN` cells are imputed server-side and not counted.
+        `output_tokens` is one predicted target per `X_test` row. `total_tokens`
+        is `input_tokens + output_tokens`.
+      required: [input_tokens, output_tokens, total_tokens]
+      properties:
+        input_tokens:
+          type: integer
+          description: Real (non-null) values sent across X_train, y_train and X_test.
+        output_tokens:
+          type: integer
+          description: Predicted targets — one per X_test row.
+        total_tokens:
+          type: integer
+          description: input_tokens + output_tokens.
+      additionalProperties: false
     ErrorResponse:
       type: object
       required: [error]

--- a/baseten/token_accounting.py
+++ b/baseten/token_accounting.py
@@ -41,3 +41,23 @@ def compute_tokens(
     output_tokens = int(X_test.shape[0])
 
     return input_tokens, output_tokens
+
+
+def usage(
+    X_train: np.ndarray, y_train: np.ndarray, X_test: np.ndarray
+) -> dict:
+    """Return an OpenAI-compatible ``usage`` block for one inference request.
+
+    Wraps :func:`compute_tokens` into the shape clients expect on the response::
+
+        {"input_tokens": ..., "output_tokens": ..., "total_tokens": ...}
+
+    ``total_tokens`` is exactly ``input_tokens + output_tokens``. Values are
+    builtin ``int`` (not numpy scalars) so the dict is JSON-serializable as-is.
+    """
+    input_tokens, output_tokens = compute_tokens(X_train, y_train, X_test)
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }

--- a/tests/test_model_response.py
+++ b/tests/test_model_response.py
@@ -1,0 +1,92 @@
+"""Response-shape tests for ``baseten/model/model.py``::``Model.predict``.
+
+These deliberately avoid the heavy inference stack: the regressor is faked and
+``fastapi`` (supplied by the Baseten/Truss runtime, not a library dependency, so
+absent from the test/library env) is stubbed. That leaves request handling +
+response assembly under test — in particular the OpenAI-compatible ``usage``
+block. ``baseten/`` is a deployment dir, not part of the installed package, so
+the repo root is made importable regardless of how pytest is invoked.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture
+def Model():
+    # model.py does `from fastapi import HTTPException` at call time; the real
+    # package isn't installed in the library/test env, so stand in a minimal stub.
+    if "fastapi" not in sys.modules:
+        fastapi = types.ModuleType("fastapi")
+
+        class HTTPException(Exception):
+            def __init__(self, status_code, detail=None):
+                super().__init__(detail)
+                self.status_code = status_code
+                self.detail = detail
+
+        fastapi.HTTPException = HTTPException
+        sys.modules["fastapi"] = fastapi
+
+    from baseten.model.model import Model as _Model
+
+    return _Model
+
+
+class _FakeRegressor:
+    """Stand-in for SynthefyTabularRegressor: one value per query row."""
+
+    def fit(self, X, y):  # noqa: D401 - signature mirrors the real fit
+        self._fitted = True
+
+    def predict(self, X_test):
+        return np.arange(np.asarray(X_test).shape[0], dtype=np.float64)
+
+
+def _model_with_fake(Model):
+    m = Model()
+    m._regressor = _FakeRegressor()
+    return m
+
+
+def test_response_carries_openai_style_usage(Model):
+    out = _model_with_fake(Model).predict(
+        {
+            "task": "regression",
+            "X_train": [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+            "y_train": [0.1, 0.2, 0.3],
+            "X_test": [[7.0, 8.0], [9.0, 10.0]],
+        }
+    )
+    assert out["task"] == "regression"
+    assert out["predictions"] == [0.0, 1.0]  # one per X_test row, from the fake
+    # input = 6 (X_train) + 3 (y_train) + 4 (X_test); output = 2 rows.
+    assert out["usage"] == {
+        "input_tokens": 13,
+        "output_tokens": 2,
+        "total_tokens": 15,
+    }
+
+
+def test_usage_excludes_null_cells(Model):
+    # null cells (JSON null -> None -> NaN) are imputed server-side, never billed.
+    out = _model_with_fake(Model).predict(
+        {
+            "X_train": [[1.0, None], [3.0, 4.0]],  # 3 known
+            "y_train": [None, 0.2],  # 1 known
+            "X_test": [[5.0, 6.0]],  # 2 known
+        }
+    )
+    assert out["usage"] == {
+        "input_tokens": 6,
+        "output_tokens": 1,
+        "total_tokens": 7,
+    }

--- a/tests/test_token_accounting.py
+++ b/tests/test_token_accounting.py
@@ -16,7 +16,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from baseten.token_accounting import compute_tokens
+from baseten.token_accounting import compute_tokens, usage
 
 
 def test_dense_request_counts_every_known_value():
@@ -107,3 +107,36 @@ def test_dense_shape_formula(n_train, n_features, n_test):
     inp, out = compute_tokens(X_train, y_train, X_test)
     assert inp == n_train * n_features + n_train + n_test * n_features
     assert out == n_test
+
+
+def test_usage_block_shape_and_values():
+    # OpenAI-compatible response block: input=13 (6+3+4), output=2, total=15.
+    X_train = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    y_train = [0.1, 0.2, 0.3]
+    X_test = [[7.0, 8.0], [9.0, 10.0]]
+    assert usage(X_train, y_train, X_test) == {
+        "input_tokens": 13,
+        "output_tokens": 2,
+        "total_tokens": 15,
+    }
+
+
+def test_usage_matches_compute_tokens_with_missing_cells():
+    # usage() must agree with compute_tokens(), missing cells excluded alike.
+    X_train = [[1.0, np.nan], [3.0, 4.0]]
+    y_train = [np.nan, 0.2]
+    X_test = [[5.0, 6.0]]
+    inp, out = compute_tokens(X_train, y_train, X_test)
+    assert usage(X_train, y_train, X_test) == {
+        "input_tokens": inp,
+        "output_tokens": out,
+        "total_tokens": inp + out,
+    }
+
+
+def test_usage_total_is_sum_and_values_are_plain_ints():
+    # The block is returned over JSON, so every value must be a builtin int and
+    # total_tokens must equal input_tokens + output_tokens exactly.
+    u = usage(np.ones((10, 5)), np.ones(10), np.ones((3, 5)))
+    assert u["total_tokens"] == u["input_tokens"] + u["output_tokens"]
+    assert all(type(v) is int for v in u.values())


### PR DESCRIPTION
## What

The Baseten `/predict` response now reports token usage in the OpenAI-compatible shape alongside the predictions:

```json
{
  "task": "regression",
  "predictions": [6.14, 5.58, ...],
  "usage": {
    "input_tokens": 640,
    "output_tokens": 8,
    "total_tokens": 648
  }
}
```

- `input_tokens` — every real (non-null) value sent across `X_train`, `y_train`, `X_test` (null/`NaN` cells are imputed server-side and not counted).
- `output_tokens` — one predicted target per `X_test` row.
- `total_tokens` — `input_tokens + output_tokens`.

## Changes

- **`baseten/token_accounting.py`** — add `usage()`, which wraps the existing `compute_tokens()` into the response block. Returns builtin `int`s so it's JSON-serializable as-is. Living here (not inline in `model.py`) keeps the response logic testable without `fastapi`, which is a Baseten-runtime dep, not a library dep.
- **`baseten/model/model.py`** — `predict()` attaches `usage` to the response, computed **outside** the inference lock (pure CPU counting, independent of the model). Added `_load_token_accounting()` that imports the sibling module both in-repo (`baseten.token_accounting`) and on the deployed Truss (top-level module one dir up). Docstring updated.
- **`baseten/openapi.yaml`** — new `Usage` schema, `usage` made required on `RegressionResponse`, 200 example updated.
- **`baseten/README.md`** — documents the field; curl example output updated.
- **Tests** — `usage()` shape/values/parity/int-and-sum invariants in `test_token_accounting.py`; new `test_model_response.py` asserts the full assembled `predict()` response (regressor faked, `fastapi` stubbed).

## Notes

- Field names follow the Anthropic / OpenAI Responses-API style (`input_tokens`/`output_tokens`/`total_tokens`), as requested. The older Chat Completions API uses `prompt_tokens`/`completion_tokens` — easy to switch if preferred.
- Independent of the parked input-token guardrail on `server-input-token-limit`; expect small, easy conflicts in `model.py`/`token_accounting.py` when that branch merges.

## Evidence it works

### Targeted tests — `uv run pytest tests/test_token_accounting.py tests/test_model_response.py -v`

```
collected 17 items

tests/test_token_accounting.py::test_dense_request_counts_every_known_value PASSED
tests/test_token_accounting.py::test_lists_and_numpy_inputs_agree PASSED
tests/test_token_accounting.py::test_missing_test_cells_excluded_from_input_none_and_nan PASSED
tests/test_token_accounting.py::test_missing_values_in_every_block_are_excluded PASSED
tests/test_token_accounting.py::test_output_tokens_count_rows_not_cells PASSED
tests/test_token_accounting.py::test_fully_missing_test_row_still_counts_as_one_output PASSED
tests/test_token_accounting.py::test_integer_inputs_are_counted PASSED
tests/test_token_accounting.py::test_returns_plain_python_ints PASSED
tests/test_token_accounting.py::test_dense_shape_formula[1-1-1] PASSED
tests/test_token_accounting.py::test_dense_shape_formula[10-5-3] PASSED
tests/test_token_accounting.py::test_dense_shape_formula[100-5-8] PASSED
tests/test_token_accounting.py::test_dense_shape_formula[50-20-1] PASSED
tests/test_token_accounting.py::test_usage_block_shape_and_values PASSED
tests/test_token_accounting.py::test_usage_matches_compute_tokens_with_missing_cells PASSED
tests/test_token_accounting.py::test_usage_total_is_sum_and_values_are_plain_ints PASSED
tests/test_model_response.py::test_response_carries_openai_style_usage PASSED
tests/test_model_response.py::test_usage_excludes_null_cells PASSED

============================== 17 passed in 0.05s ==============================
```

Full fast suite: **24 passed, 2 deselected** (`uv run pytest`). Lint clean (`uv run ruff check baseten tests`).

### End-to-end through the real Baseten `Model` wrapper

Ran `Model() -> load() -> predict()` on `baseten/examples_playground_input.json` (100 context rows x 5 features, 8 query rows), `uv run --with fastapi python`:

```json
{
  "task": "regression",
  "predictions": [
    6.141513744116719,
    5.581752921765492,
    6.991150833885014,
    5.201430104579559,
    5.684008345160313,
    4.341800439675614,
    5.986106492680406,
    4.861220856552035
  ],
  "usage": {
    "input_tokens": 640,
    "output_tokens": 8,
    "total_tokens": 648
  }
}
```

`input_tokens` = 100x5 + 100 + 8x5 = 640; `output_tokens` = 8 query rows; `total` = 648 — and it matches the standalone `usage()` computation on the same payload exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)