### PR TITLE
Add CITATION.cff for GitHub citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,28 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "Synthefy Nori: Tabular Foundation Model for Regression"
+type: software
+authors:
+  - name: "Synthefy"
+  - family-names: "Li"
+    given-names: "Po-han"
+  - family-names: "Narayanan"
+    given-names: "Aditya"
+  - family-names: "Narasimhan"
+    given-names: "Sai Shankar"
+  - family-names: "Mallampalli"
+    given-names: "Raghav"
+  - family-names: "Agrawal"
+    given-names: "Aahan"
+  - family-names: "Ajan"
+    given-names: "Bekzat"
+  - family-names: "Shah"
+    given-names: "Raimi"
+  - family-names: "Agarwal"
+    given-names: "Shubhankar"
+version: "0.3.0"
+date-released: "2026-06-15"
+doi: "10.5281/zenodo.20710462"
+url: "https://doi.org/10.5281/zenodo.20710462"
+repository-code: "https://github.com/Synthefy/synthefy-nori"
+license: Apache-2.0


### PR DESCRIPTION
Adds a [Citation File Format](https://citation-file-format.github.io/) entry so GitHub shows a native **"Cite this repository"** button.

It mirrors the BibTeX already in the README — same authors, title, version 0.3.0, and Zenodo DOI \`10.5281/zenodo.20710462\` — and adds \`repository-code\` + \`license\`. \`date-released\` is the v0.3.0 tag date (2026-06-15).

Validated: parses as YAML, all required CFF fields present, 9 authors (Synthefy as the lead entity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)