### PR TITLE
release: v0.12.0 — zero-shot text features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.11.1"
+version = "0.12.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -12,7 +12,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 __all__ = [
     "NoriRegressor",


### PR DESCRIPTION
Version bump **0.11.1 → 0.12.0** for the zero-shot text-features release (shipped in #76): `NoriRegressor(text_columns=…)` + `MultimodalPreprocessor`, with the optional `text` extra.

Minor bump — the feature is additive and backward-compatible (numeric-only path unchanged; `sentence-transformers` is an opt-in extra).

Bumps the two synced version locations:
- `pyproject.toml` → `version = "0.12.0"`
- `src/synthefy_nori/__init__.py` → `__version__ = "0.12.0"`

**After merge**, per `RELEASING.md`: cut a `v0.12.0` GitHub Release (`gh release create v0.12.0 --generate-notes`) → `publish.yml` builds, verifies the tag matches the wheel, and parks at the `pypi` environment's approval gate for a human to approve the upload. This 0.12.0 release also unblocks the client's `synthefy[text]` extra (synthefy#34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)