### PR TITLE
Fix Pohan's CODEOWNERS handle so his approval counts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # NOTE: code owners must have write access to this repository, otherwise GitHub
 # silently ignores their entries here.
 
-*	@sagarwal-atg @d31003 @yogabbagabb @raimishah @adityanarayanan03 @realPohanLi
+*	@sagarwal-atg @d31003 @yogabbagabb @raimishah @adityanarayanan03 @PohanLi-Synthefy

--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -12,6 +12,7 @@ It auto-requests review from the authorized maintainers and satisfies GitHub's
 - `yogabbagabb`
 - `raimishah`
 - `adityanarayanan03`
+- `PohanLi-Synthefy`
 
 ## One-time setup (requires repo admin)
 


### PR DESCRIPTION
## What

`CODEOWNERS` listed Pohan as `@realPohanLi`, which is **not a valid GitHub user** — so GitHub silently ignored the entry and his reviews did **not** satisfy the "Require review from Code Owners" rule. His current handle is `@PohanLi-Synthefy` (org member, `nori-maintainers` team, repo **admin**).

## Why this makes his approval "enough"

Branch protection on `main` is already configured for one-approval merges:
- `require_code_owner_reviews: true`
- `required_approving_review_count: 1`
- `CODEOWNERS` uses a single `*` line, so **any one** listed owner's approval satisfies the requirement

With the correct handle in place, Pohan's single approval now counts the same as any other maintainer's. No branch-protection change required.

> Note: CODEOWNERS takes effect from the **base branch**, so this is only live for PRs once it's merged into `main`.

## Changes
- `.github/CODEOWNERS`: `@realPohanLi` → `@PohanLi-Synthefy`
- `.github/branch-protection.md`: add him to the listed authorized reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)