### PR TITLE
Remove internal dead code unreferenced anywhere in the org

### DIFF
--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -168,24 +168,6 @@ class NoriPredictor:
 
         self.build_preprocess_pipeline()
 
-    def set_inference_config(self, inference_config: list|str, softmax_temperature:float|None=None, seed:int|None=None):
-        if isinstance(inference_config, str):
-            if os.path.isfile(inference_config):
-                with open(inference_config, 'r') as f:
-                    inference_config = json.load(f)
-            else:
-                raise ValueError(f"inference_config is not a config file path: {inference_config}")
-        self.inference_config = inference_config
-        n_estimators = len(inference_config)
-        assert n_estimators > 0, f"Invalid configuration file! the number of pipelines is 0!"
-        self.n_estimators = n_estimators
-        
-        if softmax_temperature is not None:
-            self.softmax_temperature = softmax_temperature
-        if seed is not None:
-            self.seed = seed
-        self.build_preprocess_pipeline()
-
     def build_preprocess_pipeline(self):
         self.preprocess_pipelines = []
         self.preprocess_configs = []
@@ -324,47 +306,6 @@ class NoriPredictor:
             x[integer_columns] = x[integer_columns].astype(dtypes)
         return x
     
-    def convert_category2num(self, x, dtype:np.floating=np.float64, placeholder: str = NA_PLACEHOLDER,):
-        # --- Drop high-cardinality string columns (e.g. IDs) before encoding ---
-        string_cols_pre = x.select_dtypes(include=["string", "object"]).columns
-        cols_to_drop = []
-        for col in string_cols_pre:
-            n_unique = x[col].nunique()
-            n_samples = len(x[col])
-            # If > 90% of values are unique (and there are at least 50 samples), it's likely an ID column
-            if n_samples > 50 and n_unique / n_samples > 0.90:
-                cols_to_drop.append(col)
-        if cols_to_drop:
-            x = x.drop(columns=cols_to_drop)
-
-        ordinal_encoder = OrdinalEncoder(categories="auto",
-                                        dtype=dtype,
-                                        handle_unknown="use_encoded_value",
-                                        unknown_value=-1,
-                                        encoded_missing_value=np.nan)
-        col_encoder = ColumnTransformer(transformers=[("encoder", ordinal_encoder, make_column_selector(dtype_include=["category", "string", "bool"]))],
-                                        remainder=FunctionTransformer(),
-                                        sparse_threshold=0.0,
-                                        verbose_feature_names_out=False,
-                                    )
-        
-        string_cols = x.select_dtypes(include=["string", "object"]).columns
-        if len(string_cols) > 0:
-            x[string_cols] = x[string_cols].fillna(placeholder)
-        
-        X_encoded = col_encoder.fit_transform(x)
-
-        string_cols_ix = [x.columns.get_loc(col) for col in string_cols]
-        placeholder_mask = x[string_cols] == placeholder
-        string_cols_ix_2 = list(range(len(string_cols_ix)))
-        X_encoded[:, string_cols_ix_2] = np.where(
-            placeholder_mask,
-            np.nan,
-            X_encoded[:, string_cols_ix_2],
-        )
-
-        return X_encoded
-
     def _drop_high_cardinality_string_columns(
         self,
         x_train: pd.DataFrame,

--- a/src/synthefy_nori/inference/preprocess.py
+++ b/src/synthefy_nori/inference/preprocess.py
@@ -762,14 +762,6 @@ class CategoricalFeatureEncoder(BasePreprocess):
         self.fit(x, categorical_features, seed, **kwargs)
         return self.transform(x, **kwargs)
 
-    def _fit_transform(
-        self,
-        X: np.ndarray,
-        categorical_features: list[int],
-    ) -> tuple[np.ndarray, list[int]]:
-        self.fit(X, categorical_features, self.random_seed)
-        return self.transform(X)
-
     @staticmethod
     def get_least_common_category_count(column: np.ndarray) -> int:
         """Retrieve the smallest count value among categorical features"""

--- a/src/synthefy_nori/interpretability/shapiq.py
+++ b/src/synthefy_nori/interpretability/shapiq.py
@@ -80,15 +80,3 @@ def get_nori_imputation_explainer(
         random_state=random_state,
         **kwargs,
     )
-
-
-def get_nori_explainer(model, data, *, index: str = "k-SII", max_order: int = 2, **kwargs: Any):
-    """Auto-detected shapiq explainer over the model object.
-
-    A convenience over :func:`get_nori_imputation_explainer` that hands the
-    estimator to ``shapiq.Explainer`` and lets shapiq pick the backend. Prefer the
-    imputation explainer above; this exists for parity with shapiq's generic entry
-    point.
-    """
-    shapiq = _require_shapiq()
-    return shapiq.Explainer(model=model, data=data, index=index, max_order=max_order, **kwargs)

--- a/src/synthefy_nori/model/encoders.py
+++ b/src/synthefy_nori/model/encoders.py
@@ -102,48 +102,6 @@ class LinearEncoder(nn.Module):
         input[self.out_key] = self.layer(x)
         return input
 
-class MLPEncoder(nn.Module):
-    """MLP input encoder"""
-    def __init__(
-                self,
-                num_features: int,
-                emsize: int,
-                nan_to_zero: bool = False,
-                bias: bool = True,
-                in_keys: list[str] = ['data'],
-                out_key: str = 'data',
-    ):
-        """Initialize the MLPEncoder.
-
-        Args:
-            num_features: The number of input features.
-            emsize: The embedding size, i.e. the number of output features.
-            nan_to_zero: Whether to replace NaN values in the input by zero. Defaults to False.
-            bias: Whether to use a bias term in the linear layer. Defaults to True.
-        """
-        super().__init__()
-        self.layer = nn.Sequential(
-            nn.Linear(num_features, emsize * 2, bias=bias),
-            nn.LayerNorm(emsize * 2),
-            nn.GELU(),
-            nn.Linear(emsize * 2, emsize, bias=bias),
-            nn.LayerNorm(emsize),
-            nn.GELU()
-        )
-        self.nan_to_zero = nan_to_zero
-        self.in_keys = in_keys
-        self.out_key = out_key
-        
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
-        assert 'data' in input and 'nan_encoding' in input
-        x = [input[key] for key in self.in_keys]
-        x = torch.cat(x, dim=-1) # type: ignore
-        if self.nan_to_zero:
-            x = torch.nan_to_num(x, nan=0.0)
-        input[self.out_key] = self.layer(x)
-        return input
-
-
 class RBFembedding(nn.Module):
     def __init__(
         self, 

--- a/src/synthefy_nori/training/trainer.py
+++ b/src/synthefy_nori/training/trainer.py
@@ -7,7 +7,7 @@ import os
 import time
 import math
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 
 import numpy as np
 import torch
@@ -1317,20 +1317,6 @@ class NoriTrainer:
                     ema_tensor.mul_(self.ema_decay).add_(tensor.detach(), alpha=1.0 - self.ema_decay)
                 else:
                     ema_tensor.copy_(tensor)
-
-    @contextmanager
-    def _swap_in_ema_weights(self):
-        if self.ema_state_dict is None:
-            yield
-            return
-
-        model = self._get_bare_model()
-        current_state = self._clone_current_model_state()
-        model.load_state_dict(self.ema_state_dict, strict=True)
-        try:
-            yield
-        finally:
-            model.load_state_dict(current_state, strict=True)
 
     def save_checkpoint(self, path=None):
         """Save a training checkpoint (rank 0 only in DDP)."""


### PR DESCRIPTION
## What

Removes six symbols that are unreferenced **both** in this repo and across the entire Synthefy org (verified with `gh search code --owner Synthefy`). Every org-wide hit for these names is a *definition in another repo's own forked copy* (SynthefyPFN / carpet_evolve_pfn / legacy) — never an `import` of `synthefy_nori`'s version.

| Symbol | File | Note |
|---|---|---|
| `MLPEncoder` | `model/encoders.py` | No name→class factory; not selectable by any checkpoint config (the pipeline builds `LinearEncoder` directly) |
| `Trainer._swap_in_ema_weights` | `training/trainer.py` | + now-unused `contextmanager` import |
| `_fit_transform` | `inference/preprocess.py` | private, no callers |
| `convert_category2num`, `set_inference_config` | `inference/predictor.py` | vestigial LimiX-fork methods |
| `get_nori_explainer` | `interpretability/shapiq.py` | docs steer users to `get_nori_imputation_explainer` |

Net: **5 files, −137 lines.**

## Explicitly NOT touched

The `evaluation/` surface (`EvalAnalyzer`, `NoriEnsembleWrapper`, `add_synthefy_ensemble`, `clear_cache`, `save_per_model_results`, `cleanup_all`) **looked** dead in-repo but is live: `synthefy-nori-internal/internal/eval/repro/talent_compare.py` imports `synthefy_nori.evaluation.analysis.EvalAnalyzer` for benchmark scoring (ELO / Bradley-Terry), and `EVAL_PORT_PLAN.md` lists the rest as intentional surface. It's part of the public-benchmark submission path, so it stays.

## Verification

- `import synthefy_nori` + full eval-surface import smoke ✅
- `ruff check src` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)