### PR TITLE
Release 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-tabular"
-version = "0.2.2"
+version = "0.2.3"
 description = "Synthefy Tabular foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_tabular/__init__.py
+++ b/src/synthefy_tabular/__init__.py
@@ -9,7 +9,7 @@ from synthefy_tabular.api import (
     predict,
 )
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 __all__ = [
     "SynthefyTabularRegressor",

--- a/uv.lock
+++ b/uv.lock
@@ -3269,7 +3269,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-tabular"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
## Release 0.2.3

Version bump only — ships the package changes already merged to `main` since `v0.2.2`.

### Version bump (the three places RELEASING.md requires + uv.lock)
- `pyproject.toml`: `0.2.2` → `0.2.3`
- `src/synthefy_tabular/__init__.py`: `__version__` → `0.2.3`
- `uv.lock`: synced editable entry to `0.2.3` (version-only; `revision 3` preserved)

### What this release ships (merged since v0.2.2)
- Configurable context-size budget via `SYNTHEFY_MAX_ELEMENTS_BUDGET` (#15)
- OpenAI-compatible usage block in inference output (#16)
- HF download tracking enabled; stale classification/gated-repo docs scrubbed (#18)
- Inference token accounting (#14)

### Local verification (mirrors CI + publish.yml)
- `pytest`: 24 passed, 2 deselected
- `ruff check src scripts tests`: clean
- `python -m build`: built `synthefy_tabular-0.2.3` wheel + sdist
- `twine check --strict`: PASSED (wheel + sdist)

### After merge
Cut release `v0.2.3` (`gh release create v0.2.3 --target main --generate-notes`) → `publish.yml` builds, verifies the tag matches the wheel version, and parks at the `pypi` environment reviewer gate for manual approval before the OIDC upload.

> Note: `0.2.2` is already live on PyPI, so a re-deploy isn't possible — this is why a new patch version is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)