### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.7.0"
+version = "0.8.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -9,7 +9,7 @@ from synthefy_nori.api import (
     predict,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = [
     "NoriRegressor",


### PR DESCRIPTION
Release prep for **v0.8.0**.

Bumps `version` in `pyproject.toml` and `__version__` in `src/synthefy_nori/__init__.py` from 0.7.0 → 0.8.0 (kept in sync per `RELEASING.md`).

## Changes shipping in this release (since v0.7.0)
- Remove flash-attention code; use PyTorch SDPA only (#50)
- Add third-party license attribution (TabICL BSD-3, bundled license texts)
- Clean up dead/legacy code and bugs (#49)

After merge: cut the `v0.8.0` GitHub release (`--generate-notes`), which triggers `publish.yml` → approve the `pypi` environment gate → uploads to PyPI over OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)