### PR TITLE
release: 0.11.1 (Thinking-selector error fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.11.0"
+version = "0.11.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -12,7 +12,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 __all__ = [
     "NoriRegressor",


### PR DESCRIPTION
Version bump to cut the PyPI release that carries #74 (reject Nori Thinking selectors with a clear error instead of a dead HF lookup). 0.11.0 is already published, so this is 0.11.1.

- `pyproject.toml`: `0.11.0` → `0.11.1`
- `src/synthefy_nori/__init__.py`: `__version__` → `0.11.1`

Once merged, publishing GitHub Release `v0.11.1` triggers the OIDC trusted-publish workflow → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)