### PR TITLE
docs: make Interpretability README user-facing (SHAP keyword + use cases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,14 @@ benchmark run.
 
 ## Interpretability
 
-`NoriRegressor` is a scikit-learn estimator, so it works directly with shapiq and
-the sklearn interpretability ecosystem — Shapley values & interactions, partial
-dependence / ICE, and sequential feature selection:
+Explain Nori's predictions with **SHAP / Shapley values**, feature interactions,
+partial dependence / ICE, and sequential feature selection — see which features
+drive a prediction, detect interactions, and debug unexpected outputs. Because
+`NoriRegressor` is a scikit-learn estimator, it works directly with
+[shapiq](https://github.com/mmschlk/shapiq) (a fast SHAP implementation with
+native Shapley-interaction support) and the sklearn interpretability ecosystem —
+no adapters needed beyond the thin convenience wrappers in
+`synthefy_nori.interpretability`.
 
 ```bash
 pip install "synthefy-nori[interpretability]"
@@ -280,12 +285,15 @@ from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
 model = NoriRegressor().fit(X_train, y_train)
 explainer = get_nori_imputation_explainer(model, X_train)   # imputation-based, model-agnostic
-sv = explainer.explain(X_test[:1], budget=128)              # Shapley values for one prediction
-sv.plot_waterfall()
+sv = explainer.explain(X_test[:1], budget=128)              # SHAP/Shapley values for one prediction
+sv.plot_waterfall()                                         # additive contribution waterfall
 ```
 
-Runnable: [`examples/interpretability_regression.py`](examples/interpretability_regression.py).
-More detail in [docs/interpretability.md](docs/interpretability.md).
+Also available: `interpretability.pdp.partial_dependence_plots` (global feature
+effects) and `interpretability.feature_selection.feature_selection`. Regression
+only. Runnable example:
+[`examples/interpretability_regression.py`](examples/interpretability_regression.py);
+full guide in [docs/interpretability.md](docs/interpretability.md).
 
 ## Benchmarks
 


### PR DESCRIPTION
Makes the existing interpretability section (from #29) discoverable and user-facing: leads with **SHAP / Shapley values**, notes shapiq is a fast SHAP implementation, lists what it answers (feature drivers, interactions, debugging), and surfaces the PDP + feature-selection entry points. Docs-only, no code change.

Note: the **KV cache** is intentionally *not* mentioned — it isn't in the public package yet (would need a port). Same for the preprocessing speedups, which are still in open PR #30. A 'Performance' README section can follow once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)