### PR TITLE
docs: add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Nori
 
+[![Docs](https://img.shields.io/badge/Docs-docs.synthefy.com-2ea44f?logo=readthedocs&logoColor=white)](https://docs.synthefy.com/nori/)
 [![Hugging Face](https://img.shields.io/badge/Hugging%20Face-Synthefy%2FNori-blue?logo=huggingface&logoColor=FFD21E)](https://huggingface.co/Synthefy/Nori)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20710462.svg)](https://doi.org/10.5281/zenodo.20710462)
 


### PR DESCRIPTION
Adds a **Docs** badge at the top of the README linking to <https://docs.synthefy.com/nori/>, alongside the existing Hugging Face and DOI badges.

The same docs link is being added to the Hugging Face model card (`Synthefy/Nori`) so both surfaces match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)