### PR TITLE
Fix eval loader silently dropping categorical columns (OpenML R2 reproduction)

### DIFF
--- a/src/synthefy_tabular/evaluation/datasets.py
+++ b/src/synthefy_tabular/evaluation/datasets.py
@@ -304,7 +304,7 @@ class DatasetRegistry:
         for col in df.select_dtypes(include=["object", "category", "string"]).columns:
             try:
                 le = LabelEncoder()
-                filled = df[col].fillna("__MISSING__").astype(str)
+                filled = df[col].astype(object).fillna("__MISSING__").astype(str)
                 if filled.nunique() > 100:
                     df = df.drop(columns=[col])
                     continue
@@ -627,16 +627,19 @@ class DatasetRegistry:
             X_test = pd.DataFrame(X_test) if not isinstance(X_test, pd.DataFrame) else X_test.copy()
             y_test = pd.Series(y_test) if not isinstance(y_test, pd.Series) else y_test.copy()
 
-        # Encode object/category columns
-        for col in list(X.select_dtypes(include=["object", "category"]).columns):
+        # Encode object/category/string columns. Cast to object before fillna:
+        # on category dtype, fillna with an unseen value raises, which used to
+        # silently drop every categorical column parsed from parquet/Arrow.
+        for col in list(X.select_dtypes(include=["object", "category", "string"]).columns):
             try:
                 le = LabelEncoder()
                 parts = [X[col]] + ([X_test[col]] if X_test is not None else [])
-                combined = pd.concat(parts).fillna("__MISSING__").astype(str)
+                combined = pd.concat(parts).astype(object).fillna("__MISSING__").astype(str)
                 le.fit(combined)
-                X[col] = le.transform(X[col].fillna("__MISSING__").astype(str))
+                X[col] = le.transform(X[col].astype(object).fillna("__MISSING__").astype(str))
                 if X_test is not None:
-                    X_test[col] = le.transform(X_test[col].fillna("__MISSING__").astype(str))
+                    X_test[col] = le.transform(
+                        X_test[col].astype(object).fillna("__MISSING__").astype(str))
             except Exception:
                 X = X.drop(columns=[col])
                 if X_test is not None:


### PR DESCRIPTION
## Problem

`_make_entry_from_df` encodes object/category columns with `fillna('__MISSING__')` inside a `try/except` that drops the column on any error. On **category-dtype** columns, `fillna` with an unseen value **raises** — so every categorical column parsed from parquet/Arrow (the default for any fresh `openml` package cache) was **silently dropped**:

| Dataset | Columns kept | R² (broken) | R² (published) |
|---|---|---|---|
| socmob | 1 of 5 | 0.738 | 0.868 |
| diamonds | 6 of 9 | 0.888 | 0.983 |
| MIP-2016 | 143 of 144 | 0.157 | 0.571 |
| Allstate | partial | −0.091 | 0.293 |
| sensory | **0 of 11 → dataset silently skipped** | — | 0.336 |

OpenML suite mean fell 0.6104 → 0.5360 (N=11 → 10). Dev machines didn't see this while old object-dtype pickle caches (`dataset_*.pkl.py3`) were intact — a fresh environment reproduces the bug deterministically, meaning **end users could not reproduce the README OpenML row**.

## Fix

Cast to `object` before `fillna` (no-op for object columns — previously working parses are bit-unchanged), and add `string` dtype to the column scan. Same pattern fixed in the CTU loader.

## Verification

- Loader-level: all 11 OpenML regression datasets restore published column counts/splits under BOTH numpy 2.3/pandas 2.3 and the lockfile env (numpy 2.4.4/pandas 3.0.3).
- End-to-end on GPU: OpenML suite mean **R² = 0.6106 (N=11)** vs published **0.6104**; per-dataset values match the verified June-9 run within noise. TabArena (0.8088) and TALENT (0.7566) load via CSV and were never affected.
- `ruff` clean; `pytest` 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)