### PR TITLE
Rename --model-v2/-lite flags to --model-v1/-lite

### DIFF
--- a/scripts/continue_training.sh
+++ b/scripts/continue_training.sh
@@ -129,7 +129,7 @@ SHARED_ARGS=(
   --icl-filter-model "${ICL_FILTER_MODEL:-limix}"
   --icl-filter-reg-min-r2 0.05
   --quality-filter-max-retries 5
-  --model-v2-lite
+  --model-v1-lite
   --column-specific-y-aware
   --embed-dim 128
   --hid-dim 384

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Training: tier 1 (from scratch).
 #
-# Architecture: 16 layers, E=128, H=384, nhead=2, model_v2_lite,
+# Architecture: 16 layers, E=128, H=384, nhead=2,
 # column_specific_y_aware, ~5.5M params. Regression via a 999-quantile pinball
 # loss with a monotonicity penalty.
 #
@@ -108,7 +108,7 @@ torchrun --nproc_per_node="${NPROC}" --master_port="${MASTER_PORT}" \
   --icl-filter-model "${ICL_FILTER_MODEL:-limix}" \
   --icl-filter-reg-min-r2 0.05 \
   --quality-filter-max-retries 5 \
-  --model-v2-lite \
+  --model-v1-lite \
   --column-specific-y-aware \
   --embed-dim 128 --hid-dim 384 --nhead 2 --nlayers 16 \
   --batch-size "${BATCH_SIZE}" \

--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -296,10 +296,10 @@ def main():
                         help='Enable synth_v5 SCM improvements (informative categoricals, concat aggregation, multi-dim nodes)')
     parser.add_argument('--synth-v5-mixture', action='store_true',
                         help='Enable synth_v5 mixture prior (25%% v4, 35%% v5c, 40%% v5a per dataset)')
-    parser.add_argument('--model-v2', action='store_true',
-                        help='v2 arch: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD')
-    parser.add_argument('--model-v2-lite', action='store_true',
-                        help='v2-lite arch: SwiGLU + RMSNorm + pre-norm/DeepNorm, keep RBF (no PBLD)')
+    parser.add_argument('--model-v1', action='store_true',
+                        help='v1 arch: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD')
+    parser.add_argument('--model-v1-lite', action='store_true',
+                        help='v1-lite arch: SwiGLU + RMSNorm + pre-norm/DeepNorm, keep RBF (no PBLD)')
     parser.add_argument('--embed-dim', type=int, default=None,
                         help='Override embedding dimension (default: from checkpoint)')
     parser.add_argument('--hid-dim', type=int, default=None,
@@ -497,8 +497,7 @@ def main():
         if local_rank == 0:
             print(f"Propagated features_per_group={fpg} to preprocess_config_x and encoder_config_x")
 
-    # Apply v2 architecture overrides
-    if args.model_v2:
+    if args.model_v1:
         model_config['activation'] = 'swiglu'
         model_config['norm_type'] = 'rmsnorm'
         model_config['pre_norm'] = True
@@ -506,15 +505,15 @@ def main():
         model_config['encoder_config_x']['numeric_embed_type'] = 'PBLD'
         model_config['encoder_config_x']['PBLD_config'] = {'n_frequencies': 48}
         if local_rank == 0:
-            print("Model v2 enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD")
-    elif args.model_v2_lite:
+            print("Model v1 enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD")
+    elif args.model_v1_lite:
         model_config['activation'] = 'swiglu'
         model_config['norm_type'] = 'rmsnorm'
         model_config['pre_norm'] = True
         model_config['deepnorm_alpha'] = model_config['nlayers'] ** (-0.5)
         # Keep RBF numeric embedding (no PBLD) for speed
         if local_rank == 0:
-            print("Model v2-lite enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm (RBF kept)")
+            print("Model v1-lite enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm (RBF kept)")
     if local_rank == 0:
         print(
             f"Architecture extras: QASSMax={'on' if model_config['use_qassmax'] else 'off'}, "

--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -106,8 +106,7 @@ class TrainingConfig:
     target_aware_init_scale: float = 1.0
     target_aware_warmup_steps: int = 0
 
-    # Model v2 architecture (SwiGLU, RMSNorm, pre-norm+DeepNorm, PBLD)
-    model_v2: bool = False
+    model_v1: bool = False
 
     # Synthetic data v2 augmentations
     synth_v2: bool = True


### PR DESCRIPTION
The architecture is now the public release, so rename the v2 flags to v1:
- --model-v2 -> --model-v1, --model-v2-lite -> --model-v1-lite (cli.py)
- args.model_v2 -> args.model_v1, args.model_v2_lite -> args.model_v1_lite
- config field model_v2 -> model_v1
- update train.sh / continue_training.sh callers
- drop incidental "v2" mentions from comments

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
