### PR TITLE
Remove flash-attention; add third-party license attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ tests/            fast unit/smoke tests + slow e2e tests (marked `slow`)
 
   ```bash
   WANDB_MODE=disabled uv run synthefy-nori-train \
-    --device cpu --no-mixed-precision --no-prefetch --no-flash-attn \
+    --device cpu --no-mixed-precision --no-prefetch \
     --task-type reg --total-steps 2 --run-steps 2 --save-interval 2 \
     --embed-dim 32 --hid-dim 64 --nlayers 2 --nhead 2 \
     --batch-size 2 --max-features 16 --max-budget 4000 \
@@ -120,5 +120,6 @@ re-introduce `LimiX*` naming for Synthefy's own classes. Parts of the
 synthetic-data prior generator draw on **TabICL** (BSD-3-Clause,
 <https://github.com/soda-inria/tabicl>).
 
-Keep the `LICENSE`/`NOTICE` attributions intact; check those files before
-removing upstream names.
+Keep the `LICENSE`, `NOTICE`, and `licenses/` attributions intact; check those
+files before removing upstream names. The full upstream license texts live in
+`licenses/` and are shipped via `license-files` in `pyproject.toml`.

--- a/NOTICE
+++ b/NOTICE
@@ -2,25 +2,48 @@ Nori
 Copyright 2026 Synthefy
 
 This product includes software developed by Synthefy and is licensed under
-the Apache License, Version 2.0.
+the Apache License, Version 2.0. The full license text is in the LICENSE file
+at the root of this distribution.
+
+==============================================================================
+Third-party software
+==============================================================================
+
+This project incorporates components from the projects below. Their full
+license texts are reproduced in the licenses/ directory, and their required
+copyright notices are reproduced here.
 
 ------------------------------------------------------------------------------
-Third-party attributions
-------------------------------------------------------------------------------
-
-This project originated as a fork of LimiX and incorporates components derived
-from the projects below. Their respective licenses and copyright notices are
-acknowledged here.
-
 LimiX
-  https://github.com/limix-ldm-ai/LimiX
-  Licensed under the Apache License, Version 2.0.
-  The canonical LimiX-2M model is used as an optional training-time in-context
-  learnability filter (downloaded on demand; see synthefy_nori/hf.py).
+------------------------------------------------------------------------------
+  Source:   https://github.com/limix-ldm-ai/LimiX
+  License:  Apache License, Version 2.0 (see licenses/Apache-2.0.txt)
 
+  This codebase originated as a fork of LimiX and has since substantially
+  diverged. MODIFICATIONS: numerous source files derived from LimiX have been
+  changed by Synthefy, including renaming the upstream `LimiX*` classes to
+  `Nori*` and reworking training, inference, and data-generation code.
+
+  The canonical LimiX-2M model is additionally used, unmodified, as an
+  optional training-time in-context-learnability filter (downloaded on demand;
+  see src/synthefy_nori/hf.py). Use of the LimiX model weights is subject to
+  LimiX's separate Model License; no model weights are redistributed with this
+  project.
+
+  LimiX does not distribute a NOTICE file, so there are no upstream NOTICE
+  contents to propagate.
+
+------------------------------------------------------------------------------
 TabICL
-  https://github.com/soda-inria/tabicl
-  Licensed under the BSD 3-Clause License.
+------------------------------------------------------------------------------
+  Source:   https://github.com/soda-inria/tabicl
+  License:  BSD 3-Clause License (see licenses/TabICL-BSD-3-Clause.txt)
+
+  Copyright (c) 2025, Soda team @ Inria
+  All rights reserved.
+
   Parts of the synthetic-data prior generator
-  (synthefy_nori/training/scm_prior_generator.py) are derived from TabICL's
-  prior system.
+  (src/synthefy_nori/training/scm_prior_generator.py) are derived from and
+  modified by Synthefy from TabICL's prior system (MLP/Tree SCM, Reg2Cls,
+  meta-distribution sampling, activation library). Only TabICL's BSD-3-Clause
+  prior code is used; the Apache-2.0 `forecast` component of TabICL is not used.

--- a/licenses/Apache-2.0.txt
+++ b/licenses/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 StableAI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/TabICL-BSD-3-Clause.txt
+++ b/licenses/TabICL-BSD-3-Clause.txt
@@ -1,0 +1,235 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, Soda team @ Inria
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Code in the src/tabicl/forecast directory is currently derived work from
+TabPFN-TS https://github.com/PriorLabs/tabpfn-time-series
+
+As such it is under the following license:
+
+  Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Prior Labs GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
-license-files = ["LICENSE", "NOTICE"]
+license-files = ["LICENSE", "NOTICE", "licenses/*"]
 authors = [{ name = "Synthefy" }]
 keywords = [
     "tabular",

--- a/scripts/continue_training.sh
+++ b/scripts/continue_training.sh
@@ -137,7 +137,6 @@ SHARED_ARGS=(
   --nlayers 16
   --prefetch-workers 4
   --prefetch-count 6
-  --no-flash-attn
   --gradient-checkpointing
 )
 

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -116,7 +116,6 @@ torchrun --nproc_per_node="${NPROC}" --master_port="${MASTER_PORT}" \
   --min-features 2 --max-features 250 \
   --dim-bias-samples 1.5 --dim-bias-features 1.3 \
   --prefetch-workers 4 --prefetch-count 6 \
-  --no-flash-attn \
   --gradient-checkpointing \
   --save-interval 15000 --log-interval 1000 \
   --wandb-project "${WANDB_PROJECT}" --wandb-group "${WANDB_GROUP}" \

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -3,36 +3,12 @@ from __future__ import annotations
 from typing import Callable, Literal, Optional
 import functools
 import math
-import os
 
 import torch
 import torch.nn as nn
 from torch.utils.checkpoint import checkpoint
 from functools import partial
 from torch.amp import autocast
-
-
-
-
-if os.environ.get("SYNTHEFY_NORI_NO_FLASH_ATTN", "0") == "1":
-    HAVE_FLASH_ATTN = False
-    HAVE_FLASH_ATTN_4 = False
-else:
-    # FlashAttention-4 (CuTeDSL, Hopper/Blackwell optimized)
-    HAVE_FLASH_ATTN_4 = False
-    try:
-        from flash_attn.cute import flash_attn_func as flash_attn_4_func
-        HAVE_FLASH_ATTN_4 = True
-    except (ModuleNotFoundError, ImportError):
-        pass
-
-    # FlashAttention-2 fallback
-    try:
-        from flash_attn.flash_attn_interface import flash_attn_varlen_kvpacked_func, flash_attn_varlen_qkvpacked_func
-        from flash_attn import flash_attn_func
-        HAVE_FLASH_ATTN = True
-    except (ModuleNotFoundError, ImportError):
-        HAVE_FLASH_ATTN = False
 
 from typing_extensions import override
 
@@ -260,15 +236,6 @@ class MultiheadAttention(torch.nn.Module):
             return q
         return self.qassmax(q, key_len)
     
-    def get_cu_seqlens(self, batch_size: int, seqlen: int, device: torch.device) -> torch.Tensor:
-        return torch.arange(
-            0,
-            (batch_size + 1) * seqlen,
-            step=seqlen,
-            dtype=torch.int32,
-            device=device,
-        )
-    
     def _apply_extra_attn_scale(self, q: torch.Tensor, n_keys: int) -> torch.Tensor:
         """Pre-multiply Q by (temperature * logN factor) so SDPA's internal
         1/sqrt(d) scaling combines to the desired final attention scale.
@@ -351,15 +318,7 @@ class MultiheadAttention(torch.nn.Module):
         if self.use_qassmax:
             q = self.apply_qassmax(q, kv.shape[1])
 
-        if self.qkv_proj_weight.device.type == "cuda" and not torch.compiler.is_compiling():
-            if HAVE_FLASH_ATTN_4:
-                atten_out = self.compute_attention_by_flashattn4(None, q, kv)
-            elif HAVE_FLASH_ATTN:
-                atten_out = self.compute_attention_by_flashattn(None, q, kv)
-            else:
-                atten_out = self.compute_attention_by_torch(None, q, kv, None)
-        else:
-            atten_out = self.compute_attention_by_torch(None, q, kv, None)
+        atten_out = self.compute_attention_by_torch(None, q, kv, None)
 
         atten_out = atten_out.reshape(x_flat.shape[0], x_flat.shape[1], self.num_heads, self.head_dim)
         sample_attention = None
@@ -374,7 +333,7 @@ class MultiheadAttention(torch.nn.Module):
         return out.reshape(B, S, *out.shape[1:]), sample_attention
 
     def compute_attention_by_torch(self, qkv:torch.Tensor|None, q:torch.Tensor|None, kv:torch.Tensor|None, attn_mask:torch.Tensor|None) -> torch.Tensor:
-        '''Since flash attention does not support attn_mask, use scaled_dot_product_attention to compute attention when attn_mask is not None'''
+        '''Compute attention with PyTorch scaled_dot_product_attention (supports attn_mask).'''
         if qkv is not None:
             q, k, v = qkv.unbind(dim=-3)
         elif kv is not None and q is not None:
@@ -398,86 +357,6 @@ class MultiheadAttention(torch.nn.Module):
             )
         attention_outputs = attention_outputs.transpose(1, 2)
         return attention_outputs
-    
-    def compute_attention_by_flashattn4(self, qkv:torch.Tensor|None, q:torch.Tensor|None, kv:torch.Tensor|None) -> torch.Tensor:
-        """Compute attention using FlashAttention-4 (CuTeDSL, Hopper/Blackwell optimized).
-
-        Uses the batched interface (q, k, v) instead of varlen packing.
-        All sequences in a batch have equal length, so no cu_seqlens needed.
-        """
-        assert HAVE_FLASH_ATTN_4, "FlashAttention-4 not installed. pip install flash-attn-4"
-        # FA4 beta backward kernels fail for the model's native head_dim=16 on H100. Padding the
-        # per-head dimension to 128 keeps q·k and weighted-v math unchanged as long as we also
-        # preserve the original softmax scale.
-        flash_head_dim = 128 if self.head_dim < 128 else self.head_dim
-        softmax_scale = self.head_dim ** -0.5
-        if self.qkv_combined and qkv is not None:
-            # qkv: [BS, F, 3, num_heads, head_dim]
-            q_, k_, v_ = qkv.unbind(dim=-3)
-            if flash_head_dim != self.head_dim:
-                pad = (0, flash_head_dim - self.head_dim)
-                q_ = torch.nn.functional.pad(q_, pad)
-                k_ = torch.nn.functional.pad(k_, pad)
-                v_ = torch.nn.functional.pad(v_, pad)
-            atten_out = flash_attn_4_func(
-                q_.contiguous(), k_.contiguous(), v_.contiguous(), causal=False, softmax_scale=softmax_scale,
-            )
-        elif not self.qkv_combined and q is not None and kv is not None:
-            # q: [BS, F_q, num_heads, head_dim]
-            # kv: [BS, F_kv, 2, num_heads, head_dim] (may be expanded from GQA)
-            k_, v_ = kv.unbind(dim=-3)
-            if flash_head_dim != self.head_dim:
-                pad = (0, flash_head_dim - self.head_dim)
-                q = torch.nn.functional.pad(q, pad)
-                k_ = torch.nn.functional.pad(k_, pad)
-                v_ = torch.nn.functional.pad(v_, pad)
-            atten_out = flash_attn_4_func(
-                q.contiguous(), k_.contiguous(), v_.contiguous(), causal=False, softmax_scale=softmax_scale,
-            )
-        else:
-            raise ValueError("Either qkv or (q, kv) must be provided")
-        # FA4 returns `(out, lse)` even when `return_lse=False`; only the attention output
-        # should flow into the rest of the projection path.
-        if isinstance(atten_out, tuple):
-            atten_out = atten_out[0]
-        if flash_head_dim != self.head_dim:
-            atten_out = atten_out[..., :self.head_dim].contiguous()
-        # Returns [BS, F, num_heads, head_dim] — compatible with reshape in forward()
-        return atten_out
-
-    def compute_attention_by_flashattn(self, qkv:torch.Tensor|None, q:torch.Tensor|None, kv:torch.Tensor|None) -> torch.Tensor:
-        "Compute attention using flash attention"
-        assert HAVE_FLASH_ATTN, "Flash attention is not supported. Please install/reinstall flash attention."
-        if self.qkv_combined and qkv is not None:
-            B,S = qkv.shape[:2]
-            atten_out = flash_attn_varlen_qkvpacked_func( # type: ignore
-                        qkv.reshape(B * S, 3, self.num_heads, self.head_dim),
-                        self.get_cu_seqlens(B, S, qkv.device),
-                        S,
-                        dropout_p=self.dropout,
-                        softmax_scale=None,
-                        causal=False,
-                        return_attn_probs=False,
-                        deterministic=False,
-                    )
-        elif not self.qkv_combined and q is not None and kv is not None:
-            B,S = q.shape[:2]
-            kv_shape = kv.shape
-            atten_out = flash_attn_varlen_kvpacked_func( # type: ignore
-                    q.reshape(B * S, self.num_heads, self.head_dim),
-                    kv.reshape(B * kv_shape[1], 2, self.num_heads, self.head_dim),
-                    self.get_cu_seqlens(B, S, q.device),
-                    self.get_cu_seqlens(B, kv_shape[1], kv.device),
-                    S,
-                    kv_shape[1],
-                    dropout_p=self.dropout,
-                    causal=False,
-                    return_attn_probs=False,
-                    deterministic=False,
-                )
-        else:
-            raise ValueError("compute_attention_by_flashattn: expected packed qkv or separate q+kv")
-        return atten_out # type: ignore
 
     def caculate_attention_score(self, q: torch.Tensor | None, k: torch.Tensor | None) -> torch.Tensor:
         if len(q.shape) == 3:
@@ -540,15 +419,7 @@ class MultiheadAttention(torch.nn.Module):
             if self.use_qassmax:
                 q = self.apply_qassmax(q, kv.shape[1])
 
-        if attn_mask is None and self.qkv_proj_weight.device.type == "cuda" and not torch.compiler.is_compiling():
-            if HAVE_FLASH_ATTN_4:
-                atten_out = self.compute_attention_by_flashattn4(qkv, q, kv)
-            elif HAVE_FLASH_ATTN:
-                atten_out = self.compute_attention_by_flashattn(qkv, q, kv)
-            else:
-                atten_out = self.compute_attention_by_torch(qkv, q, kv, attn_mask)
-        else:
-            atten_out = self.compute_attention_by_torch(qkv, q, kv, attn_mask)
+        atten_out = self.compute_attention_by_torch(qkv, q, kv, attn_mask)
 
         atten_out = atten_out.reshape(BS, F, self.num_heads, self.head_dim)
 

--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -14,13 +14,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import os
 from datetime import datetime
-
-# Must set before model imports which check this env var at module load time
-if '--no-flash-attn' in sys.argv:
-    os.environ["SYNTHEFY_NORI_NO_FLASH_ATTN"] = "1"
 
 import torch
 
@@ -349,8 +344,6 @@ def main():
                         help='Exponent to bias n_samples toward larger tables (1.0=uniform, 1.5=40%% > 1000)')
     parser.add_argument('--dim-bias-features', type=float, default=1.3,
                         help='Exponent to bias n_features toward larger feature counts (1.0=uniform)')
-    parser.add_argument('--no-flash-attn', action='store_true',
-                        help='Disable flash attention (use PyTorch SDPA fallback)')
     parser.add_argument('--prefetch-workers', type=int, default=4,
                         help='Number of async data generation workers (0 to disable prefetching)')
     parser.add_argument('--prefetch-count', type=int, default=4,

--- a/src/synthefy_nori/training/scm_prior_generator.py
+++ b/src/synthefy_nori/training/scm_prior_generator.py
@@ -7,6 +7,10 @@ does) but outputs numpy arrays: dict(X, y, n_classes).
 
 Reference: https://github.com/soda-inria/tabicl
            Schlegel et al., "TabICL" (ICML 2025)
+
+Derived from TabICL (https://github.com/soda-inria/tabicl), licensed under the
+BSD 3-Clause License, Copyright (c) 2025, Soda team @ Inria. Modified by
+Synthefy. See the NOTICE file and licenses/TabICL-BSD-3-Clause.txt for details.
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -416,6 +416,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colour"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/d4/5911a7618acddc3f594ddf144ecd8a03c29074a540f4494670ad8f153efe/colour-0.1.5.tar.gz", hash = "sha256:af20120fefd2afede8b001fbef2ea9da70ad7d49fafdb6489025dae8745c3aee", size = 24776, upload-time = "2017-11-19T23:20:08.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl", hash = "sha256:33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c", size = 23772, upload-time = "2017-11-19T23:20:04.56Z" },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -826,6 +835,21 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "galois"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/84/996f1c4a7e8fe973a7f8e4d7901e125a91d0abb62615e35076ff47e9383a/galois-0.4.11.tar.gz", hash = "sha256:f5055546c4b39d1e36decae9d4f21f3d66d9c6c7c9aec39189cb5d2284e9022f", size = 7402587, upload-time = "2026-05-02T18:21:28.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/dc69acbd34bde07b9dee9f9f88d7ce61ff97fd99d6d576d72d2db1461349/galois-0.4.11-py3-none-any.whl", hash = "sha256:d2e12a2b7fd44b108cc15d7de27dabcb8a98a556ea2c69c94fe695139629d9aa", size = 4197346, upload-time = "2026-05-02T18:21:26.868Z" },
 ]
 
 [[package]]
@@ -3229,6 +3253,98 @@ wheels = [
 ]
 
 [[package]]
+name = "shapiq"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10' and sys_platform == 'linux'",
+    "python_full_version < '3.10' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "colour", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/52/efce67a5be4661e716ba450eff16efdc306e518f1b28060e02cd40a7ffdc/shapiq-1.2.1.tar.gz", hash = "sha256:bd8cf707104e56ce22c34c587b433a430da10d3e91cb9441c84a7fd2d0c0e28b", size = 191239, upload-time = "2025-02-17T22:15:09.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1c/175ab917ba004ddb7bba0cc2d4289ab59bade3583b59ca66bdc57fda7c2f/shapiq-1.2.1-py3-none-any.whl", hash = "sha256:4c4a4e869c2d4a9363ddce519174cbb698622456e2e12901343a0ebb729595c5", size = 241832, upload-time = "2025-02-17T22:15:05.89Z" },
+]
+
+[[package]]
+name = "shapiq"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.10.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "colour", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "galois", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "sparse-transform", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/20/8e7bf8e1d2ad5e50c5ddb884760fe67657eee38b0ebe9d9996a0ab227221/shapiq-1.4.1.tar.gz", hash = "sha256:7f612c84fcfe4746ff826db72efa2944f9aa693c5c00c6e17a882613471534f8", size = 5781786, upload-time = "2025-11-10T19:43:31.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/cc/13fefd7203ffe71d5107221be939dd64945378b93f7c0a7cb82d7f281071/shapiq-1.4.1-py3-none-any.whl", hash = "sha256:c86667eb28ea0de56005fbe9fd072783242b74aa87fede11e07b6b915b93e7b3", size = 5871550, upload-time = "2025-11-10T19:43:29.858Z" },
+]
+
+[[package]]
+name = "shapiq"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "colour", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/bb/940b6af2c90238873b4f22011a2f2f924111bde12abeac83294d32111a94/shapiq-1.5.2.tar.gz", hash = "sha256:6336d764ce27836b69a1d3283392d69c8c2f4dcd3f52e19d2ad037d5aac1708c", size = 15210062, upload-time = "2026-06-12T22:37:09.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/17/88285cdb09af0ba8b134d3820b83681c297e606c97550b9e00a7ba0c6b88/shapiq-1.5.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d33fb803e344fd7308da4f4b5756040b789eceaa75b5ef103ba48931ff530e9", size = 17368899, upload-time = "2026-06-12T22:36:47.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/81/747eb3f7b1e2e956b58d6de2b8eee2067f2f1680984ab6fc1c422dd5eca1/shapiq-1.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:81e934435d2f91069b43aff7fe8280a7f0a43a2872c17a906e8bae6be0369c99", size = 15907854, upload-time = "2026-06-12T22:36:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e6/f91675239f7bea75d3f2cfe43c9203cd022ca801d2511b435e1520a14e85/shapiq-1.5.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93f7579f33256ff203663a41c89b018ea1306b49c732f407b0f1f1b3764ba89c", size = 17376618, upload-time = "2026-06-12T22:36:56.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f2/68c5d5a178601c5e4bd8b7c0bc57e580020da98c101d1a542e339b7b49a8/shapiq-1.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:c46560a9e63a7e986210dde141cad90f1bcb073702f4130e24eb71158524ea11", size = 15907857, upload-time = "2026-06-12T22:36:58.538Z" },
+    { url = "https://files.pythonhosted.org/packages/45/83/fdd74ce3d181195d9d3b79fc757ff979e90913417a70679e0f6c94a0069b/shapiq-1.5.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0323c0bc8e2ec0fa2340afdbb282644c5545fc939479cf5f399ce7a04ea34e67", size = 17377074, upload-time = "2026-06-12T22:37:05.5Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/48/e3595c9c650875dbe93a298f9f18b87ef4d125f1122ca7ee661f117e7c13/shapiq-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:6779bcc55841fe4977384a60051db54fc415fac3ffdb96feff969918937c1144", size = 15791234, upload-time = "2026-06-12T22:37:07.53Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3256,6 +3372,25 @@ wheels = [
 ]
 
 [[package]]
+name = "sparse-transform"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "galois", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/da/82132137fdc207c4a14abb52fedcd8cc3dd697175f548cfb8689bd2afab8/sparse_transform-0.2.1.tar.gz", hash = "sha256:470d54c884600d97254469a3d85fac775480d18a8aa2c43574350695e1015c66", size = 24803, upload-time = "2025-04-03T08:11:39.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ec/c85f95289e4638faf889ca02b588ad3af0f3ef8f92b99bee3ce936ef3860/sparse_transform-0.2.1-py3-none-any.whl", hash = "sha256:d01b19f8add68e2b4c98a17272830af0e03d163667f03b1dc2b0c9eb8471727b", size = 27034, upload-time = "2025-04-03T08:11:38.551Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3269,7 +3404,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.4.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -3305,6 +3440,13 @@ eval = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
     { name = "openml", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
+interpretability = [
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+]
 train = [
     { name = "wandb", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "xgboost", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
@@ -3318,6 +3460,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.0" },
     { name = "kditransform", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'eval'" },
+    { name = "matplotlib", marker = "extra == 'interpretability'" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "openml", marker = "extra == 'eval'" },
     { name = "pandas", specifier = ">=2.0" },
@@ -3325,13 +3468,14 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "scipy", specifier = ">=1.13" },
+    { name = "shapiq", marker = "extra == 'interpretability'", specifier = ">=1.0" },
     { name = "torch", specifier = ">=2.8,<2.9", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", specifier = ">=4.65" },
     { name = "typing-extensions", specifier = ">=4.10" },
     { name = "wandb", marker = "extra == 'train'", specifier = ">=0.15.0" },
     { name = "xgboost", marker = "extra == 'train'" },
 ]
-provides-extras = ["train", "eval", "dev"]
+provides-extras = ["train", "eval", "interpretability", "dev"]
 
 [[package]]
 name = "threadpoolctl"


### PR DESCRIPTION
Follow-up to #49 (which was merged). These two commits weren't part of that merge.

## Remove flash-attention code; use PyTorch SDPA only
Flash-attn was an optional runtime import whose default GPU path crashed with
`FlashAttention only support fp16 and bf16` (the q/k/v projection einsums emit
fp32), and the flash paths also silently skipped `_apply_extra_attn_scale`.
Removed entirely in favor of the existing `scaled_dot_product_attention` path
(already the CPU/no-flash fallback).

- `model/layer.py`: drop `flash_attn` / `flash_attn.cute` imports, the
  `HAVE_FLASH_ATTN(_4)` flags, `compute_attention_by_flashattn(4)`, and
  `get_cu_seqlens`; collapse both dispatch sites to `compute_attention_by_torch`.
- `training/cli.py`: remove `--no-flash-attn` and its `SYNTHEFY_NORI_NO_FLASH_ATTN`
  env switch.
- `scripts/train.sh`, `scripts/continue_training.sh`, `AGENTS.md`: drop `--no-flash-attn`.

## Add third-party license attribution
- `NOTICE`: expand third-party attributions.
- Bundle license texts under `licenses/` and ship them via `pyproject`
  `license-files = ["LICENSE", "NOTICE", "licenses/*"]`.
- `scm_prior_generator.py`: note TabICL (BSD-3-Clause) derivation in the docstring.

## Testing
- `ruff check src scripts tests` — pass
- `import synthefy_nori` — pass
- `pytest` (fast) — 33 passed, 1 skipped
- CPU smoke training — full loop runs, checkpoint written
- GPU inference (public checkpoint) — MAE unchanged at 0.1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)