### PR TITLE
Add RelBench evaluation harness for Nori

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,10 @@ uv build
   (sklearn-style `fit` / `predict`; `predict` takes
   `output_type="mean"/"median"/"mode"` per the `TabPFNRegressor` contract),
   plus the one-shot `infer` / `predict` helpers and `config_path`. The public
-  API is **regression-only** as of 0.2.0 (classification was removed in #10).
+  API is regression-first; `NoriClassifier` (sklearn-style `fit` /
+  `predict_proba` / `predict`) re-exposes the checkpoint's trained
+  classification head for the RelBench classification tasks. (`infer`/`predict`
+  accept `task="classification"`.)
 - `fit()` only stores the context rows; all compute happens in `predict()`.
   Uses GPU when available, else CPU.
 - Pass `model_path="…/checkpoint.pt"` to run a local checkpoint and skip the

--- a/README.md
+++ b/README.md
@@ -482,6 +482,12 @@ benchmark sources and how to evaluate a Nori checkpoint, and
 [Reproducing these numbers](#reproducing-these-numbers) for the published
 benchmark run.
 
+Nori can also be evaluated on the [RelBench](https://relbench.stanford.edu)
+relational benchmark via the entity-table tabular protocol
+(`pip install "synthefy-nori[relbench]"; synthefy-nori-eval --relbench`). See
+[docs/evaluation.md](docs/evaluation.md#relbench-relational-tasks) for details
+and the current submission status.
+
 ## Hugging Face
 
 ```bash

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -30,6 +30,41 @@ synthefy-nori-eval --download-benchmarks --openml-reg
 The command prints a per-source mean R² summary and writes per-dataset metrics
 to `results/eval/all_results.csv`.
 
+## RelBench (relational tasks)
+
+Nori can be evaluated on the [RelBench](https://relbench.stanford.edu)
+leaderboard tasks via the **entity-table tabular protocol**: each relational
+predictive task is flattened into one feature table (the task rows merged with
+their entity table) that Nori fits in-context — the same regime tabular
+foundation models (e.g. TabPFN) are listed under on the RelBench leaderboard.
+
+```bash
+pip install "synthefy-nori[relbench]"
+
+synthefy-nori-eval --relbench                       # full pinned suite
+synthefy-nori-eval --relbench --relbench-tasks rel-f1/driver-position rel-f1/driver-dnf
+```
+
+- Covers the **entity tasks** (binary classification → AUROC, regression → MAE)
+  across the seven canonical RelBench datasets; recommendation / link-prediction
+  tasks are skipped (not a tabular-model fit). The task list is pinned in
+  `synthefy_nori/evaluation/benchmark_lists/relbench_entity.csv`.
+- `--relbench-mode entity` (default) merges with the entity table only;
+  `--relbench-mode temporal` additionally adds per-entity temporal aggregations.
+- Scoring uses RelBench's own `task.evaluate`, so metrics match the leaderboard:
+  validation is scored locally; the held-out test split is scored against
+  RelBench's hidden labels.
+- Results are written to `--relbench-out` (default `results/relbench/`):
+  `classification.csv`, `regression.csv`, and `SUBMISSION.md` (results split by
+  task type, plus the current submission status).
+- Classification reuses the trained classification head already shipped in the
+  checkpoint (re-exposed via `NoriClassifier`).
+
+**Submission status:** RelBench currently has **no self-service submission
+endpoint** — the leaderboard is a maintainer-generated static page under
+redesign. `SUBMISSION.md` documents the contribution path (open an issue/PR on
+`snap-stanford/relbench`) and is formatted to match the leaderboard tables.
+
 ## Evaluate your own checkpoint
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ Changelog = "https://github.com/Synthefy/synthefy-nori/releases"
 [project.optional-dependencies]
 train = ["wandb>=0.15.0", "xgboost"]
 eval = ["matplotlib", "openml"]
+relbench = ["relbench"]
 interpretability = ["shapiq>=1.0", "matplotlib"]
 dev = ["build", "pytest", "ruff"]
 

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from synthefy_nori.api import (
+    NoriClassifier,
     NoriRegressor,
     config_path,
     infer,
@@ -12,6 +13,7 @@ from synthefy_nori.api import (
 __version__ = "0.8.0"
 
 __all__ = [
+    "NoriClassifier",
     "NoriRegressor",
     "config_path",
     "infer",

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -7,10 +7,10 @@ from typing import Literal
 
 import numpy as np
 import torch
-from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 
 
-Task = Literal["regression", "reg"]
+Task = Literal["regression", "reg", "classification", "cls"]
 
 
 def config_path(filename: str) -> str:
@@ -222,6 +222,102 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         return out
 
 
+class NoriClassifier(ClassifierMixin, BaseEstimator):
+    """Scikit-learn classification estimator wrapping the Synthefy checkpoint.
+
+    Mirrors ``NoriRegressor`` for ``__init__``/device/model-path/config
+    plumbing, but drives the model's ``task_type='cls'`` head and returns
+    calibrated-ish class probabilities suitable for binary AUROC scoring.
+
+    Subclasses ``BaseEstimator``/``ClassifierMixin`` so it works with the
+    scikit-learn ecosystem (``clone``, ``get_params``/``set_params``,
+    ``score``). The ``__init__`` arguments are stored verbatim so ``clone``
+    round trips correctly.
+    """
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        *,
+        device=None,
+        inference_config: str | None = None,
+        token: str | bool | None = None,
+        augmentations: tuple[str, ...] | list[str] | None = ("yj",),
+        yj_skew_threshold: float = 10.0,
+        quantile_collapse: str = "mean",
+        bar_temperature: float = 1.0,
+        bar_point_estimator: str = "mean",
+    ) -> None:
+        self.model_path = model_path
+        self.device = device
+        self.token = token
+        self.inference_config = inference_config or config_path(
+            "reg_allordinal_poly10_adaptive_svd256.json"
+        )
+        self.augmentations = tuple(augmentations) if augmentations else ()
+        self.yj_skew_threshold = float(yj_skew_threshold)
+        self.quantile_collapse = quantile_collapse
+        self.bar_temperature = float(bar_temperature)
+        self.bar_point_estimator = bar_point_estimator
+        self._predictor = None
+
+    def fit(self, X, y):
+        self.X_train_ = np.asarray(X, dtype=np.float32)
+        self.n_features_in_ = self.X_train_.shape[1]
+        self.classes_, y_enc = np.unique(y, return_inverse=True)
+        self.y_train_ = y_enc.astype(np.int64)
+        self.n_classes_ = len(self.classes_)
+        return self
+
+    def _get_predictor(self):
+        if self._predictor is None:
+            from synthefy_nori.inference.predictor import NoriPredictor
+
+            self._predictor = NoriPredictor(
+                device=_as_device(self.device),
+                model_path=_resolve_model_path(self.model_path, self.token),
+                inference_config=self.inference_config,
+                augmentations=self.augmentations,
+                yj_skew_threshold=self.yj_skew_threshold,
+                quantile_collapse=self.quantile_collapse,
+                bar_temperature=self.bar_temperature,
+                bar_point_estimator=self.bar_point_estimator,
+            )
+        return self._predictor
+
+    def predict_proba(self, X):
+        """Return class probabilities, shape ``(n_test, n_classes_)``.
+
+        Rows sum to 1.0. The model's cls head is fixed at 10 classes; we slice
+        to the observed classes and renormalize so each row is a valid
+        probability vector over ``self.classes_``.
+        """
+        if not hasattr(self, "X_train_"):
+            raise ValueError("Call fit(X, y) before predict_proba(X).")
+
+        X_test = np.asarray(X, dtype=np.float32)
+        predictor = self._get_predictor()
+        y_int = self.y_train_.astype(np.int64)
+
+        proba_full = predictor.predict_cls(self.X_train_, y_int, X_test)
+        proba_full = np.asarray(proba_full, dtype=np.float64)
+        if proba_full.ndim == 1:
+            proba_full = proba_full[None, :]
+
+        # Slice the fixed 10-wide head down to the observed classes and
+        # renormalize each row to sum to 1.0.
+        proba = proba_full[:, : self.n_classes_]
+        row_sums = proba.sum(axis=1, keepdims=True)
+        row_sums = np.where(row_sums > 0.0, row_sums, 1.0)
+        proba = proba / row_sums
+        return proba
+
+    def predict(self, X):
+        """Return predicted class labels for the query rows."""
+        proba = self.predict_proba(X)
+        return self.classes_[np.argmax(proba, axis=1)]
+
+
 def infer(
     X_train,
     y_train,
@@ -232,10 +328,18 @@ def infer(
     token: str | bool | None = None,
     **kwargs,
 ):
-    """Fit on context rows and infer labels for query rows."""
+    """Fit on context rows and infer labels for query rows.
+
+    For classification tasks the returned array is the class-probability
+    matrix from ``predict_proba`` (shape ``(n_test, n_classes)``), suitable for
+    AUROC scoring; regression returns point predictions.
+    """
     if task in ("regression", "reg"):
         model = NoriRegressor(model_path=model_path, token=token, **kwargs).fit(X_train, y_train)
         return model.predict(X_test)
+    if task in ("classification", "cls"):
+        model = NoriClassifier(model_path=model_path, token=token, **kwargs).fit(X_train, y_train)
+        return model.predict_proba(X_test)
     raise ValueError(f"Unsupported task: {task!r}")
 
 

--- a/src/synthefy_nori/evaluation/benchmark_lists/relbench_entity.csv
+++ b/src/synthefy_nori/evaluation/benchmark_lists/relbench_entity.csv
@@ -1,0 +1,25 @@
+# RelBench entity tasks (classification + regression) across the seven canonical
+# RelBench datasets — the set tracked by the public leaderboard. Recommendation /
+# link-prediction tasks are excluded (not a tabular-model fit).
+# Format: dataset,task   (task_type is read from relbench at runtime)
+rel-amazon,user-churn
+rel-amazon,item-churn
+rel-amazon,user-ltv
+rel-amazon,item-ltv
+rel-avito,user-clicks
+rel-avito,user-visits
+rel-avito,ad-ctr
+rel-event,user-repeat
+rel-event,user-ignore
+rel-event,user-attendance
+rel-f1,driver-dnf
+rel-f1,driver-top3
+rel-f1,driver-position
+rel-hm,user-churn
+rel-hm,item-sales
+rel-stack,user-engagement
+rel-stack,user-badge
+rel-stack,post-votes
+rel-trial,study-outcome
+rel-trial,study-adverse
+rel-trial,site-success

--- a/src/synthefy_nori/evaluation/cli.py
+++ b/src/synthefy_nori/evaluation/cli.py
@@ -25,6 +25,21 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--talent-reg-dir", default="cache/talent_reg")
     parser.add_argument("--openml-reg", action="store_true",
                         help="Include the curated OpenML regression suite (downloads from OpenML)")
+    parser.add_argument("--relbench", action="store_true",
+                        help="Run the RelBench entity tasks (classification + regression) via the "
+                             "entity-table tabular protocol. Requires the 'relbench' extra. This is a "
+                             "self-contained suite: it ignores the TabArena/TALENT/OpenML loaders above "
+                             "and writes its own per-type results.")
+    parser.add_argument("--relbench-mode", choices=["entity", "temporal", "ds_sql"], default="entity",
+                        help="RelBench feature regime: 'entity' (entity-table merge only), "
+                             "'temporal' (adds per-entity temporal aggregations), or 'ds_sql' "
+                             "(RelBench's published Data-Scientist hand-engineered SQL features, "
+                             "run via DuckDB — model-vs-model comparison on identical features).")
+    parser.add_argument("--relbench-tasks", nargs="+", default=None,
+                        help="Subset of RelBench tasks as 'dataset/task' (default: the full pinned list).")
+    parser.add_argument("--relbench-out", default="results/relbench",
+                        help="Output directory for RelBench results (classification.csv, regression.csv, "
+                             "SUBMISSION.md).")
     parser.add_argument("--download-benchmarks", action="store_true",
                         help="Download the TabArena and TALENT regression CSV caches from OpenML first")
     parser.add_argument("--custom-reg-dir", default=None)
@@ -47,6 +62,29 @@ def main(argv: list[str] | None = None) -> None:
 
     import os
     os.environ.setdefault("SYNTHEFY_MAX_ELEMENTS_BUDGET", str(args.max_elements_budget))
+
+    if args.relbench:
+        from synthefy_nori.evaluation.relbench_tasks import load_task_list, run_suite
+
+        if args.relbench_tasks:
+            tasks = []
+            for spec in args.relbench_tasks:
+                ds, _, tk = spec.partition("/")
+                if not ds or not tk:
+                    parser.error(f"--relbench-tasks expects 'dataset/task', got {spec!r}")
+                tasks.append((ds, tk))
+        else:
+            tasks = load_task_list()
+        run_suite(
+            tasks,
+            mode=args.relbench_mode,
+            device=args.device,
+            inference_config=args.reg_config,
+            max_train=args.max_train_samples,
+            out_dir=args.relbench_out,
+            download=True,
+        )
+        return
 
     from synthefy_nori.evaluation.datasets import DatasetRegistry
     from synthefy_nori.evaluation.models import ModelRegistry

--- a/src/synthefy_nori/evaluation/relbench_tasks.py
+++ b/src/synthefy_nori/evaluation/relbench_tasks.py
@@ -1,0 +1,696 @@
+"""Run Nori on the RelBench entity tasks (classification + regression).
+
+RelBench (https://relbench.stanford.edu) is a relational deep-learning
+benchmark. Tabular foundation models join its leaderboard via the *entity-table
+tabular protocol*: each predictive task is flattened into a single feature table
+(the task's train/val/test rows merged with their entity table), which a tabular
+model then fits in-context. This module implements that protocol for Nori across
+the seven canonical RelBench datasets, covering the binary-classification
+(AUROC) and regression (MAE) entity tasks. Recommendation / link-prediction
+tasks are out of scope for a tabular model and are skipped.
+
+Two feature regimes are supported, gated by ``mode``:
+
+* ``"entity"`` (Phase 1) — merge each task row with its entity table only. This
+  is RelBench's out-of-the-box tabular baseline (the regime TabPFN is listed
+  under on the leaderboard).
+* ``"temporal"`` (Phase 2) — additionally synthesize per-entity temporal
+  aggregations from related tables, computed strictly before each row's
+  timestamp to avoid leakage. Implemented per-dataset in ``TEMPORAL_BUILDERS``.
+
+Scoring uses RelBench's own ``task.evaluate`` so metrics match the leaderboard
+exactly: validation is scored locally (labels available) and the held-out test
+split is scored against RelBench's hidden labels.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import traceback
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from importlib.resources import files
+from typing import Optional
+
+import duckdb
+import jinja2
+import numpy as np
+import pandas as pd
+from sklearn.feature_selection import mutual_info_classif, mutual_info_regression
+from sklearn.preprocessing import LabelEncoder
+
+from relbench.base import TaskType
+from relbench.datasets import get_dataset
+from relbench.tasks import get_task
+
+from synthefy_nori.api import NoriClassifier, NoriRegressor
+
+# The seven canonical RelBench datasets and their entity (non-recommendation)
+# tasks — the set tracked by the public leaderboard. Used as a fallback when the
+# packaged list file is unavailable; the authoritative copy lives in
+# ``benchmark_lists/relbench_entity.csv``.
+DEFAULT_ENTITY_TASKS: tuple[tuple[str, str], ...] = (
+    ("rel-amazon", "user-churn"),
+    ("rel-amazon", "item-churn"),
+    ("rel-amazon", "user-ltv"),
+    ("rel-amazon", "item-ltv"),
+    ("rel-avito", "user-clicks"),
+    ("rel-avito", "user-visits"),
+    ("rel-avito", "ad-ctr"),
+    ("rel-event", "user-repeat"),
+    ("rel-event", "user-ignore"),
+    ("rel-event", "user-attendance"),
+    ("rel-f1", "driver-dnf"),
+    ("rel-f1", "driver-top3"),
+    ("rel-f1", "driver-position"),
+    ("rel-hm", "user-churn"),
+    ("rel-hm", "item-sales"),
+    ("rel-stack", "user-engagement"),
+    ("rel-stack", "user-badge"),
+    ("rel-stack", "post-votes"),
+    ("rel-trial", "study-outcome"),
+    ("rel-trial", "study-adverse"),
+    ("rel-trial", "site-success"),
+)
+
+# Max numeric columns to aggregate per related fact table (keeps the feature
+# count bounded on wide tables). Override via SYNTHEFY_RELBENCH_MAX_AGG_COLS.
+_MAX_AGG_COLS = int(os.environ.get("SYNTHEFY_RELBENCH_MAX_AGG_COLS", "12"))
+
+# Relational hops to traverse for temporal features: 1 = entity<-fact only,
+# 2 = also entity<-fact->dimension (DFS-style multi-hop). Default 1: across the
+# suite, generic 2-hop aggregates did not improve accuracy (even with feature
+# selection) and the entity->fact->dimension join does not scale to the largest
+# fact tables (e.g. rel-hm transactions). Override via SYNTHEFY_RELBENCH_HOPS.
+_MAX_HOPS = int(os.environ.get("SYNTHEFY_RELBENCH_HOPS", "1"))
+
+# Keep at most this many features (top-k by mutual information on the train
+# split). DFS generates many aggregates; unlike GBDTs, Nori's ICL has no built-in
+# feature selection, so we filter to the most informative before inference.
+# 0 disables. Override via SYNTHEFY_RELBENCH_TOPK.
+_TOPK_FEATURES = int(os.environ.get("SYNTHEFY_RELBENCH_TOPK", "128"))
+
+
+def _select_features(Xtr, ytr, eval_arrays, is_cls, k):
+    """Keep the top-``k`` features by mutual information with the target.
+
+    Fit the selector on the (already subsampled) train split and apply the same
+    column subset to every eval array. No-op when there are <= k features.
+    """
+    if not k or Xtr.shape[1] <= k:
+        return Xtr, eval_arrays
+    n = min(len(Xtr), 8000)  # cap rows for MI estimation speed
+    rng = np.random.default_rng(0)
+    ridx = rng.choice(len(Xtr), n, replace=False) if len(Xtr) > n else np.arange(len(Xtr))
+    scorer = mutual_info_classif if is_cls else mutual_info_regression
+    mi = scorer(Xtr[ridx], ytr[ridx], random_state=0)
+    cols = np.argsort(mi)[-k:]
+    return Xtr[:, cols], [Xe[:, cols] for Xe in eval_arrays]
+
+
+def _numeric_feature_cols(table) -> list[str]:
+    """Numeric, non-key columns of a table that are meaningful to aggregate."""
+    keys = set(table.fkey_col_to_pkey_table.keys())
+    if table.pkey_col:
+        keys.add(table.pkey_col)
+    if table.time_col:
+        keys.add(table.time_col)
+    cols = [
+        c for c in table.df.columns
+        if c not in keys and pd.api.types.is_numeric_dtype(table.df[c])
+    ]
+    return cols[:_MAX_AGG_COLS]
+
+
+def _asof_aggregate(base, right, by_key, time_key, entity_col, time_col, prefix, num_cols):
+    """As-of cumulative aggregation of ``right`` onto ``base`` rows.
+
+    For each base (entity, seed_time), looks back over ``right`` rows for that
+    entity occurring **strictly before** seed_time and returns event count,
+    recency (days since the last), and the running sum / mean / latest of every
+    ``num_cols`` value. Returns a DataFrame keyed by ``_row``. Leakage-safe
+    (``allow_exact_matches=False``) and O(n log n) via ``merge_asof``.
+    """
+    right = right.dropna(subset=[by_key]).copy()
+    if right.empty:
+        return None
+    right[by_key] = pd.to_numeric(right[by_key], errors="coerce").astype("int64")
+    right[time_key] = pd.to_datetime(right[time_key]).astype("datetime64[ns]")
+    right = right.sort_values(time_key, kind="stable")
+    grp = right.groupby(by_key, sort=False)
+    # DFS aggregation primitives, accumulated chronologically per entity so an
+    # as-of join yields the value over all events strictly before the seed time:
+    # count, sum, running max/min, and sum-of-squares (for std). mean/std derive
+    # from these; last = the as-of row's own value; recency from its timestamp.
+    right[f"{prefix}__cnt"] = grp.cumcount() + 1
+    for c in num_cols:
+        right[f"{prefix}__sum_{c}"] = grp[c].cumsum()
+        right[f"{prefix}__sq_{c}"] = grp[c].transform(lambda s: (s * s).cumsum())
+        right[f"{prefix}__max_{c}"] = grp[c].cummax()
+        right[f"{prefix}__min_{c}"] = grp[c].cummin()
+
+    merged = pd.merge_asof(
+        base, right,
+        left_on=time_col, right_on=time_key,
+        left_by=entity_col, right_by=by_key,
+        direction="backward", allow_exact_matches=False,
+    )
+    out = pd.DataFrame({"_row": merged["_row"].to_numpy()})
+    cnt = merged[f"{prefix}__cnt"]
+    out[f"{prefix}__cnt"] = cnt.fillna(0).to_numpy()
+    out[f"{prefix}__recency_days"] = (merged[time_col] - merged[time_key]).dt.days.to_numpy()
+    for c in num_cols:
+        csum = merged[f"{prefix}__sum_{c}"]
+        mean = csum / cnt
+        var = (merged[f"{prefix}__sq_{c}"] / cnt) - (mean * mean)
+        out[f"{prefix}__sum_{c}"] = csum.to_numpy()
+        out[f"{prefix}__mean_{c}"] = mean.to_numpy()
+        out[f"{prefix}__max_{c}"] = merged[f"{prefix}__max_{c}"].to_numpy()
+        out[f"{prefix}__min_{c}"] = merged[f"{prefix}__min_{c}"].to_numpy()
+        out[f"{prefix}__std_{c}"] = np.sqrt(var.clip(lower=0)).to_numpy()
+        out[f"{prefix}__last_{c}"] = merged[c].to_numpy()
+    return out
+
+
+def add_temporal_features(task, db, base_df: pd.DataFrame) -> pd.DataFrame:
+    """Append leakage-safe per-entity temporal aggregations to ``base_df``.
+
+    Walks the schema from the task's entity table and aggregates related events
+    occurring **strictly before** each row's seed timestamp:
+
+    * **1-hop:** every fact table with a foreign key into the entity table —
+      event count, recency, and running sum/mean/latest of its numeric columns.
+    * **2-hop (DFS-style):** for each such fact table that *also* references a
+      dimension table, the dimension's numeric attributes are joined in and
+      aggregated over the entity's history (e.g. the price/attributes of the
+      items a user bought). This cross-table signal is what the strong
+      TabPFN+DFS tabular baseline on the RelBench leaderboard relies on.
+
+    All aggregation is via ``merge_asof`` (``allow_exact_matches=False``), so it
+    is leakage-safe and scales to multi-million-row tables. One generic pass
+    covers all seven datasets.
+    """
+    entity_col, time_col = task.entity_col, task.time_col
+    entity_table = task.entity_table
+    if time_col not in base_df.columns:
+        return base_df
+
+    # Stable key to merge aggregates back onto base_df rows. merge_asof requires
+    # the `by` keys to share an exact dtype and the `on` keys to be comparable,
+    # so normalize entity ids to int64 and timestamps to datetime64[ns].
+    base = base_df[[entity_col, time_col]].copy()
+    base[entity_col] = pd.to_numeric(base[entity_col], errors="coerce").astype("int64")
+    base[time_col] = pd.to_datetime(base[time_col]).astype("datetime64[ns]")
+    base["_row"] = np.arange(len(base))
+    base = base.sort_values(time_col, kind="stable")
+
+    feat_frames: list[pd.DataFrame] = []
+    for fname, ftable in db.table_dict.items():
+        if fname == entity_table or ftable.time_col is None:
+            continue
+        fks = [c for c, tab in ftable.fkey_col_to_pkey_table.items() if tab == entity_table]
+        if not fks:
+            continue
+        ftime = ftable.time_col
+        fnum = _numeric_feature_cols(ftable)
+        for fk in fks:
+            # 1-hop: aggregate the fact table's own numeric columns.
+            cols = [fk, ftime] + fnum
+            out = _asof_aggregate(base, ftable.df[cols], fk, ftime, entity_col,
+                                  time_col, f"{fname}.{fk}", fnum)
+            if out is not None:
+                feat_frames.append(out)
+
+            # 2-hop: for each other dimension this fact references, join the
+            # dimension's numeric attributes and aggregate over the entity's
+            # history (DFS-style entity -> fact -> dimension).
+            if _MAX_HOPS < 2:
+                continue
+            for dk, dtab_name in ftable.fkey_col_to_pkey_table.items():
+                if dk == fk or dtab_name == entity_table or dtab_name not in db.table_dict:
+                    continue
+                dtab = db.table_dict[dtab_name]
+                dnum = _numeric_feature_cols(dtab)
+                if not dnum or not dtab.pkey_col:
+                    continue
+                left = ftable.df[[fk, ftime, dk]]
+                right2 = left.merge(
+                    dtab.df[[dtab.pkey_col] + dnum].rename(columns={c: f"{dtab_name}_{c}" for c in dnum}),
+                    left_on=dk, right_on=dtab.pkey_col, how="left",
+                )
+                dcols = [f"{dtab_name}_{c}" for c in dnum]
+                out2 = _asof_aggregate(base, right2[[fk, ftime] + dcols], fk, ftime,
+                                       entity_col, time_col, f"{fname}.{fk}.{dtab_name}", dcols)
+                if out2 is not None:
+                    feat_frames.append(out2)
+
+    if not feat_frames:
+        return base_df
+    feats = feat_frames[0]
+    for f in feat_frames[1:]:
+        feats = feats.merge(f, on="_row", how="outer")
+    feats = feats.sort_values("_row").drop(columns="_row").reset_index(drop=True)
+    return pd.concat([base_df.reset_index(drop=True), feats], axis=1)
+
+
+@dataclass
+class TaskResult:
+    dataset: str
+    task: str
+    task_type: str
+    n_train: int = 0
+    n_val: int = 0
+    n_test: int = 0
+    n_features: int = 0
+    latency_ms: float = 0.0
+    metrics: dict[str, float] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def row(self) -> dict:
+        r = {
+            "dataset": self.dataset,
+            "task": self.task,
+            "task_type": self.task_type,
+            "n_train": self.n_train,
+            "n_val": self.n_val,
+            "n_test": self.n_test,
+            "n_features": self.n_features,
+            "latency_ms": round(self.latency_ms, 1),
+            "error": self.error or "",
+        }
+        r.update({k: v for k, v in self.metrics.items()})
+        return r
+
+
+def load_task_list(list_path: Optional[str] = None) -> list[tuple[str, str]]:
+    """Read the pinned ``dataset,task`` list, falling back to the constant."""
+    path = list_path
+    if not path:
+        try:
+            packaged = files("synthefy_nori.evaluation.benchmark_lists") / "relbench_entity.csv"
+            if packaged.is_file():
+                path = str(packaged)
+        except Exception:
+            path = None
+    if not path or not os.path.exists(path):
+        return list(DEFAULT_ENTITY_TASKS)
+    tasks: list[tuple[str, str]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 2 and parts[0] and parts[1]:
+                tasks.append((parts[0], parts[1]))
+    return tasks or list(DEFAULT_ENTITY_TASKS)
+
+
+def _key_columns(task, entity_table) -> set[str]:
+    """Columns that are primary/foreign keys or join/time/target — not features."""
+    keys = {task.entity_col, task.time_col, task.target_col}
+    if entity_table.pkey_col:
+        keys.add(entity_table.pkey_col)
+    keys.update(entity_table.fkey_col_to_pkey_table.keys())
+    return keys
+
+
+# RelBench's published "Data Scientist" hand-engineered SQL features
+# (snap-stanford/relbench-user-study). Running these and feeding them to Nori
+# gives a model-vs-model comparison against LightGBM on identical features.
+_DS_SQL_BASE = "https://raw.githubusercontent.com/snap-stanford/relbench-user-study/main"
+_DS_SQL_CACHE = "cache/relbench_ds_sql"
+
+
+def fetch_ds_feats_sql(dataset_name: str, task_name: str) -> Optional[str]:
+    """Fetch (and cache) the task's hand-written feats.sql, or None if absent."""
+    short = dataset_name.replace("rel-", "")
+    local = os.path.join(_DS_SQL_CACHE, short, task_name, "feats.sql")
+    if os.path.exists(local):
+        with open(local, "r", encoding="utf-8") as f:
+            return f.read()
+    url = f"{_DS_SQL_BASE}/{short}/{task_name}/feats.sql"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            text = resp.read().decode("utf-8")
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return None
+    os.makedirs(os.path.dirname(local), exist_ok=True)
+    with open(local, "w", encoding="utf-8") as f:
+        f.write(text)
+    return text
+
+
+def build_ds_sql_features(dataset_name, task_name, task, db, split, sql_text):
+    """Run the task's Data-Scientist SQL in DuckDB and return ``(X_df, y)``.
+
+    Registers the RelBench base tables and the label splits, renders the
+    Jinja-templated query for ``split`` (no subsampling), executes it, then
+    re-aligns the result to ``task.get_table(split)`` row order (DuckDB joins do
+    not preserve order) so predictions line up with ``task.evaluate``. The SQL's
+    per-row ``timestamp > event_time`` cutoffs make it leakage-safe by design.
+    """
+    con = duckdb.connect()
+    try:
+        for name, t in db.table_dict.items():
+            con.register(name, t.df)
+        task_us = task_name.replace("-", "_")
+        for s in ("train", "val", "test"):
+            con.register(f"{task_us}_{s}", task.get_table(s).df)
+        rendered = jinja2.Template(sql_text).render(set=split, subsample=0)
+        con.execute(rendered)
+        feats = con.execute(f"SELECT * FROM {task_us}_{split}_feats").df()
+    finally:
+        con.close()
+
+    # Re-align to the canonical task-table order via the (entity, time) key.
+    ekey, tkey = task.entity_col, task.time_col
+    canon = task.get_table(split).df[[ekey, tkey]].copy()
+    feats = feats.drop_duplicates(subset=[ekey, tkey])
+    merged = canon.merge(feats, on=[ekey, tkey], how="left")
+    y = merged[task.target_col].to_numpy() if task.target_col in merged.columns else None
+    drop = {ekey, tkey, task.target_col}
+    feature_cols = [c for c in merged.columns if c not in drop]
+    return merged[feature_cols], y
+
+
+def build_feature_table(task, db, split: str, mode: str = "entity"):
+    """Flatten a RelBench entity task split into ``(X_df, y)`` (``y`` may be None).
+
+    ``mode="entity"`` merges the task rows with their entity table only;
+    ``mode="temporal"`` additionally applies the dataset's temporal builder.
+    """
+    table = task.get_table(split)  # test split is label-masked by RelBench
+    df = table.df.copy()
+
+    entity_table = db.table_dict[task.entity_table]
+    ent_df = entity_table.df.copy()
+    pk = entity_table.pkey_col
+    df = df.merge(
+        ent_df, how="left", left_on=task.entity_col, right_on=pk, suffixes=("", "__ent")
+    )
+
+    if mode == "temporal":
+        df = add_temporal_features(task, db, df)
+
+    y = df[task.target_col].to_numpy() if task.target_col in df.columns else None
+
+    drop = _key_columns(task, entity_table) | {pk}
+    feature_cols = [c for c in df.columns if c not in drop]
+    return df[feature_cols], y
+
+
+def _encode(train_df: pd.DataFrame, eval_dfs: list[pd.DataFrame]) -> list[np.ndarray]:
+    """Numeric-encode features, fitting category/datetime maps on all splits.
+
+    Mirrors ``DatasetRegistry._make_entry_from_df`` so the relational path
+    matches the established CSV path: label-encode object/category/string
+    columns (shared vocabulary across splits), convert datetimes to int64,
+    coerce the rest to numeric, fill NaN with 0, cast to float32. Returns the
+    encoded train array followed by one array per eval frame.
+    """
+    frames = [train_df] + eval_dfs
+    combined = pd.concat(frames, axis=0, ignore_index=True)
+
+    # Booleans (incl. pandas nullable 'boolean') -> object so the later
+    # to_numeric coerces True/False -> 1/0 and NA -> NaN. Without this, the
+    # final fillna(0) raises "Invalid value '0' for dtype boolean".
+    for col in combined.columns:
+        if combined[col].dtype == bool or str(combined[col].dtype) == "boolean":
+            for fr in frames:
+                if col in fr.columns:
+                    fr[col] = fr[col].astype(object)
+            combined[col] = combined[col].astype(object)
+
+    # Datetime -> int64 nanoseconds (keep the temporal signal as a feature).
+    for col in combined.select_dtypes(include=["datetime", "datetimetz"]).columns:
+        for fr in frames:
+            if col in fr.columns:
+                fr[col] = pd.to_datetime(fr[col], errors="coerce").astype("int64")
+        combined[col] = pd.to_datetime(combined[col], errors="coerce").astype("int64")
+
+    # Label-encode strings/categoricals with a shared vocabulary.
+    for col in list(combined.select_dtypes(include=["object", "category", "string"]).columns):
+        try:
+            le = LabelEncoder()
+            le.fit(combined[col].astype(object).fillna("__MISSING__").astype(str))
+            for fr in frames:
+                if col in fr.columns:
+                    fr[col] = le.transform(fr[col].astype(object).fillna("__MISSING__").astype(str))
+        except Exception:
+            for fr in frames:
+                if col in fr.columns:
+                    fr.drop(columns=[col], inplace=True, errors="ignore")
+
+    out = []
+    for fr in frames:
+        arr = fr.apply(pd.to_numeric, errors="coerce").fillna(0).astype(np.float32).to_numpy()
+        out.append(arr)
+    return out
+
+
+def _subsample(X: np.ndarray, y: np.ndarray, max_rows: int, *, stratify: bool = False, seed: int = 0):
+    """Subsample context rows to ``max_rows``.
+
+    For classification (``stratify=True``) the context is balanced across
+    classes rather than sampled uniformly: with a uniform 50k draw on a
+    rare-positive task (churn / DNF) Nori's in-context learner sees almost no
+    positives and ranks near-randomly. Balancing the context surfaces the
+    minority signal; AUROC is rank-based, so re-balancing the prior does not
+    distort the well-behaved tasks.
+    """
+    n = len(X)
+    if not max_rows or n <= max_rows:
+        return X, y
+    rng = np.random.default_rng(seed)
+    if not stratify:
+        idx = rng.choice(n, max_rows, replace=False)
+        return X[idx], y[idx]
+
+    classes = np.unique(y)
+    per_class = max(1, max_rows // len(classes))
+    picks = []
+    for c in classes:
+        ci = np.where(y == c)[0]
+        picks.append(rng.choice(ci, min(len(ci), per_class), replace=False))
+    idx = np.concatenate(picks)
+    if len(idx) < max_rows:  # a class was smaller than its quota — backfill
+        remaining = np.setdiff1d(np.arange(n), idx, assume_unique=False)
+        if len(remaining):
+            extra = rng.choice(remaining, min(len(remaining), max_rows - len(idx)), replace=False)
+            idx = np.concatenate([idx, extra])
+    rng.shuffle(idx)
+    return X[idx], y[idx]
+
+
+def run_task(
+    dataset_name: str,
+    task_name: str,
+    *,
+    mode: str = "entity",
+    device: str = "cuda:0",
+    inference_config: Optional[str] = None,
+    max_train: int = 50000,
+    download: bool = True,
+) -> TaskResult:
+    """Run one RelBench entity task end-to-end and score val + hidden test."""
+    task = get_task(dataset_name, task_name, download=download)
+    task_type = str(task.task_type).split(".")[-1]
+    res = TaskResult(dataset=dataset_name, task=task_name, task_type=task_type)
+
+    if task.task_type not in (TaskType.BINARY_CLASSIFICATION, TaskType.REGRESSION):
+        res.error = f"unsupported task_type {task_type} (tabular path covers cls/reg only)"
+        return res
+
+    try:
+        dataset = get_dataset(dataset_name, download=download)
+        db = dataset.get_db()
+
+        if mode == "ds_sql":
+            sql_text = fetch_ds_feats_sql(dataset_name, task_name)
+            if sql_text is None:
+                res.error = "no Data-Scientist feats.sql published for this task"
+                return res
+            Xtr_df, ytr = build_ds_sql_features(dataset_name, task_name, task, db, "train", sql_text)
+            Xval_df, yval = build_ds_sql_features(dataset_name, task_name, task, db, "val", sql_text)
+            Xte_df, _ = build_ds_sql_features(dataset_name, task_name, task, db, "test", sql_text)
+        else:
+            Xtr_df, ytr = build_feature_table(task, db, "train", mode)
+            Xval_df, yval = build_feature_table(task, db, "val", mode)
+            Xte_df, _ = build_feature_table(task, db, "test", mode)
+
+        # Align to the features available in every split. RelBench masks extra
+        # input columns in the test table, so train/val can carry columns the
+        # model would never see at inference — restrict to the common set (in
+        # train order) so fit and predict use an identical, inference-available
+        # feature schema.
+        common = [c for c in Xtr_df.columns if c in set(Xval_df.columns) & set(Xte_df.columns)]
+        Xtr_df, Xval_df, Xte_df = Xtr_df[common], Xval_df[common], Xte_df[common]
+        Xtr, Xval, Xte = _encode(Xtr_df, [Xval_df, Xte_df])
+
+        res.n_train, res.n_val, res.n_test = len(Xtr), len(Xval), len(Xte)
+        res.n_features = Xtr.shape[1] if Xtr.ndim > 1 else 1
+
+        is_cls = task.task_type == TaskType.BINARY_CLASSIFICATION
+        Xtr_s, ytr_s = _subsample(Xtr, ytr, max_train, stratify=is_cls)
+        Xtr_s, (Xval, Xte) = _select_features(Xtr_s, ytr_s, (Xval, Xte), is_cls, _TOPK_FEATURES)
+        res.n_features = Xtr_s.shape[1] if Xtr_s.ndim > 1 else 1
+
+        t0 = time.time()
+        cls = NoriClassifier if is_cls else NoriRegressor
+        model = cls(device=device, inference_config=inference_config).fit(Xtr_s, ytr_s)
+        # The predictor chunks the forward over the (large) RelBench eval splits
+        # internally; chunk_size is sequence-capped so it stays under the CUDA
+        # grid limit even with these few-feature tables.
+        if is_cls:
+            val_pred = model.predict_proba(Xval)[:, 1]   # positive-class score for AUROC
+            test_pred = model.predict_proba(Xte)[:, 1]
+        else:
+            val_pred = model.predict(Xval)
+            test_pred = model.predict(Xte)
+        res.latency_ms = (time.time() - t0) * 1000.0
+
+        val_metrics = task.evaluate(val_pred, task.get_table("val"))
+        test_metrics = task.evaluate(test_pred)
+        for k, v in val_metrics.items():
+            res.metrics[f"val_{k}"] = float(v)
+        for k, v in test_metrics.items():
+            res.metrics[f"test_{k}"] = float(v)
+        # NMAE = MAE / train-split std — the RelBench leaderboard's regression
+        # metric, so the reported number is directly comparable to it.
+        if not is_cls:
+            train_std = float(np.std(ytr))
+            if train_std > 0:
+                res.metrics["test_nmae"] = float(test_metrics.get("mae", np.nan)) / train_std
+                res.metrics["val_nmae"] = float(val_metrics.get("mae", np.nan)) / train_std
+    except Exception as e:  # noqa: BLE001 — record and continue the suite
+        res.error = f"{type(e).__name__}: {e}".replace("\n", " | ")[:300]
+        res.metrics["_traceback"] = traceback.format_exc()[-2000:]
+    return res
+
+
+def run_suite(
+    tasks: Optional[list[tuple[str, str]]] = None,
+    *,
+    mode: str = "entity",
+    device: str = "cuda:0",
+    inference_config: Optional[str] = None,
+    max_train: int = 50000,
+    out_dir: str = "results/relbench",
+    download: bool = True,
+) -> dict[str, pd.DataFrame]:
+    """Run the RelBench entity suite, writing per-type CSVs + a submission doc.
+
+    Returns a dict with ``classification`` and ``regression`` DataFrames.
+    Honors the dataset-crash-reporting rule: failed tasks are kept (with their
+    error) and the crash count is printed in the summary.
+    """
+    tasks = tasks or load_task_list()
+    os.makedirs(out_dir, exist_ok=True)
+
+    results: list[TaskResult] = []
+    for i, (ds, tk) in enumerate(tasks, 1):
+        print(f"[relbench {i}/{len(tasks)}] {ds}/{tk} (mode={mode}) ...", flush=True)
+        res = run_task(
+            ds, tk, mode=mode, device=device,
+            inference_config=inference_config, max_train=max_train, download=download,
+        )
+        if res.error:
+            print(f"  CRASH {ds}/{tk}: {res.error}", flush=True)
+        else:
+            headline = res.metrics.get("test_roc_auc", res.metrics.get("test_mae"))
+            print(f"  ok {ds}/{tk}: test={headline:.4f}  ({res.latency_ms:.0f} ms)", flush=True)
+        results.append(res)
+
+    rows = [r.row() for r in results]
+    # Drop the bulky traceback column from the saved tables (kept only in-memory).
+    for row in rows:
+        row.pop("_traceback", None)
+    df = pd.DataFrame(rows)
+
+    cls_df = df[df["task_type"] == "BINARY_CLASSIFICATION"].copy()
+    reg_df = df[df["task_type"] == "REGRESSION"].copy()
+    cls_path = os.path.join(out_dir, "classification.csv")
+    reg_path = os.path.join(out_dir, "regression.csv")
+    cls_df.to_csv(cls_path, index=False)
+    reg_df.to_csv(reg_path, index=False)
+
+    _write_submission(cls_df, reg_df, results, mode, out_dir)
+
+    n_crash = sum(1 for r in results if r.error)
+    print("\n=== RelBench summary ===")
+    print(f"  tasks run: {len(results)}  |  crashed: {n_crash}  |  ok: {len(results) - n_crash}")
+    ok_cls = cls_df[cls_df["error"] == ""]
+    ok_reg = reg_df[reg_df["error"] == ""]
+    if len(ok_cls) and "test_roc_auc" in ok_cls:
+        print(f"  classification: {len(ok_cls)} tasks  mean test AUROC = {ok_cls['test_roc_auc'].mean():.4f}")
+    if len(ok_reg) and "test_mae" in ok_reg:
+        print(f"  regression:     {len(ok_reg)} tasks  mean test MAE  = {ok_reg['test_mae'].mean():.4f}")
+    print(f"  wrote {cls_path}, {reg_path}, {os.path.join(out_dir, 'SUBMISSION.md')}")
+    return {"classification": cls_df, "regression": reg_df}
+
+
+def _write_submission(cls_df, reg_df, results, mode, out_dir) -> None:
+    regime = "Tabular (entity-table)" if mode == "entity" else "Tabular (temporal)"
+    n_crash = sum(1 for r in results if r.error)
+    lines = [
+        "# Nori on RelBench — submission package",
+        "",
+        f"**Method:** Nori  ·  **Regime:** {regime}  ·  "
+        f"**Protocol:** entity-table tabular flattening + in-context learning.",
+        "",
+        "Metrics are computed with RelBench's own `task.evaluate` (validation "
+        "scored locally; test scored against RelBench's hidden labels), so they "
+        "match the leaderboard definitions: **AUROC** for classification, "
+        "**MAE** for regression (the public leaderboard reports normalized MAE).",
+        "",
+        f"Tasks attempted: {len(results)}  ·  crashed: {n_crash}  ·  "
+        f"ok: {len(results) - n_crash}.",
+        "",
+        "## Classification (AUROC ↑)",
+        "",
+        "| Dataset | Task | Val AUROC | Test AUROC |",
+        "|---|---|---:|---:|",
+    ]
+    for _, r in cls_df.iterrows():
+        if r["error"]:
+            lines.append(f"| {r['dataset']} | {r['task']} | — | _crashed_ |")
+        else:
+            lines.append(
+                f"| {r['dataset']} | {r['task']} | "
+                f"{r.get('val_roc_auc', float('nan')):.4f} | {r.get('test_roc_auc', float('nan')):.4f} |"
+            )
+    lines += [
+        "",
+        "## Regression (MAE ↓)",
+        "",
+        "| Dataset | Task | Val MAE | Test MAE | Test R² |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for _, r in reg_df.iterrows():
+        if r["error"]:
+            lines.append(f"| {r['dataset']} | {r['task']} | — | _crashed_ | — |")
+        else:
+            lines.append(
+                f"| {r['dataset']} | {r['task']} | "
+                f"{r.get('val_mae', float('nan')):.4f} | {r.get('test_mae', float('nan')):.4f} | "
+                f"{r.get('test_r2', float('nan')):.4f} |"
+            )
+    lines += [
+        "",
+        "## Submitting to the leaderboard",
+        "",
+        "RelBench has **no self-service submission endpoint** at this time. The "
+        "leaderboard (https://huggingface.co/spaces/relbench/leaderboard) is a "
+        "maintainer-generated static page and is being redesigned ("
+        "\"expecting submissions in the near future\"). `CONTRIBUTING.md` covers "
+        "contributing datasets/tasks, not results. To submit these numbers, open "
+        "an issue/PR on https://github.com/snap-stanford/relbench referencing "
+        "this package and the tables above, and watch the leaderboard banner for "
+        "the redesign going live.",
+        "",
+    ]
+    with open(os.path.join(out_dir, "SUBMISSION.md"), "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -495,6 +495,32 @@ class NoriPredictor:
             preds = self._maybe_snap_discrete_y(y_train, preds)
         return preds
 
+    def predict_cls(self, x_train: np.ndarray, y_train_int: np.ndarray,
+                    x_test: np.ndarray) -> np.ndarray:
+        """Classification inference: return class probabilities.
+
+        Args:
+            x_train: Training features, shape [n_train, n_features].
+            y_train_int: Integer class labels in 0..K-1, shape [n_train].
+            x_test: Query features, shape [n_test, n_features].
+
+        Returns the temperatured-softmax probabilities over the model's full
+        cls head (num_classes=10), shape [n_test, 10]. The caller slices to the
+        observed classes and renormalizes. Shares the regression inference loop
+        via _predict_reg_single(..., task_type="cls"), which returns the
+        ensemble-averaged class logits without regression collapse.
+        """
+        logits = self._predict_reg_single(
+            x_train, y_train_int, x_test, task_type="cls",
+        )
+        if not torch.is_tensor(logits):
+            logits = torch.as_tensor(logits)
+        if logits.ndim == 1:
+            logits = logits.unsqueeze(0)
+        temperature = float(getattr(self, "softmax_temperature", 1.0)) or 1.0
+        proba = torch.softmax(logits.float() / temperature, dim=-1)
+        return proba.detach().cpu().numpy()
+
     @staticmethod
     def _unwrap_model_output(output, *, task_type: str):
         """Normalize model forward outputs across training/inference contracts.
@@ -963,7 +989,8 @@ class NoriPredictor:
             return base_pred
 
     def _predict_reg_single(self, x_train:np.ndarray, y_train:np.ndarray, x_test:np.ndarray,
-                            return_distribution: bool = False) -> np.ndarray:
+                            return_distribution: bool = False,
+                            task_type: str = "reg") -> np.ndarray:
         # Check size constraints to avoid OOM
         n_features = x_train.shape[1] if x_train.ndim > 1 else 1
         n_samples_train = x_train.shape[0]
@@ -1014,7 +1041,7 @@ class NoriPredictor:
                     feature_attention_score, sample_attention_score = step.inference(X_train=x_train_.astype(np.float32),
                                                                                      y_train=y_.astype(np.float32),
                                                                                      X_test=x_test_.astype(np.float32),
-                                                                                     task_type="reg",device=self.device)
+                                                                                     task_type=task_type,device=self.device)
                     
                 elif isinstance(step, SubSampleData):
                     step.fit(torch.from_numpy(x_train_), torch.from_numpy(y_train),
@@ -1058,7 +1085,7 @@ class NoriPredictor:
                                                  "use_cluster", False),
                                              cluster_num=self.inference_config[id_pipe]["retrieval_config"].get(
                                                  "cluster_num", 20),
-                                             task_type="reg",
+                                             task_type=task_type,
                                              use_threshold=self.inference_config[id_pipe]["retrieval_config"].get(
                                                  "use_threshold", False),
                                              threshold=self.inference_config[id_pipe]["retrieval_config"].get(
@@ -1070,7 +1097,7 @@ class NoriPredictor:
                 inference = InferenceResultWithRetrieval(model=self.model,
                                                          sample_selection_type="DDP")
                 output = inference.inference(x_[:len(y_train)].squeeze(1), y_, x_[len(y_train):].squeeze(1),
-                                             task_type="reg")
+                                             task_type=task_type)
                 outputs.append(output)
             if not self.inference_config[id_pipe]["retrieval_config"]["use_retrieval"] and not self.inference_with_DDP:
                 # Calculate max allowed test samples per batch to avoid OOM.
@@ -1078,6 +1105,18 @@ class NoriPredictor:
                 # Use the post-HighDimFeatureSelector feature count — the model
                 # never sees the raw count when the config reduces dimensionality.
                 chunk_size = max(256, (MAX_ELEMENTS_BUDGET // budget_n_features) - n_samples_train)
+
+                # Also bound the chunk by a max sequence length. The per-forward
+                # sequence is (n_samples_train + chunk_size); a CUDA kernel grid
+                # dimension is tied to it and overflows the 65535 grid-dim limit
+                # ("invalid configuration argument") on long sequences. This is
+                # only reachable when budget_n_features is small (few features),
+                # which lets the element-budget chunk above grow huge — e.g. flat
+                # RelBench entity tables. With many features the element budget
+                # already yields a far smaller chunk, so this cap is a no-op for
+                # the standard tabular benchmarks. Override via SYNTHEFY_MAX_SEQ_LEN.
+                max_seq_len = int(os.environ.get("SYNTHEFY_MAX_SEQ_LEN", "60000"))
+                chunk_size = min(chunk_size, max(256, max_seq_len - n_samples_train))
 
                 # --- Cached train-KV fast path (ON by default) ---
                 # Numerically equivalent to the chunked path below (cache==chunked,
@@ -1090,7 +1129,8 @@ class NoriPredictor:
                 # SYNTHEFY_DISABLE_CACHED_INFERENCE=1 kill switch.
                 bare_model = self.model.module if hasattr(self.model, "module") else self.model
                 use_cached = (
-                    hasattr(bare_model, "forward_cached_regression")
+                    task_type == "reg"
+                    and hasattr(bare_model, "forward_cached_regression")
                     and not self.mask_prediction
                     and n_samples_test > chunk_size
                     and os.environ.get("SYNTHEFY_ENABLE_CACHED_INFERENCE", "1") == "1"
@@ -1120,7 +1160,7 @@ class NoriPredictor:
                                 eval_pos=len(y_train),
                                 row_chunk_size=chunk_size,
                             )
-                        output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
+                        output = self._unwrap_model_output(output, task_type=task_type).squeeze(0)
                         if not torch.isfinite(output).all():
                             output = torch.nan_to_num(output, nan=0.0, posinf=0.0, neginf=0.0)
                         outputs.append(output)
@@ -1138,7 +1178,9 @@ class NoriPredictor:
                     # Recombine train + test chunk
                     x_chunk_combined = torch.cat([x_[:len(y_train)], x_chunk_test], dim=0)
                     
-                    # Create dummy y for test chunk
+                    # Create dummy y for test chunk. For cls the padding rows
+                    # must be integer class labels (the model indexes the cls
+                    # head with integer y); reg uses the float y dtype as before.
                     y_chunk_test = torch.zeros(end_idx - i, dtype=y_.dtype, device=y_.device)
                     y_chunk_combined = torch.cat([y_[:len(y_train)], y_chunk_test], dim=0)
 
@@ -1147,7 +1189,7 @@ class NoriPredictor:
                         x_in = x_chunk_combined.unsqueeze(0)
                         y_in = y_chunk_combined.unsqueeze(0)
 
-                        chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type='reg')
+                        chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type=task_type)
 
                     if self.mask_prediction:
                         process_config = chunk_output['process_config']
@@ -1156,7 +1198,7 @@ class NoriPredictor:
                         mask_predictions.append(chunk_output_feature_pred)
                         chunk_output = chunk_output['reg_output']
 
-                    chunk_output = self._unwrap_model_output(chunk_output, task_type="reg").squeeze(0)
+                    chunk_output = self._unwrap_model_output(chunk_output, task_type=task_type).squeeze(0)
                     if not torch.isfinite(chunk_output).all():
                         chunk_output = torch.nan_to_num(
                             chunk_output,
@@ -1172,6 +1214,11 @@ class NoriPredictor:
                     outputs.append(output)
             
         output = torch.stack(outputs).mean(dim=0)
+        if task_type == "cls":
+            # Classification: return the ensemble-averaged class logits
+            # [n_test, num_classes] WITHOUT regression collapse. The caller
+            # (predict_cls) applies the temperatured softmax + class slicing.
+            return output
         if return_distribution:
             # Return the ensemble-averaged decoder output BEFORE collapse: the
             # per-row quantile bank [n_test, num_reg_quantiles] (pinball head) or

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,5 +5,7 @@ def test_public_imports():
     assert callable(synthefy_nori.predict)
     assert callable(synthefy_nori.infer)
     assert synthefy_nori.NoriRegressor is not None
-    # The classifier is intentionally not part of the published package.
-    assert not hasattr(synthefy_nori, "NoriClassifier")
+    # NoriClassifier is re-exposed for the RelBench classification tasks
+    # (entity-table tabular protocol); it reuses the trained cls head shipped in
+    # the checkpoint.
+    assert synthefy_nori.NoriClassifier is not None

--- a/tests/test_nori_classifier.py
+++ b/tests/test_nori_classifier.py
@@ -1,0 +1,116 @@
+"""End-to-end tests for the re-exposed NoriClassifier.
+
+These download the default HuggingFace checkpoint and run a real forward pass
+through the model's classification head, so they carry the ``slow`` marker (the
+same convention as ``test_inference_e2e.py``). They are deselected by default.
+
+Run explicitly with::
+
+    pytest -m slow tests/test_nori_classifier.py
+
+Override the checkpoint location without touching HF by setting
+``SYNTHEFY_NORI_TEST_CHECKPOINT=/abs/path/to/checkpoint.pt``.
+"""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.slow
+
+
+def _checkpoint_kwargs():
+    local = os.environ.get("SYNTHEFY_NORI_TEST_CHECKPOINT")
+    if local:
+        return {"model_path": local}
+    return {}
+
+
+def _auroc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Rank-based AUROC for binary labels (no sklearn dependency)."""
+    labels = np.asarray(labels).astype(int)
+    scores = np.asarray(scores, dtype=np.float64)
+    order = np.argsort(scores)
+    ranks = np.empty_like(order, dtype=np.float64)
+    ranks[order] = np.arange(1, len(scores) + 1)
+    # Average ranks for ties.
+    _, inv, counts = np.unique(scores, return_inverse=True, return_counts=True)
+    sums = np.zeros_like(counts, dtype=np.float64)
+    np.add.at(sums, inv, ranks)
+    ranks = (sums / counts)[inv]
+    n_pos = int(labels.sum())
+    n_neg = len(labels) - n_pos
+    assert n_pos > 0 and n_neg > 0, "AUROC needs both classes present"
+    sum_pos_ranks = ranks[labels == 1].sum()
+    return (sum_pos_ranks - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg)
+
+
+def _separable_binary(seed: int = 0):
+    rng = np.random.default_rng(seed)
+    n_train, n_test, d = 200, 50, 3
+    X_train = rng.normal(size=(n_train, d)).astype(np.float32)
+    y_train = (X_train[:, 0] > 0).astype(np.int64)
+    X_test = rng.normal(size=(n_test, d)).astype(np.float32)
+    y_test = (X_test[:, 0] > 0).astype(np.int64)
+    return X_train, y_train, X_test, y_test
+
+
+def test_classifier_predict_proba_is_valid_and_separates():
+    from synthefy_nori import NoriClassifier
+
+    X_train, y_train, X_test, y_test = _separable_binary()
+
+    model = NoriClassifier(device="cpu", **_checkpoint_kwargs())
+    model.fit(X_train, y_train)
+
+    assert model.n_classes_ == 2
+    np.testing.assert_array_equal(model.classes_, np.array([0, 1]))
+
+    proba = model.predict_proba(X_test)
+    assert proba.shape == (X_test.shape[0], 2)
+    assert np.all(np.isfinite(proba))
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-4)
+
+    auroc = _auroc(proba[:, 1], y_test)
+    assert auroc > 0.7, f"expected easy separation, got AUROC={auroc:.3f}"
+
+    preds = model.predict(X_test)
+    assert preds.shape == (X_test.shape[0],)
+    assert set(np.unique(preds)).issubset({0, 1})
+
+
+def test_infer_classification_task_returns_proba():
+    from synthefy_nori import infer
+
+    X_train, y_train, X_test, y_test = _separable_binary(seed=1)
+
+    proba = infer(X_train, y_train, X_test, task="classification",
+                  device="cpu", **_checkpoint_kwargs())
+    assert proba.shape == (X_test.shape[0], 2)
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-4)
+    assert _auroc(proba[:, 1], y_test) > 0.7
+
+
+def test_regressor_still_works_unchanged():
+    """Smoke test proving the classification work did not break regression."""
+    from synthefy_nori import NoriRegressor
+
+    rng = np.random.default_rng(0)
+    n_train, n_test, d = 200, 50, 4
+    X_train = rng.normal(size=(n_train, d)).astype(np.float32)
+    true_w = rng.normal(size=d).astype(np.float32)
+    y_train = (X_train @ true_w + rng.normal(scale=0.1, size=n_train)).astype(np.float32)
+    X_test = rng.normal(size=(n_test, d)).astype(np.float32)
+    y_truth = X_test @ true_w
+
+    model = NoriRegressor(device="cpu", **_checkpoint_kwargs())
+    model.fit(X_train, y_train)
+    pred = model.predict(X_test)
+
+    assert pred.shape == (n_test,)
+    assert np.all(np.isfinite(pred))
+    corr = float(np.corrcoef(pred, y_truth)[0, 1])
+    assert corr > 0.8, f"regression regressed: corr={corr:.3f}"

--- a/tests/test_relbench_smoke.py
+++ b/tests/test_relbench_smoke.py
@@ -1,0 +1,74 @@
+"""RelBench entity-task smoke tests for the Nori tabular protocol.
+
+Deselected by default (the ``slow`` marker): these download both the RelBench
+``rel-f1`` database (the smallest, ~74K rows) and the public ``Synthefy/Nori``
+checkpoint, then run real in-context inference. ``rel-f1`` is used because it is
+the cheapest dataset to fetch and run.
+
+Run explicitly with::
+
+    pytest -m slow tests/test_relbench_smoke.py
+
+Requires the ``relbench`` extra (``pip install "synthefy-nori[relbench]"``).
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+
+pytestmark = pytest.mark.slow
+
+relbench = pytest.importorskip("relbench", reason="requires the 'relbench' extra")
+
+
+def test_relbench_regression_smoke():
+    from synthefy_nori.evaluation.relbench_tasks import run_task
+
+    res = run_task(
+        "rel-f1", "driver-position",
+        mode="entity", device="cpu", max_train=2000, download=True,
+    )
+    assert res.error is None, f"regression task crashed: {res.error}"
+    assert res.task_type == "REGRESSION"
+    assert res.n_train > 0 and res.n_val > 0 and res.n_test > 0
+    # task.evaluate exposes mae for regression; it must be a finite number.
+    assert "test_mae" in res.metrics
+    assert math.isfinite(res.metrics["test_mae"])
+    assert math.isfinite(res.metrics["val_mae"])
+
+
+def test_relbench_classification_smoke():
+    from synthefy_nori.evaluation.relbench_tasks import run_task
+
+    res = run_task(
+        "rel-f1", "driver-dnf",
+        mode="entity", device="cpu", max_train=2000, download=True,
+    )
+    assert res.error is None, f"classification task crashed: {res.error}"
+    assert res.task_type == "BINARY_CLASSIFICATION"
+    # task.evaluate exposes roc_auc for binary classification.
+    assert "test_roc_auc" in res.metrics
+    auroc = res.metrics["test_roc_auc"]
+    assert math.isfinite(auroc) and 0.0 <= auroc <= 1.0
+
+
+def test_feature_table_builds_numeric():
+    """The flattened feature table must be all-numeric and label-aligned."""
+    from relbench.base import TaskType
+    from relbench.datasets import get_dataset
+    from relbench.tasks import get_task
+    from synthefy_nori.evaluation.relbench_tasks import build_feature_table
+
+    task = get_task("rel-f1", "driver-position", download=True)
+    db = get_dataset("rel-f1", download=True).get_db()
+    X_df, y = build_feature_table(task, db, "val", mode="entity")
+    assert y is not None and len(y) == len(X_df)
+    assert task.target_col not in X_df.columns
+    assert task.entity_col not in X_df.columns
+    # test split is label-masked: y is absent
+    X_test_df, y_test = build_feature_table(task, db, "test", mode="entity")
+    assert y_test is None
+    assert task.task_type in (TaskType.REGRESSION, TaskType.BINARY_CLASSIFICATION)

--- a/uv.lock
+++ b/uv.lock
@@ -3404,7 +3404,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

Evaluate Nori on the [RelBench](https://relbench.stanford.edu) relational benchmark via the **entity-table tabular protocol** (flatten each relational task into one feature table, then fit Nori in-context). Covers the binary-classification (AUROC) and regression (MAE/NMAE) entity tasks across the seven canonical RelBench datasets; recommendation/link-prediction is out of scope for a tabular model.

**What's added**
- `synthefy_nori.evaluation.relbench_tasks` with three feature modes: `entity` (entity-table merge), `temporal` (leakage-safe per-entity aggregations via `merge_asof` with a strict before-seed-time cutoff; optional 2-hop), and `ds_sql` (run RelBench's published "Data Scientist" SQL in DuckDB for a model-vs-model comparison on identical features). Plus class-balanced (stratified) context subsampling and top-k mutual-information feature selection.
- Re-exposed `NoriClassifier` (reuses the classification head already in the checkpoint); `task_type` threaded through the predictor (default `"reg"`, regression path unchanged).
- Predictor chunk-size capped by a max sequence length so few-feature tables stay under the CUDA grid limit (no-op for existing tabular benchmarks).
- CLI flags (`--relbench`, `--relbench-mode`, `--relbench-tasks`, `--relbench-out`), pinned task list, `relbench` extra, NoriClassifier + rel-f1 smoke tests.

Metrics use relbench's own `task.evaluate` (validation locally; hidden test split), so they match the leaderboard: **AUROC** (classification), **NMAE = MAE / train-split std** (regression).

## Results — best config (50k context, temporal features, stratified context)

Anchors from the live leaderboard: **LightGBM (raw entity)** and **TabPFN-2.5 + DFS** (strongest tabular zero-shot).

### Classification — AUROC (higher better)

| Task | Nori | LightGBM-entity | TabPFN-2.5+DFS |
|---|---:|---:|---:|
| rel-stack/user-badge | 0.793 | 0.634 | 0.821 |
| rel-f1/driver-top3 | 0.786 | 0.739 | 0.804 |
| rel-stack/user-engagement | 0.780 | 0.634 | 0.853 |
| rel-event/user-ignore | 0.739 | 0.799 | 0.832 |
| rel-amazon/item-churn | 0.692 | 0.625 | 0.796 |
| rel-hm/user-churn | 0.611 | 0.552 | 0.668 |
| rel-avito/user-clicks | 0.604 | 0.536 | 0.633 |
| rel-avito/user-visits | 0.603 | 0.530 | 0.617 |
| rel-event/user-repeat | 0.507 | 0.680 | 0.731 |
| rel-amazon/user-churn | 0.461 | 0.522 | 0.645 |
| rel-trial/study-outcome | 0.443 | 0.701 | 0.626 |
| rel-f1/driver-dnf | 0.313 | 0.686 | 0.717 |
| **Mean** | **0.611** | **0.637** | **0.729** |

### Regression — NMAE (lower better)

| Task | Nori | LightGBM-entity | DataScientist+LightGBM |
|---|---:|---:|---:|
| rel-amazon/item-ltv | 0.091 | 0.103 | 0.070 |
| rel-trial/study-adverse | 0.118 | 0.130 | 0.120 |
| rel-hm/item-sales | 0.143 | 0.153 | 0.073 |
| rel-stack/post-votes | 0.171 | 0.133 | 0.127 |
| rel-amazon/user-ltv | 0.297 | 0.292 | 0.242 |
| rel-avito/ad-ctr | 0.389 | 0.429 | 0.460 |
| rel-event/user-attendance | 0.478 | 0.345 | 0.371 |
| rel-f1/driver-position | 0.551 | 0.594 | 0.564 |
| rel-trial/site-success | 0.951 | 0.893 | 0.855 |
| **Mean** | **0.354** | **0.341** | **0.320** |

### Model-vs-model on identical features (`ds_sql`: Nori vs LightGBM on the same hand-engineered SQL features)

| Task | Nori @ DS-feats (NMAE) | DS + LightGBM (NMAE) |
|---|---:|---:|
| rel-amazon/item-ltv | 0.073 | 0.070 |
| rel-f1/driver-position | 0.580 | 0.564 |
| rel-hm/item-sales | 0.088 | 0.073 |
| rel-event/user-attendance | 0.470 | 0.371 |
| **Mean (4)** | **0.303** | **0.269** |

## Takeaways

- **Nori is LightGBM-tier on RelBench** (cls mean AUROC 0.611 vs 0.637; reg NMAE 0.354 vs 0.341), below TabPFN-2.5+DFS (0.729). It matches/beats TabPFN on some tasks (driver-top3 0.786, user-engagement 0.780) and beats LightGBM-raw on a majority.
- **Biggest accuracy lever: stratified (class-balanced) context** — +0.25 AUROC on rare-positive tasks (rel-hm/user-churn 0.385 → 0.612). nori is a **large-context** model; a 1024-example regime (TabPFN's) is broadly worse for it.
- **On identical expert features (`ds_sql`), Nori is modestly behind LightGBM** (0.303 vs 0.269) and does not exploit rich hand-crafted features the way GBDTs do — its edge is large balanced context on simple features with no feature engineering.
- **Weak spots**: a few small, rare-positive or low-signal tasks (driver-dnf stays inverted even with gold features — a model-level issue; site-success near the trivial baseline).

## Submission status

RelBench has no self-service submission endpoint (the leaderboard is a maintainer-generated static page under redesign). `results/relbench*/SUBMISSION.md` is formatted to match the leaderboard tables for the GitHub contribution path on snap-stanford/relbench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)