### PR TITLE
Promote staging to public + release 0.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,14 @@ uv build
   for higher rate limits or for pointing at a private/custom repo.
 - Public API (`src/synthefy_nori/api.py`): `NoriRegressor`
   (sklearn-style `fit` / `predict`; `predict` takes
-  `output_type="mean"/"median"/"mode"` per the `TabPFNRegressor` contract),
-  plus the one-shot `infer` / `predict` helpers and `config_path`. The public
-  API is **regression-only** as of 0.2.0 (classification was removed in #10).
+  `output_type="mean"/"median"/"mode"` per the `TabPFNRegressor` contract,
+  plus opt-in `discretize=`/`categorical_levels=`
+  to return labels on a discrete target's lattice — strategies in
+  `synthefy_nori/discretize.py`), plus the one-shot `infer` / `predict`
+  helpers and `config_path`. The public API is **regression-only** as of
+  0.2.0 (classification was removed in #10). The predictor's legacy low-K
+  auto-snap (`discrete_y_snap_max_unique`) is **off by default** — lattice
+  snapping is opt-in only.
 - `fit()` only stores the context rows; all compute happens in `predict()`.
   Uses GPU when available, else CPU.
 - Pass `model_path="…/checkpoint.pt"` to run a local checkpoint and skip the
@@ -56,6 +61,7 @@ uv build
 ```
 src/synthefy_nori/
   api.py          Public API (sklearn-style NoriRegressor + one-shot helpers).
+  discretize.py   Categorical-target lattice math (cell masses, snap, strategies).
   hf.py           HF download/upload + console-script entry points
   model/          FeaturesTransformer architecture
   inference/      NoriPredictor + preprocessing

--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ Quantiles are returned in original-`y` units and sorted to a valid (monotone)
 quantile function per row. `quantiles`/`full` require the default pinball
 checkpoint; a `bar_distribution` checkpoint raises `NotImplementedError`.
 
+### Categorical / ordinal targets
+
+If the target only takes a few discrete values (ratings, counts, quality
+scores), pass `discretize=` and predictions are mapped onto the levels seen in
+`fit`'s `y` — `"map-cell"` (the mode of the induced discrete posterior) is
+best for accuracy, `"median-cell"` is the MAE-optimal alternative,
+`"snap-mean"`/`"snap-median"` snap the point estimate. Snapping is strictly
+opt-in — the default `predict()` always returns the continuous point estimate —
+and for R²-scored tasks that default is what you want. See
+[docs/inference.md](docs/inference.md#categorical--ordinal-targets-discretize--categorical_levels).
+
+```python
+labels = model.predict(X_test, discretize="map-cell")  # values from y_train's lattice
+```
+
 Runnable example: [`examples/inference_regression.py`](examples/inference_regression.py).
 More detail in [docs/inference.md](docs/inference.md).
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -37,3 +37,76 @@ Q, taus = dist["quantiles"], dist["taus"]   # Q: (n_samples, 999), ascending per
 The default checkpoint exposes a 999-quantile pinball head; quantiles come back
 in original-`y` units, sorted per row. `"quantiles"`/`"full"` require the
 pinball checkpoint — a `bar_distribution` checkpoint raises `NotImplementedError`.
+
+## Categorical / ordinal targets (`discretize=` / `categorical_levels=`)
+
+When the target only takes a small set of discrete values (ratings, counts,
+quality scores), declare it and predictions are mapped onto the level lattice
+observed in `fit`'s `y`:
+
+```python
+reg = NoriRegressor().fit(X_train, y_train)          # y ∈ {3, 4, 5, 6, 7, 8}
+labels = reg.predict(X_test, discretize="map-cell")                 # accuracy-optimal
+labels = reg.predict(X_test, discretize="median-cell")              # MAE-optimal
+labels = reg.predict(X_test, categorical_levels=[3, 4, 5, 6, 7, 8]) # known lattice, map-cell
+```
+
+`discretize` picks the lattice summary; **choose it by the metric you are
+scored on** (benchmarked on the K≤10 discrete-target datasets of
+TALENT / OpenML-CTR23 / TabArena):
+
+| `discretize` | What it is | Optimal for | Needs quantile bank |
+| --- | --- | --- | --- |
+| `"map-cell"` (default) | mode of the discrete posterior: integrate the predictive distribution's mass in a cell around each level, take the argmax | accuracy, macro-F1 | yes |
+| `"median-cell"` | median of that discrete posterior (cumulative cell mass crosses 0.5) | MAE / ordinal closeness | yes |
+| `"snap-mean"` | nearest level to the point mean | quadratically-penalized agreement (QWK) | no |
+| `"snap-median"` | nearest level to the distribution median | MAE (bank-free fallback) | no |
+| `"expected-level"` | Σ level·P(level) — lattice-informed **continuous** expectation (not on-lattice) | analysis / sanity (≈ plain mean) | yes |
+| `"prior-match"` | rank rows by point prediction, assign labels to match training priors | calibration experiments — **benchmarked worse** than snap-mean on accuracy (p=0.048) and MAE (p=0.027); prefer map-cell/median-cell | no |
+
+Notes:
+
+- **Discretization is strictly opt-in.** Nothing is snapped unless you ask:
+  passing `discretize=` (a strategy) or `categorical_levels=` (a known
+  lattice) is the activation — there is no separate flag. `categorical_levels`
+  alone uses the default strategy (`DEFAULT_DISCRETIZE_METHOD`, map-cell).
+  (The predictor's legacy auto-snap for low-K targets,
+  `discrete_y_snap_max_unique`, is now **off by default**; re-enable it via
+  `NoriRegressor(discrete_y_snap_max_unique=30)` if you want the old
+  always-snap behavior.)
+- **If the task is scored by squared error / R², do not discretize** — the
+  continuous mean is optimal and any lattice projection trades R² away
+  (~0.05–0.14 R² on the benchmark). `discretize=` is for when you need
+  *labels*, not a regression score.
+- The gains are largest on **skewed** discrete targets, where the mean falls
+  between levels or on a low-probability one; map-cell recovered +48pp
+  accuracy over snap-mean on the most skewed benchmark dataset.
+- `categorical_levels` is the set of values the target can take — the label
+  set, in classification terms. It is named *levels* (ordinal terminology)
+  rather than *labels* because the values must be numeric and their **order
+  matters**: the `map-cell`/`median-cell` strategies build probability cells
+  from the midpoints between adjacent values; string/unordered class labels
+  are unsupported. Every predicted label is one of these levels. By default
+  they come from the training `y` (leak-safe); if the context is small and
+  may under-cover the true lattice (e.g. a 1–5 scale whose context has no
+  1s), pass the full known set explicitly:
+  `predict(X, categorical_levels=[1, 2, 3, 4, 5])`.
+- Failed predictions stay visible: a `NaN` point prediction stays `NaN` after
+  snapping rather than becoming a confident label.
+- `"map-cell"`/`"median-cell"` read the quantile bank, so they share the
+  pinball-checkpoint requirement above; the `snap-*` strategies work with any
+  checkpoint (`snap-mean` always snaps the *mean*, independent of the
+  configured `quantile_collapse`).
+- The one-shot helpers accept the same arguments:
+  `infer(X_train, y_train, X_test, discretize="map-cell")`.
+- Both are also **estimator parameters**, so the sklearn ecosystem can
+  reach them — `predict` kwargs override per call:
+
+  ```python
+  gs = GridSearchCV(NoriRegressor(),
+                    {"discretize": ["map-cell", "median-cell", "snap-mean"]},
+                    scoring="accuracy", cv=5)
+  ```
+
+The underlying lattice math is importable from `synthefy_nori.discretize`
+(`cell_masses`, `discretize_predictions`, `snap_to_levels`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.10.0"
+version = "0.11.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -12,7 +12,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 __all__ = [
     "NoriRegressor",

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from synthefy_nori import discretize
 from synthefy_nori.api import (
     NoriRegressor,
     config_path,
@@ -15,6 +16,7 @@ __version__ = "0.10.0"
 
 __all__ = [
     "NoriRegressor",
+    "discretize",
     "NoriEmbedding",
     "billable_price",
     "config_path",

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -9,6 +9,14 @@ import numpy as np
 import torch
 from sklearn.base import BaseEstimator, RegressorMixin
 
+from synthefy_nori.discretize import (
+    DEFAULT_DISCRETIZE_METHOD,
+    DISCRETIZE_METHODS,
+    SNAP_METHODS,
+    discretize_predictions,
+    target_levels,
+)
+
 
 Task = Literal["regression", "reg"]
 
@@ -61,7 +69,53 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         quantile_collapse: str = "mean",
         bar_temperature: float = 1.0,
         bar_point_estimator: str = "mean",
+        discrete_y_snap_max_unique: int = 0,
+        discretize: str | None = None,
+        categorical_levels=None,
     ) -> None:
+        """Configure the estimator (arguments are stored verbatim; see class docs).
+
+        Args:
+            model_path: path to a local ``.pt`` checkpoint. ``None`` (default)
+                downloads/caches the public Hugging Face checkpoint.
+            model: variant selector (``"nori"`` default / ``"nori-6m"`` /
+                ``"nori-30m"``), resolved to a Hugging Face repo. Ignored when
+                ``model_path`` is given.
+            device: torch device for inference (``"cuda:0"``, ``"cpu"``, ...).
+                ``None`` picks CUDA when available, else CPU.
+            inference_config: path to an inference-config JSON. ``None`` uses
+                the bundled default config.
+            token: Hugging Face token (higher rate limits / private repos);
+                never required for the public checkpoint.
+            augmentations: preprocessing ensemble members, e.g. ``("yj",)`` for
+                the Yeo-Johnson pipeline (default). Empty/None disables.
+            yj_skew_threshold: absolute target-skew above which the YJ member
+                is used (only relevant when ``"yj"`` is in ``augmentations``).
+            quantile_collapse: how the pinball head's quantile bank collapses
+                to a point estimate for ``output_type="mean"`` (``"mean"``,
+                ``"median"``, ``"trimmed_mean"``, ...).
+            bar_temperature: softmax temperature for bar-distribution heads.
+            bar_point_estimator: point decode for bar-distribution heads
+                (``"mean"``/``"median"``/``"mode"``).
+            discrete_y_snap_max_unique: legacy auto-snap threshold. ``0``
+                (default) = off. If ``> 0`` and the training target has at
+                most that many distinct values, point predictions are snapped
+                to the nearest training-y value. Prefer ``discretize=``.
+            discretize: declare a categorical/ordinal target and pick the
+                discretization strategy — ``"map-cell"``, ``"median-cell"``,
+                ``"snap-mean"``, ``"snap-median"``, ``"expected-level"``, or
+                ``"prior-match"`` (see ``synthefy_nori.discretize``).
+                ``None`` (default) = ordinary continuous regression.
+            categorical_levels: the complete set of values the target can
+                take (numeric, order matters — NOT arbitrary class labels),
+                e.g. ``[1, 2, 3, 4, 5]`` for a 1–5 rating. Setting it alone
+                declares a categorical target with the default strategy
+                (``DEFAULT_DISCRETIZE_METHOD``); ``None`` (default) uses the
+                distinct values of the fitted ``y`` when a strategy is set.
+
+        The last two are estimator-level defaults; the same-named ``predict``
+        kwargs override them per call.
+        """
         self.model_path = model_path
         # Variant selector: "nori" (default, ~6M base) / "nori-6m" / "nori-30m", resolved to a
         # Hugging Face repo via synthefy_nori.hf.NORI_MODELS. Ignored when model_path is given.
@@ -76,6 +130,12 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         self.quantile_collapse = quantile_collapse
         self.bar_temperature = float(bar_temperature)
         self.bar_point_estimator = bar_point_estimator
+        self.discrete_y_snap_max_unique = int(discrete_y_snap_max_unique)
+        # estimator-level defaults for the categorical-target path, so the
+        # feature is reachable through the sklearn ecosystem (clone/get_params/
+        # GridSearchCV/cross_val_score); predict() kwargs override per call.
+        self.discretize = discretize
+        self.categorical_levels = categorical_levels
         self._predictor = None
 
     def fit(self, X, y):
@@ -100,10 +160,19 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 quantile_collapse=self.quantile_collapse,
                 bar_temperature=self.bar_temperature,
                 bar_point_estimator=self.bar_point_estimator,
+                discrete_y_snap_max_unique=self.discrete_y_snap_max_unique,
             )
         return self._predictor
 
-    def predict(self, X, *, output_type: str = "mean", quantiles: list[float] | None = None):
+    def predict(
+        self,
+        X,
+        *,
+        output_type: str = "mean",
+        quantiles: list[float] | None = None,
+        discretize: str | None = None,
+        categorical_levels=None,
+    ):
         """Predict targets for the query rows.
 
         ``output_type`` selects what is returned from the model's predictive
@@ -123,7 +192,50 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         ``"quantiles"`` / ``"full"`` are only available for the pinball
         (quantile-head) checkpoint shipped by default; a ``bar_distribution``
         checkpoint raises ``NotImplementedError``.
+
+        Categorical/ordinal targets — passing ``discretize=`` (a strategy) or
+        ``categorical_levels=`` (a known lattice) declares the target discrete
+        and returns labels on its level lattice:
+
+        - ``discretize`` — the strategy that picks WHICH lattice point:
+          ``"map-cell"`` (most-probable level — accuracy-optimal; the default
+          when only ``categorical_levels`` is given), ``"median-cell"``
+          (discrete median — MAE-optimal), ``"snap-mean"`` (nearest level to
+          the mean — QWK), ``"snap-median"`` (nearest level to the
+          distribution median), ``"expected-level"`` (lattice-informed
+          CONTINUOUS expectation — analysis tool, not on-lattice), and
+          ``"prior-match"`` (label frequencies match training priors —
+          benchmarked worse; calibration experiments only). Full guidance in
+          ``synthefy_nori.discretize`` and docs/inference.md.
+        - ``categorical_levels`` — the complete set of values the target can
+          take, when you know it: numeric, order-significant (cells are built
+          between adjacent values), NOT arbitrary class labels. Example: a
+          1–5 rating whose small context happens to contain no 1s →
+          ``categorical_levels=[1, 2, 3, 4, 5]`` makes 1 predictable anyway.
+          ``None`` (default) uses the distinct values of the fitted ``y``.
+
+        Discretization is opt-in (for R²-scored tasks keep the continuous
+        default). Both are also constructor params (so
+        ``clone``/``GridSearchCV``/``cross_val_score`` see them); ``predict``
+        kwargs override the estimator values per call.
         """
+        if discretize is None:
+            discretize = self.discretize
+        if categorical_levels is None:
+            categorical_levels = self.categorical_levels
+        if discretize is not None or categorical_levels is not None:
+            if output_type != "mean" or quantiles is not None:
+                raise ValueError(
+                    "categorical output (discretize=/categorical_levels=) "
+                    "returns discrete labels; combine it only with the default "
+                    "output_type='mean' (the discretize= strategy chooses the "
+                    "summary), not output_type/quantiles."
+                )
+            return self._predict_categorical(
+                X,
+                method=DEFAULT_DISCRETIZE_METHOD if discretize is None else discretize,
+                levels=categorical_levels,
+            )
         if output_type in ("quantiles", "full"):
             return self._predict_distribution(X, output_type=output_type, quantiles=quantiles)
         if output_type == "main":
@@ -141,6 +253,23 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 "quantiles= is only valid with output_type='quantiles'."
             )
 
+        # Drive the predictor's distribution-collapse from output_type. "mean"
+        # uses the regressor's configured collapse so the default path is
+        # byte-for-byte the prior behavior; "median"/"mode" override it for this
+        # call. A quantile head has no native mode, so "mode" falls back to the
+        # median there, while bar-distribution heads decode a true mode.
+        if output_type == "mean":
+            return self._predict_point(
+                X,
+                quantile_collapse=self.quantile_collapse,
+                bar_point_estimator=self.bar_point_estimator,
+            )
+        return self._predict_point(
+            X, quantile_collapse="median", bar_point_estimator=output_type)
+
+    def _predict_point(self, X, *, quantile_collapse: str, bar_point_estimator: str):
+        """One point-prediction pass with an explicit collapse, predictor state
+        restored afterwards (so no call leaks its collapse into the next)."""
         if not hasattr(self, "X_train_"):
             raise ValueError("Call fit(X, y) before predict(X).")
 
@@ -148,19 +277,13 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         y_norm = ((self.y_train_ - self.y_mean_) / self.y_std_).astype(np.float32)
 
         predictor = self._get_predictor()
-        # Drive the predictor's distribution-collapse from output_type. "mean"
-        # restores the regressor's configured collapse so the default path is
-        # byte-for-byte the prior behavior; "median"/"mode" override it for this
-        # call. A quantile head has no native mode, so "mode" falls back to the
-        # median there, while bar-distribution heads decode a true mode.
-        if output_type == "mean":
-            predictor.quantile_collapse = self.quantile_collapse
-            predictor.bar_point_estimator = self.bar_point_estimator
-        else:
-            predictor.quantile_collapse = "median"
-            predictor.bar_point_estimator = output_type
-
-        pred = predictor.predict(self.X_train_, y_norm, X_test)
+        saved = (predictor.quantile_collapse, predictor.bar_point_estimator)
+        try:
+            predictor.quantile_collapse = quantile_collapse
+            predictor.bar_point_estimator = bar_point_estimator
+            pred = predictor.predict(self.X_train_, y_norm, X_test)
+        finally:
+            predictor.quantile_collapse, predictor.bar_point_estimator = saved
         if isinstance(pred, torch.Tensor):
             pred = pred.detach().cpu().numpy()
         pred = np.asarray(pred, dtype=np.float64).squeeze()
@@ -260,6 +383,44 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             out[i] = (1.0 - w) * Q[:, lo] + w * Q[:, hi]
         return out
 
+    def _predict_categorical(self, X, *, method: str, levels=None):
+        """Predict onto a discrete target's level lattice (``discretize=``/``categorical_levels=``).
+
+        ``snap-*`` methods discretize a point prediction with the collapse the
+        method names (mean/median), regardless of the configured
+        ``quantile_collapse`` — so ``snap-mean`` always snaps the mean; they
+        work for every checkpoint, as does ``prior-match`` (point + training
+        priors). ``map-cell``/``median-cell``/``expected-level`` need the
+        quantile bank and share ``_predict_distribution``'s pinball-checkpoint
+        requirement (``expected-level`` returns CONTINUOUS values).
+        """
+        # validate before the (expensive) forward pass; discretize_predictions
+        # re-checks as the canonical gate for direct module users
+        if method not in DISCRETIZE_METHODS:
+            raise ValueError(
+                f"Unknown discretize method {method!r}; expected one of "
+                f"{DISCRETIZE_METHODS}."
+            )
+        if not hasattr(self, "X_train_"):
+            raise ValueError("Call fit(X, y) before predict(X).")
+        lattice = target_levels(self.y_train_ if levels is None else levels)
+        if method in SNAP_METHODS or method == "prior-match":
+            collapse = "median" if method == "snap-median" else "mean"
+            point = self._predict_point(
+                X, quantile_collapse=collapse, bar_point_estimator=collapse)
+            return discretize_predictions(
+                method, lattice, point=point, y_train=self.y_train_)
+        try:
+            dist = self._predict_distribution(X, output_type="full", quantiles=None)
+        except NotImplementedError as err:
+            raise NotImplementedError(
+                f"discretize={method!r} needs the quantile bank, which this "
+                "bar_distribution checkpoint does not expose. Use "
+                "discretize='snap-mean', 'snap-median', or 'prior-match' instead."
+            ) from err
+        return discretize_predictions(
+            method, lattice, Q=dist["quantiles"], taus=dist["taus"])
+
 
 def infer(
     X_train,
@@ -270,18 +431,26 @@ def infer(
     model_path: str | None = None,
     model: str | None = None,
     token: str | bool | None = None,
+    discretize: str | None = None,
+    categorical_levels=None,
     **kwargs,
 ):
     """Fit on context rows and infer labels for query rows.
 
     ``model`` selects a variant (e.g. ``"nori-30m"``); ``model_path`` still takes an explicit
     local checkpoint and wins over ``model`` when both are given.
+    ``discretize`` / ``categorical_levels`` map predictions onto a discrete
+    target's levels — see ``NoriRegressor.predict``.
     """
     if task in ("regression", "reg"):
         estimator = NoriRegressor(
             model_path=model_path, model=model, token=token, **kwargs
         ).fit(X_train, y_train)
-        return estimator.predict(X_test)
+        return estimator.predict(
+            X_test,
+            discretize=discretize,
+            categorical_levels=categorical_levels,
+        )
     raise ValueError(f"Unsupported task: {task!r}")
 
 

--- a/src/synthefy_nori/discretize.py
+++ b/src/synthefy_nori/discretize.py
@@ -1,0 +1,232 @@
+"""Discretize predictions onto a categorical/ordinal target's level lattice.
+
+When a regression target only takes a small set of discrete values (ratings,
+counts, wine-quality scores, ...), the caller may want a prediction *on* that
+lattice, and which lattice point is optimal depends on the loss:
+
+- ``"map-cell"`` — the mode of the discrete posterior: carve the real line into
+  cells around each level (split at midpoints), integrate the predictive
+  distribution's mass per cell, predict the level with the most mass. Optimal
+  for exact-hit accuracy; the default.
+- ``"median-cell"`` — the median of that discrete posterior (first level where
+  cumulative cell mass reaches 0.5). Optimal for absolute error (MAE) on
+  ordinal targets.
+- ``"snap-mean"`` / ``"snap-median"`` — nearest level to the model's point
+  prediction (mean / distribution median). No distribution needed, so they
+  also work for bar-distribution checkpoints; ``snap-mean`` is preferable when
+  the error metric penalizes large misses quadratically (QWK-like losses).
+- ``"expected-level"`` — Σ level·P(level) under the discrete posterior: a
+  lattice-informed CONTINUOUS expectation (not on the lattice). Benchmarked
+  ≈ the plain mean; mainly an analysis/sanity tool.
+- ``"prior-match"`` — rank rows by point prediction and assign levels so the
+  predicted label frequencies match the training priors. Benchmarked
+  significantly WORSE than snap-mean on accuracy and MAE — provided for
+  completeness/calibration experiments; prefer map-cell or median-cell.
+
+Benchmarked head-to-head on the K<=10 discrete-target datasets of
+TALENT/OpenML-CTR23/TabArena (nori-monorepo experiment
+``experiments/categorical-discretization``): map-cell wins accuracy/macro-F1,
+median-cell wins MAE, and for R²-scored tasks the *undiscretized* mean remains
+the right output — discretization always costs squared-error performance.
+
+Discretization is strictly opt-in: nothing here runs unless the caller passes
+``discretize=`` / ``categorical_levels=`` to ``NoriRegressor.predict`` /
+``infer`` (or uses these helpers directly).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+DISCRETIZE_METHODS = (
+    "map-cell", "median-cell", "snap-mean", "snap-median",
+    "expected-level", "prior-match",
+)
+SNAP_METHODS = ("snap-mean", "snap-median")   # need only a point prediction
+CONTINUOUS_METHODS = ("expected-level",)      # output is NOT on the lattice
+DEFAULT_DISCRETIZE_METHOD = "map-cell"  # accuracy-optimal; what the bare flag means
+
+# One-paragraph explanation per strategy — importable for CLIs/UIs/agents and
+# kept in lockstep with DISCRETIZE_METHODS (tested).
+DISCRETIZE_METHOD_DESCRIPTIONS = {
+    "map-cell": (
+        "Mode of the discrete posterior. The real line is split into cells at "
+        "the midpoints between adjacent levels; the predictive distribution's "
+        "probability mass is integrated per cell and the level with the most "
+        "mass is predicted. The best bet for hitting the exact level - "
+        "optimal for accuracy and macro-F1, strongest on skewed targets where "
+        "the mean falls between levels."
+    ),
+    "median-cell": (
+        "Median of the discrete posterior: walk the level cells in order and "
+        "predict the first level where cumulative mass reaches 0.5. Optimal "
+        "when being close counts (ordinal MAE) - small misses are fine, big "
+        "misses are not."
+    ),
+    "snap-mean": (
+        "Nearest level to the distribution MEAN (the mean is used regardless "
+        "of the configured quantile_collapse). Needs no quantile bank, so it "
+        "works for every checkpoint. The best lattice choice under "
+        "quadratically-penalized agreement metrics (QWK), where the mean's "
+        "small systematic misses beat the mode's occasional large ones."
+    ),
+    "snap-median": (
+        "Nearest level to the distribution median. Bank-free fallback with "
+        "near-identical behavior to median-cell; use when you want "
+        "MAE-oriented labels on a bar_distribution checkpoint."
+    ),
+    "expected-level": (
+        "Sum of level x P(level) under the discrete posterior: a "
+        "lattice-informed CONTINUOUS expectation, deliberately NOT on the "
+        "lattice. Benchmarked within noise of the plain mean - an "
+        "analysis/sanity tool, not a labeling strategy."
+    ),
+    "prior-match": (
+        "Rank rows by their point prediction and hand out labels so the "
+        "predicted label frequencies match the training priors "
+        "(largest-remainder quotas). Benchmarked significantly WORSE than "
+        "snap-mean on accuracy and MAE - provided for calibration "
+        "experiments; prefer map-cell or median-cell for real use."
+    ),
+}
+
+# Above this many distinct levels the target is unlikely to be categorical and
+# cell probabilities degenerate toward one bank-quantile per cell; warn.
+_MANY_LEVELS_WARN = 256
+
+
+def target_levels(y) -> np.ndarray:
+    """The sorted, finite, distinct values of a target column."""
+    arr = np.asarray(y, dtype=np.float64).ravel()
+    levels = np.unique(arr[np.isfinite(arr)])
+    if levels.size == 0:
+        raise ValueError("target has no finite values to derive levels from.")
+    if levels.size > _MANY_LEVELS_WARN:
+        warnings.warn(
+            f"discretization requested but the target has {levels.size} "
+            "distinct values - is it really categorical? Predictions will be "
+            "snapped to this large lattice.",
+            stacklevel=3,
+        )
+    return levels
+
+
+def snap_to_levels(values, levels: np.ndarray) -> np.ndarray:
+    """Nearest level to each value.
+
+    Ties go to the *upper* level (same convention as
+    ``NoriPredictor._maybe_snap_discrete_y``). ``NaN`` propagates — a failed
+    prediction must stay visible, not become a confident label. ``±inf`` snap
+    to the extreme levels.
+    """
+    v = np.asarray(values, dtype=np.float64).ravel()
+    out = np.full(v.shape, np.nan)
+    finite = np.isfinite(v)
+    if levels.size == 1:
+        out[finite] = levels[0]
+    else:
+        vf = v[finite]
+        idx = np.searchsorted(levels, vf).clip(1, levels.size - 1)
+        lo, hi = levels[idx - 1], levels[idx]
+        out[finite] = np.where(np.abs(vf - lo) < np.abs(vf - hi), lo, hi)
+    out[v == np.inf] = levels[-1]
+    out[v == -np.inf] = levels[0]
+    return out
+
+
+def cell_masses(Q: np.ndarray, taus: np.ndarray, levels: np.ndarray) -> np.ndarray:
+    """Predictive probability mass per level cell, ``(n_rows, n_levels)``.
+
+    Cells split the real line at midpoints between adjacent levels; row ``i``'s
+    CDF is the linear interpolation of ``taus`` over its (ascending) quantile
+    bank ``Q[i]``, clamped to 0 below the bank and 1 at/above its top value.
+    Rows sum to 1. ``levels`` must be sorted ascending and unique
+    (``target_levels`` / ``discretize_predictions`` guarantee this).
+    """
+    Q = np.asarray(Q, dtype=np.float64)
+    taus = np.asarray(taus, dtype=np.float64).ravel()
+    if Q.ndim != 2 or Q.shape[1] != taus.size:
+        raise ValueError(f"Q {Q.shape} does not match taus ({taus.size},).")
+    levels = np.asarray(levels, dtype=np.float64)
+    n = Q.shape[0]
+    if n == 0:
+        return np.empty((0, levels.size), dtype=np.float64)
+    Qs = np.sort(Q, axis=1)
+    mids = (levels[:-1] + levels[1:]) / 2.0
+    if mids.size:
+        F = np.stack([np.interp(mids, q, taus, left=0.0, right=1.0) for q in Qs])
+        # np.interp returns taus[-1] when a midpoint EQUALS the bank top; the
+        # CDF convention here is "mass at or below" -> clamp those to 1.
+        F = np.where(mids[None, :] >= Qs[:, -1:], 1.0, F)
+    else:  # single level -> one cell holding all the mass
+        F = np.empty((n, 0), dtype=np.float64)
+    F = np.hstack([np.zeros((n, 1)), F, np.ones((n, 1))])
+    return np.clip(np.diff(F, axis=1), 0.0, None)  # clip float round-off
+
+
+def prior_match(point: np.ndarray, levels: np.ndarray, y_train) -> np.ndarray:
+    """Assign levels to rows (ranked by ``point``) matching training priors.
+
+    Level quotas follow the training label frequencies (largest-remainder
+    rounding); rows with the lowest point predictions get the lowest levels.
+    Levels absent from ``y_train`` get zero quota and are never predicted.
+    """
+    y = np.asarray(y_train, dtype=np.float64).ravel()
+    y = y[np.isfinite(y)]
+    counts = np.array([(y == lv).sum() for lv in levels], dtype=np.float64)
+    if counts.sum() == 0:
+        raise ValueError("prior-match: no training values fall on the given levels.")
+    point = np.asarray(point, dtype=np.float64).ravel()
+    quota = counts / counts.sum() * point.size
+    n_k = np.floor(quota).astype(int)
+    rem = quota - n_k
+    for k in np.argsort(-rem)[: point.size - int(n_k.sum())]:
+        n_k[k] += 1
+    out = np.empty(point.size, dtype=np.float64)
+    out[np.argsort(point, kind="stable")] = np.repeat(levels, n_k)
+    return out
+
+
+def discretize_predictions(
+    method: str,
+    levels,
+    *,
+    point: np.ndarray | None = None,
+    Q: np.ndarray | None = None,
+    taus: np.ndarray | None = None,
+    y_train=None,
+) -> np.ndarray:
+    """Map predictions onto ``levels`` with one of ``DISCRETIZE_METHODS``.
+
+    ``levels`` may be unsorted / contain duplicates — it is normalized here.
+    ``snap-*`` methods need ``point`` (the already-collapsed point prediction);
+    ``prior-match`` needs ``point`` and ``y_train`` (for the priors);
+    the ``*-cell`` methods and ``expected-level`` need the quantile bank
+    ``Q`` and its ``taus``. ``expected-level`` returns CONTINUOUS values.
+    """
+    if method not in DISCRETIZE_METHODS:
+        raise ValueError(
+            f"Unknown discretize method {method!r}; expected one of {DISCRETIZE_METHODS}."
+        )
+    levels = np.asarray(levels, dtype=np.float64).ravel()
+    levels = np.unique(levels[np.isfinite(levels)])
+    if levels.size == 0:
+        raise ValueError("levels has no finite values.")
+    if method in SNAP_METHODS or method == "prior-match":
+        if point is None:
+            raise ValueError(f"discretize method {method!r} requires point predictions.")
+        if method == "prior-match":
+            if y_train is None:
+                raise ValueError("discretize method 'prior-match' requires y_train.")
+            return prior_match(point, levels, y_train)
+        return snap_to_levels(point, levels)
+    if Q is None or taus is None:
+        raise ValueError(f"discretize method {method!r} requires the quantile bank (Q, taus).")
+    P = cell_masses(Q, taus, levels)
+    if method == "map-cell":
+        return levels[P.argmax(axis=1)]
+    if method == "expected-level":
+        return P @ levels
+    # median-cell: first level where cumulative mass reaches 0.5
+    return levels[np.argmax(np.cumsum(P, axis=1) >= 0.5, axis=1)]

--- a/src/synthefy_nori/evaluation/datasets.py
+++ b/src/synthefy_nori/evaluation/datasets.py
@@ -574,9 +574,20 @@ class DatasetRegistry:
                 if X_test is not None:
                     X_test = X_test.drop(columns=[col])
 
-        X = X.apply(pd.to_numeric, errors="coerce").fillna(0).astype(np.float32)
+        # Impute numeric NaNs with the per-column TRAIN median, then 0 for
+        # all-missing columns — matching the production evaluator's
+        # X.fillna(medians).fillna(0.0). Test rows are filled with TRAIN
+        # medians so no test statistics leak into preprocessing.
+        X = X.apply(pd.to_numeric, errors="coerce")
+        train_medians = X.median()
+        X = X.fillna(train_medians).fillna(0.0).astype(np.float32)
         if X_test is not None:
-            X_test = X_test.apply(pd.to_numeric, errors="coerce").fillna(0).astype(np.float32)
+            X_test = (
+                X_test.apply(pd.to_numeric, errors="coerce")
+                .fillna(train_medians)
+                .fillna(0.0)
+                .astype(np.float32)
+            )
 
         numeric_y = pd.to_numeric(y, errors="coerce")
         n_coerced = int(numeric_y.isna().sum() - y.isna().sum())

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -48,7 +48,7 @@ class NoriPredictor:
                  quantile_collapse: str = 'mean',
                  bar_temperature: float = 1.0,
                  bar_point_estimator: str = 'mean',
-                 discrete_y_snap_max_unique: int = 30):
+                 discrete_y_snap_max_unique: int = 0):
         """
         init NoriPredictor
 
@@ -484,13 +484,13 @@ class NoriPredictor:
         if return_distribution:
             return self._predict_reg(x_train, y_train, x_test, return_distribution=True)
         preds = self._predict_reg(x_train, y_train, x_test)
-        # V12r3: discrete-y snap. If training y has very low unique
-        # count (≤ discrete_y_snap_max_unique, default 30), snap each
-        # prediction to the nearest training-y value. Helps datasets
-        # like wine_quality (6 unique y), sensory (11), ERA (9),
-        # CookbookReviews (6), chscase_foot (3) at inference WITHOUT
-        # retraining. Disabled when threshold is 0 or training y is
-        # genuinely continuous.
+        # V12r3: discrete-y snap. If enabled (discrete_y_snap_max_unique > 0)
+        # and training y has a low unique count (≤ the threshold), snap each
+        # prediction to the nearest training-y value. OFF by default since
+        # v0.3: snapping is opt-in (via NoriRegressor's discretize= or by
+        # setting this threshold explicitly) — the raw conditional mean
+        # is the R²-optimal point output, and benchmarking showed lattice
+        # snapping costs ~0.05 R² on K≤10 targets.
         if getattr(self, 'discrete_y_snap_max_unique', 0) > 0:
             preds = self._maybe_snap_discrete_y(y_train, preds)
         return preds
@@ -529,7 +529,7 @@ class NoriPredictor:
             if y_finite.size == 0:
                 return preds
             unique_y = np.unique(y_finite)
-            threshold = int(getattr(self, 'discrete_y_snap_max_unique', 30))
+            threshold = int(getattr(self, "discrete_y_snap_max_unique", 0))
             if len(unique_y) > threshold or len(unique_y) < 2:
                 return preds
             # Sort uniques and snap each prediction to nearest by absolute

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -1,0 +1,377 @@
+"""Unit tests for synthefy_nori.discretize + the discretize=/categorical_levels= API wiring."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from synthefy_nori.api import NoriRegressor
+from synthefy_nori.discretize import (
+    DISCRETIZE_METHOD_DESCRIPTIONS,
+    DISCRETIZE_METHODS,
+    cell_masses,
+    discretize_predictions,
+    prior_match,
+    snap_to_levels,
+    target_levels,
+)
+
+
+def _bank_from_normal(mu, sigma, k=99):
+    """Quantile bank rows of N(mu, sigma) at taus = i/(k+1)."""
+    taus = (np.arange(k) + 1.0) / (k + 1.0)
+    mu = np.atleast_1d(np.asarray(mu, dtype=float))
+    sigma = np.atleast_1d(np.asarray(sigma, dtype=float))
+    Q = mu[:, None] + sigma[:, None] * norm.ppf(taus)[None, :]
+    return Q, taus
+
+
+class TestSnapToLevels:
+    def test_nearest(self):
+        levels = np.array([3.0, 4.0, 5.0, 6.0])
+        assert snap_to_levels([5.37, 3.9, 100.0, -7.0], levels).tolist() == [5.0, 4.0, 6.0, 3.0]
+
+    def test_tie_goes_up(self):
+        # same convention as NoriPredictor._maybe_snap_discrete_y
+        assert snap_to_levels([4.5], np.array([4.0, 5.0])).tolist() == [5.0]
+
+    def test_nan_propagates(self):
+        out = snap_to_levels([np.nan, 4.1], np.array([3.0, 4.0, 5.0]))
+        assert np.isnan(out[0]) and out[1] == 4.0
+
+    def test_infinities_snap_to_extremes(self):
+        out = snap_to_levels([np.inf, -np.inf], np.array([3.0, 4.0, 5.0]))
+        assert out.tolist() == [5.0, 3.0]
+
+    def test_single_level(self):
+        assert snap_to_levels([1.2, -9.0], np.array([7.0])).tolist() == [7.0, 7.0]
+
+
+class TestCellMasses:
+    def test_rows_sum_to_one(self):
+        Q, taus = _bank_from_normal([5.0, 4.2], [0.5, 2.0])
+        P = cell_masses(Q, taus, np.array([3.0, 4.0, 5.0, 6.0, 7.0]))
+        np.testing.assert_allclose(P.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_tight_distribution_concentrates(self):
+        Q, taus = _bank_from_normal([5.0], [0.05])
+        P = cell_masses(Q, taus, np.array([3.0, 4.0, 5.0, 6.0]))
+        assert P[0].argmax() == 2
+        assert P[0, 2] > 0.99
+
+    def test_mass_below_and_above_bank(self):
+        Q, taus = _bank_from_normal([0.0], [1.0])
+        P = cell_masses(Q, taus, np.array([-100.0, 0.0, 100.0]))
+        assert P[0, 1] > 0.95
+
+    def test_single_level_single_cell(self):
+        Q, taus = _bank_from_normal([5.0], [1.0])
+        P = cell_masses(Q, taus, np.array([7.0]))
+        assert P.shape == (1, 1) and P[0, 0] == 1.0
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            cell_masses(np.zeros((2, 5)), np.linspace(0.1, 0.9, 4), np.array([0.0, 1.0]))
+
+    def test_empty_rows(self):
+        taus = np.linspace(0.01, 0.99, 9)
+        P = cell_masses(np.empty((0, 9)), taus, np.array([1.0, 2.0, 3.0]))
+        assert P.shape == (0, 3)
+
+
+class TestDiscretizePredictions:
+    def test_mode_vs_mean_on_skewed_posterior(self):
+        # two-lobe bank: 60% of mass near level 7, 40% near level 3 ->
+        # mean lands mid-lattice (bad for accuracy), mode picks 7.
+        taus = (np.arange(99) + 1.0) / 100.0
+        row = np.where(taus < 0.4, 3.0, 7.0) + np.linspace(0, 0.01, 99)
+        Q = row[None, :]
+        levels = np.array([3.0, 5.0, 7.0])
+        mode = discretize_predictions("map-cell", levels, Q=Q, taus=taus)
+        assert mode.tolist() == [7.0]
+        snapped_mean = discretize_predictions("snap-mean", levels, point=Q.mean(axis=1))
+        assert snapped_mean.tolist() == [5.0]  # mean ~5.4 snaps to the wrong level
+
+    def test_median_cell_crosses_half(self):
+        taus = (np.arange(99) + 1.0) / 100.0
+        row = np.where(taus < 0.4, 3.0, 7.0) + np.linspace(0, 0.01, 99)
+        out = discretize_predictions(
+            "median-cell", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
+        assert out.tolist() == [7.0]
+
+    def test_unsorted_duplicate_levels_normalized(self):
+        Q, taus = _bank_from_normal([7.0], [0.05])
+        out = discretize_predictions(
+            "map-cell", np.array([7.0, 3.0, 5.0, 3.0]), Q=Q, taus=taus)
+        assert out.tolist() == [7.0]
+
+    def test_single_level_cell_method(self):
+        Q, taus = _bank_from_normal([5.0], [1.0])
+        out = discretize_predictions("map-cell", np.array([7.0]), Q=Q, taus=taus)
+        assert out.tolist() == [7.0]
+
+    def test_expected_level_matches_posterior_mean(self):
+        taus = (np.arange(99) + 1.0) / 100.0
+        row = np.where(taus < 0.4, 3.0, 7.0) + np.linspace(0, 0.01, 99)
+        out = discretize_predictions(
+            "expected-level", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
+        # ~40% mass at 3, ~60% at 7 -> expectation ~ 5.4 (continuous, off-lattice)
+        assert 5.0 < out[0] < 5.8
+        assert out[0] not in (3.0, 5.0, 7.0)
+
+    def test_prior_match_matches_train_frequencies(self):
+        y_train = np.array([3.0] * 6 + [5.0] * 3 + [7.0] * 3)  # 50/25/25
+        point = np.linspace(0, 10, 8)
+        out = discretize_predictions(
+            "prior-match", np.array([3.0, 5.0, 7.0]), point=point, y_train=y_train)
+        vals, counts = np.unique(out, return_counts=True)
+        assert vals.tolist() == [3.0, 5.0, 7.0]
+        assert counts.tolist() == [4, 2, 2]  # 8 rows at 50/25/25
+        # lowest-ranked points get the lowest levels
+        assert out[np.argsort(point)[0]] == 3.0
+        assert out[np.argsort(point)[-1]] == 7.0
+
+    def test_prior_match_requires_y_train(self):
+        with pytest.raises(ValueError, match="y_train"):
+            discretize_predictions("prior-match", np.array([1.0, 2.0]),
+                                   point=np.array([1.0]))
+
+    def test_prior_match_direct_zero_overlap_raises(self):
+        with pytest.raises(ValueError, match="no training values"):
+            prior_match(np.array([1.0]), np.array([10.0, 20.0]), np.array([1.0, 2.0]))
+
+    def test_unknown_method_raises(self):
+        with pytest.raises(ValueError, match="Unknown discretize"):
+            discretize_predictions("banana", np.array([1.0]), point=np.array([1.0]))
+
+    def test_missing_inputs_raise(self):
+        with pytest.raises(ValueError, match="requires point"):
+            discretize_predictions("snap-mean", np.array([1.0, 2.0]))
+        with pytest.raises(ValueError, match="requires the quantile bank"):
+            discretize_predictions("map-cell", np.array([1.0, 2.0]))
+
+
+class TestTargetLevels:
+    def test_unique_sorted_finite(self):
+        levels = target_levels([5, 3, 5, np.nan, 4, 3])
+        assert levels.tolist() == [3.0, 4.0, 5.0]
+
+    def test_many_levels_warns(self):
+        with pytest.warns(UserWarning, match="distinct values"):
+            target_levels(np.arange(1000, dtype=float))
+
+    def test_all_nan_raises(self):
+        with pytest.raises(ValueError):
+            target_levels([np.nan, np.inf])
+
+
+class TestPackageSurface:
+    def test_descriptions_cover_all_methods(self):
+        assert set(DISCRETIZE_METHOD_DESCRIPTIONS) == set(DISCRETIZE_METHODS)
+        assert all(len(v) > 40 for v in DISCRETIZE_METHOD_DESCRIPTIONS.values())
+
+
+    def test_submodule_attribute_access(self):
+        # docs promise `synthefy_nori.discretize.snap_to_levels` works
+        import synthefy_nori
+
+        assert synthefy_nori.discretize.snap_to_levels is snap_to_levels
+
+
+class TestPredictCategoricalAPI:
+    """API wiring without a real checkpoint (distribution/point paths stubbed)."""
+
+    def _fitted(self, monkeypatch):
+        model = NoriRegressor()
+        X = np.zeros((6, 2), dtype=np.float32)
+        y = np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0])
+        model.fit(X, y)
+        Q, taus = _bank_from_normal([6.9, 3.1, 5.0], [0.1, 0.1, 0.1])
+        monkeypatch.setattr(
+            NoriRegressor, "_predict_distribution",
+            lambda self, X, *, output_type, quantiles:
+                {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
+        )
+        return model
+
+    def test_map_cell_default_via_levels_only(self, monkeypatch):
+        # categorical_levels alone activates with the default (map-cell) strategy
+        model = self._fitted(monkeypatch)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            categorical_levels=[3.0, 5.0, 7.0])
+        assert out.tolist() == [7.0, 3.0, 5.0]
+
+    def test_snap_mean_forces_mean_collapse(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        seen = {}
+
+        def fake_point(self, X, *, quantile_collapse, bar_point_estimator):
+            seen["collapse"] = (quantile_collapse, bar_point_estimator)
+            return np.array([6.6, 2.0, 4.9])
+
+        monkeypatch.setattr(NoriRegressor, "_predict_point", fake_point)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            discretize="snap-mean")
+        assert out.tolist() == [7.0, 3.0, 5.0]
+        # snap-mean must snap the MEAN even if the regressor was configured
+        # with a different quantile_collapse
+        assert seen["collapse"] == ("mean", "mean")
+
+    def test_snap_median_forces_median_collapse(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        seen = {}
+
+        def fake_point(self, X, *, quantile_collapse, bar_point_estimator):
+            seen["collapse"] = (quantile_collapse, bar_point_estimator)
+            return np.array([6.6, 2.0, 4.9])
+
+        monkeypatch.setattr(NoriRegressor, "_predict_point", fake_point)
+        model.predict(np.zeros((3, 2), dtype=np.float32),
+                      discretize="snap-median")
+        assert seen["collapse"] == ("median", "median")
+
+    def test_categorical_levels_override(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        # supply a lattice richer than the fitted y (e.g. known 1-9 scale)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            categorical_levels=np.arange(1.0, 10.0))
+        assert out.tolist() == [7.0, 3.0, 5.0]
+
+    def test_discretize_alone_activates(self, monkeypatch):
+        # per review: passing discretize= (or categorical_levels=) alone is
+        # enough -- no separate flag needed
+        model = self._fitted(monkeypatch)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize="median-cell")
+        assert set(out.tolist()) <= {3.0, 5.0, 7.0}
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            categorical_levels=[3.0, 5.0, 7.0])
+        assert set(out.tolist()) <= {3.0, 5.0, 7.0}
+
+    def test_infer_helper_implication(self, monkeypatch):
+        # the one-shot helper routes discretize= through the same implication
+        from synthefy_nori.api import infer
+
+        Q, taus = _bank_from_normal([6.9, 3.1, 5.0], [0.1, 0.1, 0.1])
+        monkeypatch.setattr(
+            NoriRegressor, "_predict_distribution",
+            lambda self, X, *, output_type, quantiles:
+                {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
+        )
+        out = infer(np.zeros((6, 2), dtype=np.float32),
+                    np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]),
+                    np.zeros((3, 2), dtype=np.float32),
+                    discretize="map-cell")
+        assert out.tolist() == [7.0, 3.0, 5.0]
+
+    def test_flag_is_gone(self, monkeypatch):
+        # categorical_target was removed entirely (PR review) -- passing it
+        # must fail loudly, not be silently swallowed
+        model = self._fitted(monkeypatch)
+        with pytest.raises(TypeError):
+            model.predict(np.zeros((3, 2), dtype=np.float32), categorical_target=True)
+
+    def test_rejects_output_type_combo(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        with pytest.raises(ValueError, match="categorical output"):
+            model.predict(np.zeros((3, 2), dtype=np.float32),
+                          discretize="map-cell", output_type="median")
+
+    def test_unknown_strategy_raises(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        with pytest.raises(ValueError, match="Unknown discretize"):
+            model.predict(np.zeros((3, 2), dtype=np.float32), discretize="banana")
+
+    def test_bar_checkpoint_gets_actionable_error(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+
+        def raise_ni(self, X, *, output_type, quantiles):
+            raise NotImplementedError("bar_distribution")
+
+        monkeypatch.setattr(NoriRegressor, "_predict_distribution", raise_ni)
+        with pytest.raises(NotImplementedError, match="snap-mean"):
+            model.predict(np.zeros((3, 2), dtype=np.float32), discretize="map-cell")
+
+    def test_requires_fit(self):
+        with pytest.raises(ValueError, match="fit"):
+            NoriRegressor().predict(np.zeros((1, 2), dtype=np.float32),
+                                    discretize="map-cell")
+
+    def test_expected_level_via_predict(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            discretize="expected-level")
+        assert out.shape == (3,)  # continuous, near the per-row bank means
+
+    def test_prior_match_via_predict(self, monkeypatch):
+        model = self._fitted(monkeypatch)
+        monkeypatch.setattr(
+            NoriRegressor, "_predict_point",
+            lambda self, X, *, quantile_collapse, bar_point_estimator:
+                np.array([6.6, 2.0, 4.9]))
+        out = model.predict(np.zeros((3, 2), dtype=np.float32),
+                            discretize="prior-match")
+        # fitted y is 2x each of {3,5,7} -> 3 rows get one of each, rank-ordered
+        assert sorted(out.tolist()) == [3.0, 5.0, 7.0]
+        assert out.tolist() == [7.0, 3.0, 5.0]
+
+    @pytest.mark.parametrize("method", DISCRETIZE_METHODS[:2])
+    def test_outputs_are_on_lattice(self, monkeypatch, method):
+        model = self._fitted(monkeypatch)
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize=method)
+        assert set(out.tolist()) <= {3.0, 5.0, 7.0}
+
+
+class TestSklearnEcosystem:
+    """Estimator-level categorical params: clone/get_params/CV reachability."""
+
+    def _patch_distribution(self, monkeypatch):
+        def fake_dist(self, X, *, output_type, quantiles):
+            n = np.asarray(X).shape[0]
+            taus = (np.arange(99) + 1.0) / 100.0
+            Q = 5.0 + 0.1 * norm.ppf(taus)[None, :] * np.ones((n, 1))
+            return {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)}
+
+        monkeypatch.setattr(NoriRegressor, "_predict_distribution", fake_dist)
+
+    def test_constructor_params_drive_predict(self, monkeypatch):
+        self._patch_distribution(monkeypatch)
+        model = NoriRegressor(discretize="map-cell")
+        model.fit(np.zeros((6, 2), dtype=np.float32),
+                  np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
+        out = model.predict(np.zeros((4, 2), dtype=np.float32))
+        assert out.tolist() == [5.0, 5.0, 5.0, 5.0]
+
+    def test_per_call_override_wins(self, monkeypatch):
+        self._patch_distribution(monkeypatch)
+        model = NoriRegressor(discretize="median-cell")
+        model.fit(np.zeros((6, 2), dtype=np.float32),
+                  np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
+        monkeypatch.setattr(
+            NoriRegressor, "_predict_point",
+            lambda self, X, *, quantile_collapse, bar_point_estimator:
+                np.array([5.37] * np.asarray(X).shape[0]))
+        out = model.predict(np.zeros((2, 2), dtype=np.float32),
+                            discretize="map-cell")
+        assert set(out.tolist()) <= {3.0, 5.0, 7.0}  # per-call strategy override
+
+    def test_clone_roundtrip(self):
+        from sklearn.base import clone
+
+        model = NoriRegressor(discretize="median-cell",
+                              categorical_levels=[1.0, 2.0, 3.0])
+        params = clone(model).get_params()
+        assert params["discretize"] == "median-cell"
+        assert params["categorical_levels"] == [1.0, 2.0, 3.0]
+
+    def test_gridsearch_over_discretize(self, monkeypatch):
+        from sklearn.model_selection import GridSearchCV
+
+        self._patch_distribution(monkeypatch)
+        X = np.zeros((12, 2), dtype=np.float32)
+        y = np.tile([3.0, 5.0, 7.0], 4)
+        gs = GridSearchCV(
+            NoriRegressor(),
+            {"discretize": ["map-cell", "median-cell"]},
+            scoring="accuracy", cv=2, error_score="raise")
+        gs.fit(X, y)
+        assert gs.best_params_["discretize"] in ("map-cell", "median-cell")

--- a/tests/test_evaluation_datasets.py
+++ b/tests/test_evaluation_datasets.py
@@ -1,0 +1,66 @@
+"""Fast unit tests for DatasetRegistry preprocessing (imputation semantics)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from synthefy_nori.evaluation.datasets import DatasetRegistry
+
+
+@pytest.fixture
+def registry(tmp_path):
+    return DatasetRegistry(cache_dir=str(tmp_path / "cache"))
+
+
+def _make_frames():
+    # Column "a": train median is 4.0 (NaN excluded); test has a NaN and a
+    # deliberately different value distribution so train/test medians differ.
+    X_train = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 4.0, 4.0, 4.0, 4.0, np.nan],
+        "b": [np.nan] * 12,
+        "c": np.arange(12, dtype=float),
+    })
+    y_train = pd.Series(np.arange(12, dtype=float))
+    X_test = pd.DataFrame({
+        "a": [100.0, np.nan, 100.0],
+        "b": [np.nan, np.nan, np.nan],
+        "c": [1.0, 2.0, 3.0],
+    })
+    y_test = pd.Series([1.0, 2.0, 3.0])
+    return X_train, y_train, X_test, y_test
+
+
+def test_numeric_nan_filled_with_train_median(registry):
+    X_train, y_train, X_test, y_test = _make_frames()
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
+                                         X_test=X_test, y_test=y_test)
+    assert entry is not None
+    # Train NaN in "a" (row 11) -> train median 4.0, not 0.
+    assert entry.X_train[11, 0] == pytest.approx(4.0)
+
+
+def test_test_nan_filled_with_train_median_not_test_median(registry):
+    X_train, y_train, X_test, y_test = _make_frames()
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
+                                         X_test=X_test, y_test=y_test)
+    # Test NaN in "a" (row 1) -> TRAIN median 4.0; the test median (100.0)
+    # must not leak in, and the legacy zero-fill must not return.
+    assert entry.X_test[1, 0] == pytest.approx(4.0)
+
+
+def test_all_missing_column_filled_with_zero(registry):
+    X_train, y_train, X_test, y_test = _make_frames()
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
+                                         X_test=X_test, y_test=y_test)
+    # "b" has no observed train values -> median is NaN -> falls back to 0
+    # in both frames.
+    assert np.all(entry.X_train[:, 1] == 0.0)
+    assert np.all(entry.X_test[:, 1] == 0.0)
+
+
+def test_no_nan_survives_preprocessing(registry):
+    X_train, y_train, X_test, y_test = _make_frames()
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
+                                         X_test=X_test, y_test=y_test)
+    assert np.isfinite(entry.X_train).all()
+    assert np.isfinite(entry.X_test).all()


### PR DESCRIPTION
Promotes the two staging-only commits into public and bumps the version for the 0.11.0 release.

## Commits (cherry-picked verbatim from staging, patch-identical for cascade dedup)
- `evaluation: impute numeric NaNs with train median (production-aligned)` (staging #6)
- `feat: opt-in categorical-target discretization in predict; disable low-K auto-snap by default` (staging #7)
- Version bump `0.10.0` → `0.11.0` in `pyproject.toml` + `__init__.py`

## Merge note
**Rebase-merge this PR (do not squash)** — the cascade's rebase-sync dedups the promoted commits by patch-id; squashing would make staging's copies collide on the next sync.

## Verification
- `uv run ruff check src scripts tests` — clean
- `uv run pytest -m "not slow"` — 76 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)