### PR TITLE
Add branch protection and approval workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS — required reviewers for synthefy-tabular.
+#
+# Every change (the `*` glob) is owned by the maintainers below. With branch
+# protection's "Require review from Code Owners" enabled on the default branch,
+# a pull request cannot be merged until at least one of them approves it.
+#
+# The companion `.github/workflows/require-approval.yml` enforces the same rule
+# as a status check. See `.github/branch-protection.md` for the one-time
+# settings that make either mechanism actually block the merge button.
+#
+# NOTE: code owners must have write access to this repository, otherwise GitHub
+# silently ignores their entries here.
+
+*	@sagarwal-atg @d31003 @yogabbagabb @raimishah @adityanarayanan03

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -1,0 +1,44 @@
+# Protecting the default branch
+
+This repo ships two complementary pieces of scaffolding so that changes can only
+land on the default branch (`main`) after an approving review from an authorized
+maintainer:
+
+| File | Role |
+| --- | --- |
+| [`CODEOWNERS`](CODEOWNERS) | Auto-requests review from the authorized maintainers and satisfies GitHub's "Require review from Code Owners" rule. |
+| [`workflows/require-approval.yml`](workflows/require-approval.yml) | A status check that fails unless at least one authorized maintainer has approved the PR. |
+
+**Authorized reviewers** — a PR needs an approving review from at least one of:
+
+- `sagarwal-atg`
+- `d31003`
+- `yogabbagabb`
+- `raimishah`
+- `adityanarayanan03`
+
+## One-time setup (requires repo admin)
+
+The files above describe the rule, but only a branch protection rule (or
+ruleset) can actually *block* the merge button. A repo admin must enable this
+once, under **Settings → Branches → Add branch ruleset** (or **Add rule**)
+targeting the default branch:
+
+1. **Require a pull request before merging**, with **Required approvals** set to
+   at least `1`.
+2. **Require review from Code Owners** — ties the required approval to the
+   `CODEOWNERS` list above.
+3. **Require status checks to pass before merging** — add the
+   **`require-approval`** check (it shows up in the list once the workflow has
+   run at least once).
+4. *(Recommended)* **Dismiss stale pull request approvals when new commits are
+   pushed**, and **Do not allow bypassing the above settings** (include
+   administrators), so the rule cannot be sidestepped.
+
+> `require-approval` and `CODEOWNERS` are belt-and-suspenders: the workflow
+> encodes the exact allowlist in version control, while Code Owners provides
+> reviewer auto-assignment. Enable either or both. Code owners must have
+> **write** access to the repo, or GitHub ignores their `CODEOWNERS` entries.
+
+To change the authorized reviewer set, edit **both** `CODEOWNERS` and the
+`AUTHORIZED_REVIEWERS` array in `workflows/require-approval.yml`.

--- a/.github/workflows/require-approval.yml
+++ b/.github/workflows/require-approval.yml
@@ -1,0 +1,84 @@
+name: require-approval
+
+# Blocks merging a pull request into the default branch unless at least one of
+# the authorized reviewers below has submitted an approving review.
+#
+# To actually PREVENT a merge, this job must be marked as a required status
+# check on the protected branch (see .github/branch-protection.md). The
+# CODEOWNERS file is the companion mechanism that auto-requests review from
+# these same users.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  require-approval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify an approval from an authorized reviewer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Merging into the protected branch requires an approving review
+            // from at least one of these GitHub users. Keep this list in sync
+            // with .github/CODEOWNERS.
+            const AUTHORIZED_REVIEWERS = [
+              'sagarwal-atg',
+              'd31003',
+              'yogabbagabb',
+              'raimishah',
+              'adityanarayanan03',
+            ].map((login) => login.toLowerCase());
+
+            const pr = context.payload.pull_request;
+            const defaultBranch = context.payload.repository.default_branch;
+
+            // Only gate PRs that target the protected (default) branch. Other
+            // PRs pass trivially, so this check can be marked "required" without
+            // ever getting stuck on unrelated PRs.
+            if (pr.base.ref !== defaultBranch) {
+              core.info(
+                `PR targets '${pr.base.ref}', not the protected branch ` +
+                `'${defaultBranch}'. Approval gate not required.`
+              );
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            // Reviews are returned chronologically; keep the latest meaningful
+            // state per reviewer (a plain COMMENTED review does not change an
+            // existing approval).
+            const latestStateByUser = new Map();
+            for (const review of reviews) {
+              const login = review.user?.login?.toLowerCase();
+              if (!login || review.state === 'COMMENTED') continue;
+              latestStateByUser.set(login, review.state);
+            }
+
+            const approvers = AUTHORIZED_REVIEWERS.filter(
+              (login) => latestStateByUser.get(login) === 'APPROVED'
+            );
+
+            if (approvers.length === 0) {
+              core.setFailed(
+                'This pull request needs an approving review from at least one ' +
+                'authorized reviewer before it can be merged:\n  ' +
+                AUTHORIZED_REVIEWERS.join(', ')
+              );
+              return;
+            }
+
+            core.info(`Approved by authorized reviewer(s): ${approvers.join(', ')}`);


### PR DESCRIPTION
## Summary
This PR establishes a branch protection mechanism for the default branch by adding a GitHub Actions workflow that enforces approval from authorized maintainers before merging, along with supporting documentation and a CODEOWNERS file.

## Key Changes
- **`.github/workflows/require-approval.yml`** — A GitHub Actions workflow that runs on pull request events and validates that at least one authorized reviewer has approved the PR before it can be merged. The workflow:
  - Only gates PRs targeting the default branch
  - Tracks the latest review state per reviewer (ignoring COMMENTED reviews)
  - Fails the status check if no authorized approvals are found
  - Maintains an `AUTHORIZED_REVIEWERS` list that must be kept in sync with CODEOWNERS

- **`.github/CODEOWNERS`** — Designates five maintainers as code owners for all files in the repository, enabling GitHub's native "Require review from Code Owners" branch protection rule

- **`.github/branch-protection.md`** — Documentation explaining:
  - The complementary roles of CODEOWNERS and the require-approval workflow
  - The list of authorized reviewers
  - One-time setup instructions for a repo admin to enable branch protection rules
  - Guidance on keeping the authorized reviewer list in sync across both files

## Implementation Details
- The workflow uses `actions/github-script@v7` to query the GitHub API and inspect pull request reviews
- Review state tracking is case-insensitive (logins are normalized to lowercase)
- The workflow passes trivially for PRs targeting non-default branches, allowing it to be marked as a required status check without blocking unrelated work
- Both the workflow and CODEOWNERS file encode the same five authorized reviewers, providing redundant enforcement mechanisms

https://claude.ai/code/session_01PGV1723tZhZkWZ3HDWzg2k