### PR TITLE
Release: NoriEmbedding sklearn transformer + get_embeddings API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,21 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv sync --extra dev
       - run: uv run pytest -m slow tests/test_training_smoke.py
+
+  # Merge gate (part 3): the embedding feature end-to-end — NoriEmbedding, the
+  # get_embeddings API, the clustering-quality checks, and the shipped examples
+  # (run on tiny data). Downloads the public checkpoint. These are `slow`, so the
+  # default `test` job deselects them; this job is what actually exercises the
+  # real embedding path (and the examples) on every PR. Needs the `eval` extra
+  # for the TabArena example's dataset registry.
+  embedding:
+    name: CI test embeddings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: uv sync --extra dev --extra eval
+      - run: uv run pytest -m slow tests/embedding/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ src/synthefy_nori/
   hf.py           HF download/upload + console-script entry points
   model/          FeaturesTransformer architecture
   inference/      NoriPredictor + preprocessing
+  embedding/      NoriEmbedding (sklearn transformer for row embeddings)
   training/       data generation, trainer, loss, config, CLI (GPU / DDP)
   evaluation/     benchmark runner + CLI
   configs/*.json  bundled inference configs (shipped via package-data)

--- a/examples/embedding_synthetic.py
+++ b/examples/embedding_synthetic.py
@@ -1,0 +1,132 @@
+"""Nori embeddings on a synthetic dataset: extract, probe, and visualize.
+
+Nori's encoder turns every row into a learned vector. This example shows the two
+ways to pull those vectors out, uses them for a downstream probe, and draws a
+t-SNE that makes the target structure visible — all on a small synthetic
+regression dataset. See ``embedding_tabarena.py`` for the same workflow on a real
+dataset.
+
+    uv run python examples/embedding_synthetic.py     # extract + probe
+    uv sync --extra eval                              # adds matplotlib (t-SNE)
+    uv run python examples/embedding_synthetic.py     # ... now also writes a PNG
+
+Two ways to get embeddings — both return a 3D array
+``(n_estimators, n_samples, embed_dim)``; average over axis 0 (the
+preprocessing-pipeline ensemble) for a 2D feature matrix:
+  1. ``NoriRegressor.get_embeddings(X, data_source=...)`` — the low-level call.
+  2. ``NoriEmbedding`` — an sklearn transformer; with ``n_fold >= 2`` it produces
+     leakage-free out-of-fold embeddings for the training rows.
+
+The first run downloads the public ~47MB checkpoint; GPU if available, else CPU.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from sklearn.metrics import r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.preprocessing import StandardScaler
+
+from synthefy_nori import NoriEmbedding, NoriRegressor
+
+OUT_DIR = "results"
+
+
+def extract_embeddings(X_train, y_train, X_test):
+    """Return OOF train embeddings, test embeddings (both 2D), and Nori's own
+    native test prediction — using a single fitted model for all three.
+
+    Demonstrates both embedding APIs: the ``NoriEmbedding`` transformer (for the
+    leakage-free out-of-fold train embeddings) and the low-level
+    ``get_embeddings`` call on its final full-data model.
+    """
+    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
+                             model=NoriRegressor())
+    Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
+    Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
+
+    # Low-level call on the same fitted model (no extra load); shows the raw 3D
+    # shape before we average over the ensemble axis.
+    raw = embedder.model_.get_embeddings(X_test, data_source="test")
+    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}"
+          f"; averaged to 2D {Z_test.shape}")
+
+    native = np.asarray(embedder.model_.predict(X_test))  # Nori's native head
+    return Z_train, Z_test, native
+
+
+def knn_probe(Z_train, y_train, Z_test, y_test):
+    """A plain kNN regressor on the embeddings — the simplest downstream head."""
+    knn = KNeighborsRegressor(n_neighbors=10).fit(Z_train, y_train)
+    return float(r2_score(y_test, knn.predict(Z_test)))
+
+
+def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
+    """Side-by-side t-SNE (raw features | Nori embeddings). Skipped if matplotlib
+    is not installed, so the extract/probe path still runs without ``--extra eval``.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # headless: straight to file
+        import matplotlib.pyplot as plt
+        from sklearn.manifold import TSNE
+    except ImportError:
+        print("  [skip t-SNE] matplotlib not installed (uv sync --extra eval)")
+        return None
+
+    def _tsne(M):
+        M = StandardScaler().fit_transform(M)
+        perp = float(min(30, max(5, (len(M) - 1) // 3)))  # valid for small n
+        return TSNE(n_components=2, perplexity=perp, init="pca",
+                    random_state=0).fit_transform(M)
+
+    os.makedirs(OUT_DIR, exist_ok=True)
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5.2))
+    sc = None
+    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"),
+                         (axes[1], _tsne(Z_embed), "Nori embeddings")):
+        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18,
+                        alpha=0.85, edgecolors="none")
+        ax.set_title(sub, fontsize=12)
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.suptitle(title, fontsize=14, fontweight="bold")
+    fig.colorbar(sc, ax=axes, fraction=0.046, pad=0.04).set_label(cbar_label)
+    path = os.path.join(OUT_DIR, fname)
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  wrote {path}")
+    return path
+
+
+def make_dataset(n=400, seed=0):
+    """A smooth, nonlinear regression target with an interaction term."""
+    rng = np.random.default_rng(seed)
+    X = rng.uniform(-2.0, 2.0, size=(n, 5)).astype(np.float32)
+    y = (np.sin(X[:, 0]) + X[:, 1] ** 2 + 0.5 * X[:, 2] * X[:, 3]).astype(np.float64)
+    return train_test_split(X, y, test_size=0.3, random_state=0)
+
+
+def main():
+    X_train, X_test, y_train, y_test = make_dataset()
+    print(f"synthetic regression: train={len(X_train)} test={len(X_test)} "
+          f"features={X_train.shape[1]}")
+
+    Z_train, Z_test, native = extract_embeddings(X_train, y_train, X_test)
+
+    probe_r2 = knn_probe(Z_train, y_train, Z_test, y_test)
+    native_r2 = float(r2_score(y_test, native))
+    print("\n=== R2 ===")
+    print(f"  embedding dim            : {Z_train.shape[1]}")
+    print(f"  kNN probe on embeddings  : {probe_r2:.4f}")
+    print(f"  Nori native head (ref.)  : {native_r2:.4f}")
+
+    tsne_plot(X_test, Z_test, y_test,
+              "t-SNE — synthetic regression (color = target y)",
+              "embedding_synthetic_tsne.png", cbar_label="target y")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/embedding_tabarena.py
+++ b/examples/embedding_tabarena.py
@@ -1,0 +1,172 @@
+"""Nori embeddings on a real TabArena dataset: extract, probe, and visualize.
+
+The same workflow as ``embedding_synthetic.py``, but on a real regression dataset
+from the TabArena suite (downloaded once from OpenML, pinned by dataset ID). It
+extracts Nori row embeddings, runs a downstream Ridge probe, compares against
+Nori's own native head, and draws a t-SNE of raw features vs embeddings.
+
+    uv sync --extra eval                                    # openml + matplotlib
+    uv run python examples/embedding_tabarena.py            # default dataset
+    uv run python examples/embedding_tabarena.py --dataset wine_quality
+    uv run python examples/embedding_tabarena.py --list     # available names
+
+Two ways to get embeddings — both return a 3D array
+``(n_estimators, n_samples, embed_dim)``; average over axis 0 (the
+preprocessing-pipeline ensemble) for a 2D feature matrix:
+  1. ``NoriRegressor.get_embeddings(X, data_source=...)`` — the low-level call.
+  2. ``NoriEmbedding`` — an sklearn transformer; with ``n_fold >= 2`` it produces
+     leakage-free out-of-fold embeddings for the training rows.
+
+The first run downloads the dataset CSVs and the public ~47MB checkpoint; GPU if
+available, else CPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import numpy as np
+from sklearn.linear_model import RidgeCV
+from sklearn.metrics import r2_score
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from synthefy_nori import NoriEmbedding, NoriRegressor
+from synthefy_nori.evaluation.datasets import DatasetRegistry
+
+OUT_DIR = "results"
+CACHE_DIR = "cache/tabarena_reg"
+DEFAULT_DATASET = "wine_quality"
+MAX_TRAIN, MAX_TEST = 3000, 1500   # keep the demo fast (embeddings scale w/ context)
+
+
+def load_registry():
+    """Download (once) and load the TabArena regression suite."""
+    reg = DatasetRegistry(cache_dir="cache/eval_datasets", max_train_samples=MAX_TRAIN)
+    if not os.path.isdir(CACHE_DIR) or not os.listdir(CACHE_DIR):
+        reg.download_tabarena(reg_dir=CACHE_DIR)   # needs `openml`
+    reg.load_tabarena(reg_dir=CACHE_DIR)
+    return reg
+
+
+def extract_embeddings(X_train, y_train, X_test):
+    """Return OOF train embeddings, test embeddings (both 2D), and Nori's own
+    native test prediction — using a single fitted model for all three.
+
+    Demonstrates both embedding APIs: the ``NoriEmbedding`` transformer (for the
+    leakage-free out-of-fold train embeddings) and the low-level
+    ``get_embeddings`` call on its final full-data model.
+    """
+    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
+                             model=NoriRegressor())
+    Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
+    Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
+
+    raw = embedder.model_.get_embeddings(X_test, data_source="test")
+    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}"
+          f"; averaged to 2D {Z_test.shape}")
+
+    native = np.asarray(embedder.model_.predict(X_test))  # Nori's native head
+    return Z_train, Z_test, native
+
+
+def ridge_probe(Z_train, y_train, Z_test, y_test):
+    """A standardized Ridge regressor on the embeddings — a solid linear probe
+    for the higher-dimensional embeddings of real data."""
+    probe = make_pipeline(StandardScaler(),
+                          RidgeCV(alphas=(0.1, 1.0, 10.0, 100.0, 1000.0)))
+    probe.fit(Z_train, y_train)
+    return float(r2_score(y_test, probe.predict(Z_test)))
+
+
+def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
+    """Side-by-side t-SNE (raw features | Nori embeddings). Skipped if matplotlib
+    is not installed, so the extract/probe path still runs without it.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")  # headless: straight to file
+        import matplotlib.pyplot as plt
+        from sklearn.manifold import TSNE
+    except ImportError:
+        print("  [skip t-SNE] matplotlib not installed (uv sync --extra eval)")
+        return None
+
+    def _tsne(M):
+        M = StandardScaler().fit_transform(M)
+        perp = float(min(30, max(5, (len(M) - 1) // 3)))  # valid for small n
+        return TSNE(n_components=2, perplexity=perp, init="pca",
+                    random_state=0).fit_transform(M)
+
+    os.makedirs(OUT_DIR, exist_ok=True)
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5.2))
+    sc = None
+    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"),
+                         (axes[1], _tsne(Z_embed), "Nori embeddings")):
+        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18,
+                        alpha=0.85, edgecolors="none")
+        ax.set_title(sub, fontsize=12)
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.suptitle(title, fontsize=14, fontweight="bold")
+    fig.colorbar(sc, ax=axes, fraction=0.046, pad=0.04).set_label(cbar_label)
+    path = os.path.join(OUT_DIR, fname)
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  wrote {path}")
+    return path
+
+
+def subsample(X, y, n, seed=0):
+    """Deterministically cap rows so the demo stays fast."""
+    if len(X) <= n:
+        return X, y
+    idx = np.random.RandomState(seed).choice(len(X), n, replace=False)
+    return X[idx], y[idx]
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dataset", default=DEFAULT_DATASET,
+                   help="TabArena regression dataset name (see --list)")
+    p.add_argument("--list", action="store_true",
+                   help="print available dataset names and exit")
+    args = p.parse_args()
+
+    reg = load_registry()
+    names = [k.split("/", 1)[1] for k in reg.list_datasets() if k.startswith("tabarena/")]
+    if args.list:
+        print("Available TabArena regression datasets:")
+        for n in names:
+            print(f"  {n}")
+        return
+    if not names:
+        raise SystemExit("No TabArena datasets loaded (check network / `openml`).")
+
+    entry = reg.get(f"tabarena/{args.dataset}")
+    if entry is None:
+        raise SystemExit(f"Dataset '{args.dataset}' not found. Try --list "
+                         f"(e.g. {names[0]}).")
+
+    X_train, y_train = entry.X_train, entry.y_train
+    X_test, y_test = subsample(entry.X_test, entry.y_test, MAX_TEST)
+    print(f"{entry.name}: train={len(X_train)} test={len(X_test)} "
+          f"features={X_train.shape[1]}")
+
+    Z_train, Z_test, native = extract_embeddings(X_train, y_train, X_test)
+
+    probe_r2 = ridge_probe(Z_train, y_train, Z_test, y_test)
+    native_r2 = float(r2_score(y_test, native))
+    print("\n=== R2 ===")
+    print(f"  embedding dim              : {Z_train.shape[1]}")
+    print(f"  Ridge probe on embeddings  : {probe_r2:.4f}")
+    print(f"  Nori native head (ref.)    : {native_r2:.4f}")
+
+    tsne_plot(X_test, Z_test, y_test,
+              f"t-SNE — {entry.name} (color = target y)",
+              f"embedding_tabarena_{entry.name}_tsne.png", cbar_label="target y")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -8,12 +8,14 @@ from synthefy_nori.api import (
     infer,
     predict,
 )
+from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
 __version__ = "0.9.0"
 
 __all__ = [
     "NoriRegressor",
+    "NoriEmbedding",
     "billable_price",
     "config_path",
     "infer",

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -161,6 +161,40 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         pred = np.asarray(pred, dtype=np.float64).squeeze()
         return pred * self.y_std_ + self.y_mean_
 
+    def get_embeddings(self, X=None, *, data_source: str = "test") -> np.ndarray:
+        """Return the model's learned representation of rows.
+
+        Embeds ``X`` against the context stored by ``fit`` and returns the
+        final-layer target-token representation per row.
+
+        - ``data_source="test"`` (default): embed the query rows ``X`` (required).
+        - ``data_source="train"``: embed the stored context rows. ``X`` is
+          genuinely ignored here and may be omitted — the context embeddings
+          depend only on the data passed to ``fit`` — so it is neither validated
+          against the fitted feature count nor preprocessed.
+
+        Returns an array of shape ``(n_estimators, n_samples, embed_dim)``,
+        where ``n_estimators`` is the number of preprocessing pipelines in the
+        inference config. Pick a member (``embeds[0]``) or average across
+        ``axis=0`` for a 2D feature matrix.
+        """
+        if not hasattr(self, "X_train_"):
+            raise ValueError("Call fit(X, y) before get_embeddings(X).")
+        y_norm = ((self.y_train_ - self.y_mean_) / self.y_std_).astype(np.float32)
+        predictor = self._get_predictor()
+        if data_source == "train":
+            # X is ignored for context embeddings; do not touch it so a
+            # missing/mismatched X cannot raise. The predictor synthesizes a
+            # dummy query from the context.
+            return predictor.get_embeddings(
+                self.X_train_, y_norm, None, data_source=data_source)
+        if X is None:
+            raise ValueError(
+                "get_embeddings requires X for data_source='test'.")
+        X_test = np.asarray(X, dtype=np.float32)
+        return predictor.get_embeddings(
+            self.X_train_, y_norm, X_test, data_source=data_source)
+
     def _predict_distribution(self, X, *, output_type: str, quantiles: list[float] | None):
         """Return the model's predictive distribution as quantiles.
 

--- a/src/synthefy_nori/embedding/__init__.py
+++ b/src/synthefy_nori/embedding/__init__.py
@@ -1,0 +1,14 @@
+"""Embedding extraction for Nori regression.
+
+Nori's encoder produces a learned representation of every row that downstream
+models (kNN, linear probes, clustering, retrieval) can consume.
+:class:`NoriEmbedding` is a scikit-learn ``TransformerMixin`` that wraps
+:class:`synthefy_nori.NoriRegressor` and exposes those embeddings, with an
+optional out-of-fold mode for leakage-free training embeddings.
+
+    from synthefy_nori.embedding import NoriEmbedding
+"""
+
+from synthefy_nori.embedding.embedding import NoriEmbedding
+
+__all__ = ["NoriEmbedding"]

--- a/src/synthefy_nori/embedding/embedding.py
+++ b/src/synthefy_nori/embedding/embedding.py
@@ -1,0 +1,149 @@
+"""scikit-learn transformer that extracts Nori embeddings."""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.base import BaseEstimator, TransformerMixin, clone
+from sklearn.model_selection import KFold
+from sklearn.utils.validation import check_is_fitted
+
+from synthefy_nori.api import NoriRegressor
+
+
+class NoriEmbedding(TransformerMixin, BaseEstimator):
+    """scikit-learn style transformer that extracts Nori embeddings.
+
+    When ``n_fold >= 2``, ``fit`` produces out-of-fold (OOF) embeddings for the
+    training data — each training row is embedded by a model that did *not*
+    have it in its context, avoiding leakage — and then refits a single model
+    on the full training set for use on unseen data. The OOF embeddings are
+    stored on ``train_embeddings_`` and returned by ``fit_transform``.
+
+    ``transform(X)`` ALWAYS uses the final, full-data model — it does NOT
+    return cached OOF embeddings, even when ``X`` happens to equal the training
+    set. For OOF embeddings call ``fit_transform`` (or read
+    ``train_embeddings_``).
+
+    Note on output shape: ``transform`` returns a 3D array of shape
+    ``(n_estimators, n_samples, embed_dim)`` (``n_estimators`` is the number of
+    preprocessing pipelines in the inference config). It is not a drop-in input
+    for ``sklearn.pipeline.Pipeline`` / ``ColumnTransformer``, which expect 2D
+    output. Pick an ensemble member (``embeds[0]``) or aggregate across
+    ``axis=0`` before passing to a downstream 2D estimator.
+
+    Parameters
+    ----------
+    n_fold : int, default=0
+        Number of folds for cross-validation. ``0`` disables CV — the model is
+        fit once on the entire training set and used for both train and unseen
+        data. Must be ``0`` or ``>= 2``.
+    model : NoriRegressor, optional
+        Pre-configured estimator. When ``None``, a default ``NoriRegressor`` is
+        constructed at ``fit`` time.
+    shuffle : bool, default=False
+        Whether to shuffle the K-fold split. Independent of ``random_state``.
+    random_state : int, optional
+        Seed used by the K-fold split when ``shuffle=True``.
+
+    Attributes
+    ----------
+    model_ : NoriRegressor
+        The fitted model (cloned from ``model`` or auto-constructed). After
+        ``fit`` with ``n_fold >= 2`` this is the model fit on the full
+        training set.
+    train_embeddings_ : np.ndarray
+        Embeddings for the training set. For ``n_fold >= 2`` these are OOF
+        embeddings aligned to the original sample order; for ``n_fold == 0``
+        they come from the single full-data model.
+
+    Examples
+    --------
+    >>> from synthefy_nori.embedding import NoriEmbedding
+    >>> embedding = NoriEmbedding(n_fold=5)
+    >>> train_embeds = embedding.fit_transform(X_train, y_train)  # OOF
+    >>> test_embeds = embedding.transform(X_test)                 # final model
+    """
+
+    def __init__(
+        self,
+        n_fold: int = 0,
+        *,
+        model: NoriRegressor | None = None,
+        shuffle: bool = False,
+        random_state: int | None = None,
+    ) -> None:
+        self.n_fold = n_fold
+        self.model = model
+        self.shuffle = shuffle
+        self.random_state = random_state
+
+    def _resolve_template(self) -> NoriRegressor:
+        """Return a fresh model to use (a clone of ``model`` or a default)."""
+        if self.model is not None:
+            return clone(self.model)
+        return NoriRegressor()
+
+    def _compute_oof(self, X: np.ndarray, y: np.ndarray) -> np.ndarray:
+        """Run K-fold and return OOF embeddings aligned to original order."""
+        X = np.asarray(X)
+        y = np.asarray(y)
+
+        rs = self.random_state if self.shuffle else None
+        cv = KFold(n_splits=self.n_fold, shuffle=self.shuffle, random_state=rs)
+
+        chunks: list[np.ndarray] = []
+        val_indices: list[np.ndarray] = []
+        for train_idx, val_idx in cv.split(X):
+            # Reuse the single self.model_ instance across folds instead of
+            # clone()-ing per fold. NoriRegressor.fit only overwrites the stored
+            # context arrays and leaves the cached _predictor (checkpoint +
+            # torch.compile) intact, and get_embeddings takes the context
+            # explicitly, so nothing is fold-specific — one compiled predictor
+            # serves every fold. clone() resets _predictor (it is set in the
+            # __init__ body, not a get_params() param), which would pay the cold
+            # torch.compile (~minutes on CUDA) again on every fold.
+            self.model_.fit(X[train_idx], y[train_idx])
+            chunks.append(self.model_.get_embeddings(X[val_idx], data_source="test"))
+            val_indices.append(val_idx)
+
+        oof = np.concatenate(chunks, axis=1)
+        order = np.argsort(np.concatenate(val_indices))
+        return oof[:, order, ...]
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> NoriEmbedding:
+        if self.n_fold < 0 or self.n_fold == 1:
+            raise ValueError("n_fold must be 0 (vanilla) or >= 2.")
+
+        self.model_ = self._resolve_template()
+
+        if self.n_fold == 0:
+            self.model_.fit(X, y)
+            self.train_embeddings_ = self.model_.get_embeddings(X, data_source="test")
+            return self
+
+        self.train_embeddings_ = self._compute_oof(X, y)
+        self.model_.fit(X, y)
+        return self
+
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        """Embed unseen data ``X`` using the full-data model.
+
+        Always runs inference through ``model_`` (fit on the full training set)
+        and never returns cached embeddings. For *training*-data embeddings,
+        prefer ``fit_transform`` (OOF for ``n_fold >= 2``) or read
+        ``train_embeddings_``.
+        """
+        check_is_fitted(self, "model_")
+        return self.model_.get_embeddings(X, data_source="test")
+
+    def fit_transform(self, X: np.ndarray, y: np.ndarray, **fit_params) -> np.ndarray:
+        """Fit and return embeddings for the training data.
+
+        For ``n_fold >= 2`` these are out-of-fold embeddings; for ``n_fold == 0``
+        they come from the single full-data model.
+        """
+        self.fit(X, y)
+        return self.train_embeddings_
+
+
+__all__ = ["NoriEmbedding"]

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -789,6 +789,42 @@ class NoriPredictor:
             # components) — leave the budget conservative (no reduction).
         return max(1, eff)
 
+    def _default_max_elements_budget(self) -> int:
+        """Default per-forward element budget, scaled to the GPU's total VRAM.
+
+        Anchored at 2M elements for a ~24GB GPU (the historical conservative
+        default) and linear in total VRAM, so e.g. a 140GB H200 gets ~11.7M
+        without manual tuning. Falls back to the 2M floor on CPU, when CUDA is
+        unavailable, or if the device can't be queried. Overridden by
+        SYNTHEFY_MAX_ELEMENTS_BUDGET when that env var is set.
+        """
+        base = 2_000_000
+        try:
+            dev = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
+            if dev.type == "cuda" and torch.cuda.is_available():
+                total_gb = torch.cuda.get_device_properties(dev).total_memory / (1024 ** 3)
+                return max(base, int(base * (total_gb / 24.0)))
+        except Exception:
+            pass
+        return base
+
+    def _resolve_max_elements_budget(self) -> int:
+        """Per-forward element budget: ``SYNTHEFY_MAX_ELEMENTS_BUDGET`` when set,
+        else the VRAM-aware default. Single source of truth shared by the predict
+        (``_predict_reg_single``) and embedding (``get_embeddings``) paths, which
+        had duplicated — and drifted on — this resolution.
+        """
+        env_budget = os.environ.get("SYNTHEFY_MAX_ELEMENTS_BUDGET")
+        return int(env_budget) if env_budget else self._default_max_elements_budget()
+
+    @staticmethod
+    def _chunk_size(max_elements: int, budget_n_features: int, n_train: int) -> int:
+        """Query rows per forward so ``(n_train + chunk) * budget_n_features``
+        stays within ``max_elements``; floored at 256. Shared by predict and
+        ``get_embeddings`` so the chunking formula cannot drift between them.
+        """
+        return max(256, (max_elements // max(budget_n_features, 1)) - n_train)
+
     def PostProcessInModel(self, feature_pred:torch.tensor, config: dict) -> torch.tensor:
         # Revert preprocess in model forward
         feature_pred = feature_pred / torch.sqrt(config['features_per_group'] / config['num_used_features'].to(self.device))
@@ -873,6 +909,162 @@ class NoriPredictor:
                     feature_pred = restored.copy()
         return feature_pred
         
+    def get_embeddings(self, x_train: np.ndarray, y_train: np.ndarray,
+                       x_test: np.ndarray | None = None,
+                       data_source: Literal["test", "train"] = "test") -> np.ndarray:
+        """Extract per-row Nori embeddings for a context/query split.
+
+        Runs each preprocessing pipeline (the inference ensemble) through the
+        backbone with ``return_embeddings=True`` and collects the final-layer
+        target-token representation for the requested rows.
+
+        Args:
+            x_train, y_train: context rows the model conditions on.
+            x_test: query rows to embed. Required for ``data_source="test"``;
+                genuinely ignored for ``data_source="train"`` (may be ``None``) —
+                the context embeddings depend only on ``x_train``.
+            data_source: ``"test"`` returns one embedding per query row,
+                ``"train"`` returns one embedding per context row.
+
+        Returns:
+            ``np.ndarray`` of shape ``(n_estimators, n_samples, embed_dim)`` —
+            one slice per preprocessing pipeline, never averaged. ``n_samples``
+            is ``len(x_test)`` for ``data_source="test"`` and ``len(x_train)``
+            for ``data_source="train"``.
+        """
+        if data_source not in ("test", "train"):
+            raise ValueError(
+                f"data_source must be 'test' or 'train', got {data_source!r}.")
+
+        x_train, y_train = self.validate_data(
+            x_train, y_train, reset=True, validate_separately=False,
+            accept_sparse=False, dtype=None, ensure_all_finite=False)
+        if data_source == "train":
+            # Context embeddings ignore the query rows entirely (the train branch
+            # below uses a dummy query drawn from the context). Replace whatever
+            # the caller passed with a single context row so no feature-count
+            # check or full-size query preprocessing applies to unused input —
+            # this is what lets x_test be omitted / mismatched for "train".
+            x_test = x_train[:1]
+        else:
+            if x_test is None:
+                raise ValueError(
+                    "get_embeddings requires x_test for data_source='test'.")
+            x_test = self.validate_data(
+                x_test, reset=False, validate_separately=False,
+                accept_sparse=False, dtype=None, ensure_all_finite=False)
+
+        x_train_base, x_test_base, categorical_idx = self._prepare_inductive_features(
+            x_train, x_test,
+        )
+
+        n_train = len(y_train)
+        n_test = len(x_test)
+        # Chunk the query rows along the same element budget the predictor uses,
+        # so wide/large tables don't OOM while embedding.
+        budget_n_features = self._effective_budget_n_features(
+            x_train.shape[1] if x_train.ndim > 1 else 1, x_train)
+        max_elements = self._resolve_max_elements_budget()
+
+        # Context-size guard. Chunking below only splits the QUERY rows; every
+        # forward still concatenates the full train context (and data_source=
+        # "train" runs one unchunked forward over it). So when the context alone
+        # is over budget, chunking cannot prevent an OOM. Unlike predict(), we do
+        # NOT subsample the context here: it would silently change which rows
+        # condition each embedding (breaking the NoriEmbedding OOF leakage
+        # guarantee), and for data_source="train" it would return fewer rows than
+        # requested. Raise a clear error instead — anything but OOM. This also
+        # honors SYNTHEFY_FORBID_SUBSAMPLE by construction (we never subsample).
+        base_elements = (n_train + 1) * budget_n_features
+        if base_elements > max_elements:
+            raise RuntimeError(
+                f"get_embeddings: train context too large for the element budget "
+                f"(n_train={n_train}, eff_features={budget_n_features}, "
+                f"base_elements={base_elements} > budget={max_elements}). "
+                f"Unlike predict(), embedding does not subsample the context "
+                f"(it would change embedding semantics). Raise "
+                f"SYNTHEFY_MAX_ELEMENTS_BUDGET or reduce the context size to run."
+            )
+        chunk_size = self._chunk_size(max_elements, budget_n_features, n_train)
+
+        # Run embeddings through the UNWRAPPED backbone (skip torch.compile). The
+        # compiled graph is specialized for predict() and guards on the
+        # return_embeddings bool (a dynamo constant); calling it with
+        # return_embeddings=True fails those guards and triggers a second
+        # multi-minute cold compile of a structurally different graph (early
+        # return before the decoder) — a stall the predict-only warmup cannot
+        # hide. The embedding path early-returns before the decoder, so it gains
+        # nothing from the compiled decoder graph; eager is the right default for
+        # this offline/OOF path.
+        bare_model = self._bare_model()
+
+        per_pipeline = []
+        for id_pipe, pipe in enumerate(self.preprocess_pipelines):
+            x_train_ = x_train_base.copy()
+            x_test_ = x_test_base.copy()
+            y_ = y_train.copy()
+            categorical_idx_ = categorical_idx.copy()
+            for id_step, step in enumerate(pipe):
+                if isinstance(step, (InferenceAttentionMap, SubSampleData)):
+                    raise NotImplementedError(
+                        "get_embeddings does not support retrieval-based inference "
+                        "configs (per-query-row context selection makes the train "
+                        "embedding ill-defined). Use a non-retrieval config such as "
+                        "reg_default_noretrieval.json.")
+                x_train_, x_test_, categorical_idx_ = self._fit_transform_step_inductive(
+                    step, x_train_, x_test_, categorical_idx_,
+                    self.seeds[id_pipe * self.preprocess_num
+                               + self._seed_step_index(pipe, id_step)],
+                    y_train=y_,
+                )
+
+            y_dev = torch.from_numpy(y_).float().to(self.device)
+            train_t = torch.from_numpy(x_train_).float().to(self.device)
+            # Feature positional embeddings are regenerated randomly on EVERY
+            # forward pass (add_embeddings -> randn + orthogonal_). Reseed
+            # immediately before each forward (below) so every query chunk — and
+            # the data_source="train" forward — is embedded under the SAME random
+            # basis. Seeding once here would leave chunks 2+ in an incomparable
+            # subspace, adding a spurious chunk-boundary artifact and making
+            # transform(X) depend on len(X). Mirrors _predict_reg_single.
+
+            if data_source == "train":
+                # Context embeddings are independent of the query rows, so one
+                # forward with a single dummy query row suffices.
+                x_all = torch.cat([train_t, train_t[:1]], dim=0).unsqueeze(0)
+                y_all = torch.cat([y_dev, y_dev[:1]], dim=0).unsqueeze(0)
+                bare_model.to(self.device)
+                torch.manual_seed(self.seed)
+                torch.cuda.manual_seed_all(self.seed)
+                with torch.autocast(
+                    device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                    enabled=self.mix_precision), torch.inference_mode():
+                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train,
+                                     task_type='reg', return_embeddings=True)
+                per_pipeline.append(emb[0, :n_train].float().cpu().numpy())
+                continue
+
+            # data_source == "test": embed every query row, chunked.
+            test_t = torch.from_numpy(x_test_).float().to(self.device)
+            chunks = []
+            for i in range(0, n_test, chunk_size):
+                end = min(i + chunk_size, n_test)
+                x_all = torch.cat([train_t, test_t[i:end]], dim=0).unsqueeze(0)
+                y_pad = torch.zeros(end - i, dtype=y_dev.dtype, device=y_dev.device)
+                y_all = torch.cat([y_dev, y_pad], dim=0).unsqueeze(0)
+                bare_model.to(self.device)
+                torch.manual_seed(self.seed)
+                torch.cuda.manual_seed_all(self.seed)
+                with torch.autocast(
+                    device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                    enabled=self.mix_precision), torch.inference_mode():
+                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train,
+                                     task_type='reg', return_embeddings=True)
+                chunks.append(emb[0, n_train:].float().cpu().numpy())
+            per_pipeline.append(np.concatenate(chunks, axis=0))
+
+        return np.stack(per_pipeline, axis=0)
+
     def _predict_reg(self, x_train:np.ndarray, y_train:np.ndarray, x_test:np.ndarray,
                      return_distribution: bool = False) -> np.ndarray:
         """Regression predict with optional inference-time augmentations.
@@ -970,12 +1162,13 @@ class NoriPredictor:
         n_samples_test = x_test.shape[0]
         
         # If the number of elements is too large, we must chunk the test set to avoid OOM.
-        # The default (2M elements) is conservative for ~24GB GPUs. On larger GPUs
-        # (A100/H100/H200) raise it via SYNTHEFY_MAX_ELEMENTS_BUDGET so big tables use
-        # their full context instead of being silently subsampled — e.g. set
-        # SYNTHEFY_MAX_ELEMENTS_BUDGET=16000000 for large-context (50K-row) inference.
-        MAX_ELEMENTS_BUDGET = int(os.environ.get("SYNTHEFY_MAX_ELEMENTS_BUDGET", "2000000"))
-        
+        # The default is VRAM-aware: anchored at 2M elements for a ~24GB GPU (the
+        # historical conservative value) and scaled linearly with total VRAM, so a
+        # large GPU (A100/H100/H200) uses big tables' full context instead of
+        # silently subsampling, without manual tuning. SYNTHEFY_MAX_ELEMENTS_BUDGET
+        # still overrides explicitly when set.
+        MAX_ELEMENTS_BUDGET = self._resolve_max_elements_budget()
+
         # Calculate elements for one full forward pass (train + 1 test row at
         # minimum). Use the post-HighDimFeatureSelector feature count — the
         # model never sees the raw count when the config reduces dimensionality.
@@ -1077,7 +1270,7 @@ class NoriPredictor:
                 # We need: (n_train + chunk_size) * budget_n_features <= MAX_ELEMENTS_BUDGET.
                 # Use the post-HighDimFeatureSelector feature count — the model
                 # never sees the raw count when the config reduces dimensionality.
-                chunk_size = max(256, (MAX_ELEMENTS_BUDGET // budget_n_features) - n_samples_train)
+                chunk_size = self._chunk_size(MAX_ELEMENTS_BUDGET, budget_n_features, n_samples_train)
 
                 # --- Cached train-KV fast path (ON by default) ---
                 # Numerically equivalent to the chunked path below (cache==chunked,

--- a/src/synthefy_nori/model/transformer.py
+++ b/src/synthefy_nori/model/transformer.py
@@ -230,6 +230,7 @@ class FeaturesTransformer(nn.Module):
                 task_type: Literal['reg', 'cls'] = 'cls',
                 calculate_sample_attention: bool = False,
                 calculate_feature_attention: bool = False,
+                return_embeddings: bool = False,
                 **kwargs
                 ) -> torch.Tensor | dict[str, torch.Tensor] | tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         '''
@@ -237,6 +238,10 @@ class FeaturesTransformer(nn.Module):
             y: The input y, which includes both train y and test y, Shape: [batch, label]
             eval_pos: Train x and train y split point
             task_type: Type of task, options: cls(classification), reg(regression)
+            return_embeddings: when True, skip the decoder head and return the
+                per-row target-token representation from the final encoder layer
+                (post encoder_out_norm), shape [batch, seq, embed_dim]. Callers
+                slice context (``:eval_pos``) vs query (``eval_pos:``) themselves.
         '''
         assert x is not None and y is not None, "x and y must not be none"
         assert eval_pos > 0, "eval_pos must be a positive number"
@@ -325,6 +330,14 @@ class FeaturesTransformer(nn.Module):
             pass
         encoder_out = self.transformer_encoder(embedded_all, feature_atten_mask=None, eval_pos=eval_pos, **kwargs)[0]
         encoder_out = self.encoder_out_norm(encoder_out)
+
+        if return_embeddings:
+            # Per-row target-token representation at the final encoder layer.
+            # The target token is the last feature-group slot (index -1); this
+            # is the same representation the regression/classification decoders
+            # consume. [batch, seq, embed_dim] — context rows are [:, :eval_pos]
+            # and query rows are [:, eval_pos:].
+            return encoder_out[:, :, -1]
 
         test_encoder_out = encoder_out[:, eval_pos:, -1]
         encoder_out_4_feature = encoder_out[:, :, :-1, :]

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -1,0 +1,92 @@
+"""NoriEmbedding: OOF/fold logic + sklearn compliance behind a stub model,
+plus a slow end-to-end embedding extraction against the real checkpoint."""
+
+import numpy as np
+import pytest
+from sklearn.base import BaseEstimator, RegressorMixin, clone
+
+from synthefy_nori import NoriEmbedding, NoriRegressor
+
+
+class _StubEmbModel(RegressorMixin, BaseEstimator):
+    """A fitted-regressor stand-in whose embedding of a row is the row itself.
+
+    Returns shape (1, n_samples, n_features) — the (n_estimators, n, d) contract
+    with a single ensemble member — so OOF reassembly is checkable exactly.
+    """
+
+    def fit(self, X, y):
+        self.X_ = np.asarray(X)
+        return self
+
+    def get_embeddings(self, X, *, data_source="test"):
+        return np.asarray(X, dtype=float)[None, :, :]
+
+
+def test_embedding_is_sklearn_estimator_and_clones():
+    e = NoriEmbedding(n_fold=5, shuffle=True, random_state=7)
+    params = e.get_params()
+    assert params["n_fold"] == 5 and params["random_state"] == 7
+    c = clone(e)
+    assert c.get_params()["n_fold"] == 5
+
+    # default template construction is a NoriRegressor (no weights touched)
+    assert isinstance(NoriEmbedding()._resolve_template(), NoriRegressor)
+
+
+def test_n_fold_one_is_rejected():
+    X = np.arange(20).reshape(10, 2).astype(float)
+    y = np.arange(10).astype(float)
+    with pytest.raises(ValueError, match="n_fold must be 0"):
+        NoriEmbedding(n_fold=1, model=_StubEmbModel()).fit(X, y)
+
+
+def test_vanilla_transform_uses_full_data_model():
+    X = np.arange(20).reshape(10, 2).astype(float)
+    y = np.arange(10).astype(float)
+    e = NoriEmbedding(n_fold=0, model=_StubEmbModel())
+    train_emb = e.fit_transform(X, y)
+    assert train_emb.shape == (1, 10, 2)
+    np.testing.assert_allclose(train_emb[0], X)
+
+    X_new = np.full((3, 2), 99.0)
+    test_emb = e.transform(X_new)
+    np.testing.assert_allclose(test_emb[0], X_new)
+
+
+def test_oof_embeddings_are_aligned_to_original_order():
+    """Each row is embedded as itself, so OOF output must reconstruct X exactly
+    in the original row order despite the K-fold shuffle."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(25, 4))
+    y = rng.normal(size=25)
+    e = NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=_StubEmbModel())
+    oof = e.fit_transform(X, y)
+    assert oof.shape == (1, 25, 4)
+    np.testing.assert_allclose(oof[0], X)
+    # fit also refits the full-data model for transform()
+    np.testing.assert_allclose(e.transform(X[:2])[0], X[:2])
+
+
+@pytest.mark.slow
+def test_end_to_end_embeddings_real_checkpoint():
+    """Downloads the public checkpoint and extracts real embeddings."""
+    rng = np.random.default_rng(0)
+    X_train = rng.normal(size=(60, 5)).astype(np.float32)
+    y_train = (X_train[:, 0] * 2 - X_train[:, 1]).astype(np.float64)
+    X_test = rng.normal(size=(8, 5)).astype(np.float32)
+
+    model = NoriRegressor().fit(X_train, y_train)
+
+    test_emb = model.get_embeddings(X_test, data_source="test")
+    assert test_emb.ndim == 3
+    n_estimators, n_samples, embed_dim = test_emb.shape
+    assert n_samples == 8 and n_estimators >= 1 and embed_dim > 0
+    assert np.isfinite(test_emb).all()
+
+    train_emb = model.get_embeddings(X_test, data_source="train")
+    assert train_emb.shape == (n_estimators, 60, embed_dim)
+
+    # Same end-to-end through the sklearn transformer.
+    emb = NoriEmbedding(n_fold=0).fit_transform(X_train, y_train)
+    assert emb.shape[1] == 60 and emb.shape[2] == embed_dim

--- a/tests/embedding/test_embedding_clustering.py
+++ b/tests/embedding/test_embedding_clustering.py
@@ -1,0 +1,101 @@
+"""Embeddings cluster by target — a representation-quality check.
+
+Motivated by "A Closer Look at TabPFN v2: Strength, Limitation, and Extension"
+(arXiv:2502.17361), which shows the model's learned embeddings are strong
+representations whose geometry reflects the target: same-class points group
+together, and downstream models on the embeddings are competitive. Nori is
+regression-only, so we treat a binary target as a {0,1} regression target and
+also bin a continuous target into quantile groups.
+
+For each synthetic dataset we extract the test-row embeddings (averaged over the
+inference-pipeline ensemble) and check they cluster by label markedly better
+than the RAW features do — silhouette, KMeans agreement (adjusted Rand), and a
+kNN probe. These are marked slow: they download the public checkpoint.
+"""
+
+import numpy as np
+import pytest
+from sklearn.cluster import KMeans
+from sklearn.datasets import make_moons
+from sklearn.metrics import (
+    accuracy_score,
+    adjusted_rand_score,
+    r2_score,
+    silhouette_score,
+)
+from sklearn.model_selection import cross_val_predict, train_test_split
+from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+from sklearn.preprocessing import StandardScaler
+
+from synthefy_nori import NoriRegressor
+
+pytestmark = pytest.mark.slow
+
+
+def _embed_test_rows(X_train, y_train, X_test):
+    """Fit on the context, return mean-over-ensemble test embeddings [n, dim]."""
+    model = NoriRegressor().fit(X_train, y_train)
+    emb = model.get_embeddings(X_test, data_source="test")   # (n_est, n, dim)
+    return emb.mean(axis=0)
+
+
+def _kmeans_ari(Z, labels, k):
+    km = KMeans(n_clusters=k, n_init=10, random_state=0).fit_predict(Z)
+    return adjusted_rand_score(labels, km)
+
+
+def test_binary_classification_embeddings_separate_by_class():
+    """Two interleaving moons: not linearly separable, so KMeans on the raw
+    features barely recovers the classes. Nori's embeddings — whose target token
+    encodes the (predicted) class — should separate the two moons much better."""
+    X, y = make_moons(n_samples=500, noise=0.18, random_state=0)
+    X = X.astype(np.float32)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.4, random_state=0, stratify=y)
+
+    Z = _embed_test_rows(X_train, y_train.astype(np.float64), X_test)
+    Xs = StandardScaler().fit_transform(X_test)  # fair raw baseline (scaled)
+
+    sil_emb, sil_raw = silhouette_score(Z, y_test), silhouette_score(Xs, y_test)
+    ari_emb, ari_raw = _kmeans_ari(Z, y_test, 2), _kmeans_ari(Xs, y_test, 2)
+    # Unsupervised kNN probe on the embeddings (leave-one-out style via CV).
+    knn_acc = accuracy_score(
+        y_test, cross_val_predict(KNeighborsClassifier(15), Z, y_test, cv=5))
+
+    print(f"\n[moons] silhouette  embed={sil_emb:+.3f} raw={sil_raw:+.3f}")
+    print(f"[moons] KMeans ARI  embed={ari_emb:+.3f} raw={ari_raw:+.3f}")
+    print(f"[moons] kNN acc on embeddings = {knn_acc:.3f}")
+
+    assert sil_emb > sil_raw                 # embeddings are more clusterable
+    assert ari_emb > ari_raw + 0.10          # KMeans recovers classes far better
+    assert ari_emb > 0.5                      # and recovers them well in absolute terms
+    assert knn_acc > 0.9                      # near-perfectly class-separated
+
+
+def test_regression_embeddings_organize_by_target():
+    """Continuous nonlinear target. Embeddings should be organized by target
+    magnitude: binning y into low/mid/high groups, the embeddings separate the
+    groups better than raw features, and a kNN regressor on them scores high."""
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(500, 5)).astype(np.float32)
+    y = (np.sin(X[:, 0]) + X[:, 1] ** 2 + 0.5 * X[:, 2] * X[:, 3]).astype(np.float64)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.4, random_state=0)
+
+    Z = _embed_test_rows(X_train, y_train, X_test)
+    Xs = StandardScaler().fit_transform(X_test)
+
+    # Quantile bins of the (held-out) target define the "clusters".
+    bins = np.digitize(y_test, np.quantile(y_test, [1 / 3, 2 / 3]))
+    sil_emb, sil_raw = silhouette_score(Z, bins), silhouette_score(Xs, bins)
+    ari_emb, ari_raw = _kmeans_ari(Z, bins, 3), _kmeans_ari(Xs, bins, 3)
+    knn_r2 = r2_score(
+        y_test, cross_val_predict(KNeighborsRegressor(15), Z, y_test, cv=5))
+
+    print(f"\n[reg] silhouette(target-bins)  embed={sil_emb:+.3f} raw={sil_raw:+.3f}")
+    print(f"[reg] KMeans ARI(target-bins)  embed={ari_emb:+.3f} raw={ari_raw:+.3f}")
+    print(f"[reg] kNN-on-embeddings R2 = {knn_r2:.3f}")
+
+    assert sil_emb > sil_raw                 # embeddings group same-target points
+    assert ari_emb > ari_raw                 # and KMeans recovers target groups better
+    assert knn_r2 > 0.85                      # embedding neighbors share the target

--- a/tests/embedding/test_examples_smoke.py
+++ b/tests/embedding/test_examples_smoke.py
@@ -1,0 +1,66 @@
+"""Smoke tests for the shipped embedding examples.
+
+These exist because the examples were previously never executed by CI. That gap
+let an internal-only ``NoriRegressor(compile_model=...)`` kwarg ship in a public
+example, which crashes at construction on the public package. The fast test
+guards the exact public construction API the examples/README rely on; the slow
+tests import each example module and run its own ``extract_embeddings`` end-to-end
+on tiny data against the real checkpoint.
+"""
+import importlib.util
+import pathlib
+
+import numpy as np
+import pytest
+from sklearn.model_selection import train_test_split
+
+from synthefy_nori import NoriEmbedding, NoriRegressor
+
+EXAMPLES_DIR = pathlib.Path(__file__).resolve().parents[2] / "examples"
+EXAMPLE_NAMES = ["embedding_synthetic", "embedding_tabarena"]
+
+
+def _load_example(name):
+    spec = importlib.util.spec_from_file_location(name, EXAMPLES_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_public_construction_api_the_examples_use():
+    """The exact public construction the examples/README rely on must not depend
+    on any internal-only kwarg. Regression guard for the ``compile_model`` leak.
+
+    Fast: construction is lazy (no checkpoint download), so this runs in the
+    default (non-slow) suite and blocks the merge before an example can ship
+    with an internal-only constructor argument again.
+    """
+    NoriRegressor()
+    NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=NoriRegressor())
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", EXAMPLE_NAMES)
+def test_example_imports(name):
+    """Each shipped example imports cleanly against the public package."""
+    assert hasattr(_load_example(name), "extract_embeddings")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", EXAMPLE_NAMES)
+def test_example_extract_embeddings_end_to_end(name):
+    """Run the example's own ``extract_embeddings`` on tiny synthetic data against
+    the real checkpoint — exercises the actual shipped example code path."""
+    module = _load_example(name)
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(60, 5)).astype(np.float32)
+    y = (np.sin(X[:, 0]) + X[:, 1] ** 2).astype(np.float64)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.4, random_state=0)
+
+    Z_train, Z_test, native = module.extract_embeddings(X_train, y_train, X_test)
+
+    assert Z_train.shape[0] == len(X_train)
+    assert Z_test.shape[0] == len(X_test)
+    assert Z_train.shape[1] == Z_test.shape[1] > 0
+    assert np.asarray(native).shape[0] == len(X_test)


### PR DESCRIPTION
## What

Publishes the **embedding** feature to the open-core package (`staging → public`). Squashed release of `synthefy-nori-staging` main — PRs [#4](https://github.com/Synthefy/synthefy-nori-staging/pull/4) (feature) + [#5](https://github.com/Synthefy/synthefy-nori-staging/pull/5) (fix + CI). Original author: @saishankarn (internal #112).

- **`NoriEmbedding`** — sklearn transformer; optional out-of-fold (leak-free) training embeddings.
- **`NoriRegressor.get_embeddings` / `NoriPredictor.get_embeddings`** — low-level extraction.
- **`FeaturesTransformer.forward(return_embeddings=True)`** — final-layer target-token representation.
- Examples: `examples/embedding_{synthetic,tabarena}.py`.
- Tests: `tests/embedding/` (unit, clustering-quality, example smoke) + a new **`CI test embeddings`** job that runs the real embedding path on every PR.

## Cleaned for open-core (not carried from internal)
- Dropped the analysis/plotting tooling that referenced the private monorepo, `/data/…`, and the `internal-eval` extra.
- No internal-only paths (`internal/`, `baseten/`) and no internal-only APIs: the `compile_model` (torch.compile) kwarg was removed from examples/tests (behaviorally identical here — public has no compile path), and the VRAM-aware element-budget helper the feature needs is bundled.

## Behavior note
Brings **VRAM-aware element-budget auto-scaling** to the `predict` path (was a fixed 2M default); scales with GPU VRAM, `SYNTHEFY_MAX_ELEMENTS_BUDGET` still overrides, floors at 2M on CPU.

## Verification
- Local GPU: `pytest -m slow tests/embedding/` → **7 passed** (e2e, both clustering, both example end-to-end).
- Staging CI (#5): all green incl. the new `CI test embeddings` gate.
- Version left at `0.9.0` — a PyPI release (version bump + GitHub Release) is a **separate follow-up** if you want to ship it to PyPI now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)