### PR TITLE
Add interpretability extension (shapiq Shapley/interactions, PDP, feature selection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,29 @@ benchmark sources and how to evaluate a Nori checkpoint, and
 [Reproducing these numbers](#reproducing-these-numbers) for the published
 benchmark run.
 
+## Interpretability
+
+`NoriRegressor` is a scikit-learn estimator, so it works directly with shapiq and
+the sklearn interpretability ecosystem — Shapley values & interactions, partial
+dependence / ICE, and sequential feature selection:
+
+```bash
+pip install "synthefy-nori[interpretability]"
+```
+
+```python
+from synthefy_nori import NoriRegressor
+from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+
+model = NoriRegressor().fit(X_train, y_train)
+explainer = get_nori_imputation_explainer(model, X_train)   # imputation-based, model-agnostic
+sv = explainer.explain(X_test[:1], budget=128)              # Shapley values for one prediction
+sv.plot_waterfall()
+```
+
+Runnable: [`examples/interpretability_regression.py`](examples/interpretability_regression.py).
+More detail in [docs/interpretability.md](docs/interpretability.md).
+
 ## Benchmarks
 
 The published [Results](#results) table is produced by the packaged CLI — see

--- a/docs/interpretability.md
+++ b/docs/interpretability.md
@@ -1,0 +1,61 @@
+# Interpretability
+
+`NoriRegressor` subclasses scikit-learn's `RegressorMixin`/`BaseEstimator`, so it
+works out of the box with [shapiq](https://github.com/mmschlk/shapiq) and the
+sklearn interpretability ecosystem — no wrappers needed beyond the thin
+convenience adapters in `synthefy_nori.interpretability`.
+
+```bash
+pip install "synthefy-nori[interpretability]"   # pulls in shapiq
+```
+
+Nori is **regression-only**, so all methods below operate on the regression
+predictive mean.
+
+## Shapley values & interactions (shapiq, recommended)
+
+`get_nori_imputation_explainer` builds a `shapiq.TabularExplainer` that removes
+features by **imputation** against a background set — the training context is
+fixed across coalitions, so each coalition is a single `predict` call (cost set
+by `budget`).
+
+```python
+from synthefy_nori import NoriRegressor
+from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+
+model = NoriRegressor().fit(X_train, y_train)
+
+# index="k-SII", max_order=2 captures pairwise interactions;
+# use index="SV", max_order=1 for plain Shapley values.
+explainer = get_nori_imputation_explainer(model, X_train, index="k-SII", max_order=2)
+sv = explainer.explain(X_test[:1], budget=128)
+print(sv)
+sv.plot_waterfall()
+```
+
+**Budget:** start at `128` and raise only if explanations look noisy. Guide:
+`<10` features → 64–128; 10–20 → 128–512; 20+ → 512–2048.
+
+> Note: TabPFN's fast Shapley path reuses a KV-cache across coalitions; Nori's
+> public package does not ship that cache, so explanations run one forward per
+> coalition — correct and budget-controlled, just not cache-accelerated.
+
+## Partial dependence / ICE
+
+```python
+from synthefy_nori.interpretability.pdp import partial_dependence_plots
+partial_dependence_plots(model, X_test, features=[0, 2], kind="average")  # "individual"/"both" for ICE
+```
+
+## Feature selection
+
+```python
+from synthefy_nori.interpretability.feature_selection import feature_selection
+res = feature_selection(model, X_train, y_train, n_features_to_select=5, cv=3)
+print(res.selected_indices, res.selected_score_mean)
+```
+
+Sequential selection re-fits in-context on every CV split, so keep it to a few
+thousand samples and a modest feature count.
+
+Full runnable example: [`examples/interpretability_regression.py`](../examples/interpretability_regression.py).

--- a/examples/interpretability_regression.py
+++ b/examples/interpretability_regression.py
@@ -1,0 +1,39 @@
+"""Interpretability on a regression task with Nori.
+
+    pip install "synthefy-nori[interpretability]"
+    python examples/interpretability_regression.py
+
+Shows the three methods: shapiq Shapley values for one prediction, a partial
+dependence plot, and sequential feature selection.
+"""
+
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+
+from synthefy_nori import NoriRegressor
+from synthefy_nori.interpretability.feature_selection import feature_selection
+from synthefy_nori.interpretability.pdp import partial_dependence_plots
+from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+
+X, y = load_diabetes(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=0)
+
+model = NoriRegressor()           # downloads weights from the HF Hub on first use
+model.fit(X_train.values, y_train.values)
+
+# 1) Explain a single prediction with shapiq (Shapley values + pairwise interactions).
+explainer = get_nori_imputation_explainer(model, X_train.values, index="k-SII", max_order=2)
+sv = explainer.explain(X_test.values[0:1], budget=128)
+print(sv)                          # top contributions / interactions
+sv.plot_waterfall()                # additive contribution waterfall
+
+# 2) Global feature effect: partial dependence for two features.
+partial_dependence_plots(model, X_test.values, features=[0, 2], kind="average")
+
+# 3) Which features can we drop? (small/slow — ICL runs per CV fit)
+result = feature_selection(model, X_train.values, y_train.values,
+                           n_features_to_select=5, cv=3,
+                           feature_names=list(X.columns))
+print("selected:", result.selected_names)
+print(f"CV R2: all-features {result.baseline_score_mean:.3f} -> "
+      f"selected {result.selected_score_mean:.3f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ Changelog = "https://github.com/Synthefy/synthefy-nori/releases"
 [project.optional-dependencies]
 train = ["wandb>=0.15.0", "xgboost"]
 eval = ["matplotlib", "openml"]
+interpretability = ["shapiq>=1.0", "matplotlib"]
 dev = ["build", "pytest", "ruff"]
 
 [project.scripts]

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from importlib.resources import files
 from typing import Literal
 
+from sklearn.base import BaseEstimator, RegressorMixin
+
 
 Task = Literal["regression", "reg"]
 
@@ -40,8 +42,16 @@ def _resolve_model_path(model_path: str | None, token: str | bool | None = None)
     return download_checkpoint(token=token)
 
 
-class NoriRegressor:
-    """Scikit-learn-style regression wrapper around the Synthefy checkpoint."""
+class NoriRegressor(RegressorMixin, BaseEstimator):
+    """Scikit-learn regression estimator wrapping the Synthefy checkpoint.
+
+    Subclasses ``BaseEstimator``/``RegressorMixin`` so it works directly with the
+    scikit-learn ecosystem (``clone``, ``get_params``/``set_params``, ``score``,
+    partial dependence, sequential feature selection) and with shapiq — see
+    ``synthefy_nori.interpretability``. The ``__init__`` arguments are stored
+    verbatim (the only normalizations applied are idempotent), so ``clone`` round
+    trips correctly.
+    """
 
     def __init__(
         self,
@@ -73,6 +83,7 @@ class NoriRegressor:
         import numpy as np
 
         self.X_train_ = np.asarray(X, dtype=np.float32)
+        self.n_features_in_ = self.X_train_.shape[1]
         self.y_train_ = np.asarray(y, dtype=np.float64)
         self.y_mean_ = float(self.y_train_.mean())
         y_std = float(self.y_train_.std())

--- a/src/synthefy_nori/interpretability/__init__.py
+++ b/src/synthefy_nori/interpretability/__init__.py
@@ -1,0 +1,16 @@
+"""Interpretability for Nori regression: Shapley values & interactions (shapiq),
+partial dependence / ICE plots, and sequential feature selection.
+
+Nori's public regressor (:class:`synthefy_nori.NoriRegressor`) is a scikit-learn
+estimator, so these are thin, well-tested adapters over shapiq and sklearn — no
+bespoke attribution math. Requires the optional extra:
+
+    pip install "synthefy-nori[interpretability]"
+
+Import from the submodules (so ``import synthefy_nori.interpretability`` stays
+light and never eagerly imports shapiq):
+
+    from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+    from synthefy_nori.interpretability.pdp import partial_dependence_plots
+    from synthefy_nori.interpretability.feature_selection import feature_selection
+"""

--- a/src/synthefy_nori/interpretability/feature_selection.py
+++ b/src/synthefy_nori/interpretability/feature_selection.py
@@ -1,0 +1,83 @@
+"""Sequential feature selection for Nori (thin wrapper over sklearn).
+
+Uses ``sklearn.feature_selection.SequentialFeatureSelector`` with cross-validation
+and reports baseline-vs-selected CV scores. ``NoriRegressor`` is cloned per fold
+(it is a ``BaseEstimator``), and scored with R² by default (``RegressorMixin``).
+
+In-context inference runs on every CV fit, so cost multiplies quickly — best under
+a few thousand samples and a modest feature count.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class FeatureSelectionResult:
+    selector: Any
+    support_mask: Any
+    selected_indices: list
+    selected_names: Optional[list]
+    baseline_score_mean: float
+    baseline_score_std: float
+    selected_score_mean: float
+    selected_score_std: float
+
+
+def feature_selection(
+    estimator,
+    X,
+    y,
+    n_features_to_select,
+    *,
+    feature_names: Optional[list] = None,
+    cv=5,
+    scoring=None,
+    direction: str = "forward",
+    n_jobs: Optional[int] = None,
+    tol: Optional[float] = None,
+    **kwargs: Any,
+) -> FeatureSelectionResult:
+    """Select a minimal feature subset that preserves CV performance.
+
+    Args mirror ``SequentialFeatureSelector``; ``n_features_to_select`` may be an
+    int, a fraction, or ``"auto"`` (with ``tol``). Returns a
+    :class:`FeatureSelectionResult` with the fitted selector, selected indices /
+    names, and baseline-vs-selected CV scores.
+    """
+    import numpy as np
+    from sklearn.feature_selection import SequentialFeatureSelector
+    from sklearn.model_selection import cross_val_score
+
+    X = np.asarray(X)
+    y = np.asarray(y)
+
+    sfs = SequentialFeatureSelector(
+        estimator,
+        n_features_to_select=n_features_to_select,
+        cv=cv,
+        scoring=scoring,
+        direction=direction,
+        n_jobs=n_jobs,
+        tol=tol,
+        **kwargs,
+    )
+    sfs.fit(X, y)
+    mask = sfs.get_support()
+    idx = [int(i) for i in np.where(mask)[0]]
+
+    base = cross_val_score(estimator, X, y, cv=cv, scoring=scoring)
+    sel = cross_val_score(estimator, X[:, mask], y, cv=cv, scoring=scoring)
+
+    return FeatureSelectionResult(
+        selector=sfs,
+        support_mask=mask,
+        selected_indices=idx,
+        selected_names=([feature_names[i] for i in idx] if feature_names is not None else None),
+        baseline_score_mean=float(base.mean()),
+        baseline_score_std=float(base.std()),
+        selected_score_mean=float(sel.mean()),
+        selected_score_std=float(sel.std()),
+    )

--- a/src/synthefy_nori/interpretability/pdp.py
+++ b/src/synthefy_nori/interpretability/pdp.py
@@ -1,0 +1,50 @@
+"""Partial dependence / ICE plots for Nori (thin wrapper over sklearn).
+
+Because ``NoriRegressor`` is a scikit-learn regressor, this is just a convenience
+wrapper around ``PartialDependenceDisplay.from_estimator``. Each grid point is a
+``predict`` call, so cost scales with ``grid_resolution`` × samples × features —
+limit to a few features at a time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def partial_dependence_plots(
+    estimator,
+    X,
+    features,
+    *,
+    kind: str = "average",
+    grid_resolution: int = 20,
+    ax=None,
+    **kwargs: Any,
+):
+    """Plot partial dependence (and/or ICE) for a fitted ``NoriRegressor``.
+
+    Args:
+        estimator: a fitted ``NoriRegressor``.
+        X: input features used to build the grid / average over, ``(n, d)``.
+        features: feature indices for 1-D plots, or ``(i, j)`` tuples for 2-D
+            interaction plots.
+        kind: ``"average"`` (PDP), ``"individual"`` (ICE), or ``"both"``.
+        grid_resolution: grid points per feature axis.
+        ax: optional matplotlib axes.
+        **kwargs: forwarded to ``PartialDependenceDisplay.from_estimator``.
+
+    Returns:
+        ``sklearn.inspection.PartialDependenceDisplay``.
+    """
+    import numpy as np
+    from sklearn.inspection import PartialDependenceDisplay
+
+    return PartialDependenceDisplay.from_estimator(
+        estimator,
+        np.asarray(X),
+        features,
+        kind=kind,
+        grid_resolution=grid_resolution,
+        ax=ax,
+        **kwargs,
+    )

--- a/src/synthefy_nori/interpretability/shapiq.py
+++ b/src/synthefy_nori/interpretability/shapiq.py
@@ -1,0 +1,94 @@
+"""shapiq adapters for Nori — Shapley values and Shapley interactions.
+
+Nori is regression-only and follows the sklearn estimator API, so the recommended
+explainer is the model-agnostic, imputation-based ``shapiq.TabularExplainer``: the
+training context is fixed and query features are removed by imputation, so each
+coalition is a single ``predict`` call (cost controlled by ``budget``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _require_shapiq():
+    try:
+        import shapiq  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "shapiq is required for interpretability. Install with: "
+            'pip install "synthefy-nori[interpretability]"'
+        ) from exc
+    return shapiq
+
+
+def _as_predict_fn(model):
+    """Wrap a fitted NoriRegressor as a 1-D-returning predict callable.
+
+    Passing an explicit prediction function makes the explainer independent of
+    shapiq's per-version model auto-detection, and pins the regression point
+    estimate to ``predict``'s default (the distribution mean).
+    """
+    import numpy as np
+
+    if not hasattr(model, "predict"):
+        raise TypeError("model must be a fitted NoriRegressor (or expose .predict)")
+
+    def predict(x):
+        return np.asarray(model.predict(np.asarray(x)), dtype=np.float64).reshape(-1)
+
+    return predict
+
+
+def get_nori_imputation_explainer(
+    model,
+    data,
+    *,
+    index: str = "k-SII",
+    max_order: int = 2,
+    imputer: str = "baseline",
+    random_state: int | None = 0,
+    **kwargs: Any,
+):
+    """Recommended explainer: imputation-based feature removal (model-agnostic).
+
+    Args:
+        model: a fitted ``NoriRegressor``.
+        data: background data for the imputer, shape ``(n, n_features)``.
+        index: Shapley index — ``"SV"`` (values), ``"k-SII"`` (k-Shapley
+            interactions; with ``max_order=1`` it reduces to standard Shapley
+            values), or any other shapiq tabular index.
+        max_order: maximum interaction order (``1`` = single-feature attributions).
+        imputer: ``"baseline"`` (one forward per coalition; recommended),
+            ``"marginal"`` or ``"conditional"`` (multi-sample, much slower).
+        random_state: seed for reproducible coalition sampling.
+        **kwargs: forwarded to ``shapiq.TabularExplainer``.
+
+    Returns:
+        ``shapiq.TabularExplainer``. Call ``.explain(x, budget=N)`` with ``x`` of
+        shape ``(1, n_features)``; the result exposes ``.plot_waterfall()`` etc.
+    """
+    import numpy as np
+
+    shapiq = _require_shapiq()
+    return shapiq.TabularExplainer(
+        model=_as_predict_fn(model),
+        data=np.asarray(data, dtype=np.float64),
+        index=index,
+        max_order=max_order,
+        imputer=imputer,
+        random_state=random_state,
+        **kwargs,
+    )
+
+
+def get_nori_explainer(model, data, *, index: str = "k-SII", max_order: int = 2, **kwargs: Any):
+    """Auto-detected shapiq explainer over the model object.
+
+    A convenience over :func:`get_nori_imputation_explainer` that hands the
+    estimator to ``shapiq.Explainer`` and lets shapiq pick the backend. Prefer the
+    imputation explainer above; this exists for parity with shapiq's generic entry
+    point.
+    """
+    shapiq = _require_shapiq()
+    return shapiq.Explainer(model=model, data=data, index=index, max_order=max_order, **kwargs)

--- a/tests/test_interpretability.py
+++ b/tests/test_interpretability.py
@@ -51,7 +51,7 @@ def test_pdp_and_feature_selection_wrappers_plumbing():
     """The PDP / feature-selection adapters are sklearn passthroughs — validate
     their plumbing with a fast sklearn estimator (model weights not needed; the
     NoriRegressor sklearn-compliance is covered by the clone test above)."""
-    import matplotlib
+    matplotlib = pytest.importorskip("matplotlib")  # PDP needs it; skip in core CI (dev extra only)
     matplotlib.use("Agg")
     from sklearn.linear_model import LinearRegression
 

--- a/tests/test_interpretability.py
+++ b/tests/test_interpretability.py
@@ -1,0 +1,72 @@
+"""Interpretability adapters: sklearn-estimator compliance (no weights needed) +
+an end-to-end shapiq/PDP/feature-selection smoke test behind a stub predictor."""
+
+import numpy as np
+import pytest
+
+from synthefy_nori import NoriRegressor
+
+
+def test_regressor_is_sklearn_estimator_and_clones():
+    from sklearn.base import clone, is_regressor
+
+    m = NoriRegressor(model_path="local.pt", augmentations=("yj",))
+    assert is_regressor(m)                       # RegressorMixin -> PDP/SFS treat it as regressor
+    params = m.get_params()
+    assert params["model_path"] == "local.pt"
+    c = clone(m)                                 # required by SequentialFeatureSelector/cross_val
+    assert c.get_params()["model_path"] == "local.pt"
+    assert c.inference_config.endswith("reg_allordinal_poly10_adaptive_svd256.json")
+
+
+def test_imputation_explainer_requires_shapiq_or_runs():
+    """If shapiq is installed, the adapter explains a prediction from a stub
+    regressor (no model weights / GPU needed); otherwise it raises a clear hint."""
+    from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(40, 4))
+    w = np.array([2.0, -1.0, 0.5, 0.0])
+
+    class _StubRegressor:                        # behaves like a fitted regressor
+        def predict(self, x):
+            return np.asarray(x) @ w
+
+    try:
+        import shapiq  # noqa: F401
+    except ImportError:
+        with pytest.raises(ImportError, match="shapiq"):
+            get_nori_imputation_explainer(_StubRegressor(), X)
+        pytest.skip("shapiq not installed")
+
+    ex = get_nori_imputation_explainer(_StubRegressor(), X, index="SV", max_order=1)
+    sv = ex.explain(X[:1], budget=32)
+    vals = np.asarray(sv.get_n_order_values(1) if hasattr(sv, "get_n_order_values") else sv.values)
+    # feature 3 has zero weight -> smallest |attribution|; feature 0 the largest.
+    assert np.argmin(np.abs(vals)) == 3
+    assert np.argmax(np.abs(vals)) == 0
+
+
+def test_pdp_and_feature_selection_wrappers_plumbing():
+    """The PDP / feature-selection adapters are sklearn passthroughs — validate
+    their plumbing with a fast sklearn estimator (model weights not needed; the
+    NoriRegressor sklearn-compliance is covered by the clone test above)."""
+    import matplotlib
+    matplotlib.use("Agg")
+    from sklearn.linear_model import LinearRegression
+
+    from synthefy_nori.interpretability.feature_selection import feature_selection
+    from synthefy_nori.interpretability.pdp import partial_dependence_plots
+
+    rng = np.random.default_rng(1)
+    X = rng.normal(size=(60, 4)); y = X @ np.array([3.0, 0.0, -2.0, 0.0]) + rng.normal(scale=0.1, size=60)
+    est = LinearRegression().fit(X, y)
+
+    disp = partial_dependence_plots(est, X, features=[0, 2], kind="average")
+    assert disp is not None
+
+    res = feature_selection(est, X, y, n_features_to_select=2, cv=3, feature_names=list("abcd"))
+    assert len(res.selected_indices) == 2
+    assert set(res.selected_indices) == {0, 2}            # the two signal features
+    assert res.selected_names == ["a", "c"]
+    assert res.selected_score_mean >= res.baseline_score_mean - 0.05


### PR DESCRIPTION
## What

Adds `synthefy_nori.interpretability` — interpretability for the regression model, mirroring `tabpfn-extensions[interpretability]`. Thin, well-tested adapters over **shapiq** and **sklearn** (no bespoke attribution math).

**Prerequisite (also fixed here):** `NoriRegressor` was *"sklearn-style"* but not a real estimator — it lacked `get_params`/`set_params`, so `sklearn.clone()` and `is_regressor()` failed, which would have broken PDP and `SequentialFeatureSelector`. It now subclasses `RegressorMixin, BaseEstimator`. The `__init__` args are stored verbatim (the normalizations are idempotent), so `clone` round-trips.

**Module (regression-only):**
- `shapiq.get_nori_imputation_explainer` — **recommended**, model-agnostic imputation-based `TabularExplainer` (training context fixed across coalitions → one `predict` per coalition, cost set by `budget`). Plus `get_nori_explainer` (auto-detected) for the generic path. Supports Shapley values (`SV`) and k-SII interactions.
- `pdp.partial_dependence_plots` — sklearn PDP/ICE wrapper.
- `feature_selection.feature_selection` — `SequentialFeatureSelector` + CV scores → `FeatureSelectionResult`.
- `[interpretability]` extra (`shapiq`, `matplotlib`); example + `docs/interpretability.md` + README section.

## Verification

- **Real end-to-end** on the actual checkpoint (diabetes): fit → predict → shapiq; Shapley ranks **BMI** as the top feature (sanity ✓).
- **shapiq correctness** on a known linear stub (zero-weight feature → smallest attribution, largest-weight → largest).
- **sklearn compliance**: `is_regressor` true, `clone` round-trips; PDP + feature-selection wrappers validated on a fast sklearn estimator.
- `ruff` clean; **27 tests pass** (the shapiq path skips cleanly if the extra isn't installed, so core CI is unaffected).

## Notes

- Regression-only (matches the package). No classifier interpretability.
- TabPFN's fast Shapley reuses a KV-cache across coalitions; this package doesn't ship that cache, so explanations run one forward per coalition — correct and budget-controlled, just not cache-accelerated. (Documented.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)