### PR TITLE
feat(api): zero-shot text features for NoriRegressor

### DIFF
--- a/examples/text_features_synthetic.py
+++ b/examples/text_features_synthetic.py
@@ -1,0 +1,90 @@
+"""Zero-shot text features on a synthetic text + numeric dataset.
+
+Nori is a numeric tabular model, but ``NoriRegressor.fit`` can take free-text
+columns directly: pass ``text_columns=`` and Nori embeds them with a frozen
+sentence encoder, reduces the embedding to ``svd_dim`` columns (TruncatedSVD, fit
+on train), and appends them to the numeric/categorical block — no training, the
+encoder and Nori stay frozen. ``predict`` replays the same transform.
+
+This example builds a small synthetic dataset whose target depends on numeric
+columns (``x1``, ``x2``), a categorical column (``brand``), AND the sentiment word
+buried in a free-text ``review``. Nori on the tabular columns alone cannot see the
+review, so adding the text feature recovers the missing signal and lifts R².
+
+    uv sync --extra text                              # adds sentence-transformers
+    uv run python examples/text_features_synthetic.py
+
+The first run downloads the public ~47MB Nori checkpoint and the MiniLM encoder;
+GPU if available, else CPU.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import r2_score
+
+from synthefy_nori import NoriRegressor
+
+# sentiment word -> its (hidden) contribution to the target
+_SENTIMENTS = [("terrible", -2.0), ("poor", -1.0), ("okay", 0.0),
+               ("good", 1.0), ("excellent", 2.0)]
+_FILLERS = ["fast shipping", "arrived late", "nice packaging",
+            "exactly as described", "would buy again"]
+_BRANDS = {"acme": 0.5, "globex": -0.5, "initech": 0.0}
+
+
+def make_dataset(n: int, seed: int):
+    """Synthetic rows with numeric (``x1``,``x2``), categorical (``brand``) and
+    free-text (``review``) columns.
+
+    The target is a linear function of the numerics and brand PLUS a large term
+    driven by the review's sentiment word — signal that lives only in the text.
+    Returns ``(DataFrame, y)``.
+    """
+    rng = np.random.default_rng(seed)
+    x1 = rng.normal(size=n)
+    x2 = rng.normal(size=n)
+    brand = rng.choice(list(_BRANDS), size=n)
+    idx = rng.integers(0, len(_SENTIMENTS), size=n)
+    words = [_SENTIMENTS[i][0] for i in idx]
+    sval = np.array([_SENTIMENTS[i][1] for i in idx])
+    fillers = rng.choice(_FILLERS, size=n)
+    review = [f"Customer review: the item was {w}. {f}." for w, f in zip(words, fillers)]
+    brand_effect = np.array([_BRANDS[b] for b in brand])
+
+    y = 2.0 * x1 - 1.5 * x2 + brand_effect + 3.0 * sval + rng.normal(scale=0.5, size=n)
+    df = pd.DataFrame({"x1": x1, "x2": x2, "brand": brand, "review": review})
+    return df, y.astype(np.float64)
+
+
+def run(n_train: int = 800, n_test: int = 200, svd_dim: int = 64,
+        device=None, seed: int = 0):
+    """Fit Nori with and without the text column; return ``(r2_tabular, r2_text)``."""
+    df_train, y_train = make_dataset(n_train, seed)
+    df_test, y_test = make_dataset(n_test, seed + 1)
+    cols = ["x1", "x2", "brand", "review"]
+
+    tab_cols = ["x1", "x2", "brand"]
+    # Tabular-only baseline: review dropped, text_columns=[] -> numeric passthrough
+    # + categorical label-encoding, no embedder. Same estimator as the +text run
+    # below, just without the text column. Text config lives in the constructor.
+    tab = NoriRegressor(device=device, text_columns=[]).fit(df_train[tab_cols], y_train)
+    r_tab = float(r2_score(y_test, tab.predict(df_test[tab_cols])))
+
+    # + text: same columns plus the review, embedded -> SVD -> appended columns.
+    reg = NoriRegressor(device=device, text_columns=["review"], svd_dim=svd_dim)
+    reg.fit(df_train[cols], y_train)
+    r_text = float(r2_score(y_test, reg.predict(df_test[cols])))
+    return r_tab, r_text
+
+
+def main():
+    r_tab, r_text = run()
+    print(f"Nori tabular-only (x1, x2, brand)   R2 = {r_tab:.4f}")
+    print(f"Nori + text review (svd-64)         R2 = {r_text:.4f}")
+    print(f"text lift                           {r_text - r_tab:+.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,10 @@ Changelog = "https://github.com/Synthefy/synthefy-nori/releases"
 train = ["wandb>=0.15.0", "xgboost"]
 eval = ["matplotlib", "openml"]
 interpretability = ["shapiq>=1.0", "matplotlib"]
+# Zero-shot text features: embed free-text columns and append them as numeric
+# columns (NoriRegressor(text_columns=...)). sentence-transformers is imported
+# lazily, so numeric-only use never needs it.
+text = ["sentence-transformers"]
 dev = ["build", "pytest", "ruff"]
 
 [project.scripts]

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -16,6 +16,7 @@ from synthefy_nori.discretize import (
     discretize_predictions,
     target_levels,
 )
+from synthefy_nori.text_features import MultimodalPreprocessor
 
 
 Task = Literal["regression", "reg"]
@@ -72,6 +73,11 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         discrete_y_snap_max_unique: int = 0,
         discretize: str | None = None,
         categorical_levels=None,
+        text_columns=None,
+        svd_dim: int | None = 128,
+        embedder="minilm",
+        text_max_cardinality: int = 128,
+        text_normalize: bool | None = None,
     ) -> None:
         """Configure the estimator (arguments are stored verbatim; see class docs).
 
@@ -112,9 +118,29 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 declares a categorical target with the default strategy
                 (``DEFAULT_DISCRETIZE_METHOD``); ``None`` (default) uses the
                 distinct values of the fitted ``y`` when a strategy is set.
+            text_columns: enables the zero-shot text path when set (requires ``X``
+                to be a :class:`pandas.DataFrame`). A list of column names embeds
+                those columns; ``[]`` is a valid numeric+categorical-only fit (no
+                embedder loaded). ``None`` (default) treats ``X`` as a plain numeric
+                array. Columns must be named explicitly; the estimator does not
+                infer which columns are text.
+            svd_dim: width of the TruncatedSVD text block appended to the numeric
+                features (fit on train only). Default 128; ``None`` appends the full
+                raw embedding.
+            embedder: sentence encoder for ``text_columns`` — a short name / HF id
+                string (e.g. ``"minilm"``; needs the optional
+                ``sentence-transformers`` extra), a preloaded encoder object, or a
+                callable ``texts -> ndarray``.
+            text_max_cardinality: a non-numeric column with more than this many
+                distinct values is embedded rather than label-encoded; categorical
+                encoding also caps at this many values (rarer/unseen -> "other").
+            text_normalize: cosine-normalize the text embeddings. ``None`` (default)
+                auto-enables for known LLM encoders; set True/False to override
+                (needed for a preloaded encoder object).
 
-        The last two are estimator-level defaults; the same-named ``predict``
-        kwargs override them per call.
+        The discretize/categorical_levels pair are estimator-level defaults; the
+        same-named ``predict`` kwargs override them per call. The text_* params
+        take effect at ``fit``.
         """
         self.model_path = model_path
         # Variant selector: "nori" (default, ~6M base) / "nori-6m" / "nori-30m", resolved to a
@@ -136,16 +162,61 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # GridSearchCV/cross_val_score); predict() kwargs override per call.
         self.discretize = discretize
         self.categorical_levels = categorical_levels
+        # Zero-shot text config — constructor params (not fit kwargs) so the
+        # feature round-trips through clone/get_params/GridSearchCV/cross_val_score
+        # and pickle, like discretize/categorical_levels above.
+        #   text_columns: None -> numeric-array path; [] -> DataFrame numeric+
+        #     categorical only; list of names -> embed those columns.
+        #   svd_dim: SVD width of the appended text block (None = raw embedding).
+        #   embedder: short name / preloaded encoder / callable.
+        self.text_columns = text_columns
+        self.svd_dim = svd_dim
+        self.embedder = embedder
+        self.text_max_cardinality = int(text_max_cardinality)
+        self.text_normalize = text_normalize
         self._predictor = None
+        # Fitted text preprocessor (embed -> SVD -> extra columns), built by fit()
+        # when text_columns is not None; None = numeric-only.
+        self._text_preprocessor = None
 
     def fit(self, X, y):
-        self.X_train_ = np.asarray(X, dtype=np.float32)
-        self.n_features_in_ = self.X_train_.shape[1]
+        """Fit the in-context regressor on ``(X, y)``.
+
+        Numeric-only (default, ``text_columns=None``): ``X`` is any array-like
+        coerced to a float32 matrix. Zero-shot text: set ``text_columns`` in the
+        constructor and pass ``X`` as a DataFrame — the named columns are embedded
+        by a frozen sentence encoder, reduced to ``svd_dim`` columns (SVD fit on
+        train), and appended; the encoder and Nori stay frozen. ``predict`` replays
+        the transform, so its ``X`` must be a DataFrame with these columns.
+        """
+        if self.text_columns is not None:
+            self._text_preprocessor = MultimodalPreprocessor(
+                self.text_columns, svd_dim=self.svd_dim, embedder=self.embedder,
+                device=self.device, max_cardinality=self.text_max_cardinality,
+                normalize=self.text_normalize)
+            X_mat = self._text_preprocessor.fit_transform(X)
+            # sklearn contract: n_features_in_ counts INPUT features, not the
+            # widened SVD block; record column names when we have them.
+            self.n_features_in_ = X.shape[1]
+            if hasattr(X, "columns"):
+                self.feature_names_in_ = np.asarray(X.columns, dtype=object)
+        else:
+            self._text_preprocessor = None
+            X_mat = np.asarray(X, dtype=np.float32)
+            self.n_features_in_ = X_mat.shape[1]
+        self.X_train_ = X_mat.astype(np.float32)
         self.y_train_ = np.asarray(y, dtype=np.float64)
         self.y_mean_ = float(self.y_train_.mean())
         y_std = float(self.y_train_.std())
         self.y_std_ = y_std if y_std >= 1e-12 else 1.0
         return self
+
+    def _prepare_query_features(self, X) -> np.ndarray:
+        """Coerce query rows to the model's float32 matrix, applying the fitted
+        text transform (embed -> SVD -> append) when fit configured one."""
+        if getattr(self, "_text_preprocessor", None) is not None:
+            return self._text_preprocessor.transform(X).astype(np.float32)
+        return np.asarray(X, dtype=np.float32)
 
     def _get_predictor(self):
         if self._predictor is None:
@@ -273,7 +344,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         if not hasattr(self, "X_train_"):
             raise ValueError("Call fit(X, y) before predict(X).")
 
-        X_test = np.asarray(X, dtype=np.float32)
+        X_test = self._prepare_query_features(X)
         y_norm = ((self.y_train_ - self.y_mean_) / self.y_std_).astype(np.float32)
 
         predictor = self._get_predictor()
@@ -319,7 +390,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         if X is None:
             raise ValueError(
                 "get_embeddings requires X for data_source='test'.")
-        X_test = np.asarray(X, dtype=np.float32)
+        X_test = self._prepare_query_features(X)
         return predictor.get_embeddings(
             self.X_train_, y_norm, X_test, data_source=data_source)
 
@@ -351,7 +422,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 "(quantile-head) checkpoint is required."
             )
 
-        X_test = np.asarray(X, dtype=np.float32)
+        X_test = self._prepare_query_features(X)
         y_norm = ((self.y_train_ - self.y_mean_) / self.y_std_).astype(np.float32)
 
         bank = predictor.predict(self.X_train_, y_norm, X_test, return_distribution=True)

--- a/src/synthefy_nori/text_features.py
+++ b/src/synthefy_nori/text_features.py
@@ -1,0 +1,291 @@
+"""Zero-shot text features for Nori.
+
+Turns free-text columns of a :class:`pandas.DataFrame` into a handful of extra
+numeric columns that a frozen, pretrained Nori can consume like any other feature
+— no gradient training anywhere:
+
+    text columns
+      -> one column-prefixed paragraph per row     (:func:`build_paragraphs`)
+      -> frozen sentence embedding                  (a sentence-transformer)
+      -> TruncatedSVD to ``svd_dim`` columns        (fit on train only, unsupervised)
+      -> appended to the numeric / categorical block
+
+:class:`MultimodalPreprocessor` owns the whole train-only transform so a fitted
+instance reproduces it exactly at predict time. Non-text columns are handled the
+same way the standalone zero-shot script does — numeric columns pass through,
+categorical (string) columns are label-encoded — except the label maps are fit on
+train only and unseen categories at transform time map to a reserved code.
+
+``sentence-transformers`` is an optional dependency; it is imported lazily only
+when a string / model embedder is used (a plain callable embedder needs nothing).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+from sklearn.decomposition import TruncatedSVD
+
+# short name -> HF model id (embedding backbones)
+MODELS = {
+    "minilm": "sentence-transformers/all-MiniLM-L6-v2",   # 384-d, fast baseline
+    "qwen0.6b": "Qwen/Qwen3-Embedding-0.6B",              # 1024-d, public, fast
+    "qwen4b": "Qwen/Qwen3-Embedding-4B",                  # 2560-d, powerful, public
+    "qwen8b": "Qwen/Qwen3-Embedding-8B",                  # 4096-d, public
+    "gemma": "google/embeddinggemma-300m",                # 768-d — GATED
+    "bge-m3": "BAAI/bge-m3",                              # 1024-d, public
+    "bge-large": "BAAI/bge-large-en-v1.5",               # 1024-d
+}
+
+_MISSING = "__MISSING__"
+
+
+def _canon_cat(s: pd.Series) -> pd.Series:
+    """Canonical string keys for a categorical column, stable across train/test.
+
+    NaN/None -> the _MISSING sentinel; an int-valued float renders like the int
+    ("5.0" -> "5"), so a column read as int in one split and float in another
+    (e.g. a NaN promoted it) still maps to the same code; everything else via str.
+    """
+    def one(v):
+        if v is None or (isinstance(v, float) and np.isnan(v)):
+            return _MISSING
+        if isinstance(v, float) and v.is_integer():
+            return str(int(v))
+        return str(v)
+    return s.astype(object).map(one)
+
+
+def build_paragraphs(df: pd.DataFrame, text_columns) -> list[str]:
+    """One column-prefixed paragraph per row: ``"col: value. col2: value2."``.
+
+    Matches the zero-shot pipeline's ``paragraph`` helper. Missing values become
+    empty strings; an empty ``text_columns`` yields ``[""] * len(df)``.
+    """
+    cols = [c for c in (text_columns or []) if c in df.columns]
+    if not cols:
+        return [""] * len(df)
+    # Row-vectorized: the loop is over the (few) text columns, not the rows — each
+    # "col: value" is a vectorized pandas string op, joined in one str.cat call.
+    # (astype(object) first: fillna on a category-dtype column raises.)
+    parts = [str(c) + ": " + df[c].astype(object).fillna("").astype(str) for c in cols]
+    joined = parts[0] if len(parts) == 1 else parts[0].str.cat(parts[1:], sep=". ")
+    return (joined + ".").tolist()
+
+
+def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
+                  normalize: bool | None = None) -> Callable[[list[str]], np.ndarray]:
+    """Resolve ``embedder`` to a ``texts -> (n, dim) float32 ndarray`` callable.
+
+    Accepts a short name / HF id (str), a preloaded SentenceTransformer-like object
+    (anything with ``.encode``), or a plain callable ``texts -> ndarray``.
+    """
+    # plain callable (not a str, not a SentenceTransformer) — used as-is.
+    # NB: check str first, since str has a (bytes) .encode method that would
+    # otherwise masquerade as a SentenceTransformer-like encoder.
+    if not isinstance(embedder, str) and callable(embedder) and not hasattr(embedder, "encode"):
+        def _enc_call(texts):
+            return np.asarray(embedder(texts), dtype=np.float32)
+        return _enc_call
+
+    st = embedder
+    model_id = None
+    if isinstance(embedder, str):
+        # string: lazily load a sentence-transformer
+        model_id = MODELS.get(embedder, embedder)
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as e:  # pragma: no cover - dependency hint
+            raise ImportError(
+                "Text features need the optional 'sentence-transformers' package. "
+                "Install it with `pip install synthefy-nori[text]` (or "
+                "`pip install sentence-transformers`), or pass a preloaded encoder "
+                "object / callable as the embedder."
+            ) from e
+        kwargs = {"trust_remote_code": True}
+        if "Qwen" in model_id or "bge-large" in model_id.lower():
+            kwargs["model_kwargs"] = {"torch_dtype": "float16"}  # fit large LLM encoders
+        st = SentenceTransformer(model_id, device=str(device) if device else "cpu", **kwargs)
+        if "Qwen" in model_id or "gemma" in model_id.lower():
+            st.max_seq_length = min(getattr(st, "max_seq_length", 512) or 512, 512)
+
+    is_llm = bool(model_id) and (
+        "Qwen" in model_id or "gemma" in model_id.lower() or "bge" in model_id.lower())
+    bs = batch_size or (8 if (model_id and "Qwen" in model_id) else 32 if is_llm else 256)
+    norm = normalize if normalize is not None else is_llm  # cosine-normalize LLM encoders
+
+    def _enc_st(texts):
+        return st.encode(texts, batch_size=bs, convert_to_numpy=True,
+                         show_progress_bar=False,
+                         normalize_embeddings=norm).astype(np.float32)
+    return _enc_st
+
+
+class MultimodalPreprocessor:
+    """Fit-once / apply-many transform: DataFrame -> widened numeric matrix.
+
+    ``fit`` / ``fit_transform`` learn the column split, the train-only categorical
+    label maps, and the text SVD; ``transform`` replays them on new rows.
+
+    Args:
+        text_columns: column names to treat as free text.
+        svd_dim: number of SVD columns to append (clamped to the embedding dim and
+            ``n_train - 1``).
+        embedder: short name / HF id (str), a preloaded SentenceTransformer-like
+            object, or a callable ``texts -> ndarray``.
+        device: torch device string for a string embedder (ignored otherwise).
+        seed: TruncatedSVD ``random_state``.
+        max_cardinality: keep only the ``max_cardinality`` most frequent values of
+            each categorical column; rarer values AND any value unseen at fit map
+            to a single in-range "other" code. This bounds the encoded range so an
+            unseen test value can't become an out-of-distribution outlier (which
+            otherwise wrecks high-cardinality columns under Nori's context
+            normalization). Very high-cardinality columns are better passed as text.
+    """
+
+    def __init__(self, text_columns, svd_dim: int | None = 128, embedder="minilm",
+                 device=None, seed: int = 0, max_cardinality: int = 128,
+                 normalize: bool | None = None):
+        # kept raw (None / str / list / Index); resolved to self.text_columns_ at fit
+        self.text_columns = text_columns
+        self.svd_dim = None if svd_dim is None else int(svd_dim)
+        self.embedder = embedder
+        self.device = device
+        self.seed = int(seed)
+        self.max_cardinality = int(max_cardinality)
+        # cosine-normalize embeddings: None = auto (on for LLM encoders keyed by a
+        # known model id, off otherwise). Set True/False to override — needed for a
+        # preloaded encoder OBJECT, whose model id can't be inspected.
+        self.normalize = normalize
+
+    def __getstate__(self):
+        # Drop the cached encoder callable (a closure / live torch model) so a
+        # fitted preprocessor pickles; _embed rebuilds it lazily from self.embedder.
+        state = self.__dict__.copy()
+        state["_encoder"] = None
+        return state
+
+    # -- non-text (numeric passthrough + train-only categorical label maps) --
+    def _fit_tabular(self, df: pd.DataFrame) -> None:
+        self.nontext_columns_ = [c for c in df.columns if c not in set(self.text_columns_)]
+        self.numeric_columns_ = []
+        self.categorical_columns_ = []
+        # col -> {value: code}; codes are 0..k-1 for the k<=max_cardinality most
+        # frequent train values. Rare train values and any unseen value map to the
+        # single "other" code len(map) at transform, so the encoded range stays
+        # bounded (no out-of-distribution sentinel).
+        self.category_maps_ = {}
+        for c in self.nontext_columns_:
+            s = df[c]
+            if pd.api.types.is_numeric_dtype(s):
+                self.numeric_columns_.append(c)
+            else:
+                self.categorical_columns_.append(c)
+                vals = _canon_cat(s)
+                vc = vals.value_counts()
+                # keep the max_cardinality most frequent, breaking count ties by
+                # key so the surviving set and their codes are deterministic across
+                # runs / pandas versions (value_counts tie order is not stable).
+                top = sorted(vc.index, key=lambda k: (-int(vc[k]), k))[: self.max_cardinality]
+                self.category_maps_[c] = {v: i for i, v in enumerate(top)}
+
+    def _transform_tabular(self, df: pd.DataFrame) -> np.ndarray:
+        # build columns in the original non-text order for a stable feature layout
+        out = np.empty((len(df), len(self.nontext_columns_)), dtype=np.float32)
+        for j, c in enumerate(self.nontext_columns_):
+            if c in self.category_maps_:
+                m = self.category_maps_[c]
+                other = len(m)  # in-range code for rare/unseen values
+                # vectorized dict lookup; unseen -> NaN -> the bounded "other" code
+                out[:, j] = _canon_cat(df[c]).map(m).fillna(other).to_numpy(dtype=np.float32)
+            else:
+                col = pd.to_numeric(df[c], errors="coerce").fillna(0.0)
+                out[:, j] = col.to_numpy(dtype=np.float32)
+        return out
+
+    # -- text (embed + train-fit SVD) --
+    def _embed(self, df: pd.DataFrame) -> np.ndarray:
+        if getattr(self, "_encoder", None) is None:
+            self._encoder = _make_encoder(self.embedder, self.device, normalize=self.normalize)
+        return self._encoder(build_paragraphs(df, self.text_columns_))
+
+    def _resolve_text_columns(self, df: pd.DataFrame) -> list[str]:
+        """Normalize the `text_columns` argument to a validated list of names.
+
+        Handles None (numeric-only), a lone string (single column), and any
+        iterable of names (list / tuple / pandas Index). Raises if a named column
+        is absent, rather than silently dropping it. Text columns must be named
+        explicitly — the preprocessor does not guess which columns are text.
+        """
+        tc = self.text_columns
+        if tc is None:
+            return []
+        if isinstance(tc, str):
+            tc = [tc]                       # a lone column name, not chars to iterate
+        cols = list(tc)                     # handles pandas Index / tuple / ndarray
+        missing = [c for c in cols if c not in df.columns]
+        if missing:
+            raise ValueError(f"text_columns not found in the DataFrame: {missing}")
+        return cols
+
+    def fit_transform(self, df: pd.DataFrame) -> np.ndarray:
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(
+                "MultimodalPreprocessor requires a pandas DataFrame (so text "
+                f"columns can be located by name); got {type(df).__name__}.")
+        self._encoder = None
+        self.svd_ = None
+        self.text_columns_ = self._resolve_text_columns(df)
+        self._fit_tabular(df)
+        Xnum = self._transform_tabular(df)
+
+        # No text columns -> pure tabular; never resolve/load the embedder (so the
+        # numeric+categorical path needs no sentence-transformers dependency).
+        if not self.text_columns_:
+            self.n_text_features_ = 0
+            self.n_features_out_ = Xnum.shape[1]
+            return Xnum
+
+        E = self._embed(df)
+        if E.shape[1] == 0:
+            # text columns were requested but the encoder returned a zero-width
+            # embedding — fail loudly rather than silently degrade to pure tabular.
+            raise ValueError(
+                f"embedder produced a zero-width embedding for text columns "
+                f"{self.text_columns_}; check the encoder / that the text is non-empty.")
+
+        if self.svd_dim is None:
+            # raw mode: append the full embedding, no reduction
+            Xtext = E.astype(np.float32)
+        else:
+            k = min(self.svd_dim, E.shape[1], max(1, E.shape[0] - 1))
+            self.svd_ = TruncatedSVD(n_components=k, random_state=self.seed).fit(E)
+            Xtext = self.svd_.transform(E).astype(np.float32)
+        self.n_text_features_ = Xtext.shape[1]
+        self.n_features_out_ = Xnum.shape[1] + self.n_text_features_
+        return np.hstack([Xnum, Xtext]).astype(np.float32)
+
+    def fit(self, df: pd.DataFrame) -> "MultimodalPreprocessor":
+        self.fit_transform(df)
+        return self
+
+    def transform(self, df: pd.DataFrame) -> np.ndarray:
+        if not hasattr(self, "n_features_out_"):
+            raise RuntimeError("Call fit()/fit_transform() before transform().")
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(
+                "MultimodalPreprocessor.transform requires a pandas DataFrame with "
+                f"the same columns seen at fit; got {type(df).__name__}.")
+        missing = [c for c in (self.nontext_columns_ + self.text_columns_)
+                   if c not in df.columns]
+        if missing:
+            raise ValueError(f"transform() is missing columns seen at fit: {missing}")
+        Xnum = self._transform_tabular(df)
+        if not self.text_columns_:          # no text at all -> tabular only
+            return Xnum
+        E = self._embed(df)
+        # raw mode (svd_dim=None) appends the embedding directly; else SVD-transform
+        Xtext = E.astype(np.float32) if self.svd_ is None else self.svd_.transform(E).astype(np.float32)
+        return np.hstack([Xnum, Xtext]).astype(np.float32)

--- a/tests/test_text_example.py
+++ b/tests/test_text_example.py
@@ -1,0 +1,40 @@
+"""Smoke tests for the shipped text-features example.
+
+The fast test guards the synthetic-dataset builder and the public API surface the
+example relies on (no checkpoint / encoder download). The slow test runs the
+example end-to-end against the real checkpoint + MiniLM encoder and asserts the
+text column actually helps — it is skipped when sentence-transformers is absent.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+EXAMPLE = (pathlib.Path(__file__).resolve().parents[1]
+           / "examples" / "text_features_synthetic.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("text_features_synthetic", EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_make_dataset_shapes_and_columns():
+    module = _load()
+    df, y = module.make_dataset(20, seed=0)
+    assert list(df.columns) == ["x1", "x2", "brand", "review"]
+    assert len(df) == len(y) == 20
+    assert df["review"].str.startswith("Customer review:").all()
+    assert set(df["brand"]).issubset({"acme", "globex", "initech"})
+
+
+@pytest.mark.slow
+def test_text_example_text_helps_end_to_end():
+    pytest.importorskip("sentence_transformers")
+    module = _load()
+    r_tab, r_text = module.run(n_train=150, n_test=50, svd_dim=16, seed=0)
+    # the review's sentiment drives a large target term the tabular columns
+    # cannot see, so the text feature must improve held-out R2
+    assert r_text > r_tab

--- a/tests/test_text_features.py
+++ b/tests/test_text_features.py
@@ -1,0 +1,235 @@
+"""Zero-shot text-feature preprocessing (synthefy_nori.text_features).
+
+Uses a deterministic fake embedder so the tests are fast and offline (no model
+download / GPU). The heavy end-to-end check — that the widened matrix reproduces
+the standalone zero-shot script's R² through NoriRegressor — is exercised
+separately against a real split.
+"""
+
+import hashlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from synthefy_nori.text_features import MultimodalPreprocessor, build_paragraphs
+
+
+def _fake_embed(texts):
+    """Deterministic 16-d embedding: same text -> same vector (fit/transform consistent)."""
+    out = []
+    for t in texts:
+        h = hashlib.sha1(t.encode("utf-8")).digest()
+        out.append(np.frombuffer(h[:16], dtype=np.uint8).astype(np.float32) / 255.0)
+    return np.stack(out)
+
+
+def _frame(n_rows):
+    return pd.DataFrame({
+        "price": np.arange(n_rows, dtype=float) * 10.0,
+        "brand": (["A", "B"] * n_rows)[:n_rows],
+        "review": [f"row {i} some free text here" for i in range(n_rows)],
+    })
+
+
+def test_build_paragraphs_prefixes_and_missing():
+    df = pd.DataFrame({"a": ["x", None], "b": ["y", "z"]})
+    paras = build_paragraphs(df, ["a", "b"])
+    assert paras[0] == "a: x. b: y."
+    assert paras[1] == "a: . b: z."          # missing -> empty
+    assert build_paragraphs(df, []) == ["", ""]  # no text cols
+
+
+def test_widened_matrix_shape_and_layout():
+    train = _frame(6)
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=8, embedder=_fake_embed)
+    X = mp.fit_transform(train)
+    # 2 non-text cols + min(svd_dim=8, emb=16, n_train-1=5) = 5 text cols
+    assert mp.numeric_columns_ == ["price"]
+    assert mp.categorical_columns_ == ["brand"]
+    assert mp.n_text_features_ == 5
+    assert X.shape == (6, 7)
+    assert X.dtype == np.float32
+
+
+def test_svd_dim_clamped_to_embed_dim():
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=128, embedder=_fake_embed)
+    mp.fit_transform(_frame(40))          # 40 rows, 16-d embedding
+    assert mp.n_text_features_ == 16      # clamped to embedding dim
+
+
+def test_unseen_category_and_nan_handled_at_transform():
+    train = _frame(6)
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    mp.fit_transform(train)
+    unknown_code = len(mp.category_maps_["brand"])   # A,B -> 0,1 ; unseen -> 2
+    test = pd.DataFrame({"price": [5.0, np.nan], "brand": ["A", "C"],
+                         "review": ["seen-ish", "totally new text"]})
+    Xt = mp.transform(test)
+    assert Xt.shape[1] == mp.n_features_out_
+    assert Xt[1, 1] == unknown_code                  # 'C' unseen
+    assert Xt[0, 1] == mp.category_maps_["brand"]["A"]
+    assert Xt[1, 0] == 0.0                           # NaN price -> 0
+
+
+def test_transform_before_fit_raises():
+    mp = MultimodalPreprocessor(text_columns=["review"], embedder=_fake_embed)
+    with pytest.raises(RuntimeError):
+        mp.transform(_frame(3))
+
+
+def test_ndarray_input_rejected_when_text_configured():
+    mp = MultimodalPreprocessor(text_columns=["review"], embedder=_fake_embed)
+    with pytest.raises(TypeError):
+        mp.fit_transform(np.zeros((4, 3)))
+
+
+def test_missing_nontext_column_at_transform_raises():
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    mp.fit_transform(_frame(6))
+    bad = pd.DataFrame({"brand": ["A"], "review": ["x"]})  # dropped 'price'
+    with pytest.raises(ValueError):
+        mp.transform(bad)
+
+
+def test_no_text_columns_skips_embedder():
+    # A pure tabular transform must NOT resolve/load the embedder (so it needs no
+    # sentence-transformers). Passing an embedder that explodes if called proves it.
+    def _boom(_texts):
+        raise AssertionError("embedder must not be called when there are no text columns")
+
+    mp = MultimodalPreprocessor(text_columns=[], embedder=_boom)
+    X = mp.fit_transform(_frame(5)[["price", "brand"]])
+    assert mp.n_text_features_ == 0
+    assert X.shape == (5, 2)                 # price + brand, no text cols
+    mp.transform(_frame(3)[["price", "brand"]])   # transform path also skips the embedder
+
+
+def test_csv_loaded_dataframe_matches_pickle(tmp_path):
+    # A DataFrame read back from CSV must produce the same widened matrix as the
+    # in-memory one -- the package is format-agnostic; CSV is just a DataFrame.
+    train = _frame(8)
+    csv = tmp_path / "train.csv"
+    train.to_csv(csv, index=False)
+    reloaded = pd.read_csv(csv)
+
+    a = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    b = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    Xa = a.fit_transform(train)
+    Xb = b.fit_transform(reloaded)
+    assert Xa.shape == Xb.shape
+    assert a.numeric_columns_ == b.numeric_columns_
+    assert a.categorical_columns_ == b.categorical_columns_
+    np.testing.assert_allclose(Xa, Xb, rtol=1e-5, atol=1e-6)
+
+
+def test_categorical_encoding_bounded_by_max_cardinality():
+    # Codes must stay in [0, max_cardinality]: the k most frequent train values
+    # get 0..k-1, everything rarer or unseen collapses to the in-range "other" code
+    # (no out-of-distribution sentinel).
+    n = 60
+    train = pd.DataFrame({
+        "x": np.arange(n, dtype=float),
+        "hc": [f"v{i % 40}" for i in range(n)],     # 40 distinct categories
+        "review": [f"row {i}" for i in range(n)],
+    })
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=4,
+                                embedder=_fake_embed, max_cardinality=5)
+    Xtr = mp.fit_transform(train)
+    hc_col = mp.nontext_columns_.index("hc")
+    assert len(mp.category_maps_["hc"]) == 5            # capped to top-5
+    assert Xtr[:, hc_col].max() <= 5                    # rare -> "other" == 5, bounded
+    # an unseen category at transform also lands on the same in-range "other" code
+    test = pd.DataFrame({"x": [1.0], "hc": ["totally_new"], "review": ["new row"]})
+    Xte = mp.transform(test)
+    assert Xte[0, hc_col] == 5
+
+
+def test_svd_dim_none_appends_raw_embedding():
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=None, embedder=_fake_embed)
+    X = mp.fit_transform(_frame(8))
+    assert mp.svd_ is None
+    assert mp.n_text_features_ == 16               # full fake-embedding dim, no reduction
+    assert X.shape[1] == 2 + 16                    # price + brand + raw text
+    assert mp.transform(_frame(3)).shape[1] == X.shape[1]
+
+
+def test_text_columns_accepts_lone_string_and_index():
+    df = _frame(6)
+    # a lone string is one column name, not characters to iterate
+    m1 = MultimodalPreprocessor(text_columns="review", svd_dim=4, embedder=_fake_embed)
+    m1.fit_transform(df)
+    assert m1.text_columns_ == ["review"]
+    # a pandas Index (df.select_dtypes(...).columns idiom) must not raise on truthiness
+    m2 = MultimodalPreprocessor(text_columns=df.columns[[2]], svd_dim=4, embedder=_fake_embed)
+    m2.fit_transform(df)
+    assert m2.text_columns_ == ["review"]
+
+
+def test_unknown_text_column_raises_at_fit():
+    with pytest.raises(ValueError):
+        MultimodalPreprocessor(text_columns=["not_a_column"],
+                               embedder=_fake_embed).fit_transform(_frame(5))
+
+
+def test_missing_text_column_at_transform_raises():
+    m = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    m.fit_transform(_frame(6))
+    with pytest.raises(ValueError):
+        m.transform(_frame(3)[["price", "brand"]])   # 'review' dropped
+
+
+def test_zero_width_embedding_raises():
+    # text requested but the encoder returns 0 columns -> fail loudly, don't
+    # silently degrade to pure tabular.
+    zero = lambda texts: np.zeros((len(texts), 0), dtype=np.float32)
+    with pytest.raises(ValueError):
+        MultimodalPreprocessor(text_columns=["review"], embedder=zero).fit_transform(_frame(5))
+
+
+def test_noriregressor_clone_and_pickle_carry_text_config():
+    # text config lives in __init__, so clone/get_params keep it and a fitted
+    # model pickles (the encoder is dropped and rebuilt lazily).
+    import pickle
+    from sklearn.base import clone
+    from synthefy_nori import NoriRegressor
+
+    reg = NoriRegressor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    assert clone(reg).get_params()["text_columns"] == ["review"]
+    reg.fit(_frame(8), np.arange(8.0, dtype=float))
+    assert reg.n_features_in_ == 3                 # input cols, not the widened SVD block
+    assert list(reg.feature_names_in_) == ["price", "brand", "review"]
+    round_tripped = pickle.loads(pickle.dumps(reg))
+    assert round_tripped._text_preprocessor.text_columns_ == ["review"]
+    assert round_tripped._text_preprocessor._encoder is None      # dropped on pickle
+
+
+def test_categorical_key_canonicalization_int_vs_float():
+    # a categorical read as int in train but float in test (NaN promotion) must map
+    # to the same code, not collapse to "other".
+    tr = pd.DataFrame({"c": pd.Series([5, 6, 5, 6], dtype=object),
+                       "review": ["a", "b", "a", "b"]})
+    te = pd.DataFrame({"c": pd.Series([5.0, 6.0], dtype=object), "review": ["a", "b"]})
+    m = MultimodalPreprocessor(text_columns=["review"], svd_dim=2, embedder=_fake_embed)
+    m.fit_transform(tr)
+    Xte = m.transform(te)
+    ci = m.nontext_columns_.index("c")
+    other = len(m.category_maps_["c"])
+    assert (Xte[:, ci] != other).all()             # 5.0/6.0 hit the int codes, not "other"
+
+
+def test_categorical_tiebreak_is_deterministic():
+    df = pd.DataFrame({"c": ["b", "a", "c", "a", "b", "c"], "review": ["x"] * 6})  # a,b,c each 2
+    m = MultimodalPreprocessor(text_columns=["review"], svd_dim=2,
+                               embedder=_fake_embed, max_cardinality=2)
+    m.fit_transform(df)
+    assert m.category_maps_["c"] == {"a": 0, "b": 1}  # ties broken by key ascending
+
+
+def test_string_embedder_does_not_masquerade_as_encoder():
+    # regression guard: str has a (bytes) .encode; it must take the model path,
+    # not be treated as a preloaded encoder object. We only check resolution
+    # doesn't misfire by passing an explicit callable instead (offline).
+    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=3, embedder=_fake_embed)
+    X = mp.fit_transform(_frame(5))
+    assert X.shape[1] == 2 + 3


### PR DESCRIPTION
## Zero-shot text features for NoriRegressor

Adds zero-shot text support to `NoriRegressor`: free-text columns of a DataFrame
are embedded by a frozen sentence encoder, reduced with TruncatedSVD, and appended
as extra numeric columns that the frozen, pretrained Nori consumes like any other
feature. **No gradient training anywhere** — the encoder and Nori both stay frozen;
the only fitted state is an unsupervised SVD.

```python
from synthefy_nori import NoriRegressor

reg = NoriRegressor(text_columns=["title", "description"], svd_dim=128)
reg.fit(df_train, y_train)          # df has numeric, categorical AND text columns
reg.predict(df_test)
```

### How it works

```
text columns
  -> one column-prefixed paragraph per row      (build_paragraphs)
  -> frozen sentence embedding                   (sentence-transformers, e.g. MiniLM)
  -> TruncatedSVD to svd_dim columns             (fit on train only, unsupervised)
  -> appended to the numeric / categorical block
  -> NoriRegressor (frozen, in-context) predicts
```

`predict` re-embeds the query rows and applies the already-fit SVD, so the
train/test transform is symmetric.

### What's included

- **`src/synthefy_nori/text_features.py`** — `MultimodalPreprocessor` (DataFrame →
  widened numeric matrix: numeric passthrough, train-only **bounded** categorical
  encoding, text → embed → SVD) and `build_paragraphs`.
- **`api.py`** — `NoriRegressor` gains constructor params `text_columns` / `svd_dim`
  / `embedder` / `text_max_cardinality` / `text_normalize`; all query-time coercions
  route through one `_prepare_query_features`.
- **`pyproject.toml`** — optional `text` extra (`sentence-transformers`, imported
  lazily; numeric-only use never needs it).
- **`examples/text_features_synthetic.py`** — runnable synthetic text+numeric demo.
- **`tests/`** — offline unit tests (fake embedder) + an example smoke test.

### Config surface

- `text_columns`: `None` → plain numeric array (unchanged legacy path); a list of
  names → embed those; `[]` → DataFrame numeric+categorical only (no embedder).
  Columns are named explicitly — the estimator does not infer text columns.
- `svd_dim`: SVD width of the text block (`None` = append the full raw embedding).
- `embedder`: short name (`"minilm"`, …), a preloaded encoder object, or a callable.

### Design notes

- **Numeric-only path is byte-for-byte unchanged** (`text_columns=None`, the default).
- **High-cardinality columns** (> `text_max_cardinality`, default 128) are embedded
  rather than label-encoded; the bounded categorical encoding maps rare/unseen values
  to a single in-range "other" code (no out-of-distribution sentinel), with a
  deterministic tie-break.
- **sklearn-compatible**: text config lives in `__init__`, so the estimator
  round-trips through `clone` / `get_params` / `GridSearchCV` / `cross_val_score` and
  `pickle` (`n_features_in_` reports the input column count; `feature_names_in_` set).

### Results

On a synthetic dataset whose target depends on a review's sentiment (signal the
numeric columns can't see), text lifts held-out R² from **0.15 → 0.99**
(`examples/text_features_synthetic.py`, deterministic).

### Testing

- `tests/test_text_features.py` — offline unit tests: preprocessing round-trip,
  unseen-category / NaN handling, bounded & deterministic encoding, CSV parity,
  `clone`+`pickle` round-trip, input-validation guards.
- `tests/test_text_example.py` — fast dataset-builder check + a slow end-to-end
  (skipped without `sentence-transformers`) asserting the text feature helps.
- `ruff check` clean on the changed files.

benchmark harness is deliberately not part of this open-core change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
