### PR TITLE
ci: notify-sync — trigger rebase-sync in internal on push to main

### DIFF
--- a/.github/workflows/notify-sync.yml
+++ b/.github/workflows/notify-sync.yml
@@ -1,0 +1,24 @@
+name: notify-sync
+
+# On every push to public main, ask synthefy-nori-internal to run rebase-sync.
+# This (public) repo holds NO code-write credential: SYNC_DISPATCH_TOKEN is a
+# narrow fine-grained PAT scoped to "Actions: write" on synthefy-nori-internal
+# ONLY, so it can trigger that one workflow but cannot read or write any code.
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rebase-sync in internal
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run rebase-sync.yml \
+            --repo Synthefy/synthefy-nori-internal \
+            --ref main \
+            -f reason="public@${GITHUB_SHA:0:10} pushed"


### PR DESCRIPTION
## What

Adds `notify-sync` — a tiny workflow that, on every push to `main`, asks
`synthefy-nori-internal` to run its `rebase-sync` cascade.

## How

- Trigger: `push` to `main`.
- Holds **no code-write credential**. Uses `SYNC_DISPATCH_TOKEN`, a fine-grained
  PAT scoped to **Actions: write on `synthefy-nori-internal` only** — it can
  trigger that one workflow and nothing else.
- This is the public-facing half of the "dispatch" security pattern: the
  write-everywhere token lives only in the private internal repo.

## Pairs with

The actual cascade lives in the companion PR on `synthefy-nori-internal`.

## Test plan

Secrets already set. After both PRs merge: an empty push to `main` here should
appear as a `rebase-sync` run in internal.
