### PR TITLE
Replace LabelEncoder with a shared ordinal encode helper

### DIFF
--- a/src/synthefy_nori/evaluation/datasets.py
+++ b/src/synthefy_nori/evaluation/datasets.py
@@ -20,7 +20,32 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
+# Keep in sync with synthefy_nori.inference.predictor.NA_PLACEHOLDER (not
+# imported: this module must stay importable without pulling in torch).
+NA_PLACEHOLDER = "__MISSING__"
+
+
+def encode_categorical_column(col, classes=None):
+    """Ordinal-encode one categorical feature column to sorted-unique int64
+    codes 0..K-1 — exactly what sklearn's LabelEncoder produced here, via the
+    same primitives (np.unique / searchsorted), minus the 0-row raise.
+
+    Missing values are mapped to NA_PLACEHOLDER so they get a real code
+    (callers that want NaN restore it afterwards). Cast to object before
+    fillna: on category dtype, fillna with an unseen value raises. When
+    ``classes`` is given the codes index into it (every value must be present,
+    e.g. classes derived from train+test combined); otherwise classes are
+    derived from ``col``. Returns ``(codes, classes)``.
+    """
+    arr = col.astype(object).fillna(NA_PLACEHOLDER).astype(str).to_numpy()
+    if classes is None:
+        classes, codes = np.unique(arr, return_inverse=True)
+        # numpy 2.0.0 briefly returned a 2-D inverse; ravel so codes are 1-D
+        # on any numpy>=2.0 (keeps written CSV codes reproducible).
+        codes = codes.ravel()
+    else:
+        codes = np.searchsorted(classes, arr)
+    return codes.astype(np.int64), classes
 
 
 @dataclass
@@ -262,8 +287,9 @@ class DatasetRegistry:
             for col in X.columns:
                 if not pd.api.types.is_numeric_dtype(X[col]):
                     mask = X[col].isna()
-                    X[col] = X[col].astype(object).fillna("__MISSING__")
-                    X[col] = LabelEncoder().fit_transform(X[col].astype(str))
+                    # int64 codes keep the written CSVs byte-identical to the
+                    # published ones (same sorted-unique codes as before).
+                    X[col], _ = encode_categorical_column(X[col])
                     if mask.any():
                         X.loc[mask, col] = np.nan
 
@@ -534,19 +560,15 @@ class DatasetRegistry:
             X_test = pd.DataFrame(X_test) if not isinstance(X_test, pd.DataFrame) else X_test.copy()
             y_test = pd.Series(y_test) if not isinstance(y_test, pd.Series) else y_test.copy()
 
-        # Encode object/category/string columns. Cast to object before fillna:
-        # on category dtype, fillna with an unseen value raises, which used to
-        # silently drop every categorical column parsed from parquet/Arrow.
+        # Encode object/category/string columns, classes fit on train+test
+        # combined so a test-only value can't fall outside the code range.
         for col in list(X.select_dtypes(include=["object", "category", "string"]).columns):
             try:
-                le = LabelEncoder()
                 parts = [X[col]] + ([X_test[col]] if X_test is not None else [])
-                combined = pd.concat(parts).astype(object).fillna("__MISSING__").astype(str)
-                le.fit(combined)
-                X[col] = le.transform(X[col].astype(object).fillna("__MISSING__").astype(str))
+                _, classes = encode_categorical_column(pd.concat(parts))
+                X[col], _ = encode_categorical_column(X[col], classes)
                 if X_test is not None:
-                    X_test[col] = le.transform(
-                        X_test[col].astype(object).fillna("__MISSING__").astype(str))
+                    X_test[col], _ = encode_categorical_column(X_test[col], classes)
             except Exception:
                 X = X.drop(columns=[col])
                 if X_test is not None:

--- a/src/synthefy_nori/utils/retrieval_utils.py
+++ b/src/synthefy_nori/utils/retrieval_utils.py
@@ -2,21 +2,29 @@ from __future__ import annotations
 
 import numpy as np
 import torch
-from sklearn.preprocessing import LabelEncoder
 
 
 class RelabelRetrievalY:
+    """Relabel per-batch classification targets to dense 0..K-1 codes.
+
+    This is target relabeling, not feature encoding: np.unique with
+    return_inverse=True is exactly the fit_transform of the LabelEncoder it
+    replaces, and indexing the sorted classes array is its inverse_transform.
+    """
+
     def __init__(self, y_train: torch.Tensor):
         """
         Args:
             y_train: (batch_size, n_samples, 1)
         """
         self.y_train = y_train.cpu().numpy()
-        self.label_encoders = [LabelEncoder() for i in range(y_train.shape[0])]
+        self.classes_ = [None] * y_train.shape[0]
 
     def transform_y(self, ):
         for i in range(self.y_train.shape[0]):
-            self.y_train[i] = np.expand_dims(self.label_encoders[i].fit_transform(self.y_train[i].ravel()), axis=1)
+            classes, inverse = np.unique(self.y_train[i].ravel(), return_inverse=True)
+            self.classes_[i] = classes
+            self.y_train[i] = np.expand_dims(inverse, axis=1)
         self.label_y = self.y_train.copy().astype(np.int32)
         self.y_train = torch.tensor(self.y_train, dtype=torch.float32)
         return self.y_train
@@ -33,7 +41,7 @@ class RelabelRetrievalY:
         result = np.full((X.shape[0], num_classes), fill_value=-np.inf)
         for i in range(X.shape[0]):
             batch_label = np.unique(self.label_y[i])
-            reverse_perm = self.label_encoders[i].inverse_transform(batch_label).astype(np.int32)
+            reverse_perm = self.classes_[i][batch_label].astype(np.int32)
             reverse_output = np.full(num_classes, fill_value=-np.inf)
             reverse_output[reverse_perm] = X[i, batch_label]
             result[i] = reverse_output

--- a/tests/test_benchmark_performance.py
+++ b/tests/test_benchmark_performance.py
@@ -39,7 +39,6 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import LabelEncoder
 
 # NOTE: torch and synthefy_nori are imported lazily inside main(), after
 # SYNTHEFY_MAX_ELEMENTS_BUDGET is set, since the predictor reads it at import.
@@ -73,16 +72,19 @@ def compute_reg_metrics(y_true, y_pred):
 # Preprocessing (mirror evaluation/datasets.py: categorical encode + coerce)
 # --------------------------------------------------------------------------- #
 def _prepare_xy(X_train_df, X_test_df):
-    """Label-encode categorical columns (fit on train+test), coerce to float32."""
+    """Ordinal-encode categorical columns (fit on train+test), coerce to float32."""
+    # Lazy import (module-level synthefy_nori imports are deferred, see NOTE
+    # above); reusing the loader's encoder keeps this mirror from drifting.
+    from synthefy_nori.evaluation.datasets import encode_categorical_column
+
     X_train_df = X_train_df.copy()
     X_test_df = X_test_df.copy()
     cat_cols = X_train_df.select_dtypes(include=["object", "category"]).columns
     for col in cat_cols:
-        le = LabelEncoder()
-        combined = pd.concat([X_train_df[col], X_test_df[col]]).fillna("__MISSING__").astype(str)
-        le.fit(combined)
-        X_train_df[col] = le.transform(X_train_df[col].fillna("__MISSING__").astype(str))
-        X_test_df[col] = le.transform(X_test_df[col].fillna("__MISSING__").astype(str))
+        combined = pd.concat([X_train_df[col], X_test_df[col]])
+        _, classes = encode_categorical_column(combined)
+        X_train_df[col], _ = encode_categorical_column(X_train_df[col], classes)
+        X_test_df[col], _ = encode_categorical_column(X_test_df[col], classes)
 
     X_train = X_train_df.apply(pd.to_numeric, errors="coerce").fillna(0).astype(np.float32).to_numpy()
     X_test = X_test_df.apply(pd.to_numeric, errors="coerce").fillna(0).astype(np.float32).to_numpy()


### PR DESCRIPTION
## What

Removes `sklearn.preprocessing.LabelEncoder` from the codebase, replacing all uses with a single shared `encode_categorical_column` helper (built on `np.unique`/`np.searchsorted`) in `evaluation/datasets.py`, and `np.unique(return_inverse=True)` in `RelabelRetrievalY`.

## Why

`LabelEncoder` is documented for encoding **targets**, not feature columns — using it on features is a known sklearn anti-pattern. The replacement uses the same underlying primitive (`np.unique` sorted-unique codes), so it produces **byte-identical output**: sorted-unique `0..K-1` int64 codes with the `__MISSING__` sentinel for NaN. The pinned benchmark CSVs stay reproducible.

This also collapses a snippet that was copy-pasted across five sites (two loader paths + the benchmark test) into one helper, and centralizes the `__MISSING__` sentinel (kept in sync with `predictor.NA_PLACEHOLDER`).

## Behavior fixes that fall out of the shared helper

- **`_make_entry_from_df` no longer silently drops categorical columns on 0-row splits.** `LabelEncoder.transform` (and `OrdinalEncoder`) raise on empty input; that exception hit the blanket `except` and dropped every categorical column from both train and test. `np.unique` handles empty input, so a header-only test CSV keeps its columns.
- **The benchmark test's `_prepare_xy` now casts to object before `fillna`**, matching the loader it mirrors — OpenML `category`-dtype columns containing NaN previously raised `TypeError` and got silently skipped.

## Verification

- `ruff` + `pytest` (18 passed) green.
- Equivalence harness confirms byte-identical codes vs the old `LabelEncoder` across string / NaN / `category`-dtype / single-category / test-only-value cases, the 0-row split (now returns empty instead of raising), and a 20-batch `RelabelRetrievalY` transform + inverse round-trip.
- `.ravel()` guards the numpy 2.0.0 `return_inverse` 2-D-shape regression so codes are 1-D on any `numpy>=2.0`.