### PR TITLE
Release 0.4.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 # NOTE: code owners must have write access to this repository, otherwise GitHub
 # silently ignores their entries here.
 
-*	@sagarwal-atg @d31003 @yogabbagabb @raimishah @adityanarayanan03
+*	@sagarwal-atg @d31003 @yogabbagabb @raimishah @adityanarayanan03 @realPohanLi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.3.0"
+version = "0.4.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -9,7 +9,7 @@ from synthefy_nori.api import (
     predict,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "NoriRegressor",

--- a/uv.lock
+++ b/uv.lock
@@ -3269,7 +3269,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
## Release 0.4.0

Minor version bump from `0.3.0`, covering additions merged since the last release. Also adds a code owner (see below).

### What's new since 0.3.0
- **Interpretability extension** (#29): shapiq Shapley values & interactions, partial-dependence / ICE plots, and sequential feature selection, exposed under `synthefy_nori.interpretability` behind the new `interpretability` optional extra (`pip install "synthefy-nori[interpretability]"`).
- `NoriRegressor` now subclasses sklearn's `BaseEstimator`/`RegressorMixin`, so it works directly with the sklearn ecosystem (`clone`, `get_params`/`set_params`, `score`, partial dependence, sequential feature selection) and shapiq.
- Docs + example for interpretability; README badges/citation; CI default-branch approval gate.

### Version policy
Pre-1.0, new feature surface -> minor bump (`0.3.0` -> `0.4.0`) per `RELEASING.md`.

### Changed files
- `pyproject.toml` -> `version = "0.4.0"`
- `src/synthefy_nori/__init__.py` -> `__version__ = "0.4.0"`
- `uv.lock` -> self-reference bumped to `0.4.0` (no dependency re-resolution)
- `.github/CODEOWNERS` -> add `@realPohanLi` to the `*` rule (verified: has admin/write access, so the entry is honored)

### Pre-flight checks (local)
- `uv build` -> builds `synthefy_nori-0.4.0` sdist + wheel
- `twine check --strict dist/*` -> PASSED
- Wheel ships the new `synthefy_nori/interpretability/` package + bundled configs/CSVs; METADATA version = `0.4.0`
- `ruff check src scripts tests` -> passed

### Next steps after merge
Per `RELEASING.md`: once this is merged and `ci` is green on `main`, cut the release with `gh release create v0.4.0 --target main --title "v0.4.0" --generate-notes`, then approve the `pypi` environment gate in the running `publish` workflow to upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
