### PR TITLE
Remove dangling lazy imports for nonexistent modules

### DIFF
--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -97,10 +97,6 @@ class TrainingConfig:
     wandb_tags: tuple[str, ...] = field(default_factory=tuple)
     ema_decay: float = 0.0
 
-    # Offline dataset pool (pre-generated Parquet shards)
-    offline_pool_dir: str = ''
-    offline_pool_tier: int = 1  # Which tier subdir to read from
-
     # Compilation
     compile: bool = False
 

--- a/src/synthefy_nori/training/trainer.py
+++ b/src/synthefy_nori/training/trainer.py
@@ -138,16 +138,9 @@ class NoriTrainer:
                     )
                 self.quality_rules = None
 
-        # Offline dataset pool (pre-generated Parquet shards)
-        self.pool_loader = None
-        if config.offline_pool_dir:
-            from synthefy_nori.training.parquet_loader import ParquetPoolLoader
-            self.pool_loader = ParquetPoolLoader(
-                config.offline_pool_dir, tier=config.offline_pool_tier)
-
-        # Async data prefetching (skip if using offline pool)
+        # Async data prefetching
         self.prefetcher = None
-        if config.prefetch_workers > 0 and self.pool_loader is None:
+        if config.prefetch_workers > 0:
             self.prefetcher = DataPrefetcher(
                 num_workers=config.prefetch_workers,
                 prefetch_count=config.prefetch_count,
@@ -192,39 +185,6 @@ class NoriTrainer:
         """
         cfg = self.config
         rng = self.shared_rng  # Same across all ranks
-
-        # Offline pool: sample directly from available bucket shapes to
-        # avoid NaN-padding when the trainer asks for an unavailable shape.
-        if self.pool_loader is not None:
-            # Filter pool buckets to those within the configured tier limits
-            min_s = cfg.min_samples
-            max_s = cfg.max_samples
-            min_f = cfg.min_features
-            max_f = cfg.max_features
-            budget = cfg.max_sample_feature_budget
-            valid_keys = [
-                k for k in self.pool_loader._index.keys()
-                if min_s <= k[0] <= max_s
-                and min_f <= k[1] <= max_f
-                and k[0] * k[1] <= budget
-                and len(self.pool_loader._index[k]) > 0
-            ]
-            if not valid_keys:
-                # Fall back to all keys if filter is too strict
-                valid_keys = [k for k in self.pool_loader._index.keys()
-                              if len(self.pool_loader._index[k]) > 0]
-            # Consume the same number of rng draws as the random path to keep
-            # shared_rng in sync (uniform for samples, uniform for features)
-            rng.uniform(0, 1)
-            rng.uniform(0, 1)
-            idx = int(rng.integers(0, len(valid_keys)))
-            n_samples, n_features = valid_keys[idx]
-            task_type = cfg.task_type if cfg.task_type != 'both' else 'reg'
-            # Consume task rng draw
-            rng.random()
-            n_classes = None
-            context_ratio = rng.uniform(cfg.context_ratio_min, cfg.context_ratio_max)
-            return n_samples, n_features, task_type, n_classes, context_ratio
 
         if cfg.fixed_n_samples is not None and cfg.fixed_n_features is not None:
             # Fixed size mode: skip random sampling but still consume rng
@@ -1039,11 +999,7 @@ class NoriTrainer:
 
         # --- Generate batch + forward + loss (can error) ---
         try:
-            if self.pool_loader is not None:
-                # Offline pool path: read pre-generated, pre-filtered datasets
-                X_batch, y_batch, n_classes = self.pool_loader.get_batch(
-                    cfg.batch_size, n_samples, n_features, rng=self.rng)
-            elif self.prefetcher is not None:
+            if self.prefetcher is not None:
                 # Async path: get pre-generated batch from prefetcher.
                 # The batch for THIS step was submitted earlier (in
                 # _prefill_pipeline or previous train_step). We also

--- a/src/synthefy_nori/utils/loading.py
+++ b/src/synthefy_nori/utils/loading.py
@@ -6,37 +6,6 @@ import numpy as np
 from synthefy_nori.model.transformer import FeaturesTransformer
 
 def build_model(config:dict):
-    if config.get('architecture') == 'v14':
-        from synthefy_nori.model.transformer_v14 import FeaturesTransformerV14
-
-        decoder_config = config.get('decoder_config', {})
-        return FeaturesTransformerV14(
-            embed_dim=config.get('embed_dim', 128),
-            feature_group_size=config.get('v14_feature_group_size', 3),
-            num_cls_tokens=config.get('v14_num_cls_tokens', 4),
-            dist_embed_num_blocks=config.get('v14_dist_embed_num_blocks', 3),
-            dist_embed_num_inducing_points=config.get('v14_dist_embed_num_inducing_points', 128),
-            dist_embed_num_heads=config.get('v14_dist_embed_num_heads', 8),
-            feat_agg_num_blocks=config.get('v14_feat_agg_num_blocks', 3),
-            feat_agg_num_heads=config.get('v14_feat_agg_num_heads', 8),
-            icl_num_layers=config.get('v14_icl_num_layers', 16),
-            icl_num_heads=config.get('v14_icl_num_heads', 8),
-            icl_num_kv_heads_test=config.get('v14_icl_num_kv_heads_test', 1),
-            shared_test_kv_projection=config.get('v14_shared_test_kv_projection', False),
-            num_reg_quantiles=decoder_config.get(
-                'num_reg_quantiles',
-                config.get('num_reg_quantiles', 999),
-            ),
-            ff_factor=config.get('v14_ff_factor', 2),
-            rope_base=config.get('v14_rope_base', 100_000.0),
-            native_missing_indicators=config.get('v14_native_missing_indicators', True),
-            context_standardize=config.get('v14_context_standardize', False),
-            input_clip_value=config.get('v14_input_clip_value', 100.0),
-            inference_row_chunk_size=config.get('v14_inference_row_chunk_size', 2048),
-            device=config.get('device', None),
-            dtype=config.get('dtype', None),
-        )
-
     model = FeaturesTransformer(
         preprocess_config_x=config['preprocess_config_x'],
         encoder_config_x=config['encoder_config_x'],


### PR DESCRIPTION
Fixes #26.

## Problem
Two conditional lazy imports referenced modules that **never existed** in this repo — stale refs inherited from upstream whose source was never brought over:

- `utils/loading.py` — `from synthefy_nori.model.transformer_v14 import FeaturesTransformerV14`, reached only when `config['architecture'] == 'v14'`.
- `training/trainer.py` — `from synthefy_nori.training.parquet_loader import ParquetPoolLoader`, reached only when `config.offline_pool_dir` is set.

Both sit behind config conditions nothing in the repo can satisfy, so normal import/inference/training is unaffected — but exercising either path raises `ImportError`.

## Fix
Since the modules were never in git history, "add the missing modules" would mean inventing a whole transformer architecture and a Parquet-shard loader from scratch — out of scope for a bug fix. So I took the issue's first option and **deleted both dead paths**:

- **`utils/loading.py`** — dropped the `architecture == 'v14'` branch and its `v14_*` config keys (read only inside that branch). Both paths are now fully removed; `build_model` always builds `FeaturesTransformer`.
- **`training/trainer.py` + `training/config.py`** — removed the `offline_pool_dir` feature end to end: the `ParquetPoolLoader` import + `pool_loader` init, the offline branches in `_sample_data_params` and `train_step`, and the `offline_pool_dir` / `offline_pool_tier` config fields. This path was permanently dead (no CLI flag; `offline_pool_dir` defaults to `''`).

Net: 3 files, 3 insertions / 82 deletions. No behavior change for any reachable code path.

## Verification (CI gates from AGENTS.md)
- `import synthefy_nori` → OK
- `ruff check src scripts tests` → All checks passed
- `pytest` → 25 passed, 2 skipped, 2 deselected
- Grep confirms zero residual references to any removed name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)