### PR TITLE
Make fitted NoriRegressor picklable with stdlib pickle (#45)

### DIFF
--- a/src/synthefy_nori/inference/preprocess.py
+++ b/src/synthefy_nori/inference/preprocess.py
@@ -33,6 +33,26 @@ from kditransform import KDITransformer
 MAXINT_RANDOM_SEED = int(np.iinfo(np.int32).max)
 
 
+# Module-level helpers for FunctionTransformer steps. These must be importable
+# (i.e. not local lambdas) so that fitted pipelines — and the NoriRegressor that
+# owns them — can be serialized with stdlib pickle, which only pickles functions
+# by reference. See GitHub issue #45.
+def _inf_to_nan(x):
+    return np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan)
+
+
+def _identity(x):
+    return x
+
+
+def _shift_to_nonnegative(x):
+    return x + np.abs(np.nanmin(x))
+
+
+def _add_epsilon(x):
+    return x + 1e-10
+
+
 class CappedQuantileTransformer(QuantileTransformer):
     """QuantileTransformer that caps ``n_quantiles`` and ``subsample`` at fit time.
 
@@ -959,21 +979,19 @@ class RebalanceFeatureDistribution(BasePreprocess):
                                         ("save_standard", Pipeline(steps=[
                                             ("i2n_pre",
                                              FunctionTransformer(
-                                                 func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan,
-                                                                              posinf=np.nan),
-                                                 inverse_func=lambda x: x, check_inverse=False)),
+                                                 func=_inf_to_nan,
+                                                 inverse_func=_identity, check_inverse=False)),
                                             ("fill_missing_pre",
                                              SimpleImputer(missing_values=np.nan, strategy="mean",
                                                            keep_empty_features=True)),
                                             ("feature_shift",
-                                             FunctionTransformer(func=lambda x: x + np.abs(np.nanmin(x)))),
-                                            ("add_epsilon", FunctionTransformer(func=lambda x: x + 1e-10)),
+                                             FunctionTransformer(func=_shift_to_nonnegative)),
+                                            ("add_epsilon", FunctionTransformer(func=_add_epsilon)),
                                             ("logNormal", FunctionTransformer(np.log, validate=False)),
                                             ("i2n_post",
                                              FunctionTransformer(
-                                                 func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan,
-                                                                              posinf=np.nan),
-                                                 inverse_func=lambda x: x, check_inverse=False)),
+                                                 func=_inf_to_nan,
+                                                 inverse_func=_identity, check_inverse=False)),
                                             ("fill_missing_post",
                                              SimpleImputer(missing_values=np.nan, strategy="mean",
                                                            keep_empty_features=True))])),
@@ -1011,15 +1029,15 @@ class RebalanceFeatureDistribution(BasePreprocess):
                                 steps=[
                                     ("power_transformer", RobustPowerTransformer(standardize=False)),
                                     ("inf_to_nan_1", FunctionTransformer(
-                                                        func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan),
-                                                        inverse_func=lambda x: x,
+                                                        func=_inf_to_nan,
+                                                        inverse_func=_identity,
                                                         check_inverse=False,
                                                     )),
                                     ("nan_to_mean_1", nan_to_mean_transformer),
                                     ("scaler", StandardScaler()),
                                     ("inf_to_nan_2", FunctionTransformer(
-                                                        func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan),
-                                                        inverse_func=lambda x: x,
+                                                        func=_inf_to_nan,
+                                                        inverse_func=_identity,
                                                         check_inverse=False,
                                                     )),
                                     ("nan_to_mean_2", nan_to_mean_transformer),
@@ -1084,7 +1102,7 @@ class RebalanceFeatureDistribution(BasePreprocess):
             elif worker_tag=="kdi_uni":
                 sworker = KDIX(alpha=1.0, output_distribution="uniform")
             elif worker_tag is None:
-                sworker = FunctionTransformer(lambda x: x)
+                sworker = FunctionTransformer(_identity)
             elif worker_tag.startswith("kdi_uni_alpha_"):
                 alpha = float(worker_tag.split("_")[-1])
                 sworker = KDIX(alpha=alpha, output_distribution="uniform")
@@ -1094,7 +1112,7 @@ class RebalanceFeatureDistribution(BasePreprocess):
             elif worker_tag=="kdi_norm":
                 sworker = KDIX(alpha=1.0, output_distribution="normal")
             else:
-                sworker = FunctionTransformer(lambda x: x)
+                sworker = FunctionTransformer(_identity)
             if worker_tag in ["quantile_uniform_10", "quantile_uniform_5", "quantile_uniform_all_data"]:
                 self.n_quantile_features = len(trans_ixs)
             workers.append((f"feat_transform_{worker_tag}", sworker, trans_ixs))
@@ -1102,13 +1120,13 @@ class RebalanceFeatureDistribution(BasePreprocess):
         CT_worker = ColumnTransformer(workers,remainder="drop",sparse_threshold=0.0)
         if self.svd_tag == "svd" and n_features >= 2:
             svd_worker = FeatureUnion([
-                    ("default", FunctionTransformer(func=lambda x: x)),
+                    ("default", FunctionTransformer(func=_identity)),
                     ("svd",Pipeline(steps=[
                                     ("save_standard",Pipeline(steps=[
-                                    ("i2n_pre", FunctionTransformer(func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan),inverse_func=lambda x: x, check_inverse=False)),
+                                    ("i2n_pre", FunctionTransformer(func=_inf_to_nan,inverse_func=_identity, check_inverse=False)),
                                     ("fill_missing_pre", SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True)),
                                     ("standard", StandardScaler(with_mean=False)) ,
-                                    ("i2n_post", FunctionTransformer(func=lambda x: np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan),inverse_func=lambda x: x, check_inverse=False)),
+                                    ("i2n_post", FunctionTransformer(func=_inf_to_nan,inverse_func=_identity, check_inverse=False)),
                                     ("fill_missing_post", SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True))])),
                                     ("svd",_TorchTruncatedSVD(algorithm="arpack",n_components=max(1,min(n_samples // 10 + 1,n_features // 2)),random_state=static_seed))]))
                     ])

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,116 @@
+"""Regression tests for stdlib-pickle support (GitHub issue #45).
+
+A fitted ``NoriRegressor`` used to fail ``pickle.dumps`` because the
+preprocessing pipeline built ``FunctionTransformer`` steps from *local lambdas*
+in ``RebalanceFeatureDistribution._set``. Stdlib pickle can only serialize
+functions by reference, so any framework that persists models via stdlib pickle
+(AutoGluon, joblib's default, multiprocessing/Ray) could not save the model.
+
+The fix replaces those lambdas with module-level helpers. The fast tests below
+exercise the exact class that owned the lambdas without needing model weights;
+the ``slow`` test covers the full fit -> pickle -> predict round-trip from the
+issue's reproduction.
+"""
+from __future__ import annotations
+
+import os
+import pickle
+
+import numpy as np
+import pytest
+
+from synthefy_nori.inference import preprocess
+from synthefy_nori.inference.preprocess import RebalanceFeatureDistribution
+
+
+def _sample(n: int = 64, d: int = 5) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.normal(size=(n, d)).astype(np.float32)
+
+
+def test_function_transformer_helpers_are_module_level():
+    """The helpers must be importable (not local lambdas) to pickle by reference.
+
+    This is the root-cause guard: if someone reintroduces a local lambda in a
+    FunctionTransformer step, the round-trip tests below break, but this also
+    documents the contract that these names exist at module scope.
+    """
+    x = _sample()
+    for fn in (preprocess._inf_to_nan, preprocess._identity,
+               preprocess._shift_to_nonnegative, preprocess._add_epsilon):
+        assert fn.__module__ == preprocess.__name__
+        assert "<lambda>" not in fn.__qualname__
+        # Each helper pickles by reference and survives a round-trip.
+        assert pickle.loads(pickle.dumps(fn)) is fn
+
+    np.testing.assert_array_equal(preprocess._identity(x), x)
+    # _inf_to_nan maps +/-inf to NaN (its raison d'etre) while leaving finite
+    # values untouched, so a later imputer can fill them.
+    assert np.all(np.isnan(preprocess._inf_to_nan(np.array([np.inf, -np.inf]))))
+    np.testing.assert_array_equal(preprocess._inf_to_nan(x), x)
+    assert np.all(preprocess._shift_to_nonnegative(x) >= 0.0)
+
+
+# worker_tag configs whose pipelines build FunctionTransformer steps. The first
+# three carry the lambdas that caused the bug; ``None`` covers the standalone
+# identity transformer branch.
+@pytest.mark.parametrize(
+    ("worker_tags", "svd_tag"),
+    [
+        (["logNormal"], None),
+        (["power"], None),
+        (["quantile_uniform_5"], "svd"),  # svd branch builds its own transformers
+        ([None], None),
+    ],
+)
+def test_fitted_rebalance_pickles_and_round_trips(worker_tags, svd_tag):
+    x = _sample()
+    rebalance = RebalanceFeatureDistribution(worker_tags=worker_tags, svd_tag=svd_tag)
+    rebalance.fit(x, categorical_features=[], seed=0)
+
+    expected = rebalance.worker.transform(x)
+
+    # The actual fix: stdlib pickle (not cloudpickle) must succeed.
+    restored = pickle.loads(pickle.dumps(rebalance))
+
+    np.testing.assert_allclose(restored.worker.transform(x), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_rebalance_with_categorical_features_pickles():
+    """The categorical/continuous split chooses different branches in ``_set``."""
+    x = _sample()
+    rebalance = RebalanceFeatureDistribution(worker_tags=["logNormal"], svd_tag="svd")
+    rebalance.fit(x, categorical_features=[0, 2], seed=7)
+
+    expected = rebalance.worker.transform(x)
+    restored = pickle.loads(pickle.dumps(rebalance))
+    np.testing.assert_allclose(restored.worker.transform(x), expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.slow
+def test_fitted_regressor_pickles_and_predicts_identically():
+    """End-to-end reproduction from issue #45: fit, stdlib-pickle, predict.
+
+    Requires the public checkpoint (downloaded or via
+    ``SYNTHEFY_NORI_TEST_CHECKPOINT``), so it carries the ``slow`` marker like
+    the other e2e tests.
+    """
+    from synthefy_nori import NoriRegressor
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(128, 5)).astype(np.float32)
+    w = rng.normal(size=5).astype(np.float32)
+    y = (X @ w).astype(np.float32)
+    X_test = rng.normal(size=(32, 5)).astype(np.float32)
+
+    checkpoint = os.environ.get("SYNTHEFY_NORI_TEST_CHECKPOINT")
+    kwargs = {"model_path": checkpoint} if checkpoint else {}
+
+    model = NoriRegressor(**kwargs)
+    model.fit(X, y)
+    expected = model.predict(X_test)
+
+    blob = pickle.dumps(model)  # used to raise AttributeError: Can't pickle local object
+    restored = pickle.loads(blob)
+
+    np.testing.assert_allclose(restored.predict(X_test), expected, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Fixes #45.

## Problem

A fitted `NoriRegressor` could not be serialized with the standard-library `pickle`:

```
AttributeError: Can't pickle local object 'RebalanceFeatureDistribution._set.<locals>.<lambda>'
```

`RebalanceFeatureDistribution._set` (in `src/synthefy_nori/inference/preprocess.py`) builds `sklearn` `FunctionTransformer` steps from **local lambdas**. Stdlib pickle can only serialize functions *by reference* (importable, module-level), and a lambda defined inside a method has no importable qualified name — so the fitted pipeline, reachable from the fitted model, fails to pickle. This breaks any framework that persists models via stdlib pickle (AutoGluon, joblib's default, multiprocessing/Ray), which is what the TabArena integration (autogluon/tabarena#366) hit.

## Fix

Lift the four distinct lambda bodies to module-level functions and reference them at every `FunctionTransformer` site (the `logNormal` and `power` pipelines, the standalone identity branches, and the SVD `FeatureUnion`):

```python
def _inf_to_nan(x):           return np.nan_to_num(x, nan=np.nan, neginf=np.nan, posinf=np.nan)
def _identity(x):             return x
def _shift_to_nonnegative(x): return x + np.abs(np.nanmin(x))
def _add_epsilon(x):          return x + 1e-10
```

Module-level functions pickle by reference, so fitted models now serialize with stdlib `pickle` and no downstream monkeypatching is needed. The function bodies are unchanged, so behavior is identical — chosen over `cloudpickle` (which would force every consumer to opt in) and a custom `__reduce__` (more code, more fragile).

## Tests — `tests/test_pickle.py`

| Test | Covers | Speed |
|---|---|---|
| `test_function_transformer_helpers_are_module_level` | Root cause: helpers live at module scope, have no `<lambda>` qualname, pickle by reference, and behave correctly (incl. `_inf_to_nan` mapping ±inf→NaN) | fast |
| `test_fitted_rebalance_pickles_and_round_trips` | Parametrized over the lambda-bearing branches (`logNormal`, `power`, `svd`, identity): fitted pipeline pickles with **stdlib** pickle and transforms identically after round-trip | fast |
| `test_rebalance_with_categorical_features_pickles` | Categorical/continuous split takes different `_set` branches | fast |
| `test_fitted_regressor_pickles_and_predicts_identically` | Full issue reproduction: `NoriRegressor` fit → `pickle.dumps`/`loads` → predictions match | slow (needs checkpoint, `slow` marker) |

The fast tests exercise the real class that owned the lambdas without downloading weights, so they run in the default CI lane; the e2e test follows the existing `slow`-marker convention in `tests/test_inference_e2e.py`.

**Results:** 6 fast tests pass; the slow e2e round-trip passes against the real public checkpoint (~180s). The original `AttributeError` no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)