### PR TITLE
fix(deps): floor numba to >=0.60 so a fresh resolve stays buildable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "einops>=0.7",
     "huggingface-hub>=1.0",
     "kditransform>=1.0",
+    "numba>=0.60",
     "numpy>=2.0",
     "pandas>=2.0",
     "scikit-learn>=1.4",


### PR DESCRIPTION
synthefy-nori pulls numba transitively via kditransform, which pins only
numba>=0.48 (no upper bound). With numpy>=2.0 also unbounded, a fresh resolve
(e.g. `uv add synthefy-nori`) selects numpy 2.5 — which no numba supports — and
backtracks numba to 0.53.1, whose sdist has no py3.10+ wheel and hard-fails its
Python-version guard at build time. Users hit an opaque llvmlite/numba build
error at install. (A committed uv.lock shields CI, so this only bites fresh
resolves — see follow-up on adding a clean-install CI matrix.)

Add a direct numba>=0.60 floor — the last numba that still supports Python 3.9 —
so resolution stays on a wheel-shipping numba across the declared 3.9–3.13 range
without narrowing requires-python.

Verified by clean install on CPython 3.9/3.10/3.11/3.12/3.13:
- py3.9  -> numba 0.60.0 / numpy 2.0.2  (end-to-end predict OK)
- py3.10 -> numba 0.66.0 / numpy 2.2.6
- py3.11 -> numba 0.66.0 / numpy 2.4.6
- py3.12 -> numba 0.66.0 / numpy 2.4.6
- py3.13 -> numba 0.66.0 / numpy 2.4.6  (end-to-end predict OK)
and by `uv add` succeeding on requires-python >=3.9 and >=3.13, where the
unpatched package fails to build numba 0.53.1.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
