### PR TITLE
Add CI smoke gate: real inference + one training step

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -28,16 +28,20 @@ default branch:
    pushed**, and **Do not allow bypassing the above settings** (include
    administrators), so the rule cannot be sidestepped by accounts outside any
    explicitly configured bypass list.
-4. **Require status checks to pass before merging**, and add the **`smoke`** job
+4. **Require status checks to pass before merging**, and add these two jobs
    (from [`workflows/ci.yml`](workflows/ci.yml)) to the required checks. This is
-   what actually blocks the merge button on a broken model: `smoke` runs a real
-   inference forward pass (downloads the public `Synthefy/Nori` checkpoint) plus
-   one real training step on CPU. *(Add the fast `test` job too if you want lint
-   / unit tests / build to gate merges as well.)*
+   what actually blocks the merge button on a broken model:
+   - **`CI test inference`** — runs a real inference forward pass (downloads the
+     public `Synthefy/Nori` checkpoint).
+   - **`CI test train step`** — runs one real training step from scratch on CPU.
+
+   *(Add the fast `test` job too if you want lint / unit tests / build to gate
+   merges as well.)*
 
 > A workflow only *reports* status — only a required status check *blocks* the
-> merge. The check name GitHub matches is the job name (`smoke`); it appears in
-> the list once the workflow has run at least once on a PR.
+> merge. The check name GitHub matches is the job's display name (`CI test
+> inference` / `CI test train step`); each appears in the list once the workflow
+> has run at least once on a PR.
 
 > Code owners must have **write** access to the repo, or GitHub ignores their
 > `CODEOWNERS` entries.

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -38,6 +38,16 @@ default branch:
    *(Add the fast `test` job too if you want lint / unit tests / build to gate
    merges as well.)*
 
+   **Optional GPU gate** — [`workflows/gpu-ci.yml`](workflows/gpu-ci.yml) adds a
+   **`GPU test inference + train step`** job that runs the same two checks on a
+   CUDA device, catching CUDA-only / dtype / autocast regressions the CPU gate
+   cannot. It needs a runner labelled `gpu` (a GitHub-hosted GPU larger runner,
+   provisioned by an org admin under **Settings → Actions → Runners → New
+   runner**). **Do not mark this job required until that runner exists** — with
+   no runner the check sits queued forever and would block every merge. Note the
+   hosted GPU runner is an NVIDIA T4 (sm75), so it cannot run FlashAttention-2
+   (needs Ampere+); the flash-attn step in that workflow is left disabled.
+
 > A workflow only *reports* status — only a required status check *blocks* the
 > merge. The check name GitHub matches is the job's display name (`CI test
 > inference` / `CI test train step`); each appears in the list once the workflow

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -28,6 +28,16 @@ default branch:
    pushed**, and **Do not allow bypassing the above settings** (include
    administrators), so the rule cannot be sidestepped by accounts outside any
    explicitly configured bypass list.
+4. **Require status checks to pass before merging**, and add the **`smoke`** job
+   (from [`workflows/ci.yml`](workflows/ci.yml)) to the required checks. This is
+   what actually blocks the merge button on a broken model: `smoke` runs a real
+   inference forward pass (downloads the public `Synthefy/Nori` checkpoint) plus
+   one real training step on CPU. *(Add the fast `test` job too if you want lint
+   / unit tests / build to gate merges as well.)*
+
+> A workflow only *reports* status — only a required status check *blocks* the
+> merge. The check name GitHub matches is the job name (`smoke`); it appears in
+> the list once the workflow has run at least once on a PR.
 
 > Code owners must have **write** access to the repo, or GitHub ignores their
 > `CODEOWNERS` entries.

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -39,14 +39,15 @@ default branch:
    merges as well.)*
 
    **Optional GPU gate** — [`workflows/gpu-ci.yml`](workflows/gpu-ci.yml) adds a
-   **`GPU test inference + train step`** job that runs the same two checks on a
-   CUDA device, catching CUDA-only / dtype / autocast regressions the CPU gate
-   cannot. It needs a runner labelled `gpu` (a GitHub-hosted GPU larger runner,
-   provisioned by an org admin under **Settings → Actions → Runners → New
-   runner**). **Do not mark this job required until that runner exists** — with
-   no runner the check sits queued forever and would block every merge. Note the
-   hosted GPU runner is an NVIDIA T4 (sm75), so it cannot run FlashAttention-2
-   (needs Ampere+); the flash-attn step in that workflow is left disabled.
+   **`GPU test inference + train step (Modal)`** job that runs the same two
+   checks on an (Ampere+) GPU via [Modal](https://modal.com), catching
+   CUDA-only / dtype / autocast regressions the CPU gate cannot. A free
+   `ubuntu-latest` runner drives `modal run`; the GPU work happens in an
+   ephemeral Modal container. Prerequisite: repo secrets `MODAL_TOKEN_ID` and
+   `MODAL_TOKEN_SECRET` (the `token_id` / `token_secret` from `~/.modal.toml`).
+   Until those are set the job is a green no-op; fork PRs are skipped (no secret
+   access). **Do not mark this job required until the secrets are set** —
+   otherwise it would pass without actually testing.
 
 > A workflow only *reports* status — only a required status check *blocks* the
 > merge. The check name GitHub matches is the job's display name (`CI test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,19 @@ jobs:
       - run: uv run pytest tests
       - run: uv run ruff check src scripts tests
       - run: uv build
+
+  # Merge gate: a real inference forward pass + one real training step on CPU.
+  # Mark this job as a required status check in branch protection so it blocks
+  # the merge button (see .github/branch-protection.md).
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: uv sync --extra dev
+      # Inference: downloads the public Synthefy/Nori checkpoint and runs a
+      # real forward pass. Training: runs one optimizer step from scratch on CPU.
+      - run: uv run pytest -m slow tests/test_inference_e2e.py tests/test_training_smoke.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,11 @@ jobs:
       - run: uv run ruff check src scripts tests
       - run: uv build
 
-  # Merge gate: a real inference forward pass + one real training step on CPU.
-  # Mark this job as a required status check in branch protection so it blocks
-  # the merge button (see .github/branch-protection.md).
-  smoke:
+  # Merge gate (part 1): a real inference forward pass on CPU. Downloads the
+  # public Synthefy/Nori checkpoint. Mark this job as a required status check in
+  # branch protection so it blocks the merge button (see branch-protection.md).
+  inference:
+    name: CI test inference
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,6 +32,18 @@ jobs:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv sync --extra dev
-      # Inference: downloads the public Synthefy/Nori checkpoint and runs a
-      # real forward pass. Training: runs one optimizer step from scratch on CPU.
-      - run: uv run pytest -m slow tests/test_inference_e2e.py tests/test_training_smoke.py
+      - run: uv run pytest -m slow tests/test_inference_e2e.py
+
+  # Merge gate (part 2): one real training step from scratch on CPU (data-gen ->
+  # loss -> optimizer step -> checkpoint write). Offline; no checkpoint download.
+  train-step:
+    name: CI test train step
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: uv sync --extra dev
+      - run: uv run pytest -m slow tests/test_training_smoke.py

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,0 +1,51 @@
+name: gpu-ci
+
+# GPU merge gate: a real inference forward pass + one training step on a CUDA
+# device. Catches the CUDA-only / dtype / autocast class of regression that the
+# CPU `ci` workflow structurally cannot reach.
+#
+# REQUIRES a GPU runner labelled `gpu`. GitHub-hosted GPU larger runners
+# (NVIDIA T4, sm75) must be provisioned by an org/enterprise admin under
+# Settings -> Actions -> Runners -> "New runner" -> larger runner with a
+# GPU-enabled image, given the label `gpu`. Until that runner exists this job
+# has nowhere to run and will sit queued -- do NOT mark it a required status
+# check until the runner is live (see .github/branch-protection.md).
+#
+# COST: a hosted GPU runner bills per minute on every PR push. To cut spend,
+# either (a) restrict to push/dispatch by removing `pull_request:` below, or
+# (b) gate per-PR runs behind a label (see the commented `if:` on the job).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  gpu-smoke:
+    name: GPU test inference + train step
+    runs-on: gpu
+    # Cost control option (b): only run on PRs that carry the `gpu` label.
+    # if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'gpu')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: uv sync --extra dev
+      # Fail fast with a clear message if the runner has no usable GPU.
+      - name: Assert CUDA is available
+        run: uv run python -c "import torch; assert torch.cuda.is_available(), 'no CUDA device on this runner'; print('GPU:', torch.cuda.get_device_name(0))"
+      # OPTIONAL flash-attn coverage. Disabled because (1) the codebase currently
+      # has no flash path, so installing it exercises nothing, and (2) the hosted
+      # T4 (sm75) does not support FlashAttention-2 (needs Ampere+ / sm80+).
+      # Enable only on an Ampere/Hopper runner AND once flash code is reintroduced
+      # (it is a long source build -- consider a prebuilt wheel or caching):
+      # - run: uv pip install flash-attn --no-build-isolation
+      # Inference auto-selects the GPU when available; the train step is pinned
+      # to cuda:0 via the env var and keeps mixed precision on (autocast path).
+      - name: Inference + one training step on GPU
+        env:
+          SYNTHEFY_NORI_SMOKE_DEVICE: cuda:0
+        run: uv run pytest -m slow tests/test_inference_e2e.py tests/test_training_smoke.py

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,19 +1,22 @@
 name: gpu-ci
 
-# GPU merge gate: a real inference forward pass + one training step on a CUDA
-# device. Catches the CUDA-only / dtype / autocast class of regression that the
-# CPU `ci` workflow structurally cannot reach.
+# GPU merge gate via Modal. A free ubuntu-latest runner drives `modal run`, which
+# executes the inference e2e + one training step on an (Ampere+) Modal GPU in a
+# fresh, isolated, ephemeral container. The job's exit code is the gate.
 #
-# REQUIRES a GPU runner labelled `gpu`. GitHub-hosted GPU larger runners
-# (NVIDIA T4, sm75) must be provisioned by an org/enterprise admin under
-# Settings -> Actions -> Runners -> "New runner" -> larger runner with a
-# GPU-enabled image, given the label `gpu`. Until that runner exists this job
-# has nowhere to run and will sit queued -- do NOT mark it a required status
-# check until the runner is live (see .github/branch-protection.md).
+# PREREQUISITES (one-time):
+#   1. A Modal account (https://modal.com), token via `modal token new`.
+#   2. Repo secrets MODAL_TOKEN_ID and MODAL_TOKEN_SECRET (Settings -> Secrets
+#      and variables -> Actions). These are the token_id / token_secret values
+#      from ~/.modal.toml -- add the two values, NOT the file.
 #
-# COST: a hosted GPU runner bills per minute on every PR push. To cut spend,
-# either (a) restrict to push/dispatch by removing `pull_request:` below, or
-# (b) gate per-PR runs behind a label (see the commented `if:` on the job).
+# Until those secrets exist the job is a green no-op (see the guard below), so it
+# never blocks merges before you've set Modal up. GitHub does not pass secrets to
+# fork-PR workflows, so this job is also skipped for forks (a maintainer reruns
+# after review). Do not mark it a required check until the secrets are set.
+#
+# COST: a Modal GPU runs on every non-fork PR push (a few minutes, scales to
+# zero between runs). To cut spend, drop `pull_request:` and rely on push/dispatch.
 
 on:
   pull_request:
@@ -22,30 +25,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  gpu-smoke:
-    name: GPU test inference + train step
-    runs-on: gpu
-    # Cost control option (b): only run on PRs that carry the `gpu` label.
-    # if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'gpu')
+  gpu-modal:
+    name: GPU test inference + train step (Modal)
+    runs-on: ubuntu-latest
+    # Skip for fork PRs (they have no access to the Modal secrets).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == false
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v8.2.0
-      - run: uv sync --extra dev
-      # Fail fast with a clear message if the runner has no usable GPU.
-      - name: Assert CUDA is available
-        run: uv run python -c "import torch; assert torch.cuda.is_available(), 'no CUDA device on this runner'; print('GPU:', torch.cuda.get_device_name(0))"
-      # OPTIONAL flash-attn coverage. Disabled because (1) the codebase currently
-      # has no flash path, so installing it exercises nothing, and (2) the hosted
-      # T4 (sm75) does not support FlashAttention-2 (needs Ampere+ / sm80+).
-      # Enable only on an Ampere/Hopper runner AND once flash code is reintroduced
-      # (it is a long source build -- consider a prebuilt wheel or caching):
-      # - run: uv pip install flash-attn --no-build-isolation
-      # Inference auto-selects the GPU when available; the train step is pinned
-      # to cuda:0 via the env var and keeps mixed precision on (autocast path).
-      - name: Inference + one training step on GPU
+      - run: pip install modal
+      - name: Inference + one training step on a Modal GPU
         env:
-          SYNTHEFY_NORI_SMOKE_DEVICE: cuda:0
-        run: uv run pytest -m slow tests/test_inference_e2e.py tests/test_training_smoke.py
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          if [ -z "$MODAL_TOKEN_ID" ] || [ -z "$MODAL_TOKEN_SECRET" ]; then
+            echo "Modal secrets not configured; skipping GPU gate (no-op)."
+            echo "Set MODAL_TOKEN_ID / MODAL_TOKEN_SECRET to enable it."
+            exit 0
+          fi
+          modal run ci/modal_gpu_smoke.py

--- a/ci/modal_gpu_smoke.py
+++ b/ci/modal_gpu_smoke.py
@@ -76,6 +76,9 @@ def gpu_smoke() -> None:
         **os.environ,
         "SYNTHEFY_NORI_SMOKE_DEVICE": "cuda:0",
         "WANDB_MODE": "disabled",
+        # Stream subprocess (uv / pytest) output to the GitHub Actions log in
+        # real time instead of in buffered chunks.
+        "PYTHONUNBUFFERED": "1",
     }
 
     subprocess.run(["uv", "sync", "--extra", "dev"], cwd=repo, env=env, check=True)

--- a/ci/modal_gpu_smoke.py
+++ b/ci/modal_gpu_smoke.py
@@ -1,0 +1,105 @@
+"""GPU CI smoke test driven by Modal.
+
+Runs the two end-to-end checks on a real (Ampere+) GPU in a fresh, isolated,
+ephemeral Modal container:
+
+* inference e2e (downloads the public Synthefy/Nori checkpoint, real forward pass)
+* one training step from scratch on ``cuda:0`` (mixed precision / autocast path)
+
+It mounts the locally-checked-out source (whatever the GitHub job checked out),
+``uv sync``s it, and runs the same pytest selection the CPU gate uses. A failing
+test makes ``modal run`` exit non-zero, which fails the GitHub job -> merge gate.
+
+Run locally / in CI::
+
+    modal run ci/modal_gpu_smoke.py
+
+One-time setup:
+
+* a Modal account (https://modal.com), token via ``modal token new``
+* in CI: repo secrets ``MODAL_TOKEN_ID`` / ``MODAL_TOKEN_SECRET``
+
+Note: pin the ``modal`` version and verify the image/GPU API against your
+installed client -- this targets modal 1.x (``App`` / ``add_local_dir`` /
+``gpu=`` / ``max_containers``).
+"""
+from __future__ import annotations
+
+import modal
+
+app = modal.App("nori-gpu-ci")
+
+# Heavy deps are pre-warmed into the uv cache at *build* time (keyed on
+# pyproject.toml + uv.lock) so the runtime `uv sync` is a fast cache hit with no
+# per-run torch re-download. UV_LINK_MODE=copy avoids hardlink errors. The source
+# tree is mounted read-only at /src and copied to a writable dir in the function
+# (uv writes .venv into the project dir).
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("uv")
+    .env({"UV_LINK_MODE": "copy", "UV_CACHE_DIR": "/uvcache"})
+    .add_local_file("pyproject.toml", "/build/pyproject.toml", copy=True)
+    .add_local_file("uv.lock", "/build/uv.lock", copy=True)
+    .run_commands("cd /build && uv sync --no-install-project --extra dev")
+    .add_local_dir(
+        ".",
+        "/src",
+        # Keep the upload lean and never ship local build/venv/data artifacts.
+        ignore=[
+            ".git", ".venv", "dist", "build", "*.png",
+            "data", "checkpoints", "results", "wandb", "cache",
+        ],
+    )
+)
+
+
+@app.function(
+    gpu="A100",  # Ampere+ -> flash-attn-capable if flash code is reintroduced.
+    image=image,
+    timeout=1800,
+    # Cap simultaneous GPU containers (e.g. many PRs at once); extra runs queue.
+    max_containers=10,
+)
+def gpu_smoke() -> None:
+    import os
+    import shutil
+    import subprocess
+
+    # torch lives in the uv-managed venv (after `uv sync`), not the base Python,
+    # so all torch usage goes through `uv run` below.
+
+    # Writable copy of the mounted (read-only) source so `uv sync` can write .venv.
+    repo = "/root/repo"
+    shutil.copytree("/src", repo)
+
+    env = {
+        **os.environ,
+        "SYNTHEFY_NORI_SMOKE_DEVICE": "cuda:0",
+        "WANDB_MODE": "disabled",
+    }
+
+    subprocess.run(["uv", "sync", "--extra", "dev"], cwd=repo, env=env, check=True)
+    # Fail fast with a clear message if the GPU / driver isn't usable.
+    subprocess.run(
+        ["uv", "run", "python", "-c",
+         "import torch; assert torch.cuda.is_available(), 'no CUDA device on the Modal runner';"
+         " print('GPU:', torch.cuda.get_device_name(0))"],
+        cwd=repo, env=env, check=True,
+    )
+    # OPTIONAL flash-attn coverage (A100 is sm80, so FA2 is supported). Left off
+    # because the codebase currently has no flash path; enable only once flash
+    # code returns (it is a long source build):
+    # subprocess.run(["uv", "pip", "install", "flash-attn", "--no-build-isolation"],
+    #                cwd=repo, env=env, check=True)
+    subprocess.run(
+        [
+            "uv", "run", "pytest", "-m", "slow",
+            "tests/test_inference_e2e.py", "tests/test_training_smoke.py", "-q",
+        ],
+        cwd=repo, env=env, check=True,
+    )
+
+
+@app.local_entrypoint()
+def main() -> None:
+    gpu_smoke.remote()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ where = ["src"]
 testpaths = ["tests"]
 addopts = "-m 'not slow'"
 markers = [
-    "slow: end-to-end tests that download checkpoints and run real inference (run with `pytest -m slow`)",
+    "slow: opt-in end-to-end tests — download checkpoints + run real inference, or run a real training step (run with `pytest -m slow`)",
 ]
 
 [tool.ruff]

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -9,9 +9,14 @@ No network access is required (it trains a tiny model from scratch, no checkpoin
 download), but it is marked ``slow`` because it spins up the full training stack
 and is opt-in alongside the other end-to-end tests.
 
+By default it runs on CPU. Set ``SYNTHEFY_NORI_SMOKE_DEVICE`` (e.g. ``cuda:0``)
+to exercise the GPU training path instead; on a CUDA device it also leaves mixed
+precision enabled so the autocast path is covered.
+
 Run explicitly with::
 
     pytest -m slow tests/test_training_smoke.py
+    SYNTHEFY_NORI_SMOKE_DEVICE=cuda:0 pytest -m slow tests/test_training_smoke.py
 """
 from __future__ import annotations
 
@@ -25,12 +30,13 @@ import pytest
 pytestmark = pytest.mark.slow
 
 
-def test_single_cpu_training_step_writes_checkpoint(tmp_path):
+def test_single_training_step_writes_checkpoint(tmp_path):
     checkpoint_dir = tmp_path / "smoke"
+    device = os.environ.get("SYNTHEFY_NORI_SMOKE_DEVICE", "cpu")
 
     cmd = [
         sys.executable, "-m", "synthefy_nori.training.cli",
-        "--device", "cpu", "--no-mixed-precision", "--no-prefetch", "--no-wandb",
+        "--device", device, "--no-prefetch", "--no-wandb",
         "--task-type", "reg",
         "--total-steps", "1", "--run-steps", "1", "--save-interval", "1",
         # Tiny architecture so the step is fast on a CPU runner.
@@ -38,6 +44,10 @@ def test_single_cpu_training_step_writes_checkpoint(tmp_path):
         "--batch-size", "2", "--max-features", "16", "--max-budget", "4000",
         "--checkpoint-dir", str(checkpoint_dir),
     ]
+    # CPU has no autocast support here; on CUDA, keep mixed precision on (default)
+    # so the GPU run also exercises the autocast path.
+    if device == "cpu":
+        cmd.append("--no-mixed-precision")
 
     env = dict(os.environ, WANDB_MODE="disabled")
     result = subprocess.run(

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -1,0 +1,56 @@
+"""End-to-end training smoke test.
+
+Runs a single optimizer step of the real training loop on CPU (data-gen ->
+CCMM/pinball loss -> optimizer step -> checkpoint write) and asserts it exits
+cleanly and writes a checkpoint. This is the training half of the CI merge gate;
+the inference half lives in ``test_inference_e2e.py``.
+
+No network access is required (it trains a tiny model from scratch, no checkpoint
+download), but it is marked ``slow`` because it spins up the full training stack
+and is opt-in alongside the other end-to-end tests.
+
+Run explicitly with::
+
+    pytest -m slow tests/test_training_smoke.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.slow
+
+
+def test_single_cpu_training_step_writes_checkpoint(tmp_path):
+    checkpoint_dir = tmp_path / "smoke"
+
+    cmd = [
+        sys.executable, "-m", "synthefy_nori.training.cli",
+        "--device", "cpu", "--no-mixed-precision", "--no-prefetch", "--no-wandb",
+        "--task-type", "reg",
+        "--total-steps", "1", "--run-steps", "1", "--save-interval", "1",
+        # Tiny architecture so the step is fast on a CPU runner.
+        "--embed-dim", "32", "--hid-dim", "64", "--nlayers", "2", "--nhead", "2",
+        "--batch-size", "2", "--max-features", "16", "--max-budget", "4000",
+        "--checkpoint-dir", str(checkpoint_dir),
+    ]
+
+    env = dict(os.environ, WANDB_MODE="disabled")
+    result = subprocess.run(
+        cmd, env=env, capture_output=True, text=True, timeout=600,
+    )
+
+    assert result.returncode == 0, (
+        f"training step failed (exit {result.returncode})\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    checkpoints = list(checkpoint_dir.glob("checkpoint_step_*.pt"))
+    assert checkpoints, (
+        f"no checkpoint written to {checkpoint_dir}\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )


### PR DESCRIPTION
## What

Adds a `smoke` CI job that runs two real, end-to-end checks on every push/PR, intended to be marked as a **required status check** so a broken model blocks the merge button:

1. **Inference** — downloads the public `Synthefy/Nori` checkpoint and runs a real forward pass (reuses `tests/test_inference_e2e.py`).
2. **Training** — runs one optimizer step from scratch on CPU (data-gen → loss → step → checkpoint write) via a new `tests/test_training_smoke.py`.

## Changes

- `tests/test_training_smoke.py` — `slow` test that runs one training step through the CLI and asserts a checkpoint is written. No network needed; offline + CPU-only.
- `.github/workflows/ci.yml` — new `smoke` job running both slow e2e checks (kept separate from the fast `test` job).
- `.github/branch-protection.md` — documents adding `smoke` as a required status check (a workflow only *reports* status; the branch rule is what *blocks* the merge).
- `pyproject.toml` — broadened the `slow` marker description to cover the training step.

## Timing (measured on a GitHub-hosted runner)

`smoke` job total **~1m21s**: `uv sync` 32s, both checks combined **~40s** (checkpoint download + forward pass + one training step), rest is setup/teardown. Runs in parallel with the existing `test` job (55s), so PR wall-clock is ~1m21s.

## Follow-up (manual, repo admin)

The gate only blocks merges once an admin adds `smoke` to **Settings → Branches → required status checks** for `main`. See `.github/branch-protection.md`.

## Notes

- CPU-only (GitHub runners have no GPU): catches "does it run / does it crash," not GPU/DDP or numerical-quality regressions.
- The `smoke` job hits the network (HF download) each run; can be pointed at a local checkpoint via `SYNTHEFY_NORI_TEST_CHECKPOINT` if a fully-offline gate is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)