### PR TITLE
ci: exempt internal Synthefy maintainers from the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,4 +40,14 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/Synthefy/synthefy-nori/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: '*[bot]'
+          # Comma-separated GitHub usernames that are exempt from signing the CLA.
+          # Internal Synthefy contributors are covered by Synthefy's employment/IP
+          # agreements, so they don't need to sign the individual CLA — only
+          # external contributors do. Keep this in sync with the internal team
+          # (mirrors .github/CODEOWNERS).
+          #
+          # Humans only — bots are intentionally NOT allowlisted. A bot cannot
+          # sign (the flow requires the PR author to comment the agreement), so a
+          # bot-authored PR will sit with a red CLA check. If that ever needs to
+          # merge, add the specific bot login here (e.g. copilot-swe-agent[bot]).
+          allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy'


### PR DESCRIPTION
## What

Exempts internal Synthefy maintainers from the Contributor License Agreement gate added in #58. Only **external** contributors now need to sign; the internal team is covered by Synthefy's employment/IP agreements.

This uses the `contributor-assistant` action's built-in `allowlist` parameter — a comma-separated list of GitHub usernames that skip signing and pass the CLA check automatically.

```yaml
allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy'
```

## Notes

- The list mirrors `.github/CODEOWNERS` (the authoritative internal list), using Pohan's corrected `@PohanLi-Synthefy` handle from #59 — not the stale `@realPohanLi`.
- **Humans only — bots are intentionally not allowlisted.** A bot can't sign (the flow requires the PR author to comment the agreement phrase), so a bot-authored PR will sit with a red CLA check. If one ever needs to merge, add that specific bot login (e.g. `copilot-swe-agent[bot]`) explicitly.
- Keep this list in sync with the internal team as people join/leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)