### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.6.0"
+version = "0.7.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -9,7 +9,7 @@ from synthefy_nori.api import (
     predict,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = [
     "NoriRegressor",


### PR DESCRIPTION
## Release v0.7.0

Bumps the package version to **0.7.0** in both source-of-truth locations:

- `pyproject.toml` → `version = "0.7.0"`
- `src/synthefy_nori/__init__.py` → `__version__ = "0.7.0"`

### What ships in this release

The only change on `main` since PyPI **v0.6.0** (tagged before this landed) is the bugfix from #45 / #46:

- **Make fitted `NoriRegressor` picklable with stdlib `pickle`** — a fitted regressor can now be serialized with the standard library `pickle` module.

### After merge — how the PyPI package gets built

Per `RELEASING.md`, once this is approved and merged to `main`:

1. Wait for the `ci` workflow to go green on the merge commit.
2. Cut the release: `gh release create v0.7.0 --target main --title "v0.7.0" --generate-notes`.
3. That fires `publish.yml`, which builds the sdist + wheel, runs `twine check --strict`, and verifies the wheel version matches the `v0.7.0` tag (this version bump is what makes that check pass).
4. Approve the `pypi` environment's reviewer gate in the Actions run.
5. `pypa/gh-action-pypi-publish` uploads to PyPI over OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)