### PR TITLE
baseten: rename invoke env var to SYNTHEFY_NORI_API_KEY

### DIFF
--- a/baseten/README.md
+++ b/baseten/README.md
@@ -64,7 +64,7 @@ given, must be `"regression"` (or `"reg"`).
 
 ```bash
 curl -X POST https://model-{MODEL_ID}.api.baseten.co/development/predict \
-  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "Authorization: Api-Key $SYNTHEFY_NORI_API_KEY" \
   -d '{
     "task": "regression",
     "X_train": [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]],


### PR DESCRIPTION
Renames the env var in the Baseten `## Invoke` curl example from `$BASETEN_API_KEY` to `$SYNTHEFY_NORI_API_KEY`, so the hosted-API key is referred to by the same name here and in the [synthefy-docs Nori quickstart](https://github.com/Synthefy/synthefy-docs/pull/24).

## Change
- `baseten/README.md`: `Authorization: Api-Key $BASETEN_API_KEY` → `Authorization: Api-Key $SYNTHEFY_NORI_API_KEY`

The value is still a Baseten API key (obtained via `truss login` / the Baseten console) — only the shell variable name changes, to keep the docs and this README consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)