### PR TITLE
fix: reject Nori Thinking selectors with a clear error, not a dead HF lookup

### DIFF
--- a/src/synthefy_nori/hf.py
+++ b/src/synthefy_nori/hf.py
@@ -29,11 +29,34 @@ NORI_MODELS = {
 }
 
 
+def _is_thinking_model(model: str) -> bool:
+    """Return ``True`` if ``model`` names a Nori Thinking (test-time-compute) variant.
+
+    Thinking variants (e.g. ``"nori-30m-thinking-medium"`` / the ``"synthefy/..."`` gateway
+    slug) run only on the hosted Synthefy API; ``synthefy-nori`` does single-pass local
+    inference and ships no Thinking checkpoint. Matching on the ``"thinking"`` token covers
+    every budget tier and both the friendly and slug spellings.
+    """
+    return "thinking" in model.lower()
+
+
 def resolve_model_repo(model: str | None) -> str:
     """Map a variant name to its HF repo id: ``None`` -> the default (~6M) base, a known name
-    -> its repo, anything else returned unchanged (so a raw ``"org/repo"`` id also works)."""
+    -> its repo, anything else returned unchanged (so a raw ``"org/repo"`` id also works).
+
+    A Nori Thinking selector raises :class:`ValueError`: it has no downloadable checkpoint here,
+    so without this guard it would fall through to a raw-repo lookup and fail with an opaque
+    "repo not found" error instead of telling the caller it is a hosted-API-only variant."""
     if model is None:
         model = DEFAULT_MODEL
+    if _is_thinking_model(model):
+        raise ValueError(
+            f"model={model!r} selects a Nori Thinking (test-time-compute) variant, which runs "
+            "only on the hosted Synthefy API. The synthefy-nori package does single-pass local "
+            "inference and has no Thinking checkpoint. Use the hosted API (e.g. the `synthefy` "
+            "client with mode='remote') for Thinking, or select 'nori' / 'nori-6m' / 'nori-30m' "
+            "for local inference."
+        )
     return NORI_MODELS.get(model, model)
 
 

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -1,3 +1,5 @@
+import pytest
+
 from synthefy_nori import hf
 
 
@@ -14,6 +16,28 @@ def test_model_variant_registry_resolution():
     assert hf.resolve_model_repo(None) == hf.DEFAULT_MODEL_REPO_ID         # None -> default base
     assert hf.resolve_model_repo("Synthefy/Custom-Repo") == "Synthefy/Custom-Repo"  # raw id passes through
     assert {"nori", "nori-6m", "nori-30m"} <= set(hf.NORI_MODELS)
+
+
+def test_thinking_variant_is_rejected_not_downloaded():
+    # Thinking is hosted-API only: resolve_model_repo must raise a clear error rather than fall
+    # through to a raw-repo lookup that 404s with an opaque message.
+    for name in (
+        "nori-30m-thinking",
+        "nori-30m-thinking-medium",
+        "synthefy/nori-30m-thinking-high",
+    ):
+        assert hf._is_thinking_model(name)
+        with pytest.raises(ValueError, match=r"Thinking.*hosted Synthefy API"):
+            hf.resolve_model_repo(name)
+    # non-thinking selectors are unaffected
+    assert not hf._is_thinking_model("nori-30m")
+    assert hf.resolve_model_repo("nori-30m") == "Synthefy/Nori-30M"
+
+
+def test_download_checkpoint_rejects_thinking_variant():
+    # The guard fires through the download entry point too (before any network call).
+    with pytest.raises(ValueError, match=r"Thinking.*hosted Synthefy API"):
+        hf.download_checkpoint(model="nori-30m-thinking-medium", token=False)
 
 
 def test_download_checkpoint_model_overrides_repo(monkeypatch):


### PR DESCRIPTION
## Problem

Passing a Nori Thinking (test-time-compute) selector to the local package — `model="nori-30m-thinking-medium"` or the `synthefy/...` slug — fell through `resolve_model_repo`'s raw-repo passthrough and failed at **download time** with an opaque *"repository not found / access denied"* error. Nothing told the caller that Thinking is a **hosted-API-only** variant with no local checkpoint (its weights are S3-only and the TTC wrapper isn't shipped in the public package).

## Fix

`resolve_model_repo` now raises a clear `ValueError` for any `thinking` selector (every budget tier, both friendly and slug spellings), pointing the caller at the hosted API. The guard sits in `resolve_model_repo`, so it covers **every** entry point (`NoriRegressor` / `infer` / `predict` / `download_checkpoint`) and fires **before any network call**. Non-thinking custom repo ids still pass through unchanged.

```python
>>> synthefy_nori.predict(X_tr, y_tr, X_te, model="nori-30m-thinking-medium")
ValueError: model='nori-30m-thinking-medium' selects a Nori Thinking (test-time-compute)
variant, which runs only on the hosted Synthefy API. The synthefy-nori package does
single-pass local inference and has no Thinking checkpoint. Use the hosted API (e.g. the
`synthefy` client with mode='remote') for Thinking, or select 'nori' / 'nori-6m' / 'nori-30m'
for local inference.
```

## Tests

Adds `test_thinking_variant_is_rejected_not_downloaded` and `test_download_checkpoint_rejects_thinking_variant`. `tests/test_hf.py` + `tests/test_api_smoke.py`: `11 passed`. Ruff correctness gate clean.

## Companion PR

Pairs with the `synthefy` client change (Synthefy/synthefy#31), which raises the equivalent error for `SynthefyNoriClient(mode="local"/"auto", model=<thinking>)` and removes the client-side silent fallback to the base model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)