### PR TITLE
Load checkpoints with weights_only=True to block pickle RCE

### DIFF
--- a/src/synthefy_nori/utils/loading.py
+++ b/src/synthefy_nori/utils/loading.py
@@ -1,9 +1,36 @@
 from __future__ import annotations
 
+import pickle
+
 import torch
 import random
 import numpy as np
 from synthefy_nori.model.transformer import FeaturesTransformer
+
+
+def _safe_torch_load(path):
+    """Load a checkpoint without executing code embedded in it.
+
+    ``weights_only=True`` uses torch's restricted unpickler — it reconstructs
+    only tensors and plain data (dicts/lists/primitives), never arbitrary
+    classes or callables — so a malicious checkpoint cannot run code on load.
+    The public checkpoint is slim (``model_config`` dict + state-dict tensors)
+    and loads under this restriction with no allowlist.
+
+    Raw *training* checkpoints additionally pickle our own ``TrainingConfig``
+    dataclass. That single class is safe to reconstruct (it has no custom
+    ``__reduce__``/``__setstate__``, so unpickling is plain attribute
+    assignment), so we allowlist exactly it and retry. We never fall back to the
+    unsafe full unpickler, so anything else (e.g. ``os.system``) stays blocked.
+    See SECURITY.md.
+    """
+    try:
+        return torch.load(path, map_location="cpu", weights_only=True)
+    except pickle.UnpicklingError:
+        from synthefy_nori.training.config import TrainingConfig
+
+        with torch.serialization.safe_globals([TrainingConfig]):
+            return torch.load(path, map_location="cpu", weights_only=True)
 
 def build_model(config:dict):
     model = FeaturesTransformer(
@@ -43,7 +70,7 @@ def build_model(config:dict):
     return model
 
 def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None):
-    state_dict = torch.load(model_path, map_location="cpu", weights_only=False)
+    state_dict = _safe_torch_load(model_path)
 
     # Support both pretrained (.ckpt) and training checkpoint (.pt) formats
     if 'model_config' in state_dict:
@@ -59,7 +86,7 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
                 "Provide base_config_path pointing to the pretrained .ckpt file."
             )
         print(f"Loading model architecture config from {base_config_path}")
-        base_state = torch.load(base_config_path, map_location="cpu", weights_only=False)
+        base_state = _safe_torch_load(base_config_path)
         config = base_state['config']
         weights = state_dict.get('ema_state_dict') or state_dict['model_state_dict']
     else:


### PR DESCRIPTION
## Problem

`load_model()` loaded checkpoints with `torch.load(..., weights_only=False)`, which **executes arbitrary code embedded in the file during unpickling**. Because the default inference path auto-downloads a checkpoint from the Hugging Face Hub (`Synthefy/Nori`), a compromised repo — or a user tricked into pointing `model_path` at a malicious `.pt` — gets remote code execution on load. This also runs inside the Baseten serving container at warmup.

This is the classic ML pickle-deserialization RCE that `weights_only=True` (PyTorch 2.6 default) exists to close.

## Fix

`_safe_torch_load()` loads with `weights_only=True` (torch's restricted unpickler: tensors + plain data only, never arbitrary classes/callables).

- The **public checkpoint** is slim (`model_config` dict + state-dict tensors) and loads with **no allowlist**.
- **Raw training checkpoints** also pickle our own `TrainingConfig` dataclass. It's safe to reconstruct (no custom `__reduce__`/`__setstate__` — unpickling is plain attribute assignment), so we allowlist *exactly that one class* and retry. It **never** falls back to the unsafe full unpickler, so payloads like `os.system` stay blocked.

Training **resume** (`trainer.load_checkpoint`) is intentionally left on `weights_only=False`: it loads your own checkpoint on your own box and legitimately needs the optimizer/scheduler objects — a different trust boundary.

## Verification (against real artifacts)

| Case | Result |
|---|---|
| Inference `fit/predict` on real `nori.pt` | ✅ |
| Slim public checkpoint via `load_model` | ✅ loads (strict) |
| Raw training checkpoint via `load_model` | ✅ loads (allowlist retry) |
| Malicious checkpoint (`__reduce__`→callable) | ✅ **blocked**, no execution |
| Train from scratch | ✅ |
| Train resume | ✅ |
| Fast suite (32) + slow loader tests (4) + ruff | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
