### PR TITLE
Release v0.5.0

### DIFF
--- a/baseten/config.yaml
+++ b/baseten/config.yaml
@@ -1,7 +1,7 @@
 # Nori: in-context learning tabular foundation model. Each request
 # carries the context rows (X_train, y_train) and the query rows (X_test); the
 # model predicts in a single forward pass. See model/model.py for the API.
-model_name: Nori
+model_name: Synthefy Nori
 python_version: py311
 
 # Runtime dependencies. The synthefy_nori package itself is shipped via the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.4.0"
+version = "0.5.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -9,7 +9,7 @@ from synthefy_nori.api import (
     predict,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "NoriRegressor",


### PR DESCRIPTION
## Release v0.5.0

Bumps `synthefy-nori` to **0.5.0** in `pyproject.toml` and `src/synthefy_nori/__init__.py` (kept in sync, as `publish.yml` enforces against the release tag).

### What's in 0.5.0 (since v0.4.0)
- Port KV-cache inference fast path to public + **enable by default** (#35)
- Port inference speedups: GPU SVD, capped quantile, adaptive fit-subsample (#30)
- Docs: README reorder + table of contents (#37), banner (#34), documentation link (#36), user-facing Interpretability/SHAP README (#33)
- Add `CITATION.cff` for GitHub citation support (#38)
- Remove the require-approval workflow (#32)
- Add baseten config (`model_name: Synthefy Nori`)

A minor bump is appropriate per the pre-1.0 version policy in `RELEASING.md` — KV-cache being on by default plus the inference-speed changes are new behavior, not just a patch.

### Pre-flight checks (local, mirrors CI)
- `ruff check src scripts tests` → passed
- `import synthefy_nori` → `__version__ == 0.5.0`
- `uv build` → `synthefy_nori-0.5.0` sdist + wheel
- `twine check --strict dist/*` → PASSED (both)
- `pytest` (fast suite) → 25 passed, 2 skipped

### Release steps after merge
Per `RELEASING.md`, once this merges to `main`:
1. `gh release create v0.5.0 --target main --title "v0.5.0" --generate-notes`
2. `publish.yml` builds, verifies the tag matches the wheel version, and parks at the `pypi` environment reviewer gate
3. Approve the deployment → `pypa/gh-action-pypi-publish` uploads to PyPI over OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)