### PR TITLE
skills: add nori-regression Claude Code skill

### DIFF
--- a/.claude/skills/nori-regression/SKILL.md
+++ b/.claude/skills/nori-regression/SKILL.md
@@ -96,8 +96,9 @@ via their CLI flags; don't hardcode paths.
 6. **Forecasting a time series?** Build leak-safe lag/rolling/seasonal
    features, refit at every origin (fit is free), and score against last-value
    and seasonal-naive baselines over a rolling backtest — never a random
-   split. → `templates/forecast_one_step.py`,
-   `references/one-step-forecasting.md`
+   split. Need h periods ahead? Use the direct recipe — newest legal lag is
+   `lag_h`. → `templates/forecast_one_step.py`,
+   `templates/forecast_multi_step.py`, `references/one-step-forecasting.md`
 7. **Tune the practical knobs only if needed.** `device` for GPU, `model_path`
    for a local/pinned checkpoint, `HF_HUB_OFFLINE=1` for air-gapped runs,
    context subsampling for big datasets. → `references/api.md`,

--- a/.claude/skills/nori-regression/SKILL.md
+++ b/.claude/skills/nori-regression/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: nori-regression
+description: >-
+  General tabular regression with Nori, the Synthefy tabular foundation model —
+  sklearn-style in-context fit/predict with zero training, native prediction
+  intervals (quantiles / full predictive distribution), honest baseline
+  comparison under a fixed CV protocol, and SHAP / PDP / feature-selection
+  interpretability — plus leak-safe one-step time-series forecasting via lag
+  features and a rolling-origin backtest. Use when predicting a continuous
+  target from tabular features, when you need uncertainty bands without extra
+  machinery, when forecasting a single series one step ahead, or when the
+  dataset is too small to train a model on.
+---
+
+# Tabular regression with Nori
+
+## What this is and when to use it
+
+A playbook for regression with **Nori** (`synthefy-nori` on PyPI), a ~5.5M-param
+tabular foundation model that predicts by **in-context learning**: `fit()` just
+stores your training rows as context, and `predict()` conditions the frozen
+model on them. No training loop, no hyperparameters to tune, and the full
+predictive distribution comes for free.
+
+Reach for it when:
+
+- you have a **tabular regression** problem (continuous target, feature matrix);
+- the dataset is **small-to-mid sized** (tens to a few thousand context rows) —
+  exactly where training a model from scratch overfits;
+- you want **prediction intervals** without conformal/quantile-regression add-ons;
+- you want a strong baseline in ten lines before investing in anything bespoke.
+
+Not a fit: classification (Nori is regression-only), very large datasets
+(predict cost grows with context size — subsample the context first), and
+unstructured inputs (text/images) unless you featurize them yourself.
+
+> **Time series:** Nori has no time axis, but one-step-ahead forecasting works
+> well — frame the series as tabular rows where features at time *t* are built
+> only from data *before t* (lags, rolling stats), and evaluate with a
+> rolling-origin backtest, never a random split. Full recipe:
+> `references/one-step-forecasting.md` + `templates/forecast_one_step.py`.
+> For *panels* of related series (SKUs, stores, drugs), use the
+> **nori-demand-forecasting** skill instead.
+
+## Mental model (read this first)
+
+- `fit(X, y)` does **no compute** — it stores `X` (float32) and `y` (float64)
+  as the context set.
+- `predict(X_query)` runs the frozen foundation model, attending from each
+  query row to the whole context. All cost is here, and it scales with
+  context × query size.
+- The default checkpoint has a **999-quantile pinball head**, so beyond point
+  predictions (`"mean"` / `"median"` / `"mode"`) you get calibrated-ish
+  quantiles (`output_type="quantiles"`) and the whole distribution
+  (`output_type="full"`) at no extra cost.
+
+The exact, verified API is in `references/api.md` — read it before writing code.
+
+## Quickstart
+
+```python
+from synthefy_nori import NoriRegressor
+
+reg = NoriRegressor(device=None)          # None -> cuda:0 if available, else CPU
+reg.fit(X_train, y_train)                 # stores context; no training happens
+point = reg.predict(X_test)               # (n,) distribution mean
+lo, mid, hi = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
+```
+
+Install: `pip install synthefy-nori` (add `[interpretability]` for SHAP/PDP).
+First `predict` downloads the checkpoint from Hugging Face (`Synthefy/Nori`).
+
+## Workflow
+
+Templates live in `templates/` — copy them into your project and parametrize
+via their CLI flags; don't hardcode paths.
+
+1. **Prepare the data.** Numeric matrix in, finite target out: encode
+   categoricals (ordinal/one-hot), leave NaN features as NaN (missing is a
+   signal Nori accepts), don't bother scaling features. →
+   `references/data-preparation.md`
+2. **Fit, predict, pick the point estimate.** `"mean"` for symmetric targets,
+   `"median"` when the target is skewed or has outliers. →
+   `templates/regress.py`, `references/api.md`
+3. **Add prediction intervals.** `output_type="quantiles"` for e.g. P10/P50/P90;
+   check the empirical coverage of the interval on a held-out split before
+   trusting it. → `templates/regress.py`
+4. **Compare against baselines honestly.** Same folds, same metric, decided up
+   front: `cross_validate` Nori vs Ridge and RandomForest on one shared
+   `KFold`. Nori is a scikit-learn estimator, so it drops straight in. →
+   `templates/compare_baselines.py`, `references/evaluation.md`
+5. **Explain the predictions.** Shapley values (shapiq), partial dependence,
+   and sequential feature selection through
+   `synthefy_nori.interpretability`. → `templates/explain.py`,
+   `references/interpretability.md`
+6. **Forecasting a time series?** Build leak-safe lag/rolling/seasonal
+   features, refit at every origin (fit is free), and score against last-value
+   and seasonal-naive baselines over a rolling backtest — never a random
+   split. → `templates/forecast_one_step.py`,
+   `references/one-step-forecasting.md`
+7. **Tune the practical knobs only if needed.** `device` for GPU, `model_path`
+   for a local/pinned checkpoint, `HF_HUB_OFFLINE=1` for air-gapped runs,
+   context subsampling for big datasets. → `references/api.md`,
+   `references/data-preparation.md`
+
+## Guardrails
+
+- **Use only the documented public API.** The constructor and `predict`
+  signatures in `references/api.md` are exact — do not invent kwargs, env vars,
+  or telemetry flags. Unknown constructor kwargs raise `TypeError`.
+- **`quantiles=` is only valid with `output_type="quantiles"`** (else
+  `ValueError`); every τ must be strictly inside (0, 1).
+- **Fix the evaluation before comparing models.** Choose the split/folds,
+  metric, and scope up front and keep them constant across every model you
+  try. Iterating the model is science; iterating the eval until you win is
+  cheating. → `references/evaluation.md`
+- **The target must be finite.** NaN in `y` silently corrupts the stored
+  normalization stats — drop or impute target-missing rows before `fit`.
+- **No hardcoded paths.** Parametrize scripts with argparse/env and resolve
+  relative to `Path(__file__)`. Keep data and checkpoints out of git.
+- **Don't ship the checkpoint.** It downloads from the Hugging Face Hub on
+  first use and caches under `~/.cache/huggingface/hub`; pass `model_path=`
+  only to point at a checkpoint you already have locally.

--- a/.claude/skills/nori-regression/references/api.md
+++ b/.claude/skills/nori-regression/references/api.md
@@ -1,0 +1,109 @@
+# Nori public API reference
+
+Verified against `synthefy-nori` 0.9.0 (`src/synthefy_nori/api.py`). This is
+the complete public regression surface — anything not listed here is not part
+of the public API.
+
+## Install
+
+```bash
+pip install synthefy-nori                     # core fit/predict, incl. quantiles
+pip install "synthefy-nori[interpretability]" # + shapiq & matplotlib for SHAP/PDP
+```
+
+Python ≥ 3.9. Core deps: numpy≥2, pandas≥2, scikit-learn≥1.4, scipy≥1.13,
+torch≥2.8, huggingface-hub. `NoriRegressor.fit/predict` — including quantile
+output — need **no extra**; `interpretability` is only for SHAP/PDP/feature
+selection.
+
+## Construct → fit → predict
+
+```python
+from synthefy_nori import NoriRegressor
+
+reg = NoriRegressor(device=None)   # None -> cuda:0 if available, else cpu
+reg.fit(X_train, y_train)          # stores context; X -> float32 (n, d), y -> float64 (n,)
+point = reg.predict(X_test)        # (n,) distribution mean
+```
+
+**Constructor (exact signature):**
+
+```python
+NoriRegressor(model_path=None, *, device=None, inference_config=None, token=None,
+              augmentations=("yj",), yj_skew_threshold=10.0,
+              quantile_collapse="mean", bar_temperature=1.0,
+              bar_point_estimator="mean")
+```
+
+- `model_path` — local checkpoint path; `None` downloads the default from the
+  Hugging Face Hub on first `predict`.
+- `device` — `None` → `cuda:0` if available else CPU; or any torch device string.
+- `inference_config` — path to a bundled/custom inference config JSON; default
+  is `reg_allordinal_poly10_adaptive_svd256.json`. Use
+  `synthefy_nori.config_path(filename)` to resolve a bundled one.
+- `token` — Hugging Face token, only needed for gated/private checkpoints (the
+  default public checkpoint is ungated).
+- `augmentations=("yj",)` — input augmentation; `"yj"` applies a Yeo-Johnson
+  transform to skewed targets (see `yj_skew_threshold`). Pass `()` to disable.
+- `quantile_collapse`, `bar_temperature`, `bar_point_estimator` — advanced
+  head/aggregation knobs; leave at defaults unless you know why.
+
+`NoriRegressor` subclasses `RegressorMixin, BaseEstimator`, so `clone`,
+`get_params`/`set_params`, `score` (R²), `cross_validate`, and the sklearn
+interpretability ecosystem all work directly.
+
+`fit(X, y)` accepts numpy arrays, DataFrames, or lists; returns `self`.
+Calling `predict` before `fit` raises `ValueError`.
+
+## `predict` output types
+
+```python
+reg.predict(X, *, output_type="mean", quantiles=None)
+```
+
+| `output_type` | Returns | Shape | Use for |
+|---|---|---|---|
+| `"mean"` (default) | distribution mean | `(n,)` | symmetric targets |
+| `"median"` | median (τ=0.5) | `(n,)` | skewed targets / outliers |
+| `"mode"` | distribution mode | `(n,)` | rarely needed; prefer `"median"` |
+| `"quantiles"` | quantiles at `quantiles=[...]` | `(len(taus), n)` | prediction intervals |
+| `"full"` | `{"quantiles", "taus", "mean"}` | dict | whole predictive distribution |
+
+```python
+# 80% prediction interval + median in one call — note the (3, n) shape
+lo, mid, hi = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
+
+# Full distribution (e.g. for CRPS / calibration curves)
+dist = reg.predict(X_test, output_type="full")
+Q, taus = dist["quantiles"], dist["taus"]   # Q: (n, 999) ascending per row
+```
+
+Rules (all raise informative errors):
+
+- `quantiles=` is **only** valid with `output_type="quantiles"` → else `ValueError`.
+- Each τ must be strictly in (0, 1) → else `ValueError`.
+- `output_type="main"` → `NotImplementedError`; unknown strings → `ValueError`.
+- Returned quantiles are sorted ascending per row (monotone).
+- `"quantiles"`/`"full"` need the pinball (quantile-head) checkpoint — the
+  default ships one; a `bar_distribution` checkpoint raises `NotImplementedError`.
+
+## One-shot functional API
+
+```python
+from synthefy_nori import infer
+y_pred = infer(X_train, y_train, X_test)   # mean point predictions only
+```
+
+`predict(...)` (module-level) is an alias of `infer`.
+
+## Checkpoint & environment
+
+- Default checkpoint: HF repo `Synthefy/Nori` (override env
+  `SYNTHEFY_NORI_HF_REPO`), file `nori.pt` (env `SYNTHEFY_NORI_HF_FILENAME`),
+  cached under `~/.cache/huggingface/hub`. The public checkpoint is ungated.
+- **Offline:** set `HF_HUB_OFFLINE=1` (a huggingface-hub feature) to serve from
+  cache — run once online first, or pass `model_path=` to a local file.
+- **Device:** GPU optional; CPU works fine for small/mid contexts. `fit()`
+  never touches the device — all compute is in `predict`.
+- There are **no** Nori-specific telemetry or feature-flag env vars — don't
+  invent any.

--- a/.claude/skills/nori-regression/references/data-preparation.md
+++ b/.claude/skills/nori-regression/references/data-preparation.md
@@ -23,6 +23,13 @@ means in practice:
 - **Feature count:** tens of features is the sweet spot. With hundreds,
   select or project first (see `feature_selection` in
   `references/interpretability.md`, or a domain-driven cut).
+- **Engineer richer features, then sweep them.** Domain-informed combinations
+  of raw columns often beat the raw columns: differences of related
+  quantities (process − ambient temperature), physical products (torque ×
+  rotational speed = power), ratios, and load×wear interactions. Build a few
+  candidate feature sets, score each under the one fixed evaluation protocol
+  (`references/evaluation.md`), and keep a richer set only when it wins by
+  more than the fold noise — iterate until gains stop.
 
 ## Target (y)
 

--- a/.claude/skills/nori-regression/references/data-preparation.md
+++ b/.claude/skills/nori-regression/references/data-preparation.md
@@ -1,0 +1,60 @@
+# Data preparation for Nori
+
+Nori's public estimator takes a **numeric matrix** and a **finite numeric
+target**: `fit()` casts `X` to float32 and `y` to float64 up front. What that
+means in practice:
+
+## Features (X)
+
+- **Encode categoricals yourself.** Strings/categories must become numbers
+  before `fit`. Ordinal-encode (`sklearn.preprocessing.OrdinalEncoder`) is the
+  cheap default and works well — Nori's inference stack treats low-cardinality
+  numeric columns as ordinal categories internally. One-hot is fine for a
+  handful of levels; avoid exploding hundreds of columns from one
+  high-cardinality feature (target/frequency encoding is the better move
+  there).
+- **Missing values are allowed.** NaN in `X` passes validation and is treated
+  as missing by the model — you don't have to impute. ±inf is converted to NaN
+  internally. Prefer leaving genuinely-missing cells as NaN over blanket
+  zero-filling (0 is a value, NaN is "unknown").
+- **Don't scale features.** The inference pipeline normalizes and transforms
+  features internally (that's what the bundled inference config does). Feeding
+  pre-standardized features is harmless but pointless.
+- **Feature count:** tens of features is the sweet spot. With hundreds,
+  select or project first (see `feature_selection` in
+  `references/interpretability.md`, or a domain-driven cut).
+
+## Target (y)
+
+- **Must be finite.** NaN/inf in `y` corrupts the stored normalization stats
+  (`y_mean_`, `y_std_`) without an error — drop or impute target-missing rows
+  before `fit`.
+- **Skewed targets are handled — up to a point.** The default
+  `augmentations=("yj",)` applies a Yeo-Johnson transform when target skew
+  exceeds `yj_skew_threshold` (10.0). For heavily skewed positive targets
+  (revenue, counts, durations) it is still often worth fitting on
+  `np.log1p(y)` and inverting predictions with `np.expm1` — A/B it. If you
+  transform `y` yourself, remember quantile outputs come back on the
+  transformed scale and each quantile can be inverted through the monotone
+  inverse directly (`np.expm1(q)`), unlike the mean.
+- **Point estimate choice:** `output_type="median"` is the robust default for
+  skewed targets; `"mean"` minimizes squared error for symmetric ones.
+
+## Context size (rows)
+
+All compute happens in `predict`, attending from each query row to the whole
+stored context, so cost grows with `n_context × n_query`:
+
+- Up to a few thousand context rows: CPU is fine.
+- Tens of thousands: use a GPU (`device="cuda:0"`) and/or **subsample the
+  context** — a random few-thousand-row sample usually loses little accuracy;
+  stratify the sample by target quantile if the target is skewed.
+- Batch big query sets rather than predicting one row at a time — per-call
+  overhead dominates tiny queries.
+
+## Splits
+
+Use ordinary sklearn tooling — `train_test_split` for a quick holdout,
+`KFold` for evaluation. Because `fit` is instant (no training), cross-validation
+costs only `k` `predict` calls, so prefer CV over a single split when the
+dataset is small. Seed everything (`random_state=`) so runs are reproducible.

--- a/.claude/skills/nori-regression/references/evaluation.md
+++ b/.claude/skills/nori-regression/references/evaluation.md
@@ -1,0 +1,55 @@
+# Evaluating Nori honestly
+
+The single rule: **fix the yardstick before you compare anything.** Decide the
+folds, the metric(s), and the data scope up front — then score every model,
+every variant, on exactly that. Iterating the model is science; iterating the
+eval (resplitting, reslicing, metric-shopping) until a favorite wins is
+cheating yourself.
+
+## The protocol
+
+```python
+from sklearn.model_selection import KFold, cross_validate
+
+cv = KFold(n_splits=5, shuffle=True, random_state=0)   # built ONCE, shared by all models
+scoring = {"r2": "r2", "mae": "neg_mean_absolute_error"}
+
+res = cross_validate(model, X, y, cv=cv, scoring=scoring)   # same cv object for every model
+```
+
+- `NoriRegressor` is a scikit-learn estimator (`clone`-safe), so it drops into
+  `cross_validate` directly — see `templates/compare_baselines.py`.
+- Report **mean ± std over folds**, not just the mean. Two models whose means
+  differ by less than the fold noise are **tied** — say so instead of
+  declaring a winner.
+- Always include at least two cheap baselines with real signal:
+  `Ridge` (linear floor) and `RandomForestRegressor` (nonlinear floor). If
+  Nori can't beat Ridge, the relationship is probably linear — that is a
+  finding, not a failure.
+- Pick the metric to match the decision: R² for variance-explained framing,
+  MAE for robust absolute error, RMSE when large errors are disproportionately
+  costly. Decide **before** looking at results; report the others as secondary.
+
+## Prediction-interval calibration
+
+Quantile bands are only useful if their coverage is honest. Check empirically
+on held-out data:
+
+```python
+lo, hi = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.9])
+coverage = ((y_test >= lo) & (y_test <= hi)).mean()   # nominal: 0.80
+```
+
+- Coverage well **below** nominal → intervals overconfident; widen the taus
+  you act on (e.g. use [0.05, 0.95] where you report "80%") or recalibrate.
+- Coverage near 1.0 → intervals are so wide they say nothing.
+- With `output_type="full"` you can trace the whole calibration curve:
+  empirical coverage of `[τ_lo, τ_hi]` vs nominal across many τ pairs.
+
+## Knowing when to stop
+
+If several sensible variants (feature subsets, target transform on/off,
+context subsampling) all land within the fold-noise band, you're at the
+information floor of the dataset — more tuning finds noise, not signal. Say
+so and stop; only genuinely new information (new features, more rows) moves
+the number from there.

--- a/.claude/skills/nori-regression/references/interpretability.md
+++ b/.claude/skills/nori-regression/references/interpretability.md
@@ -1,0 +1,63 @@
+# Interpretability
+
+Needs the extra: `pip install "synthefy-nori[interpretability]"` (pulls in
+shapiq + matplotlib). `NoriRegressor` subclasses `RegressorMixin`/`BaseEstimator`,
+so it also works with the wider sklearn interpretability ecosystem directly.
+All methods operate on the regression predictive mean.
+
+## Shapley values & interactions (shapiq)
+
+`get_nori_imputation_explainer` builds a `shapiq.TabularExplainer` that removes
+features by **imputation** against a background set. The fitted context stays
+fixed across coalitions; each coalition costs one `predict` call, so total cost
+is set by `budget`.
+
+```python
+from synthefy_nori import NoriRegressor
+from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+
+reg = NoriRegressor().fit(X_train, y_train)
+
+# Plain first-order Shapley values:
+explainer = get_nori_imputation_explainer(reg, X_train, index="SV", max_order=1)
+iv = explainer.explain(X_test[0:1], budget=128)     # shapiq InteractionValues
+
+# Pairwise interactions on top:
+explainer = get_nori_imputation_explainer(reg, X_train, index="k-SII", max_order=2)
+iv = explainer.explain(X_test[0:1], budget=128)
+iv.plot_waterfall()                                  # additive contribution waterfall
+```
+
+- **Budget guidance:** start at 128 and raise only if attributions look noisy
+  across reruns. `<10` features → 64–128; 10–20 → 128–512; 20+ → 512–2048.
+- **Global importance:** Shapley is per-row; for a dataset-level view, average
+  `|φ|` over a sample of query rows — `templates/explain.py` does exactly this
+  and prints a sorted importance table.
+
+## Partial dependence / ICE
+
+```python
+from synthefy_nori.interpretability.pdp import partial_dependence_plots
+
+partial_dependence_plots(reg, X_test, features=[0, 2], kind="average")
+# kind="individual" for ICE curves, "both" for overlay
+```
+
+## Feature selection
+
+```python
+from synthefy_nori.interpretability.feature_selection import feature_selection
+
+res = feature_selection(reg, X_train, y_train, n_features_to_select=5, cv=3,
+                        feature_names=list(feature_names))
+print(res.selected_names)
+print(res.baseline_score_mean, "->", res.selected_score_mean)   # CV R²
+```
+
+Sequential selection re-runs in-context prediction on every CV split ×
+candidate feature, so it is the **slow** tool here — keep it to a few thousand
+rows and a modest feature count, and run it once you already have a working
+model, not before.
+
+Runnable end-to-end example: `examples/interpretability_regression.py` in this
+repo; skill template: `templates/explain.py`.

--- a/.claude/skills/nori-regression/references/one-step-forecasting.md
+++ b/.claude/skills/nori-regression/references/one-step-forecasting.md
@@ -54,9 +54,12 @@ band (nominal 0.80). `templates/forecast_one_step.py` runs this end-to-end.
 ## Beyond one step
 
 - **Multi-step:** either *recursive* (feed predictions back as lags — simple,
-  but errors compound and the bands stop being honest) or *direct* (train a
-  separate frame with target `y.shift(-h)` per horizon `h` — one Nori fit per
-  horizon, honest quantiles). Prefer direct when the horizon matters.
+  but errors compound and the bands stop being honest) or *direct* (reframe
+  the table per horizon — one Nori fit per horizon, honest quantiles). Prefer
+  direct; `templates/forecast_multi_step.py` is the runnable recipe. The
+  leak trap at horizon *h*: `lag_1..lag_{h-1}` reference periods that are
+  **not yet observed** at forecast time — the newest legal lag is `lag_h`,
+  and context targets must also stop at `t-h`.
 - **Many related series (a panel):** pool rows across series with a shared
   feature schema and a scale-free target so one model serves them all — that,
   plus cold-start handling, exogenous signals, and ensembling, is the

--- a/.claude/skills/nori-regression/references/one-step-forecasting.md
+++ b/.claude/skills/nori-regression/references/one-step-forecasting.md
@@ -1,0 +1,64 @@
+# One-step time-series forecasting with Nori
+
+Nori has no time axis — no horizon, freq, or timestamp arguments. You forecast
+by **framing the series as tabular rows**: one row per period, target = that
+period's value, features built **only from strictly earlier periods**. Done
+right, one-step-ahead forecasting is just regression with a stricter split
+discipline.
+
+## The one rule: no leakage
+
+Features for period *t* may use only data `< t`. Concretely: every derived
+column must go through `shift(1)` (or a lag) before any rolling/aggregation.
+And **never evaluate with a random split** — rows are time-ordered, so a random
+split puts the future in the context. Use a rolling-origin backtest instead.
+
+## Feature recipe (start here, sweep later)
+
+| feature | construction | why |
+|---|---|---|
+| `lag1, lag2, lag3` | `y.shift(k)` | local level & short dynamics |
+| `lag<season>` | `y.shift(season)` (12 for monthly, 7 for daily) | seasonality |
+| `roll_mean, roll_std` | `y.shift(1).rolling(season).mean() / .std()` | trailing level & volatility |
+| `trend` | row index | long-run drift |
+| `phase_sin, phase_cos` | `sin/cos(2π · (t mod season)/season)` | smooth seasonal phase |
+
+Early rows have NaN lags — that's fine, Nori accepts NaN features (leave them;
+don't zero-fill). The target still must be finite.
+
+## Fit/predict pattern (expanding context)
+
+`fit()` is free (it just stores context), so refit at every origin and reuse
+one estimator object:
+
+```python
+reg = NoriRegressor(device="cpu")            # construct ONCE, refit per origin
+for t in test_origins:                       # expanding window
+    reg.fit(X[:t], y[:t])                    # context = everything before t
+    point = reg.predict(X[t:t+1], output_type="median")
+    q10, q90 = reg.predict(X[t:t+1], output_type="quantiles", quantiles=[0.1, 0.9])
+```
+
+`"median"` is the robust default for skewed series (demand, traffic, revenue);
+for such positive skewed targets also consider fitting on `np.log1p(y)` and
+inverting with `np.expm1` — quantiles invert directly through any monotone
+transform, unlike the mean.
+
+## Evaluate against naive baselines — always
+
+A forecast that can't beat `y[t-1]` (last value) or `y[t-season]` (seasonal
+naive) isn't earning its keep. Report MAE/WAPE for Nori **and both baselines**
+over the same rolling origins, plus the empirical coverage of your [q10, q90]
+band (nominal 0.80). `templates/forecast_one_step.py` runs this end-to-end.
+
+## Beyond one step
+
+- **Multi-step:** either *recursive* (feed predictions back as lags — simple,
+  but errors compound and the bands stop being honest) or *direct* (train a
+  separate frame with target `y.shift(-h)` per horizon `h` — one Nori fit per
+  horizon, honest quantiles). Prefer direct when the horizon matters.
+- **Many related series (a panel):** pool rows across series with a shared
+  feature schema and a scale-free target so one model serves them all — that,
+  plus cold-start handling, exogenous signals, and ensembling, is the
+  **nori-demand-forecasting** skill's territory. Reach for it when you have
+  SKUs/stores/products rather than a single series.

--- a/.claude/skills/nori-regression/templates/compare_baselines.py
+++ b/.claude/skills/nori-regression/templates/compare_baselines.py
@@ -1,0 +1,82 @@
+"""Compare Nori against Ridge and RandomForest under ONE fixed CV protocol.
+
+    python compare_baselines.py                              # sklearn diabetes demo
+    python compare_baselines.py --data my.csv --target price --folds 5
+
+The folds are built once and shared by every model — that (plus deciding the
+metric up front) is what makes the comparison honest. Nori is a scikit-learn
+estimator, so it drops straight into cross_validate. Results within one
+fold-std of the best are reported as ties.
+"""
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import load_diabetes
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import Ridge
+from sklearn.model_selection import KFold, cross_validate
+
+from synthefy_nori import NoriRegressor
+
+
+def load_data(data: str | None, target: str | None) -> tuple[pd.DataFrame, pd.Series]:
+    if data is None:
+        return load_diabetes(return_X_y=True, as_frame=True)
+    if target is None:
+        raise SystemExit("--target is required with --data")
+    df = pd.read_csv(data)
+    y = df[target]
+    X = df.drop(columns=[target]).select_dtypes(include=[np.number])
+    keep = y.notna()
+    return X.loc[keep], y.loc[keep]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=None, help="CSV path (default: sklearn diabetes demo)")
+    ap.add_argument("--target", default=None, help="target column name (required with --data)")
+    ap.add_argument("--device", default=None, help="torch device for Nori (default: auto)")
+    ap.add_argument("--folds", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    X, y = load_data(args.data, args.target)
+    # NaN features are fine for Nori but not for the sklearn baselines — fill a
+    # copy for them so every model sees the same rows.
+    X_sk = X.fillna(X.median(numeric_only=True))
+
+    cv = KFold(n_splits=args.folds, shuffle=True, random_state=args.seed)  # built once, shared
+    scoring = {"r2": "r2", "mae": "neg_mean_absolute_error"}
+
+    models = {
+        "nori": (NoriRegressor(device=args.device), X),
+        "ridge": (Ridge(alpha=1.0), X_sk),
+        "random_forest": (RandomForestRegressor(n_estimators=300, random_state=args.seed), X_sk),
+    }
+
+    rows = []
+    for name, (model, X_m) in models.items():
+        res = cross_validate(model, X_m, y, cv=cv, scoring=scoring)
+        rows.append({
+            "model": name,
+            "r2_mean": res["test_r2"].mean(), "r2_std": res["test_r2"].std(),
+            "mae_mean": -res["test_mae"].mean(), "mae_std": res["test_mae"].std(),
+        })
+        print(f"{name:14s} R² {rows[-1]['r2_mean']:.3f} ± {rows[-1]['r2_std']:.3f}   "
+              f"MAE {rows[-1]['mae_mean']:.3f} ± {rows[-1]['mae_std']:.3f}")
+
+    table = pd.DataFrame(rows).sort_values("r2_mean", ascending=False).reset_index(drop=True)
+    best = table.iloc[0]
+    tied = table[table.r2_mean >= best.r2_mean - best.r2_std]
+    if len(tied) > 1:
+        print(f"\nwithin one fold-std of the best ({best.model}): "
+              f"{', '.join(tied.model)} — treat these as tied.")
+    else:
+        print(f"\nbest: {best.model} (clear of the fold-noise band)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/nori-regression/templates/explain.py
+++ b/.claude/skills/nori-regression/templates/explain.py
@@ -1,0 +1,110 @@
+"""Global feature importance for a fitted Nori model: mean(|Shapley value|)
+over a sample of query rows, plus optional PDP and feature selection.
+
+    python explain.py                                # sklearn diabetes demo
+    python explain.py --data my.csv --target price --k 10 --budget 256
+    python explain.py --pdp 0 2                      # also draw PDPs for features 0 and 2
+    python explain.py --feature-selection 5          # also run (slow) selection
+
+Needs the interpretability extra:  pip install "synthefy-nori[interpretability]"
+"""
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+
+from synthefy_nori import NoriRegressor
+
+try:
+    from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
+except ImportError as e:  # pragma: no cover - env-dependent
+    raise SystemExit(
+        'interpretability extra missing — pip install "synthefy-nori[interpretability]"'
+    ) from e
+
+
+def first_order_vector(iv, n_features: int) -> np.ndarray:
+    """Length-n first-order attribution vector from a shapiq InteractionValues.
+
+    Recent shapiq versions expose get_n_order_values(1); older ones only the
+    coalition dict — support both.
+    """
+    getter = getattr(iv, "get_n_order_values", None)
+    if callable(getter):
+        try:
+            return np.asarray(getter(1), dtype=float).reshape(-1)[:n_features]
+        except Exception:
+            pass
+    vec = np.zeros(n_features, dtype=float)
+    d = getattr(iv, "dict_values", None) or dict(iv)
+    for coalition, val in d.items():
+        if isinstance(coalition, tuple) and len(coalition) == 1 and 0 <= coalition[0] < n_features:
+            vec[coalition[0]] = float(val)
+    return vec
+
+
+def shap_importance(reg, X_context: np.ndarray, X_query: np.ndarray,
+                    feature_names: list[str], *, budget: int = 128) -> pd.DataFrame:
+    """Per-feature mean(|Shapley|) over the query rows, sorted descending."""
+    explainer = get_nori_imputation_explainer(reg, X_context, index="SV", max_order=1)
+    acc = np.zeros(len(feature_names), dtype=float)
+    for row in X_query:
+        iv = explainer.explain(row.reshape(1, -1), budget=budget)
+        acc += np.abs(first_order_vector(iv, len(feature_names)))
+    out = pd.DataFrame({"feature": feature_names, "mean_abs_shap": acc / max(len(X_query), 1)})
+    return out.sort_values("mean_abs_shap", ascending=False).reset_index(drop=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=None, help="CSV path (default: sklearn diabetes demo)")
+    ap.add_argument("--target", default=None, help="target column name (required with --data)")
+    ap.add_argument("--device", default=None, help="torch device (default: auto)")
+    ap.add_argument("--k", type=int, default=8, help="query rows to explain (Shapley is per-row)")
+    ap.add_argument("--budget", type=int, default=128, help="coalitions per row; see interpretability.md")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--pdp", nargs="+", type=int, default=None, metavar="FEAT",
+                    help="feature indices to draw partial-dependence plots for")
+    ap.add_argument("--feature-selection", type=int, default=None, metavar="N",
+                    help="run sequential selection down to N features (slow)")
+    args = ap.parse_args()
+
+    if args.data is None:
+        X, y = load_diabetes(return_X_y=True, as_frame=True)
+    else:
+        if args.target is None:
+            raise SystemExit("--target is required with --data")
+        df = pd.read_csv(args.data)
+        y = df[args.target]
+        X = df.drop(columns=[args.target]).select_dtypes(include=[np.number])
+        X, y = X.loc[y.notna()], y.loc[y.notna()]
+
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.2, random_state=args.seed)
+    reg = NoriRegressor(device=args.device)
+    reg.fit(X_train.values, y_train.values)
+
+    imp = shap_importance(reg, X_train.values, X_test.values[: args.k],
+                          list(X.columns), budget=args.budget)
+    print(f"mean(|SHAP|) over {min(args.k, len(X_test))} query rows (budget={args.budget}):")
+    print(imp.to_string(index=False))
+
+    if args.pdp:
+        from synthefy_nori.interpretability.pdp import partial_dependence_plots
+        partial_dependence_plots(reg, X_test.values, features=args.pdp, kind="average")
+
+    if args.feature_selection:
+        from synthefy_nori.interpretability.feature_selection import feature_selection
+        res = feature_selection(reg, X_train.values, y_train.values,
+                                n_features_to_select=args.feature_selection, cv=3,
+                                feature_names=list(X.columns))
+        print("selected:", res.selected_names)
+        print(f"CV R²: all-features {res.baseline_score_mean:.3f} -> "
+              f"selected {res.selected_score_mean:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/nori-regression/templates/forecast_multi_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_multi_step.py
@@ -1,0 +1,130 @@
+"""Direct multi-step time-series forecasting with Nori: predict h periods
+ahead by shifting every feature back h steps — the leak-safe way to do
+"2 months ahead" — with a rolling backtest, quantile bands, and naive
+baselines.
+
+    python forecast_multi_step.py --horizon 2                     # synthetic demo
+    python forecast_multi_step.py --data my.csv --target sales --date-col date --horizon 3
+
+Direct vs recursive: recursive feeds predictions back as lags (errors
+compound, bands stop being honest). Direct reframes the table per horizon —
+features for the row at period t may use only values from periods <= t-h,
+because at forecast time the h-1 most recent periods are not observed yet.
+That is the whole trick: lag_h is the newest usable lag; lag_1..lag_{h-1}
+would be leaks.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from synthefy_nori import NoriRegressor
+
+
+def synthetic_series(n: int = 120, season: int = 12, seed: int = 7,
+                     ar: float = 0.7, sigma: float = 3.0) -> pd.DataFrame:
+    """Trend + seasonality + AR(1) noise. The autocorrelation matters: it makes
+    horizon-2 genuinely harder than horizon-1, like real demand/telemetry."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(n)
+    eps = np.zeros(n)
+    for i in range(1, n):
+        eps[i] = ar * eps[i - 1] + rng.normal(0, sigma)
+    y = 50 + 0.3 * t + 12 * np.sin(2 * np.pi * t / season) + eps
+    dates = pd.date_range("2015-01-31", periods=n, freq="ME")
+    return pd.DataFrame({"date": dates, "y": y})
+
+
+def build_features(y: pd.Series, *, horizon: int, season: int,
+                   n_lags: int = 3) -> pd.DataFrame:
+    """Leak-safe for horizon h: every column uses only values <= t-h."""
+    df = pd.DataFrame(index=y.index)
+    for k in range(horizon, horizon + n_lags):          # lag_h is the newest legal lag
+        df[f"lag{k}"] = y.shift(k)
+    df[f"lag{max(season, horizon)}"] = y.shift(max(season, horizon))
+    trailing = y.shift(horizon).rolling(season)
+    df["roll_mean"] = trailing.mean()
+    df["roll_std"] = trailing.std()
+    t = np.arange(len(y))
+    df["trend"] = t                                      # calendar of the TARGET period is known
+    df["phase_sin"] = np.sin(2 * np.pi * (t % season) / season)
+    df["phase_cos"] = np.cos(2 * np.pi * (t % season) / season)
+    return df
+
+
+def rolling_direct(y: np.ndarray, X: np.ndarray, origins: range, *, horizon: int,
+                   device: str | None) -> pd.DataFrame:
+    """At each origin t: context = rows whose features AND target are fully in
+    the past (target rows <= t-h), then predict row t."""
+    reg = NoriRegressor(device=device)
+    rows = []
+    for t in origins:
+        cut = t - horizon + 1  # rows [0, cut) have targets <= t-h+... strictly before t's info
+        reg.fit(X[:cut], y[:cut])
+        point = float(np.atleast_1d(reg.predict(X[t:t + 1], output_type="median"))[0])
+        q = np.asarray(reg.predict(X[t:t + 1], output_type="quantiles",
+                                   quantiles=[0.1, 0.9])).reshape(2, -1)
+        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point,
+                     "q10": float(q[0, 0]), "q90": float(q[1, 0])})
+    return pd.DataFrame(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=None, help="CSV path (default: synthetic AR demo)")
+    ap.add_argument("--target", default="y")
+    ap.add_argument("--date-col", default="date")
+    ap.add_argument("--horizon", type=int, default=2, help="steps ahead (h=1 -> one-step)")
+    ap.add_argument("--season", type=int, default=12)
+    ap.add_argument("--n-test", type=int, default=24)
+    ap.add_argument("--device", default=None)
+    ap.add_argument("--out", default="results.json")
+    args = ap.parse_args()
+
+    if args.data is None:
+        df = synthetic_series(season=args.season)
+        target, date_col = "y", "date"
+    else:
+        df = pd.read_csv(args.data)
+        target, date_col = args.target, args.date_col
+        df[date_col] = pd.to_datetime(df[date_col])
+    df = df.sort_values(date_col).reset_index(drop=True)
+    y = df[target].astype(float)
+    if y.isna().any():
+        raise SystemExit("target has NaN — fill or drop those periods first")
+
+    X = build_features(y, horizon=args.horizon, season=args.season).to_numpy(np.float32)
+    yv = y.to_numpy(np.float64)
+    origins = range(len(yv) - args.n_test, len(yv))
+    print(f"{len(yv)} periods, horizon={args.horizon}, last {args.n_test} origins "
+          f"({X.shape[1]} features; newest legal lag = lag{args.horizon})")
+
+    fc = rolling_direct(yv, X, origins, horizon=args.horizon, device=args.device)
+    fc["date"] = df[date_col].iloc[fc.t].dt.date.values
+
+    truth, pred = fc.y_true.to_numpy(), fc.y_pred.to_numpy()
+    idx = np.asarray(origins)
+    results = {
+        "horizon": int(args.horizon),
+        "n_origins": int(args.n_test),
+        "mae": float(np.abs(truth - pred).mean()),
+        "mae_naive_seasonal": float(np.abs(yv[idx] - yv[idx - args.season]).mean()),
+        "mae_naive_lastknown": float(np.abs(yv[idx] - yv[idx - args.horizon]).mean()),
+        "coverage_10_90": float(((truth >= fc.q10) & (truth <= fc.q90)).mean()),
+        "interval_width_mean": float((fc.q90 - fc.q10).mean()),
+    }
+    print(f"MAE  nori={results['mae']:.3f}  last-known={results['mae_naive_lastknown']:.3f}  "
+          f"seasonal-naive={results['mae_naive_seasonal']:.3f}")
+    print(f"coverage [q10,q90] {results['coverage_10_90']:.2f} (nominal 0.80)")
+
+    fc[["date", "y_true", "y_pred", "q10", "q90"]].to_csv("forecasts.csv", index=False)
+    Path(args.out).write_text(json.dumps(results, indent=2) + "\n")
+    print(f"wrote forecasts.csv and {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/nori-regression/templates/forecast_one_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_one_step.py
@@ -1,0 +1,125 @@
+"""One-step-ahead time-series forecasting with Nori: leak-safe lag features,
+rolling-origin backtest with expanding context, quantile bands, and naive
+baselines (last-value, seasonal-naive) for an honest comparison.
+
+    python forecast_one_step.py                                   # synthetic monthly demo
+    python forecast_one_step.py --data my.csv --target sales --date-col date
+    python forecast_one_step.py --season 7 --n-test 28            # daily data
+
+Writes forecasts.csv (one row per origin) and results.json.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from synthefy_nori import NoriRegressor
+
+
+def synthetic_series(n: int = 120, season: int = 12, seed: int = 42) -> pd.DataFrame:
+    """Trend + seasonality + noise; the demo stand-in for your CSV."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(n)
+    y = 50 + 0.3 * t + 12 * np.sin(2 * np.pi * t / season) + rng.normal(0, 3, n)
+    dates = pd.date_range("2015-01-31", periods=n, freq="ME")
+    return pd.DataFrame({"date": dates, "y": y})
+
+
+def build_features(y: pd.Series, *, season: int, lags: tuple[int, ...] = (1, 2, 3)) -> pd.DataFrame:
+    """Leak-safe feature frame: every column uses only data strictly before its row."""
+    df = pd.DataFrame(index=y.index)
+    for k in (*lags, season):
+        df[f"lag{k}"] = y.shift(k)
+    trailing = y.shift(1).rolling(season)
+    df["roll_mean"] = trailing.mean()
+    df["roll_std"] = trailing.std()
+    t = np.arange(len(y))
+    df["trend"] = t
+    df["phase_sin"] = np.sin(2 * np.pi * (t % season) / season)
+    df["phase_cos"] = np.cos(2 * np.pi * (t % season) / season)
+    return df  # early rows hold NaN lags — fine as Nori context; don't zero-fill
+
+
+def rolling_one_step(y: np.ndarray, X: np.ndarray, origins: range, *,
+                     device: str | None) -> pd.DataFrame:
+    """Expanding-context backtest: refit (free) at each origin, predict one row."""
+    reg = NoriRegressor(device=device)  # construct once, refit per origin
+    rows = []
+    for t in origins:
+        reg.fit(X[:t], y[:t])
+        # single-row predict can come back 0-d — normalize the shapes
+        point = float(np.atleast_1d(reg.predict(X[t:t + 1], output_type="median"))[0])
+        q = np.asarray(reg.predict(X[t:t + 1], output_type="quantiles",
+                                   quantiles=[0.1, 0.9])).reshape(2, -1)
+        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point,
+                     "q10": float(q[0, 0]), "q90": float(q[1, 0])})
+    return pd.DataFrame(rows)
+
+
+def wape(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.abs(y_true - y_pred).sum() / max(np.abs(y_true).sum(), 1e-12))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=None, help="CSV path (default: synthetic monthly demo)")
+    ap.add_argument("--target", default="y", help="value column in the CSV")
+    ap.add_argument("--date-col", default="date", help="date column in the CSV (sorted on)")
+    ap.add_argument("--season", type=int, default=12, help="seasonal period (12 monthly, 7 daily)")
+    ap.add_argument("--lags", default="1,2,3", help="comma-separated short lags")
+    ap.add_argument("--n-test", type=int, default=24, help="rolling origins held out at the end")
+    ap.add_argument("--device", default=None, help="torch device (default: auto)")
+    ap.add_argument("--out", default="results.json")
+    args = ap.parse_args()
+
+    if args.data is None:
+        df = synthetic_series(season=args.season)
+        target, date_col = "y", "date"
+    else:
+        df = pd.read_csv(args.data)
+        target, date_col = args.target, args.date_col
+        df[date_col] = pd.to_datetime(df[date_col])
+    df = df.sort_values(date_col).reset_index(drop=True)
+    y = df[target].astype(float)
+    if y.isna().any():
+        raise SystemExit("target has NaN — fill or drop those periods first")
+
+    lags = tuple(int(k) for k in args.lags.split(","))
+    X = build_features(y, season=args.season, lags=lags).to_numpy(np.float32)
+    yv = y.to_numpy(np.float64)
+    origins = range(len(yv) - args.n_test, len(yv))
+    print(f"{len(yv)} periods, forecasting the last {args.n_test} one step ahead "
+          f"(features: {X.shape[1]})")
+
+    fc = rolling_one_step(yv, X, origins, device=args.device)
+    fc["date"] = df[date_col].iloc[fc.t].dt.date.values
+
+    truth, pred = fc.y_true.to_numpy(), fc.y_pred.to_numpy()
+    naive_last = yv[np.asarray(origins) - 1]
+    naive_seasonal = yv[np.asarray(origins) - args.season]
+    results = {
+        "n_origins": int(args.n_test),
+        "mae": float(np.abs(truth - pred).mean()),
+        "wape": wape(truth, pred),
+        "mae_naive_last": float(np.abs(truth - naive_last).mean()),
+        "mae_naive_seasonal": float(np.abs(truth - naive_seasonal).mean()),
+        "coverage_10_90": float(((truth >= fc.q10) & (truth <= fc.q90)).mean()),
+        "interval_width_mean": float((fc.q90 - fc.q10).mean()),
+    }
+
+    print(f"MAE  nori={results['mae']:.3f}  last-value={results['mae_naive_last']:.3f}  "
+          f"seasonal-naive={results['mae_naive_seasonal']:.3f}")
+    print(f"WAPE nori={results['wape']:.3%}   [q10,q90] coverage "
+          f"{results['coverage_10_90']:.2f} (nominal 0.80)")
+
+    fc[["date", "y_true", "y_pred", "q10", "q90"]].to_csv("forecasts.csv", index=False)
+    Path(args.out).write_text(json.dumps(results, indent=2) + "\n")
+    print(f"wrote forecasts.csv and {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/nori-regression/templates/regress.py
+++ b/.claude/skills/nori-regression/templates/regress.py
@@ -1,0 +1,91 @@
+"""End-to-end tabular regression with Nori: point predictions, prediction
+intervals with an empirical coverage check, and a results.json summary.
+
+    python regress.py                                  # sklearn diabetes demo
+    python regress.py --data my.csv --target price     # your CSV
+    python regress.py --device cuda:0 --out results.json
+
+The script holds out a test split, fits Nori on the rest (fit = storing
+context; all compute happens in predict), reports R²/MAE for both the mean and
+median point estimates, and checks that the nominal 80% interval [q10, q90]
+actually covers ~80% of the held-out targets.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import load_diabetes
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from synthefy_nori import NoriRegressor
+
+
+def load_data(data: str | None, target: str | None) -> tuple[pd.DataFrame, pd.Series]:
+    """Return (X, y) from a CSV, or the sklearn diabetes demo when no CSV given."""
+    if data is None:
+        X, y = load_diabetes(return_X_y=True, as_frame=True)
+        return X, y
+    if target is None:
+        raise SystemExit("--target is required with --data")
+    df = pd.read_csv(data)
+    if target not in df.columns:
+        raise SystemExit(f"target column {target!r} not in {list(df.columns)}")
+    y = df[target]
+    X = df.drop(columns=[target]).select_dtypes(include=[np.number])
+    keep = y.notna()  # the target must be finite; NaN features are fine as-is
+    return X.loc[keep], y.loc[keep]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=None, help="CSV path (default: sklearn diabetes demo)")
+    ap.add_argument("--target", default=None, help="target column name (required with --data)")
+    ap.add_argument("--device", default=None, help="torch device, e.g. cuda:0 (default: auto)")
+    ap.add_argument("--test-size", type=float, default=0.2)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", default="results.json", help="where to write the JSON summary")
+    args = ap.parse_args()
+
+    X, y = load_data(args.data, args.target)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=args.test_size, random_state=args.seed
+    )
+    print(f"rows: {len(X_train)} context / {len(X_test)} query, {X.shape[1]} features")
+
+    reg = NoriRegressor(device=args.device)
+    reg.fit(X_train, y_train)
+
+    mean_pred = reg.predict(X_test)                          # (n,) distribution mean
+    median_pred = reg.predict(X_test, output_type="median")  # robust for skewed targets
+    q10, q50, q90 = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
+
+    y_true = np.asarray(y_test, dtype=float)
+    coverage = float(((y_true >= q10) & (y_true <= q90)).mean())
+    results = {
+        "n_train": int(len(X_train)),
+        "n_test": int(len(X_test)),
+        "r2_mean": float(r2_score(y_true, mean_pred)),
+        "r2_median": float(r2_score(y_true, median_pred)),
+        "mae_mean": float(mean_absolute_error(y_true, mean_pred)),
+        "mae_median": float(mean_absolute_error(y_true, median_pred)),
+        "coverage_10_90": coverage,  # nominal 0.80
+        "interval_width_mean": float(np.mean(q90 - q10)),
+    }
+
+    print(f"R²   mean={results['r2_mean']:.3f}  median={results['r2_median']:.3f}")
+    print(f"MAE  mean={results['mae_mean']:.3f}  median={results['mae_median']:.3f}")
+    print(f"[q10, q90] empirical coverage: {coverage:.2f} (nominal 0.80), "
+          f"mean width {results['interval_width_mean']:.3f}")
+
+    out = Path(args.out)
+    out.write_text(json.dumps(results, indent=2) + "\n")
+    print(f"wrote {out.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -50,4 +50,4 @@ jobs:
           # sign (the flow requires the PR author to comment the agreement), so a
           # bot-authored PR will sit with a red CLA check. If that ever needs to
           # merge, add the specific bot login here (e.g. copilot-swe-agent[bot]).
-          allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy'
+          allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy,minkyu-choi07'

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ benchmarks/plots/
 *.safetensors
 *.onnx
 
-# Local agent / tooling state
-.claude/
+# Local agent / tooling state — but ship the project skills
+.claude/*
+!.claude/skills/
 
 # Environment files — may contain secrets, never commit
 .env


### PR DESCRIPTION
## What

Adds a project Claude Code skill, `.claude/skills/nori-regression/`, teaching agents general tabular regression with Nori — plus a one-line `.gitignore` narrowing (`.claude/` → `.claude/*` + `!.claude/skills/`) so project skills ship while local agent state stays ignored.

```
.claude/skills/nori-regression/
├── SKILL.md                        # when to use, mental model, workflow, guardrails
├── references/
│   ├── api.md                      # verified 0.9.0 public API (constructor, output types, HF env)
│   ├── data-preparation.md         # categoricals, NaN policy, target skew, context-size scaling
│   ├── evaluation.md               # fixed CV protocol, ties-within-noise, interval calibration
│   ├── interpretability.md         # shapiq SV/k-SII, budget guidance, PDP, feature selection
│   └── one-step-forecasting.md     # leak-safe lags, expanding-context refit, naive baselines
└── templates/
    ├── regress.py                  # end-to-end: points + [q10,q90] with coverage check
    ├── compare_baselines.py        # cross_validate Nori vs Ridge vs RandomForest, shared folds
    ├── explain.py                  # mean(|SHAP|) importance + optional PDP / feature selection
    └── forecast_one_step.py        # rolling one-step backtest with bands vs naive baselines
```

## Why

Nori's examples show the API; the skill encodes the *method* (leak-free protocol, honest baselines, calibrated intervals) so any Claude Code agent working in this repo applies it correctly out of the box.

## Verification

- Every reference claim checked against `src/synthefy_nori/api.py` @ 0.9.0; templates are ruff-clean and were run end-to-end on CPU (diabetes: Nori 5-fold CV R² 0.478 vs Ridge 0.420; [q10,q90] coverage 0.83 vs nominal 0.80).
- **Skill-only reproduction via an Agent-SDK sandbox** (harness in the internal monorepo, `experiments/skill-sandbox/`): a fresh agent with only this skill + task prompts solved three pinned tasks (diabetes regression+intervals, SHAP attribution, one-step forecasting); all deterministic checks passed — mandated split respected, R² within margin of Ridge, monotone quantiles, honest self-reported numbers, `solution.py` re-run by the harness reproduced outputs exactly (drift 0.0000), SHAP top-3 = bmi/s5/bp rank-stable across re-run; forecasting beat seasonal-naive/last-value (MAE 2.68 vs 4.35/4.59) while staying above the leak-detection noise floor.
- `uv run pytest` (20 passed) and `uv run ruff check src scripts tests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Also includes: `cla.yml` internal-contributor allowlist entry for the PR author (the CLA check reads the allowlist from `main`, so it stays red on this PR and turns green for all future ones after merge).
