### PR TITLE
docs: add the hands-on demo notebook (Colab-ready)

### DIFF
--- a/examples/notebooks/Nori_Demo_Local.ipynb
+++ b/examples/notebooks/Nori_Demo_Local.ipynb
@@ -1,0 +1,433 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Nori — Hands-On Demo\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Synthefy/synthefy-nori/blob/main/examples/notebooks/Nori_Demo_Local.ipynb)\n",
+    "\n",
+    "**Nori** is a 6M-parameter tabular foundation model for **regression** via in-context learning (ICL). You hand it a few labeled rows as context, and it predicts on new rows in a **single forward pass** — no gradient steps, no hyperparameter search, no per-task training. It was trained *entirely on synthetic data*, so it never saw a real dataset during training.\n",
+    "\n",
+    "This notebook walks through everything you need to use Nori in practice:\n",
+    "\n",
+    "1. [Install & imports](#install)\n",
+    "2. [Pick a device](#device)\n",
+    "3. [Fit and predict on a real regression task](#regression) — and compare against XGBoost / RandomForest\n",
+    "4. [Cross-validated comparison](#cv)\n",
+    "5. [Probabilistic output](#quantiles) — quantiles and prediction intervals\n",
+    "6. [Interpretability](#interpretability) — Shapley values for a single prediction\n",
+    "\n",
+    "Everything runs on a free Colab CPU; a GPU makes it faster but is not required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"install\"></a>\n",
+    "## 1. Install\n",
+    "\n",
+    "Running this cell is required. We install Nori plus the optional `eval` and `interpretability` extras used later in the notebook, along with the gradient-boosting baselines we compare against.\n",
+    "\n",
+    "On Colab, run the `%pip` line. Locally, prefer **uv** — the commented `uv pip install` / `uv add` lines below do the same thing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colab / pip:\n",
+    "%pip install -q \"synthefy-nori[eval,interpretability]\" xgboost scikit-learn\n",
+    "\n",
+    "# Local with uv (run in a shell instead of the line above):\n",
+    "#   uv pip install \"synthefy-nori[eval,interpretability]\" xgboost scikit-learn\n",
+    "# or, inside a uv project:\n",
+    "#   uv add \"synthefy-nori[eval,interpretability]\" xgboost scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "restart-md",
+   "metadata": {},
+   "source": [
+    "> **Colab note:** if the install pulls a new PyTorch/CUDA build, restart the runtime once (**Runtime → Restart runtime**) before continuing so the fresh libraries load cleanly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "imports-md",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "Running this cell is required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T20:33:19.873286Z",
+     "iopub.status.busy": "2026-07-17T20:33:19.873143Z",
+     "iopub.status.idle": "2026-07-17T20:33:22.332229Z",
+     "shell.execute_reply": "2026-07-17T20:33:22.331716Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from sklearn.datasets import fetch_california_housing\n",
+    "from sklearn.model_selection import train_test_split, cross_val_score, KFold\n",
+    "from sklearn.metrics import r2_score, mean_absolute_error\n",
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "\n",
+    "from synthefy_nori import NoriRegressor\n",
+    "\n",
+    "# XGBoost is an optional baseline — the notebook runs fine without it.\n",
+    "try:\n",
+    "    from xgboost import XGBRegressor\n",
+    "    HAS_XGB = True\n",
+    "except ImportError:\n",
+    "    HAS_XGB = False\n",
+    "    print(\"xgboost not installed; skipping it as a baseline. \"\n",
+    "          \"Install with: pip install xgboost\")\n",
+    "\n",
+    "RANDOM_STATE = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "device-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"device\"></a>\n",
+    "## 2. Pick a device\n",
+    "\n",
+    "Nori uses a CUDA GPU automatically when one is visible and falls back to CPU otherwise. This cell just reports what you're running on.\n",
+    "\n",
+    "> **Platform note:** macOS, including MacBooks with Apple silicon, is not currently supported. Run this notebook on Colab or a Linux machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "device-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T20:33:22.333603Z",
+     "iopub.status.busy": "2026-07-17T20:33:22.333397Z",
+     "iopub.status.idle": "2026-07-17T20:33:38.141506Z",
+     "shell.execute_reply": "2026-07-17T20:33:38.140938Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(f\"Using device: {device}\")\n",
+    "if device == \"cuda\":\n",
+    "    print(torch.cuda.get_device_name(0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "regression-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"regression\"></a>\n",
+    "## 3. A regression task: California housing\n",
+    "\n",
+    "We use the California housing dataset (20,640 rows, 8 numeric features) and predict the median house value for a block. It's a real, noisy regression problem — exactly the kind of thing Nori is built for.\n",
+    "\n",
+    "We subsample the training context (ICL conditions on the rows you give it; a few thousand rows is plenty) and hold out a test set for scoring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T20:33:38.142623Z",
+     "iopub.status.busy": "2026-07-17T20:33:38.142511Z",
+     "iopub.status.idle": "2026-07-17T20:33:38.187002Z",
+     "shell.execute_reply": "2026-07-17T20:33:38.186586Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "data = fetch_california_housing(as_frame=True)\n",
+    "X, y = data.data, data.target\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.2, random_state=RANDOM_STATE\n",
+    ")\n",
+    "\n",
+    "# ICL conditions on the context rows; a few thousand is enough for a strong fit.\n",
+    "X_ctx = X_train.sample(n=2000, random_state=RANDOM_STATE)\n",
+    "y_ctx = y_train.loc[X_ctx.index]\n",
+    "\n",
+    "X_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fit-md",
+   "metadata": {},
+   "source": [
+    "### Fit and predict\n",
+    "\n",
+    "> **Important:** `nori.fit(X, y)` does **not train or fine-tune Nori**. It only caches the labeled rows as context. The pretrained model weights never change; all model computation happens when `predict` runs its single forward pass.\n",
+    "\n",
+    "This differs from RandomForest and XGBoost: their `fit` calls train new task-specific models. We compare them on the same split, with default settings on both sides."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fit-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = {\n",
+    "    \"Nori\": NoriRegressor(),  # downloads weights from the HF Hub on first use\n",
+    "    \"RandomForest\": RandomForestRegressor(n_estimators=300, random_state=RANDOM_STATE),\n",
+    "}\n",
+    "if HAS_XGB:\n",
+    "    models[\"XGBoost\"] = XGBRegressor(n_estimators=400, random_state=RANDOM_STATE)\n",
+    "\n",
+    "results = {}\n",
+    "for name, model in models.items():\n",
+    "    # For Nori, fit only caches X_ctx/y_ctx; it does not update model weights.\n",
+    "    # The baseline estimators do train task-specific models here.\n",
+    "    model.fit(X_ctx.values, y_ctx.values)\n",
+    "    pred = model.predict(X_test.values)\n",
+    "    results[name] = {\n",
+    "        \"R2\": r2_score(y_test, pred),\n",
+    "        \"MAE\": mean_absolute_error(y_test, pred),\n",
+    "    }\n",
+    "\n",
+    "pd.DataFrame(results).T.sort_values(\"R2\", ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cv-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"cv\"></a>\n",
+    "## 4. Cross-validated comparison\n",
+    "\n",
+    "A single split can be lucky. Here we run 5-fold CV on a fixed subsample and plot mean R² with standard-deviation error bars. Nori is evaluated the same way as the baselines — no tuning, no special handling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cv-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fixed subsample keeps CV fast; Nori refits (i.e. re-stores context) per fold.\n",
+    "idx = X.sample(n=3000, random_state=RANDOM_STATE).index\n",
+    "Xs, ys = X.loc[idx].values, y.loc[idx].values\n",
+    "cv = KFold(n_splits=5, shuffle=True, random_state=RANDOM_STATE)\n",
+    "\n",
+    "cv_scores = {\n",
+    "    name: cross_val_score(model, Xs, ys, cv=cv, scoring=\"r2\")\n",
+    "    for name, model in models.items()\n",
+    "}\n",
+    "\n",
+    "names = list(cv_scores)\n",
+    "means = [cv_scores[n].mean() for n in names]\n",
+    "stds = [cv_scores[n].std() for n in names]\n",
+    "colors = [\"#e0563f\" if n == \"Nori\" else \"#7f7f7f\" for n in names]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "ax.bar(names, means, yerr=stds, capsize=6, color=colors)\n",
+    "ax.set_ylabel(\"5-fold CV R²\")\n",
+    "ax.set_title(\"California housing — higher is better\")\n",
+    "for i, m in enumerate(means):\n",
+    "    ax.text(i, m + 0.01, f\"{m:.3f}\", ha=\"center\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quantiles-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"quantiles\"></a>\n",
+    "## 5. Probabilistic output: quantiles & prediction intervals\n",
+    "\n",
+    "Nori's default checkpoint has a 999-quantile head, so you get the **full predictive distribution**, not just a point estimate. Instead of only saying \"the house is worth \\$250k,\" Nori can say \"there's an 80% chance its value is between \\$180k and \\$330k.\"\n",
+    "\n",
+    "- `output_type=\"quantiles\"` returns chosen levels — great for prediction intervals.\n",
+    "- `output_type=\"full\"` returns the whole quantile bank — useful for CRPS / interval scoring and calibration.\n",
+    "\n",
+    "Quantiles come back in original `y` units and are sorted to a valid (monotone) quantile function per row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "quantiles-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T20:33:38.187935Z",
+     "iopub.status.busy": "2026-07-17T20:33:38.187826Z",
+     "iopub.status.idle": "2026-07-17T20:33:45.201089Z",
+     "shell.execute_reply": "2026-07-17T20:33:45.200614Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "nori = NoriRegressor().fit(X_ctx.values, y_ctx.values)\n",
+    "\n",
+    "# 80% central prediction interval for the first 40 test rows.\n",
+    "q10, q50, q90 = nori.predict(\n",
+    "    X_test.values[:40], output_type=\"quantiles\", quantiles=[0.1, 0.5, 0.9]\n",
+    ")\n",
+    "\n",
+    "order = np.argsort(q50)\n",
+    "x = np.arange(len(order))\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "ax.fill_between(x, q10[order], q90[order], alpha=0.25, color=\"#e0563f\",\n",
+    "                label=\"80% interval\")\n",
+    "ax.plot(x, q50[order], color=\"#e0563f\", label=\"median (q50)\")\n",
+    "ax.scatter(x, y_test.values[:40][order], s=18, color=\"black\", zorder=3,\n",
+    "           label=\"true value\")\n",
+    "ax.set_xlabel(\"test rows (sorted by predicted median)\")\n",
+    "ax.set_ylabel(\"median house value ($100k)\")\n",
+    "ax.set_title(\"Nori predictive intervals\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "covered = np.mean((y_test.values[:40] >= q10) & (y_test.values[:40] <= q90))\n",
+    "print(f\"Empirical coverage of the nominal 80% interval: {covered:.0%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-md",
+   "metadata": {},
+   "source": [
+    "<a id=\"interpretability\"></a>\n",
+    "## 6. Interpretability: why did Nori predict that?\n",
+    "\n",
+    "`NoriRegressor` is a scikit-learn estimator, so it plugs straight into [shapiq](https://github.com/mmschlk/shapiq) for Shapley values with no adapters. Below we explain a single prediction — which features pushed it up or down — as an additive waterfall."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "interp-code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-17T20:33:45.202572Z",
+     "iopub.status.busy": "2026-07-17T20:33:45.202291Z",
+     "iopub.status.idle": "2026-07-17T20:33:49.110448Z",
+     "shell.execute_reply": "2026-07-17T20:33:49.109949Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Explaining prediction for row:\n",
+      "MedInc           4.151800\n",
+      "HouseAge        22.000000\n",
+      "AveRooms         5.663073\n",
+      "AveBedrms        1.075472\n",
+      "Population    1551.000000\n",
+      "AveOccup         4.180593\n",
+      "Latitude        32.580000\n",
+      "Longitude     -117.050000\n",
+      "Name: 14740, dtype: float64\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABYsAAALyCAYAAACb/IudAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxzJJREFUeJzs3Xd4VGX6xvH7TNokISEJCSShF0FKBEERFFnFdVVQ1J9l7XUX+7oIrm2xiyuWVXRVsKOrolhYKyp2LAhICQRCr0kI6XWSKb8/BgJhkpAyMyfJ+X6uKxeZc973vPdBwOTJO88xPB6PRwAAAAAAAAAAS7OZHQAAAAAAAAAAYD6KxQAAAAAAAAAAisUAAAAAAAAAAIrFAAAAAAAAAABRLAYAAAAAAAAAiGIxAAAAAAAAAEAUiwEAAAAAAAAAolgMAAAAAAAAABDFYgAAAAAAAACAKBYDAAAAAAAAAESxGAAAAAAAAAAgisUAAAAAAAAAgsDtduvBBx9U3759FRYWpr59+2rGjBk6/PDD5Xa7m3y9559/Xj169JDD4QhAWmsyPB6Px+wQAAAAAAAAANq3Z555Rn/72980ZcoUHXHEEerYsaOuvPJKPfbYY7ryyiubfL3Kykr16tVLd955p/72t78FILGv6upqrVixQrt371Zubq4cDof+8Ic/aMCAAc263rJly7RkyRLFx8frvPPOa9G4PXv2aMmSJcrJyZHT6VRsbKwGDhyoIUOGNDoPO4sBAAAAAAAABNwrr7yik08+WY8++qguvfRSbdq0SU6nUxdeeGGzrme323X55ZfriSeeULD2w1ZWVmrZsmUqLCxUQkJCi65VWlqq5cuXKzQ0tMXjduzYoQ8//FCVlZU68sgjdeyxx6pHjx4qLS1tUqaGkwAAAAAAAABAC1VWVmrFihW67777ao698sormjhxoux2e7Ove/7552vGjBn65ptvNG7cOH9EbVBUVJQuueQSRUVFKTc3Vx988EGzr/XLL7+oc+fO8ng8qqysbPa4qqoqffPNN+rRo4dOPvlkGYbR7EzsLAYAAAAAAAAQMFdffbUiIyPlcrn0z3/+U4ZhKCUlRStXrtQf//hHn/E7d+6U3W7XVVddVev4V199pbCwME2ePLnm2IgRI5SQkKD58+cH/D4kKSQkRFFRUS2+TlZWljZv3qxjjz22xeM2bNigiooKHX300TIMQ9XV1c3eac3OYgAAAAAAAAABc/HFFyssLEyzZs3SU089pYSEBG3cuFH33nuvhg8f7jO+a9eu+stf/qLZs2frnnvuUc+ePbV27Vqdd955Ou200/T444/XGj98+HAtWrTokDncbreqqqoalTkiIqJFO3QPlWPRokU6/PDDG2xl0dhxO3fuVFhYmMrKyvTFF1+oqKhIoaGhOuywwzR69OhDtrk4EMViAAAAAAAAAAEzbtw4LVy4UNHR0brxxhtls9k0bdo0SVLv3r3rnHPHHXfoxRdf1COPPKIHHnhAp59+unr16qW33npLNlvtZgl9+vTR66+/fsgc2dnZ+vjjjxuV+cILL1RMTEyjxjZVRkaGSktLNWHCBL+MKyoqksfj0RdffKEBAwZo5MiR2rVrl1avXq2qqiqddNJJjc5GsRgAAAAAAABAQK1cuVKDBw+uKfTm5eUpNDRUHTp0qHN8165d9de//lUvvPCCli1bpoqKCn333XeKjo72GRsfH6+KigqVl5c32CKiU6dOGj9+fKPyRkZGNmpcU1VWVmrJkiUaPnx4g2s0dpwkVVdXy+l0auDAgTruuOMkeYvwbrdbGRkZOuqoo9SxY8dG5aNYDAAAAAAAACCgVqxYoVNOOaVJc6ZOnapnnnlGK1eu1A8//KCuXbvWOW5ff95DtY2IiIhQt27dmpTB33777TdFRERo8ODBfhknqabNRL9+/Wod79evnzIyMpSTk0OxGAAAAAAAAID5CgsLtX37dqWlpdUc69Spk5xOp0pKSupt9/DQQw9JkpxOZ4M9ewsKChQVFXXIHbgul0sOh6NRme12u0+7i5YqKirS2rVrNXr0aJWXl9fK5Xa7VVJSorCwMDkcjkaNs9vtkqSoqCgVFBT43P++1429Z4liMQAAAAAAAIAAWrlypSTpiCOOqDl2+OGHS5I2b95c6/g+jz76qF588UU988wzuvXWW/XQQw/pxRdfrPP6mzdv1sCBAw+ZIycnx9SexWVlZfJ4PPrpp5/0008/+Zx/6623NGTIEPXq1atR44499lhJUlJSknbu3KmysjLFxcXVWk9qWksNisUAAAAAAAAAAmbFihWSaheLR48eLUlasmSJT7H4ww8/1O23364HHnhAN9xwg9avX69nn31Wd911V50PxFu2bJkuvvjiQ+YIZs9ip9Op0tJS2e32mh3ACQkJ+tOf/uQz9rffflN1dbWOPfZYxcbGKioqqlHj9unTp4+WL1+udevW1WrVsXbtWhmGoZSUlEbnplgMAAAAAAAAIGBWrlyprl271mol0adPHw0ZMkRfffWVrrrqqprjS5cu1cUXX6yLL75Yd911lyTpH//4h55//vk6dxcvXbpU+fn5OvPMMw+Zw189i9PT01VVVVXTImLr1q01u3iHDBmi8PBw7d69Wx9//LGGDx+uo446SpK3tUWvXr18rrdq1SpJqnWuseMkKTExUQMGDNC6devkdruVkpKirKwsbdq0ScOGDavzoYD18W/jDQAAAAAAAAA4wMqVK+tsNXHVVVfpo48+UkVFhSRpx44dOuOMM3TkkUfqhRdeqBmXmpqqq666SnPmzNHmzZtrXePdd99Vjx49NG7cuMDexAFWrlypJUuWaM2aNZKkLVu2aMmSJVqyZEmT+gP70/HHH68RI0Zo9+7d+vnnn7Vnzx6NHj1aI0eObNJ1DM++xwUCAAAAAAAAQJAUFRWpT58+mjFjhq6++uomz3c4HOrVq5duv/123XzzzQFIaD3sLAYAAAAAAAAQdB07dtQ//vEPPfroo3K73U2e/8orrygsLEzXXnttANJZEzuLAQAAAAAAAADsLAYAAAAAAAAAUCwGAAAAAAAAAIhiMQAAAAAAAABAFIsBAAAAAAAAAKJYDAAAAAAAAAAQxWIAAAAAAAAArURxcbFOOOEEFRcXmx3FkigWAwAAAAAAAGgViouL9d1331EsNgnFYgAAAAAAAAAAxWIAAAAAAAAAAMViAAAAAAAAAIAoFgMAAAAAAABoJWJjY/WHP/xBsbGxZkexJMPj8XjMDgEAAAAAAAAAkrRr1y6lpqaaHcOS2FkMAAAAAAAAoNXYvXu32REsi2IxAAAAAAAAAIA2FAAAAAAAAABaD5fLpZCQELNjWBI7iwEAAAAAAAC0GpmZmWZHsCyKxQAAAAAAAABaDYfDYXYEy6JYDAAAAAAAAKDViImJMTuCZdGzGAAAAAAAAECrUVlZKbvdbnYMS2JnMQAAAAAAAIBWY+3atWZHsCyKxQAAAAAAAAAAisUAAAAAAAAAWo9u3bqZHcGyKBYDAAAAAAAAaDWcTqfZESyLYjEAAAAAAACAViM7O9vsCJZFsRgAAAAAAAAAIMPj8XjMDgEAAAAAAAAAkrcNRWhoqNkxLImdxQAAAAAAAABajY0bN5odwbIoFgMAAAAAAABoNSoqKsyOYFkUiwEAAAAAAAC0GtHR0WZHsCx6FgMAAAAAAABoNRwOhyIiIsyOYUnsLAYAAAAAAADQamRkZJgdwbIoFgMAAAAAAAAAKBYDAAAAAAAAaD1SU1PNjmBZFIsBAAAAAAAAABSLAQAAAAAAALQeu3btMjuCZVEsBgAAAAAAAADI8Hg8HrNDAAAAAAAAAIAkORwORUREmB3DkthZDAAAAAAAAKDV2LZtm9kRLItiMQAAAAAAAIBWo6yszOwIlhVqdgAgaH7NlO7+r0TjFQAAAAAAgMAJD5Ve+ZuU1LFZ0yMjI/0cCI1Fz2JYxw3Py/PGtzL4Ew8AAAAAABA4ITZp4kjptb83a7rT6VRoKHtczUAbCliLzTA7AQAAAAAAQPvmcksf/CJ9uqRZ09PT0/0cCI1FsRgWQ7EYAAAAAAAg4AxDumm2VFRudhI0AcViWAu1YgAAAAAAgMDzeKT8Uu/zo5ooOTk5AIHQGBSLYS206AYAAAAAAAgOl1t6ZaH045omTaNfsXkoFgMAAAAAAAAIDJshXfucVFHV6Ck7duwIYCA0hGIxLIY+FAAAAAAAAEHj9kg79kjT3zU7CRqBYjEAAAAAAACAwHF7pKc/ln7f1Kjhhx9+eIADoT4Ui2Ex9CwGAAAAAAAIOsOQrn1WqnYecujOnTuDEAh1oVgMAAAAAAAAILBcbmntDmnmx4ccWlJSEoRAqAvFYliLQc9iAAAAAAAAU3jk7V28fleDwyIiIoKTBz4oFsNa6EIBAAAAAABgHrdHuu45ye2ud0j//v2DGAgHolgMi6FaDAAAAAAAYBqXW1q8Xnr5q3qHrFq1KoiBcCCKxbAY2lAAAAAAAACY7q43pB17zE6Bg1AshrVQKwYAAAAAADBflVP62wuSx/dd4J07dzYhECSKxbCaOv4BAgAAAAAAQJC53NJXK6R3F/mcstvtJgSCRLEYAAAAAAAAgBkMSVNekfYU1zq8bds2c/KAYjGshj4UAACgjfjDEOk/10jL/i1lvyateEp6epLUJa7x1zhntPT9w9LuOdKm2dIz10gJMQ3PGTVAKn7b+3GosQAAAC3hkVRaIf3jVbOTYC+KxQAAAEBrdN+F0phB0ke/eb+Beu9n6exR0o//kjp3PPT8q0+WXrlZKiiV7nxdevVrb/H4o39KEWF1zzEM6dErpNJKf94JAABA/Vxuad5P0ufLag7179/fxEDWRrEY9Zo3b54Mw9Att9zil+ulp6dr0qRJ+uabb/xyveahZzEAAGglPrlbeu66+s/f+bo07O/SPW9Kc76R7n9bOn+Gd2fxNac0fO2wEOnuP0s/rpHOfEh68Uvv/CtnSmk9pSvG1T3vypOkbp2kOV83964AAACazjCkm2ZLxeWSpJycHJMDWRfFYgTN2rVr9cILL+iXX34xOwoAAEDr99Na34fz/rRWyi+R+ndteO6g7lJ8B+n9n2sf/3yZVFIhnXOs75z4aGna+dJD70pF5S3LDgAA0BQej5RbJN37liSpqKjI5EDWRbEY1mLQsxgAALRh0RFStF3KK2l43L42ExVVvucqq6Qjevl+XfTP86WcIunlr/wSFQAAoEncHu+7oX7KUFhYPS2zEHAUi9EieXl5uuqqq9S/f3/FxMQoLCxMycnJuuyyy1RcvP9Jlg8//LDOO+88SdKdd94pwzBkGIbS0tKCG5guFAAAoC27fry3EHzwjuGDbciW3G7vw+oO1C9FSuooRUV4dxLvM7iHdOUfva0v3HzBBAAATGKzSdc+p8F9DzM7iWWFmh0AbdvGjRv1/vvva9y4cTr77LMVFhamH374QW+88YZWr16tpUuXSpLGjx+vzMxMvfrqqzrjjDM0duxYSVJqamqQE/PNDwAAMEFoiBQbVftYWIgUESolxNQ+XlDq235Cko49XLr9HO+D7r5f3fB6+SXSB79IF42V1u2UPv5NSknwPryuyimFh0r28P3jZ1whfblc+nplM24OAADAT9xuaWuuciY/qy7P/d3sNJZEsRgtkpaWppycHEVERNQ6fvXVV+vll1/W559/rlNPPVVDhw7VhAkT9Oqrr2r06NGaOnWq3zLk5+crOjq6JkNpaak8Ho9iYrzfeFVVVamkpESdJEmGKBgDAICgGzVA+vTuOk4MkM49rvahITdJ23JrHzssVXpzirRmu3TTrMatefML3oLw9Eu9H5L09g/S5hzpzGOkskrvsf8bLR3TXxp1a5NuCQAAIBA8hhTz2+aa142u+3TqVDMnKytLKSkp9b7Ozs5Wly5dZOxty9VW1ggGisVokcjIyJrPq6qqlJ+fL6fTqfHjx+vll1/Wd999p1NPPTWgGRISEmq97tChQ63X4eHh+/+i0bIYAACYIX2rNPHB2sceulTaXSg99VHt4zmFtV937SR9eKf3oXPnPiKVVjZuzeIK6cLHpG6dpB5J0vY93o8v7/c+QGbfQ+weuFj68BfvjuMeSd5jHffugu7WybsLObugKXcLAADQbIakkukXad97sppU99nr4ALrwa+Tk5NrvW4rawQDxWK02LRp0zRnzhxt375dnoPeMllQ0Mq+sajrLZ0AAACBVlgmfZvueyy70Pf4gRI6eAvFEaHeYvPBheTG2JHn/ZC8ReBhvaX/Ld5/vnui1H2MdP4Y37k//ktauUUac3vT1wUAAGgqw5BuPkMRIwcceiwCgmIxWmTq1Kl6/PHHNXz4cP3lL39R9+7dFRERoW3btun222+X2+02OyIAAEDbFBUhzbtdSomXTn9A2phd/9hunaTICGn9roavec+F3v7J//lk/7ELH/Mdd+6x0jnHSpP+I+3Ma15+AACApgixeb+muf1cbVm3RsOGDTM7kSVRLEaLvPfee0pKStLixYsVEhJSc/z111/3GbuvR4u56FkMAADaiBdvlI7qJ835RhrQ1fuxT2ml9MmS/a9n3SAdP0iKvWD/sckTpUHdpSUbJKdbOv0o6aSh0v1vS8s27R934HX2OaKX99cvlnsflgcAABBoLrf0/PVSZPihxyJgKBajRfYViN1ud83nVVVVmjFjhs/Yjh07SpLy8urenbJ48WKFh4fzkyMAAABJSuvl/fWyE70fB9qaW3eR90BrtktnjJROG+HdqbN6m3TZv6UPfw1IXAAAgGaz2aQrTpSOGyhJ6tevn8mBrMvwHNxkFthr3rx5Ou+88zRixAiNHDnS53xSUpIKCgr09NNP68gjj9QZZ5yhoqIizZ8/XyEhIdq4caP++te/avbs2ZKkkpISde7cWR07dtQ111yj+Ph4paam6vzzz5fk3XmcmJio3Nxcn7X84obn5XnzOxku/sgDAAAAAAC0CjZDSuooLX1CivU+1m7r1q3q2bOnycGsiZ3FOKSlS5dq6dKlPsdTU1O1ZcsWeTwevfvuu5o+fbo6duyoU089VTfeeKNGjx5da3xMTIyee+453X///Zo+fbqcTqeGDBlSUywGAAAAAACAxbg90sy/1hSKJamgoIBisUnYWQzruOF5ed78XoaLh+4BAAAAAACYLsQmnXWM9MrNtQ6vWrVKaWlpJoWyNpvZAQAAAAAAAABYjCGpg1169EqfUxSKzUOxGBbDRnoAAAAAAADTeSQ9dpWUGOtzauXKlcHPA0n0LIblGKJgDAAAAAAAYKIQm3TCEOn84+o87XbTQtQs7CyGpRiG2QkAAAAAAAAsLjxUmjmp3kJNQkJCkANhH4rFsBSe5wgAAAAAAGCyBy6WuifWezouLi54WVALxWIAAAAAAAAAgRdik47uJ/3l5AaHbdq0KUiBcDCKxbAY+lAAAAAAAACYwjCk566TbJQkWyv+ywAAAAAAAAAILEPSnedK/bsecmjv3r0Dnwd1olgMi6FnMQAAAAAAQFCF2KTDu0k3n9Go4cXFxQEOhPpQLAYAAAAAAAAQOG6P9Pz1Ulhoo4bn5eUFOBDqQ7EYFkPPYgAAAAAAgKCxGdJNE6Qj+zR6imFQvzELxWIAAAAAAAAA/mczpG6J0p3nNWna0KFDAxQIh0KxGBZDz2IAAAAAAICgcHuk566VoiKaNC09PT1AgXAojWsUArQbhigYAwAAAAAABFiITbr0BOn4wU2e6nQ6/Z8HjcLOYlgKHW8AAAAAAAACzDCkhA7SA5c0a3pcXJx/86DRKBbDOrolSi632SkAAAAAAADaN49HenqS1DGqWdMTExP9HAiNZXg8Ht6TD2twuZU593P179/f7CQAAAAAAADtV2iINKx3s6cvX75cw4YN818eNBo9i2EdITbZxwyRevQwOwkAAAAAAADQ6tCGApZCzxsAAAAAAIDWrVevXmZHsCyKxbCUTZs2mR0BAAAAAAAADSgrKzM7gmVRLAYAAAAAAADQauTm5podwbIoFsNSevdufnN1AAAAAAAAoD2jWAxLKS4uNjsCAAAAAAAAGjB06FCzI1gWxWJYSl5entkRAAAAAAAA0ICMjAyzI1gWxWJYimEYZkcAAAAAAABAA6qqqsyOYFkUi2EpvI0BAAAAAACgdYuNjTU7gmUZHo/HY3YIIFjS09M1ZMiQZs2tcnnkdvs5EAAAANAK2WxSeAjvygMAmKO8vFxRUVFmx7CkULMDAMHkdDqbNa/E4daJL+xWbhnVYgAAALR/0eGGPrk8Sb0T+JYRABB8mZmZGjZsmNkxLIk2FLCUuLi4Zs17+Nti5ZVTKAYAAIA1lFV5tHRTrtkxAABAkFEshqUkJiY2ec6v2x367/JyuWnYAgAAAAspLCgwOwIAwKJ69OhhdgTLolgMS9mwYUOTxldWezTlk0LZaNcGAAAAi4mIsJsdAQBgUQ6Hw+wIlkWxGGjAk4uKtaPIxa5iAAAAWE5S5ySzIwAALConJ8fsCJZFsRiW0qtXr0aPXZVdpVmLy0SdGAAAAFa0Y/t2syMAAIAgo1gMSykrK2vUuGqXt/0E3ScAAAAAAACCKy0tzewIlkWxGJaSm9u4Jzq/8Fup1u1xysW2YgAAAFhUQkKC2REAABa1fv16syNYFsVi4CCb8p16/IcSs2MAAAAAAABYUmVlpdkRLItiMSxl6NChDZ53ezya+mmBPOwoBgAAgMXl5+ebHQEAYFExMTFmR7AsisWwlIyMjAbPv7m8XEt3VtN+AgAAAAAAwCRdu3Y1O4JlUSyGpVRVVdV7LqvYpQe/Lg5iGgAAAKD16ta9u9kRAAAWtXbtWrMjWBbFYlhKbGxsncc9Ho9uX1CoKrYUAwAAAJKk3N2Nezg0AABoP0LNDgAEU3Jycp3H/5dRoW83OYKcBgAAAGi9HA4eLgQAMEe3bt3MjmBZ7CyGpWRmZvocyy936Z9fFMkwIQ8AAADQWoWHh5sdAQBgUS6Xy+wIlkWxGJZ371dFKqvyiAYUAAAAwH4pKSlmRwAAWFRWVpbZESyLYjEspUePHrVef72xUvMzKkWrYgAAAKC2rVu3mh0BAAAEGT2LYSkOx/6+xKUOt277rFCGIXkoFgOA33WOtunKo6J1ZEq40pLD1CHCpj+/uUe/bK9q9DWO6xmum0bHaEBSqEJshjbnO/XqsjJ9sLrCZ2xilE23HB+jk/raFRdpU26ZSz9tdegfnxX587YAAAAABNjgwYPNjmBZFIthKTk5OTVvp/vXd8XaU+6mUAwAAdInIVTXj4rRpnyn1u1xakTXpvW+/GO/CL3wfwlatrNaTy4qkccjTTg8Uk+eHq+ESJteWlJWMzYlxqb3LkmUJP13eZmyS1zq0iFEQ1PotwkAzRUXH292BACARW3evFn9+/c3O4Yl0YaikebNmyfDMHTLLbf47Zrp6emaNGmSvvnmG79ds7kCcX+t2W87HHr993K5KRQDQMCsyqnWEU9l6cQXduvF30qbPP/y4dHaXerWhW/v0WvLyjXn93Jd9HaethQ4dW5aVK2xD58SJ5dbGv9Krmb+VKp3VlXo6Z9L9Zf38/11OwBgOSG2ELMjAAAsqry83OwIlkWx2ERr167VCy+8oF9++cXsKJaRlpamSqdHUz4plM0wOw0AtG9lVR4VVTb/p3IdImwqqnSr6oAHIbs8Un6FW5XO/dftmxCqE/vaNevXUhVWehQRIoXyFQ4AtFhe3h6zIwAALCo6OtrsCJZFGwpYyvr16/W/nBRtK3SJTcUA0Lr9ss2h60fFaMrxMZq3qlweSWcNitQRyWG6YX5BzbgxvbytJvaUu/XmnzvpuF4Rcro9+nGLQ3ctKNKOYlc9KwAAAABojXr27Gl2BMti342f5eXl6aqrrlL//v0VExOjsLAwJScn67LLLlNxcXHNuIcffljnnXeeJOnOO++UYRgyDENpaWlNXvPrr79WWFiYjjzySLnd7prj1dXVGjx4sCIiIrRo0aKW39xeH3zwgY488khFRUUpPDxcffr00YMPPugzLi0tTUlJSdqwYYPGjRun6OhoRUREaMSIEVqyZInf8jTFmt1OPfdrGYViAGgDZv5Uqo8yKnTj6A76/pou+uGaLrrumA669oMCfZ5ZWTOuV7z3Z98Pn9JR1W6Prp+fr0e+K9ZRXcP13ws6yR7KW0kAoDm6detmdgQAgEWtWbPG7AiWxc5iP9u4caPef/99jRs3TmeffbbCwsL0ww8/6I033tDq1au1dOlSSdL48eOVmZmpV199VWeccYbGjh0rSUpNTW3ymuPGjdPUqVP1r3/9SzfffLOefvppSdJ1112nNWvW6J577tFxxx3nl/t76aWXNGnSJHXs2FGXXXaZYmJiNH/+fE2bNk0bN27UK6+8Umu8w+HQmDFjNGTIEE2ZMkWbNm3S3LlzdeaZZ2rLli0KCwvzS67GcLo9enpNnCgZAEDTGZLCG9m60uGnjbxVTo82Fzj16bpKfZ5ZoRDD0IVDo/Tk6XG65J08/b6rWpIUHe79lz23zK0r3s2v+YFgVolLz0xM0FmDIvX2SnqeAUBT5eXlSYo1OwYAAAgiisV+lpaWppycHEVERNQ6fvXVV+vll1/W559/rlNPPVVDhw7VhAkT9Oqrr2r06NGaOnVqi9Z9+OGH9e233+rZZ5/VaaedpvLycr388ssaM2aM7r333hZde5/q6mrddtttioiI0OLFi9WvXz9J0v3336/hw4frtdde00033aThw4fXzCkpKdFVV12lJ598suZYUlKSnnzySc2dO1eXXHKJX7I1xou/lWlTEZvpAaA5jukerrkXJTZq7LgXdmtjvrPFa95/ckcdmRquCa/m1hSAP15boS+v7qx7Tuqos1739tKsrN5/7sB3jnyytlL/nuDRiK7hFIsBoBkqKirMjgAAsKjmbKaEf1A587PIyMiaQnFVVZWys7O1Y8cOjR8/XpL03XffBWzt9957T3Fxcbriiis0adIkderUSfPmzfPb9RcuXKi8vDxNnDixplAsee958uTJ8ng8euONN2rNMQzDp0XFhAkTJPnvLQX5+flyOBw1r0tLS1VSUlLzuqqqSnl5eYqzs6cYAJprY75TUz4paNTH7tKWby0Os0l/PiJK32ysrFUAdrqlbzdV6ojkMIXt/SomZ+96e8rcta7h9kgFFW7F8u8/ADSLzbb/LSX7vqY+UFZWVoOvs7Oz5fHs/1e8sV+3swZrsAZrsAZrHKgt34e/1wgGdhYHwLRp0zRnzhxt37691h8KSSooKKhnVsulpqbqmWee0UUXXSRJmj9/vrp06eK362dmZkqShgwZ4nPu6KOPliRt3ry51vH4+Hh16NCh1rHk5GRJ8vkL0FwJCQm1Xh+8Xnh4uDp16qQ/J3g059dcrS0Ml4umxQDQJLllbs1LD94Os/hIm8JCDNnq+LF2mM1QiG3vObe0Kse7tTg5JuSgcVJClE355W7fiwAADql79+41n+/7mvpAKSkpDb7e93X/Po39up01WIM1WIM1WGP58uXq3Llzm78Pf68RDOws9rOpU6fqwQcfVGJiou677z698sorevPNN/Wvf/1Lkmo9gC4Q3n///ZrPFy9eHNC1GsNW13f5ex1cSA80wzA0/Y/RCuFPPQC0OqkxIeqbsP9n2HvK3SqqdOuUwyJrdhBLUlSYoZP62bUhr1qOvZ0uftnmUG6ZS2cNilTEAfXic9OiFGoz9MOW/T+9BwA03tatW8yOAAAAgoydxX723nvvKSkpSYsXL1ZIyP7vWF9//XWfsYbh37fFvvDCC5o3b55OPfVUbdu2TTNmzNCpp56qMWPG+OX6AwYMkCSlp6f7nFuyZIkkqXfv3n5ZK1BSot36x9hYPfhNsdlRAMASbhrt/Wn5YYneLzn+b0ikju4WLkl6+ufSmnFPnB6n0T0i1PORXZK8LSRmLy7VrWNj9eGliXpvdYVCDG9ritTYEN380f5/x6tc0vRvivXv0+P1zkWJ+mB1hVJjQ3TlUdH6dbtDn2dWBut2AQAAAPjBwIEDzY5gWRSL/Wxfgdjtdtd8XlVVpRkzZviM7dixo6T62zEsXrxY4eHhGjZs2CHXXb9+vW655RZ17dpVc+fO1a5du3TUUUfpwgsv1Jo1axQTE9PMO9pv3Lhx6tSpkz766CNt2rRJffr0kSQ5HA49+eSTMgyj2Q+sczgcWrFihWJiYgL6D0JWVpauOmqoPlhTobW7q2lHAQABNnVsbK3Xfz4iuubzA4vFdXnm51JtL3TpyqOi9ffjYhQeImXkOnXtB/n67KAC8PurK1Tt9ui6Y2J0x4mxKq50683lZZrxfYnc/FsPAM3SsWOc2REAABa1ffv2Ws/LQvBQLG6i77//Xtdff73P8aSkJN13330aP368nn76aR1zzDE644wzVFRUpPnz59faZbzPMcccI7vdrjfeeEPR0dGKj49Xamqqzj///JrziYmJys3NbTCTy+XS//3f/8nhcOjtt99WbGysYmNj9dhjj+m6667TxRdfrP/9739+ub9HHnlEkyZN0tFHH63zzz9fMTExmj9/vjIzM3XFFVdo+PDhjVrnYOvXr9cxxxyjIUOGaNWqVc26RmOF2Aw9MSFOp73S8O8rAKDl9u0UPpQL3qr7B6fzMyo0P6NxvZI/yqjURxnsIgYAfwkPDzM7AgDAokpLG95YgsChWNxES5cu1dKlS32Op6am6r777tPjjz8uj8ejd999V9OnT1fHjh116qmn6sYbb9To0aNrzYmJidFzzz2n+++/X9OnT5fT6dSQIUNqisWNdcMNNyg9PV3Tpk2r1XLi2muv1RdffKEPPvhAzz77bJ1F4Kbe39VXX624uDg9+OCDevXVV+V0OtWtWzc98MAD+uc//9mk3GYYPHiwJOnwpDDdOKqDnv65VGw4AwAAAHx5N60kmR0DAGBBdrvd7AiWZXiC/ZQxwESZmZnq37+/JMnh9OiUl3dra6GLtygDAAAAB5k2vFB/OXmQ2TEAABbkdDoVGsoeVzPYDj0EaD/Ky8trPo8INfT4hHjx4xIAAADAV2pqV7MjAAAsKj093ewIlkWxGJYSHR1d6/WIruG6fESUbIZJgQAAAIBWqrCw0OwIAAAgyCgWw1J69uzpc+wfY2PVOdpGwRgAAAA4QHl5mdkRAAAWlZycbHYEy6JYDEtZs2aNz7HocJtmnBZH32IAAADgACEhIWZHAABYVFhYmNkRLItiMSDpD33sOntwpELYXQwAAABIknrU8a48AACCYfv27WZHsCyKxbCU1NTUes/dc1JHxUQYol4MAAAASJs3bTI7AgAACDKKxbAUw6i/FBwfadNDf4oT3SgAAAAAAADMM2DAALMjWBbFYljKzp07Gzw/4XC7TuobQTsKAAAAWF5sbKzZEQAAFpWVlWV2BMuiWAwcwDAMTT8lThGhVIsBAABgbXZ7pNkRAAAWVVxcbHYEy6JYDEsZOHDgIcckx4To7nHsogAAAIC17d6dY3YEAIBFRUREmB3BsigWw1Ia+zTNC4ZG6ehu4bSjAAAAAAAACDJ6FpuHYjEspbS0tFHjDMPQY+PjZKNYDAAAAItKSUkxOwIAwKJWrlxpdgTLolgMS7Hb7Y0e2ys+VFPH0o4CAAAA1lRSUmJ2BAAAEGQUi2Ep/fr1a9L4vxwdrUGdQ2lHAQAAAMtp7LvyAADwt86dO5sdwbIoFsNS0tPTmzQ+1Gbo8Qnx8gQoDwAAANBa2Wx8uwgAMEdkZKTZESyL//sDhzCoc5iuH9VBbC4GAACAlfTs1cvsCAAAi9q6davZESwr1OwAQDAlJyc3a95Nx8bo642V2l7k8nMiAAAAoPWJt9ukPRukvkPMjgIAAILI8Hg8vMMeAAAAAFDL8uXLNWzYMLNjAAAsqKysTNHR0WbHsCTaUAAAAAAAfCQkJJgdAQBgUbm5uWZHsCyKxQAAAAAAH3FxcWZHAABYVGFhodkRLItiMQAAAADAx6ZNm8yOAACwqLCwMLMjWBbFYgAAAAAAAACtxuDBg82OYFkUiwEAAAAAPnr37m12BACARa1YscLsCJZFsRgAAAAA4KO4uNjsCAAAi/J4PGZHsCyKxQAAAAAAH3l5eWZHAABYVGJiotkRLItiMQAAAADAh2EYZkcAAFhUTEyM2REsi2IxAAAAAMDH0KFDzY4AALCozZs3mx3BskLNDgAAAAAAaH3S09M1ZMiQJs8rqnRr0VZHABKhLif2iVBkGPvAAAD+QbEYAAAAAODD6XQ2a94DXxfp3VUVfk6D+lw2PEoPnBxndgwA8Ku+ffuaHcGy+PEjAAAAAMBHXFxck+f8uMVBoTiIbIa0fXeR2TEAwO8KCgrMjmBZFIsBAAAAAD6a+iT68iq3pn5aIBvPxQsql8tldgQA8Lv8/HyzI1gWxWIAAAAAgI8NGzY0afxjP5Qop9QttydAgVCn0FC6SwJof0JCQsyOYFn8XwUAAAAA0CK/76rSy0vKRJ04+KKjosyOAAB+l5aWZnYEy2JnMQAAAADAR69evRo1rsrl0ZRPCmXQfsIURcXFZkcAAL9btWqV2REsi2IxAAAAAMBHWVlZo8Y990upNuU7aT8BAPAb+rGbh2IxAAAAAMBHbm7uIcdk5lbrqUUltJ8wUWRkpNkRAMDvEhISzI5gWRSLAQAAAABN5nJ7NOXTQrNjAADaofj4eLMjWBbFYgAAAACAj6FDhzZ4/rVlZVqZXS0X24pNVVFRYXYEAPC7jRs3mh3BsigWAwAAAAB8ZGRk1Htue5FT//qWB6sBANDeUCwGAAAAAPioqqqq87jH49E/PiuU0x3kQKhTx9hYsyMAgN/17t3b7AiWRbEYAAAAAOAjtp4i5Lz0Cv20tYr2E61EWXm52REAwO9KSkrMjmBZFIsBAAAAAD6Sk5N9ju0udener4pMSIP6OJ1OsyMAgN/t2bPH7AiWRbEYAAAAAOAjMzPT59i0L4tUUc2W4tYkJCTE7AgA4HeGYZgdwbJCzQ4AAAAAAGj9Ps+s0OeZlWbHwEFiOnQwOwIA+N3QoUPNjmBZ7CwGAAAAAPjo0aNHzedFlW7duaBI7PNqfQqLaAsCoP1ZvXq12REsi53FAAAAAAAfDoej5vOHvilSQYVbrbUBRWyEoTtOiNUp/e2KDDW0IqtaD35TrPSc6gbnGZLOGRKpU/tHanCXMMXZDW0vcumjjArNXlwqh6v2+JhwQzceG6NTDrMrJSZEe8pdWrTVoSd/LNWuEledawAAmq66uuF/vxE4FIsBAAAAAD5ycnKUkpKiRVsdmruywuw49TIkvXJuJw3sHKpZi0tVUO7WpcOj9faFnXT6a7naUlB/ETcyzNDjE+K1bGeV/ru8THvK3RqRGq7JY2J0XM8IXfB2Xq113vhzJx2WGKrXfy/X5nynesaH6NIjozW2t10nvbhbZVXBL6dH2u1BXxMAAi0uLs7sCJZFGwrUmDdvngzD0C233GJ2FAAAAACtQEW1W1M/LZCtFfefGH+4XUd1C9fUTwv11KJSzfm9XH9+M09uj3TLmJgG51a7PPq/N3J19ht79MzPpXp7Rblu/axQTy4q0eieETquZ3jN2OFdwzQsNVz/+rZYD39brLdXluuR70p038IipcSEaEzPiEDfap0MG9/WA2h/kpKSzI5gWfxfBQAAAADgIy0tTY//UKKsErfcrbX/hKTxAyK1u9Slz9btf/hefoVbH6+t0Mn97AoPqX9utVtautP3rc4L9j7I77BOYTXHOoR7v33eU+6uNXZ3qfd1pdOc36Ty8nJT1gWAQFq/fr3ZESyLYjEAAAAAwMfHizfqxd/K5GnFhWJJGtw5TKtzqn36Ka/IqlZUuE2945vefTGpg7fCnF+xvzC8MrtaZVVuTTk+Rsf2CFeXDjYd0z1cd5wQq+W7qvTjFkd9lwMAoM2gWIwm++CDD3TkkUcqKipK4eHh6tOnjx588EGfcWlpaUpKStKGDRs0btw4RUdHKyIiQiNGjNCSJUtMSA4AAACgMapcHs1Yam/V7Sf26dzBpt1lvn2Jd5d6j3WJaWBrcT2uPaaDih1ufbtp/27lggq3bpxfoJhwm966MFGLb0jWOxclKqfUpQvfzpPLpKJ6bGysOQsDQAD17NnT7AiWRbEYTfLSSy/p3HPP1datW3XZZZfp5ptvVmhoqKZNm6Yrr7zSZ7zD4dCYMWNks9k0ZcoUnXfeeVq5cqXOPPNMnmwJAAAAtFLP/1qqnWUhQS+AGpIiQhr3sY891FCV0/dajr1tIeyhTat43zCqg47vFaFHvi1WsaP2b0BehVurd1drxnfF+st7+Xrix2KN7Baux8bHNfFO/aeCNhQA2qGKitb7YNX2runvx4FlVVdX67bbblNERIQWL16sfv36SZLuv/9+DR8+XK+99ppuuukmDR8+vGZOSUmJrrrqKj355JM1x5KSkvTkk09q7ty5uuSSS4J9GwAAAAAasKfMpacWlcij4G8rPqZ7uOZelNioseNe2K2N+U5VOj0Kr+M724i9ReKm9BI+/XC7po6N0dsryvTG8tpF2O4dQ/T2BZ10yyeF+mxvT+MvN0g7ilx6YkK8TlhVrm83Bb8VRbWzjko5ALRxu3fvVmpqqtkxLImdxWi0hQsXKi8vTxMnTqwpFEtSZGSkJk+eLI/HozfeeKPWHMMwfFpUTJgwQZK0Zs0av+TKz8+Xw7H/i7LS0lKVlJTUvK6qqlJeXl6tOVlZWQ2+zs7OlueA5myswRqswRqswRqswRqswRpWWaNTlE1jeoTKZgS/r8LGfKemfFLQqI99bSZ2l7rVOdq31UTnvX2Hc0p8W1TUZUyvCD0xIV5fb3TozgVFPufPS4tSRKihhRsrax3/cr339VFdw5t0r/4SYvN+W9/a/1yxBmuwBms0ZY0DteX78PcawWB4DkwNS5s3b57OO+88TZ48WU888YTP+ZkzZ+rmm2/WAw88oH/+85+1zv3+++8aPny4zjrrLH3wwQeSvD2Ld+3a5fMHPT09XWlpaZo0aZJmzZoVuBsCAAAA0CzZJS6NnZUlh6v17y969sx4Hd0tXCP/k1PrIXcPn9JRZw2K1NCZ2ao6RL14WEqY3rygkzJ2O3XR3D1y1LFZd/opHXXh0CgNfCK71m7lTlE2LbspWc/+UqJHvivxnRhANsO7G/rpiQlBXRcAAs3tdstma/3/D2qP+F1HQDX0F5ufUwAAAACtU3JMiKaOCjM7RqN8uq5CnTuE6LQB9ppj8ZE2TTg8Ul9tdNQqFPeIC1GPuNq7kPt1CtUr5yZoR5FLV87Lq7NQLEmb852yGYZOP9xe6/jEgZGSpNU55jyTpbCw0JR1ASCQ1q1bZ3YEy6JnMRptwIABkrw7gw+2ZMkSSVLv3r2DmgkAAABAYEzs59FX28K1ZEdV0B901xSfrqvUsp1VevS0OPXrVKqCCrcuPTJaNkP694/Ftca+eUEnSdKY53dLkqLDDc05P0Ed7TbNWlymk/rWLgRvLXRq2S5vEfjdVeWaNLKDpp8Sp8FdwpS5x6khXcJ0wdAorcut1oLM2u0pAADNd2C7BgQXxWI02rhx49SpUyd99NFH2rRpk/r06SPJ+xf4ySeflGEYzX5gncPh0IoVKxQTE6OBAwf6MzYAAACAZsjOztaM04bojy/ubtXFYrdHuvzdPN11YqyuHBEte6ihFdnVmvJpoTblN9x/It5uU9dY77fFd5wQ63P+3VXlWrarUJJUWOnR6a/lasrxMfpjP7suHhaiwgq33llZrhnfl6ja7fdbaxR7hP3QgwCgjYmN9f03GcFBsRg+vv/+e11//fU+x5OSkvTII49o0qRJOvroo3X++ecrJiZG8+fPV2Zmpq644goNHz68WWuuX79exxxzjIYMGaJVq1a19BYAAAAA+EGv+FDdOjZW078tPvRgExU7PLrt8yLd9rnvg+kOtG9H8T47il3q+ciuRq+TU+rWPz5reI1gCwmhuySA9iclJcXsCJZFsRg+li5dqqVLl/ocT01N1c6dOxUXF6cHH3xQr776qpxOp7p161bnQ+8AAAAAtF2DBw+WJF19dLQ+XFOudbnOVr3D2KrKysvNjgAAfrdu3ToNGzbM7BiWZHh4yhgAAAAA4CCZmZnq37+/JGnN7mpNeDVXbr57bFVshjQmuVKvX9bH7CgA4FfLly+nWGwS3q8CAAAAAPBRfsCO1UGdw3T9qA4yTMyDusXGxJgdAQD8rnv37mZHsCyKxQAAAAAAH9HR0bVe33RsjHrGhchGxbhVqaysNDsCAPhddXW12REsi2IxAAAAAMBHz549a722hxp6bEKcaGTYulRRUAHQDmVnZ5sdwbIoFgMAAAAAfKxZs8bn2NHdInTp8Ch2F7ciNoP/GAAA/6FYDAAAAABotNvGxioxyiZqlK1Dx7g4syMAgN8NGTLE7AiWRbEYAAAAAOAjNTW1zuMdImyacRrtKFqLgoICsyMAgN9t2LDB7AiWRbEYAAAAAODDaGDr8Il97TprUKRC2F0MAAgAHt5pHorFAAAAAAAfO3fubPD8PSfFqkOEIerF5oqIiDA7AgD4XYcOHcyOYFkUiwEAAAAATZYQFaIHT44T3SjMFRYaanYEAPC77t27mx3BsigWAwAAAAB8DBw48JBjzhho14l9ImhHYaLSsjKzIwCA32VkZJgdwbIoFgMAAAAAfGzfvv2QYwzD0MOnxCmcajEAAO0CxWIAAAAAgI/S0tJGjUuJDdG0k2IDnAb1iaGvJ4B2qGvXrmZHsCyKxQAAAAAAH3a7vdFjLxwapaO7htGOwgSOqiqzIwCA33k8dMQ3C8ViAAAAAICPfv36NXqszTD06Ph42SgWB10VxWIA7dCuXbvMjmBZFIsBAAAAAD7S09ObNL53Qqimjo0JUBrUxzCo0AMA/CfU7AAAAAAAgPbhL0d30IerK7Ruj9PsKJbg8UhxcXFmxwAAvxs0aJDZESyLYjEAAAAAwEdycnKT54TaDD1xerxmL27cw/HQcifF75IUb3YMAPCrrVu36rDDDjM7hiVRLAYAAAAA+GhOsViSBnUO05OnU7wMluXLt5odAQD8rqyszOwIlkXPYgAAAAAA2qiEhASzIwCA30VFRZkdwbIMj8fjMTsEAAAAAABouuLiYsXGxpodAwD8qrq6WmFhYWbHsCR2FgMAAAAA0EZt2rTJ7AgA4HerV682O4JlUSwGAAAAAAAAAFAsBgAAAACgrerdu7fZEQDA71JSUsyOYFkUiwEAAAAAaKOKi4vNjgAAfhcSEmJ2BMuiWAwAAAAAQBuVl5dndgQA8LsdO3aYHcGyKBYDAAAAANBGGYZhdgQAQDtieDwej9khAAAAAAAAAECSKisrZbfbzY5hSaFmBwAAAAAAAM2Tnp6uIUOGNHmey+3RQ98Uq7SK/WP+lhhl0+QxMQoLYdc30Fw7d+5U3759zY5hSRSLAQAAAABoo5xOZ7PmvbykTC8tKVMozSn9yuORXB6pf4cynTUixew4QJtVUlJidgTLolgMAAAAAEAbFRcX1+Q5WwucmvF9sSTJ6fZzIEiS8gsKJFEsBpqLFhTm4WeIAAAAAAC0UYmJiU0a7/F49I/PCuWiSBxQFLqAljnssMPMjmBZFIsBAAAAAGijNmzY0KTxc1eW65ftVXLRqjigOiclmR0BaNNWrVpldgTLolgMAAAAAIAF5JS4dN/CYrNjWMK27dvNjgAAzUKxGAAAAACANqpXr16NHnvXl4VyONlSDKD169Kli9kRLItiMQAAAAAAbVRZWVmjxn26rkJfrnfQfiJIOnVKMDsC0KZFRESYHcGyKBYDAAAAANBG5ebmHnJMYYVbdy4olBGEPADgD9u2bTM7gmVRLAYAAAAAoB174OsiFVd6xKbi4MnLyzc7AgA0S6jZAQAAAAAAQPMMHTq0wfM/bK7UvPSKIKUBAP/o37+/2REsi53FAAAAAAC0URkZGfWeK69y69bPCmWj/0TQ9eje3ewIQJuWnZ1tdgTLolgMAAAAAEAbVVVVVe+5R78vUU6pW276TwTd7kb0kgZQv+LiYrMjWBZtKAAAAAAAaKNiY2PrPL5sZ5VeWVpGn2KTVFZWmh0BaNPCw8PNjmBZ7CwGAAAAAKCNSk5O9jlW5fJoyqcFMmg/YZoICl1AiwwcONDsCJZFsRgAAAAAgDYqMzPT59izP5dqc76L9hMmSklNMTsC0KatWLHC7AiWRbEYAAAAAIB2IjO3WjN/KqH9hMm2bNlqdgQAaBaKxQAAAAAAtFE9evSo+dzl9uiWTwvNCwMAfpKUlGR2BMviAXcAAAAAALRRDoej5vNXl5ZpVXa1iWnqFhth6I4TYnVKf7siQw2tyKrWg98UKz2n4ayGpHOGROrU/pEa3CVMcXZD24tc+iijQrMXl8rh8p2TGGXTLcfH6KS+dsVF2pRb5tJPWx36x2dFgbm5eiTExwd1PaC9iY6ONjuCZVEsBgAAAACgjcrJyVFKSoq2FTr1yHfFZsfxYUh65dxOGtg5VLMWl6qg3K1Lh0fr7Qs76fTXcrWloI6K716RYYYenxCvZTur9N/lZdpT7taI1HBNHhOj43pG6IK382qNT4mx6b1LEiVJ/11epuwSl7p0CNHQlOA/bM4WEhL0NYH2ZMuWLRo2bJjZMSyJNhRBkJ2drfDwcBmGoRkzZjQ4ds+ePbruuuvUp08f2e12RUREqFu3brr44ou1efPmICX2MgxDxxxzjF+vOWnSJM2ePduv1wQAAAAAK/N4PPrHZ4Vyus1O4mv84XYd1S1cUz8t1FOLSjXn93L9+c08uT3SLWNiGpxb7fLo/97I1dlv7NEzP5fq7RXluvWzQj25qESje0bouJ61i8APnxInl1sa/0quZv5UqndWVejpn0v1l/fzA3mLddqzZ0/Q1wQAf6BYHAQzZ86U0+lUUlKS3njjjXrHLVmyRIMGDdKsWbPUtWtXTZ06VXfeeafS0tI0d+5cHXHEEfrkk0+CmNz/XnjhBb3//vtmxwAAAACAdiEtLU3z0iv087YquVrhU+3GD4jU7lKXPltXWXMsv8Ktj9dW6OR+doU3sAG32i0t3enbqmJBpvdah3UKqznWNyFUJ/a1a9avpSqs9CgiRAql4gG0Wf369TM7gmXRhiII3nrrLaWlpWn8+PF65JFHtGLFCg0dOrTWmOLiYk2cOFH5+fl66aWXdOWVV9Y6/+WXX+rMM8/UhRdeqBUrVqh3797BvAUAAAAAQCv066oNuuebWLNj1Gtw5zCtzqnWwXXsFVnVunhYtHrHh2rdHmeTrpnUwVthzq/Yv5V6TC/vLuM95W69+edOOq5XhJxuj37c4tBdC4q0o7j+dheB0L17t6CuB7Q3e/bsUYcOHcyOYUn8nC3AFi5cqC1btujiiy/WDTfcIJvNpqeeespn3MMPP6ysrCxdcMEFPoViSTr55JM1ZcoUlZSU6K677mpwzby8PCUnJysuLk5bt26tde6KK66QYRh66KGHWnZjB5g2bZqGDx+uhIQEhYaGKi4uTn/84x+Vnp5eMyY9PV2GYUiSFixYIMMwaj4AAAAAAM3z1O9hqqxuhVuK9+rcwabdZb6F2t2l3mNdYpre2/faYzqo2OHWt5v271buFe/dC/fwKR1V7fbo+vn5euS7Yh3VNVz/vaCT7KHB/d4zb0/eoQcBqFdhYaHZESyLncUB9p///EcRERGaNGmS4uLiNGrUKM2fP18ul0shBzS8/+ijjyRJU6ZMqfdat956qx5++GF99dVXDa7ZqVMnvf766xo/frzOOeccLV68WDabTXPnztWcOXN04oknHrLg3BSzZs3SkCFDdOmll6pTp05KT0/X/Pnzdfzxxys9PV1du3ZVt27d9Oijj+rWW2/VoEGD6iyIAwAAAAAa7/PMCv2y2x609QypwbYRB3LsrQ/bQw1V1bFx2OH01JxvihtGddDxvSJ014JCFTv2F8mjw73XyS1z64p382t2MmeVuPTMxASdNShSb68sb9JaLVFeURG0tYD2KDSUkqVZ2FkcQKWlpVqwYIFOOOEExcXFSZIuu+wy5efn+/Qu3rJli+x2u4488sh6rxcbG6uuXbsqNzdXBQUFDa598skn6+abb9bSpUs1depUbd26Vddcc40SExP1zjvvtPjeDpSZmamvv/5aTz31lO6++2698847mjNnjgoLC/Xoo49KkuLi4jR16lRJUvfu3TV16tSaj5bKz8+Xw+GoeV1aWqqSkpKa11VVVcrLq/1T3aysrAZfZ2dny+PZ/4UHa7AGa7AGa7AGa7AGa7AGa7BGa1tj7opyBXO/7DHdw5U5NbVRH30TvIWeSqdH4XXUfCL2FokrnY3fFX364XZNHRujt1eU6Y3ltQu/lXtbG3+8tqJWy4tP1laq2uXRiK61H4YXaLaD3kXblv5csQZrtIY1Bg8e3C7uw99rBIPhOTA1/OqJJ57QlClT9M477+i8886TJDkcDiUlJWnYsGH6/vvva8aGhIQoLi7O5w/FwQYNGqSMjAxlZmbqsMMOa3Cs2+3WqFGjtGzZMvXu3VubN2/Wxx9/rFNPPbVR+Q3D0MiRI/Xrr782arzL5ar1B79///4aPny4fvzxx1rXPOWUU/T555836poAAAAAgLqty63Wqa/sltsTnJJxUrRNf+gd0aixCzIrVVLl0bd/7awtBU5dMS+/1vk/HxGlGafF6U8v7W5Uz+IxvSL08jkJ+mGLQ5Pez/d5mN8NozroH3+I1R2fF+rNFbULyb/d0EXLdlXpmg8a3nTlT6+eE6cT+0UFbT2gvanreV8IDvZ0B9Brr72mmJgY9e3bV7///nvN8ZEjR+q7777Tjh071K2bt+l9ZGSkKhrxNpWysjJJUmJi4iHH2mw2vf/++xowYIA2bNigG264odGF4qZ455139MADD2jdunWqrq79pNoDf0ICAAAAAPCfAUlhOr9PueZujPZ5gFwg5Ja5NS+9ae0V1uyu1tHdwmVItTIOSwlTeZVbmwsOXSgelhKm2WfHa1V2ta6f71solqRVOd7vRZMP6oEcZpMSomzKL3f7TgqgzVu26MR+g4K6JtCesLfVPBSLA2TlypVatWqVPB6PRowYUeeYmTNnasaMGZKkXr16afXq1fr999/rbUVRXFysnTt3KikpSfHx8Y3K8dFHH6m83PtT1VWrVjXjThq2YMECXXjhhUpOTtbkyZPVr18/RUdHyzAMTZo0SW53cP+HDAAAAABWcvPxcfo1362thS65W2Ft5dN1FZpweKROG2DXp+u8D6SLj7RpwuGR+mqjQ1UHPPuuR5y30LutcP/Bfp1C9cq5CdpR5NKV8/LkqKe2/Ms2h3LLXDprUKT+83NJTc/kc9OiFGoz9MMWR90TAbRKnTp1MjuCZVEsDpCZM2fK4/Ho/vvvV0JCgs/56dOna+7cuTXF4gkTJmj16tX697//rTlz5tR5zccff1wul0snnXRSozJkZGTo1ltvVffu3XXcccfp7bff1v3336+77767+Td2kJdffllut1ufffaZjjjiiJrjhYWFNbugAQAAAACBESK3npgQr/97Y4/ZUer06bpKLdtZpUdPi1O/TqUqqHDr0iOjZTOkf/9YXGvsmxd4i0Njnt8tyfvQujnnJ6ij3aZZi8t0Ut/aD/PbWujUsl3eHcVVLmn6N8X69+nxeueiRH2wukKpsSG68qho/brdoc8zK4Nwt/vte24RgOaJjY01O4JlUSwOAJfLpQ8//FA9evTQtGnT6hyzcuVKzZ49WwsWLNApp5yiO+64Q3PmzNGbb76pk08+WZdeemmt8QsXLtRjjz2mmJgYPfTQQ4fMUF1drXPOOUfV1dWaO3euRowYod9//10PPfSQ/vSnP2nUqFF+udeQEO9Pfg9+e8DkyZPrfMtARESECgsL67xWRkaGSkpKNHToUEVENK4PFgAAAABYWVZWloYP66IrRkTptWXlrW53sdsjXf5unu46MVZXjoiWPdTQiuxqTfm0UJvyXQ3Ojbfb1DXWW7a44wTfwtG7q8q1bFdhzev3V1eo2u3RdcfE6I4TY1Vc6daby8s04/uSoP++hIeFBXdBoJ3ZvHmzhg0bZnYMS+IBdwHw+uuv67LLLtOkSZM0a9asOscsWrRIY8aM0cSJEzV//nxJ0i+//KLTTz9d+fn5Ov744zV27FiFhoZq8eLF+uKLLxQREaG33npLZ5xxxiEzXH311Xr55Zd133331ewkTk9P18iRI9W5c2etWbNGUVENN9s3DEOpqak688wz6zw/ffp0ff/99zrrrLOUkpKiCy+8UOHh4frmm2+0ceNGVVZWqmfPnrXaXxx55JFas2aNrr32WvXq1UuGYejvf/+7JCktLU3p6elatWqVhgwZcsh7BAAAAACrW758uYYNG6ayKrdOenG3ckrdra5gbEX3jCjUVX+kZzHQXPv+bUPwUSwOgLFjx+qHH37QDz/8oDFjxtQ7LjU1VYWFhcrJyVFMTIwkKTc3V9OmTdOCBQuUlZUlt9utpKQk/eEPf9CDDz6oPn36HHL9efPm6fzzz9fYsWP17bff1jo3c+ZM3XzzzTrnnHM0b968Bq9jGA0/UXfjxo3q06ePZs+erUceeUQ7duxQeHi4jjrqKD377LMaO3askpOTaxWLly1bpr/85S/KyMhQZaX3bUD7/ghSLAYAAACApqmurlbY3l2s32+u1KXv5JucCBLFYqCliouLaUVhEorFAAAAAAC0UZmZmerfv3/N61s+LtAHayrYXWyyFyZG608DO5odA2iztm3bph49epgdw5JsZgcAAAAAAADNU15eXuv13Sd1VGyEoYbfJ4pAKygsMDsC0Kbl5/MuCbNQLAYAAAAAoI2Kjo6u9Tou0qbpp8SJjcXmKisrP/QgAPWy2ShZmoXfeQAAAAAA2qiePXv6HBs/wK4/9otQCNuLTRMaEmJ2BKBNO+KII8yOYFkUiwEAAAAAaKPWrFnjc8wwDE3/U5wiQqkWm6WuIj6Axlu1apXZESyLYjEAAAAAAO1Ml5gQ3X1SrNkxLGvjpk1mRwDaNJfLZXYEy6JYDAAAAABAG5WamlrvuQuOiNIx3cNpRwGgzYmPjzc7gmVRLAYAAAAAoI0yjPorwYZhaMZpcQrhO/+g6xjLrm6gJTp16mR2BMvifxkAAAAAALRRO3fubPB8r/hQTT2ewmWw2SMjzY4AtGkbNmwwO4JlUSwGAAAAAKAdu/roaA3uHEo7iiDKyckxOwIANAvFYgAAAAAA2qiBAwceckyozdDjE+LlCUIeAPCHXr16mR3BsigWAwAAAADQRm3fvr1R4wZ2DtMNozqIzcXB0dCDBwEcWmlpqdkRLItiMQAAAAAAbVRTCio3HRujnnEhtKMIgpLiYrMjAG3anj17zI5gWRSLAQAAAABoo+x2e6PHRoQaemxCnNz0owi4EnZFAmijKBYDAAAAANBG9evXr0njj+4WocuGR8nG7uKAstkotwAtMWzYMLMjWBb/egEAAAAA0Ealp6c3ec4/xsYqKdpGwTiAevNwLqBFVq9ebXYEy6JYDAAAAACAhXSIsGnGabSjCKSc7ZvMjgC0adXV1WZHsKxQswMAAAAAAIDmSU5Obta8E/rY9fI5CSqpcvs5ETpF2hRTtNvsGECb1rFjR7MjWJbh8Xj4WSIAAAAAAICfbNu2TT169DA7BtBmlZeXKyoqyuwYlkQbCgAAAAAAAD+Ki4szOwLQpmVmZpodwbIoFgMAAAAAAPjRpk30LAbQNlEsBgAAAAAAANBq0MbFPBSLAQAAAAAA/Kh3795mRwDatMrKSrMjWBbFYgAAAAAAAD8qLi42OwLQpu3evdvsCJZFsRgAAAAAAMCP8vLyzI4AAM1CsRgAAAAAAMCPDMMwOwLQpqWlpZkdwbIMj8fjMTsEAAAAAAAAAEhSRkaGBg4caHYMS2JnMQAAAAAAgB+lp6ebHQFo0xwOh9kRLCvU7AAAAAAAAAAtVlQunfmQtC235dea9Cfp9nObPd3pdLY8A2BhMTExZkewLIrFAAAAAACg7du6W1q20T/XeuR96fSjpSE9mzU9Li7OPzkAi+ratavZESyLNhQAAAAAAAAHu/ZZyelq1tTExEQ/hwGsZe3atWZHsCyKxQAAAAAAAAdyuaWVW6VnP23W9A0bNvg5EAAEB8ViAAAAAACAutw/V9qUbXYKwHK6detmdgTLolgMAAAAAABQF5dbumGW5PE0aVqvXr0CkwewCB4SaR6KxQAAAAAAAHVxuaVFGdKcb5o0raysLECBAGvIzmZHv1koFgMAAAAAADTk9jlSVn6jh+fm5gYwDAAEDsViAAAAAACAhlRWSZNfanI7CgDNM2TIELMjWBbFYgAAAAAAgIa43NKnS6X5vzZq+NChQwMcCGjfNm7caHYEy6JYDAAAAAAAcCiGpJtflPJLDzk0IyMj8HmAdqyiosLsCJZFsRgAAAAAAOBQPJKKy6U75xxyaFVVVeDzAO1YdHS02REsi2IxAAAAAABAY7jc0pvfSwtXNDgsNjY2SIGA9qlHjx5mR7AsisUAAAAAAACNZTOkG2ZJpZX1DklOTg5iIKD9oZWLeSgWAwAAAAAANJbbI2UXSA+8Xe+QzMzMIAYCAP+hWAwAAAAAANAUbo/0/OfS4vVmJwHapdTUVLMjWBbFYgAAAAAAgKay2aRrn5Uc1T6n6LcKoK2iWAwAAAAAANBULre0MVt6/EOfUw6HI/h5gHZk165dZkewLIrFAAAAAAAAzeHxSI9+IK3ZXutwTk5O8LMUlkl/my31/quUfLk04X5p+ebGz1+3Uzr7YSnlcqnH1dJfn5H2FPuO25gtXfqEd0yXy6Q/3SN9v9p/9wHAVBSLAQAAAAAAWuLaZ707jc3idkvnPSK9u0iadIp0/0VSbrG3YLwh69Dzd+ZJp94rbcqW7r5A+tvp0oLfpTMfkqqc+8ft2CP9cZr08zrvmHsukMoqpbOmS4syAnZ7sJ6BAweaHcGyKBbDb7KzsxUeHi7DMDRjxow6xyQlJckwjJoPm82muLg4DRkyRE8++WRwAwMAAAAA0FIut3cH73Of1RxKS0vz7xrj7/MWpOvz4a/Sr5nSc9dJd5zrLRh/ercUYpOmv3vo6z/2oVTukD6eJl13mjT1bOm1v0urtkr//Xb/uCf+JxWVS5/d4x1z/Xjpy/ul5Djpjjktu0fgANu2bTM7gmVRLIbfzJw5U06nU0lJSXrjjTfqHZeQkKBHH31Ujz76qB5++GFdcsklys/P1+TJk3XrrbcGMTEAAAAAAH5y39vSZm/7ifXr1wd37fm/Sp07ShNH7j+WGCudPUr6dGmdD+Gr5X+LpVOHS90T9x87MU3qlyJ98Mv+Yz+vlY7oJR2Wuv9YVIR02ghvwbwxu5iBRigrKzM7gmVRLIbfvPXWW0pLS9PVV1+t9PR0rVixos5x0dHRmjp1qqZOnarbbrtNzzzzjH777TeFhITo3Xcb8RNPAAAAAABaG6dLumm25PGosrIyuGuv2CIN7S3ZDirzjOjr3THcUBF3V76UWyQd2cf33Ii+3mvv46iWIsN9x0VFeH9tSo9koAGRkZFmR7AsisXwi4ULF2rLli26+OKLdcMNN8hms+mpp55q9Pzk5GSFhYUpNDQ0gCkBAAAAAAgQl9v7oLf/fqeYmJjgrp1T4G0FcbAu8d5fswrqn5u991yXOuYnx0sFpft3Jh+WKq3eJpVU1B7389q96+Q3JTVQr759+5odwbIoFsMv/vOf/ygiIkKTJk1St27dNGrUKM2fP18ul8tnrMvl0o4dO7Rjxw5t3rxZ33zzjU4//XRVVlbq8ssvNyE9AAAAAAB+8o9X1TU0uvnzq51SXnHtj2qX5KjjuHvvQ/UqqqTwMN9r2fceq6yqf7195yLqmL/vWMXeMVf/USosk654SlqxWVq/S7rtNen3TbXHAS2Unp5udgTLoliMFistLdWCBQt0wgknKC4uTpJ02WWXKT8/v87exbt27VL37t3VvXt39enTR+PGjdPChQt17733atq0aU1ePz8/Xw6Ho1aekpKSmtdVVVXKy8urNScrK6vB19nZ2fJ4PKzBGqzBGqzBGqzBGqzBGqzBGqzRhtZoFSqqtGnZqlqHmnQfv6yTek+q/fFrpvTeT77Ht+/xzokMV3lhse8a+wrB9vD6/3vYvW0lnOWVPv89SvMKaq4vSVlpydKjV0g/ZUjH3yGNuEWeBb9Ld18gSSoz3O3yzxVrBH+NA7Xl+/D3GsFgeA5MDTTDE088oSlTpuidd97ReeedJ0lyOBxKSkrSsGHD9P3339eMTUpKkmEYNS0qPB6Ptm/frv/+979KT0/Xgw8+qDvvvNOU+wAAAAAAtGErt0hjbjc3g2FId5yr5af21bBhw5p3jYJS396/d70udY6Tbj6j9vHRA7zF3mF/l/omS+8ddP9zvpZunC39PEMa3KPu9XblS4dfL91/kfT3ibXP/fUZ6Yvl0tYXax8vq5TSt0nhod4H3s35Wrr5Rend26RTjmza/QJ1yM7OVnJystkxLIkGsWix1157TTExMerbt69+//33muMjR47Ud999px07dqhbt241x+12uy688MJa15g8ebL69eun+++/X5dffrm6du0atPwAAAAAALRYiM1bsL3lTHUrLmz+deI7SCem1T4WF+3tSXzw8X2O6Cn9tNbbluLAh9wt2eB9+Fy/lPrXS02QEmP3t5I40NKN3msfLNouHdN//+tv0727j0cNqH8doAl4ppV5aEOBFlm5cqVWrVqlkpISjRgxQsOHD6/5WLhwoZxOp2bOnHnI64SHh2vUqFFyOBz68ssvg5AcAAAAAAA/cnuk56+XwkPrfH5PQJ15jLS7SPrf4v3H8oqlD3+VTh1eux/xpmzvR635I6XPl0k79uw/9u0qaUOWdNaohtf+dZ133UtPlDpGtfxeAEk7duwwO4JlUaZHi8ycOVMej0f333+/EhISfM5Pnz5dc+fO1YwZMw55LafTKUkqLi4+xEgAAAAAAFoRmyFdf5p0VD9J3j6jXbp0Cd76Z42Snv1Muv55ae1OqVOM9OIXksst3XVe7bETH/T+mv7M/mNTzpI++FWa8IB03WneNhNPfeRtXXHJCfvHbcuVLn9SGn+U1KWjlLFDevkraUgP6Z4LAnyTAIKBYjGazeVy6cMPP1SPHj3qfTDdypUrNXv2bC1YsECnnHJKvdcqLS3VokWLJEljxowJSF4AAAAAAPzOZkgpCdJd55uXIcQmzbtNmvZf6fnPpcoqaXgf6bnrpMNSDz2/W6L02d3SHa9L977l7UX8pyOl6ZfU3pUcEyklx0uzF3h7K6cmSNeeKk0923sO8JPDDz/c7AiWxQPu0Gyvv/66LrvsMk2aNEmzZs2qc8yiRYs0ZswYTZw4UfPnz1dSUpLcbrfuuOMOSZLb7dbOnTv1wQcfaPv27Tr99NP10UcfBfM2AAAAAADtgZkPuPvfXdIJ+/sJV1dXKywsrIEJABqyceNG9e3b1+wYlsTOYjTbCy+8IEm69NJL6x1z3HHHKSUlRV9++aVKSkokSfn5+br11ltrxoSHh6t79+6aNm2a7rnnnsCGBgAAAADAX0Js0oVjaxWKJWnz5s3q379/PZMAHMq+GhKCj2Ixmu37779v1Lhdu3bVfJ6bmxuoOAAAAAAABI8hKS5aeugSn1Pl5eXBzwO0IxEREWZHsCyb2QEAAAAAAADaHI+kp/4qxXfwORUdHR38PEA7ws5881AsBgAAAAAAaIoQm3TG0dLEkXWe7tmzZ5ADAe3LqlWrzI5gWRSLAQAAAAAAmiIyXHri6npPr1mzJohhAMB/KBYDAAAAAAA0xYwrpC5xZqcA2q3OnTubHcGyeMAdAAAAAABAY4TYpOMGShf/ocFhqampQQoEtE92u93sCJbFzmIAAAAAAIDGCA2Rnp4kGUaDw4xDnAfQsG3btpkdwbIoFgMAAAAAADTGPRdIvbscctjOnTuDEAYA/I82FAAAAAAAAA0JsUlpPaXrTjM7CWAJ/fv3NzuCZbGzGAAAAAAA4FCev95bNG6EgQMHBjgM0L7l5OSYHcGyKBYDAAAAAADUxzCkW8+WBnVv9JTt27cHMBDQ/hUVFZkdwbJoQwEAAAAAAFCXEJu3R/GUs5o0rbS0NDB5AIsICwszO4JlsbMYAAAAAACgLm63t/1ERNMKV3a7PUCBAGsYPHiw2REsi2IxAAAAAADAwWyGdO2p0sjDmjy1X79+AQgEWMfy5cvNjmBZFIsBAAAAAAAOZDOk5Hhp2gXNmp6enu7nQAAQHBSLAQAAAAAADuT2SP+5RupAOwnADImJiWZHsCyKxQAAAAAAoO1LjpMSOvjnWheNlU4a2vwoycn+yQFYVIcOfvq7jCYzPB6Px+wQAAAAAAAALVZRpVVLliltyJCWXaeDXQoL9U8mAE22fPlyDRs2zOwYlsS/fAAAAAAAoH2IDFfHnqlSPLsSAaA5aEMBAAAAAADajbi4OLMjAGihfv36mR3BsigWAwAAAACAdmPTpk1mRwDQQnl5eWZHsCyKxQAAAAAAAABajYKCArMjWBbFYgAAAAAA0G707t3b7AgAWigkJMTsCJZFsRgAAAAAALQbxcXFZkcA0EJpaWlmR7AsisUAAAAAAKDdoNcp0PatXLnS7AiWRbEYAAAAAAC0G4ZhmB0BQAu53W6zI1iW4fF4PGaHAAAAAAAAAABJ2rZtm3r06GF2DEsKNTsAAAAAAACAv6Snp2vIkCFNnlde5dbWQtchx8XZbUqJ5eFbQCDFxcWZHcGyKBYDAAAAAIB2w+l0NmvePV8V6Z1VFYccFxEiLfxrZ3XvSEkFCJRNmzZp2LBhZsewJHoWAwAAAACAdqM5OxJ/3OJoVKFYkhwuKXNbbpPXAIC2gGIxAAAAAABoNxITE5s0vrzKrVs/K5CtCc/Fy8vLa2IqAE3Ru3dvsyNYFsViAAAAAADQbmzYsKFJ4x//oUTZJW65PY2fExkZ2cRUAJqiuLjY7AiWRbEYAAAAAABY0vJdVXppSVmTCsWS1CW5S2ACAZDE7n0zUSwGAAAAAADtRq9evRo1rsrl0S2fFDap/cQ+WzZvafokAI1mGM34iwm/oFgMAAAAAADajbKyskaNe+6XUm3Kd8rVxF3FAAJv6NChZkewLIrFAAAAAACg3cjNzT3kmMw91XpqUYmaWydOSkpq5kwAjZGenm52BMuiWAwAAAAAACzD5fZo6qeFZscA0ACn02l2BMuiWAwAAAAAANqNQ719fc6yMq3Iqm5R+4nG7F4G0HxxcXFmR7AsisUAAAAAAKDdyMjIqPfc9iKnHv6uOIhpADRHYmKi2REsi2IxAAAAAABoN6qqquo87vF4dNtnhXK6Wr5Gr969Wn4RAPXasGGD2REsi2IxAAAAAABoN2JjY+s8/v7qCi3aWtWi9hP75GTntPwiANAKUSwGAAAAAADtRnJyss+x3DKX7v6yyG9rVFRU+O1aAHz16tXL7AiWRbEYAAAAAAC0G5mZmT7H7v6ySBXVfthSvFeEPcJv1wLgq6yszOwIlkWxGAAAAAAAtFtfrK/Qp+sq/dJ+Yp9uXbv572IAfOTm5podwbIoFgMAAAAAgHajR48eNZ8XVbp1++dFMvy8xsaNG/18RQBoHULNDgAAAAAAAFqHokq3Hv62WAsyK1Xh9GhoSpj+eWKs0pLDGzV//Z5qPfB1sX7bUaWwEGlcX7umjYtVp6gQn7FbC5x67IcSLdrqUGmVWykxIZpweKT+MbbuB9Q1lsPhqPl8+jdFKqhwy4+bigEEwdChQ82OYFkUiwEAAAAAgNwej66cl6eM3U5dM7KD4qNsen1ZmS54K08fX56k3gkNlxCyil06/808xUQY+sfYGJVVezR7canW5VZr/mVJCg/Zv793dU61Lnhrj7p0CNFfj45WXKRNu4pdyip2tfg+cnJylJKSop+2OvT2ysA8iK5Tp04BuS4Ar4yMDA0aNMjsGJZEGwq0WHZ2tsLDw2UYhmbMmFHvuD179ui6665Tnz59ZLfbFRERoW7duuniiy/W5s2bg5gYAAAAAHCwT9dWaunOaj02Pk5/HxOjy4dHa+5FnWQzpCd+LDnk/Gd+KVF5tUdvXdhJVx7VQTeOjtGzZyZozW6n5q0qrxnn9ng0+eMC9U0I1ceXJ+m6UTG6cGi0phwfq8cmxPvlXiqq3Zr6aaFs/u4/sVdIqO9OaQD+U1VVZXYEy6JYjBabOXOmnE6nkpKS9MYbb9Q5ZsmSJRo0aJBmzZqlrl27aurUqbrzzjuVlpamuXPn6ogjjtAnn3wS5OQAAAAAgH0+XVehpGibThtgrznWKSpEpx8eqS83VMrhbLiZw+frKnVS3wh1jd2/A3lMrwj1SQjRx2v37/D9frND6/Y4dfNxMbKHGaqodsvl9l+jiLS0NP37xxLtKnHJj5etZXfO7sBcGIAkKTa2Ze1o0Hy0oUCLvfXWW0pLS9P48eP1yCOPaMWKFbV6yxQXF2vixInKz8/XSy+9pCuvvLLW/C+//FJnnnmmLrzwQq1YsUK9e/cO9i0AAAAAgOWt3l2twV3CZDNqb8cdmhKmN1eUa3OBU4cnhdU5N7vEpT3lbh2R4nt+aEq4vtlYWfP6xy3ensLhoYZOfy1Xq7KrFR4inXKYXQ/+KU5xkS3b1/bJ4o2avbgDfYqBNiw5OdnsCJbFzmK0yMKFC7VlyxZdfPHFuuGGG2Sz2fTUU0/VGvPwww8rKytLF1xwgU+hWJJOPvlkTZkyRSUlJbrrrruCFR0AAAAAcIDdpW51jvZtr9C5g/dYTkn9/YR3l3rP1Tk/2qbCSk/NzuQtBd6xN8z3tqJ47qx4XXtMB32WWamr3suTx9P8Mm+1y6MZS+0Baz+xT69evQK7AGBxmZmZZkewLIrFaJH//Oc/ioiI0KRJk9StWzeNGjVK8+fPl8u1/4uIjz76SJI0ZcqUeq9z6623KiQkRF999VXAMwMAAABAe+f2eFTpbNzHvuJspdOj8DrefxwRatScr8++cwc+xK6++WXVbknSEclheuqMeI0fEKkpx8dqyvExWrqzWou2Nr9X6azFpdpRFiJXgLcV786lDQWA9ok2FGi20tJSLViwQCeccILi4uIkSZdddpmuueYavfHGG7r88sslSVu2bJHdbteRRx5Z77ViY2PVtWtXbdu2TQUFBYqP989DDQAAAADAin7dXqUL3spr1NiFf0lSv05hsocaqnL6nt+3I9geWv923X3nquqo0h48f9+vZw6KrDXuzEGReuS7Ei3dWaUxvSIalf1A2wqd+vePJfIowNuKJZWXlR96EIBm69Gjh9kRLIudxWi22bNnq7y8XFdffXXNscsvv1wxMTF66aWXao5VVFQoKirqkNeLjo6WJO3Zs6dJOfLz8+VwOGpel5aWqqRk/5N6q6qqlJdX+4ukrKysBl9nZ2fXeusTa7AGa7AGa7AGa7AGa7AGa7BGW1ojxpmnx8bH1XxMO87Qo6d1rHl93x9C9a+To/XY+Dh17hCi0tJSJUZJu8tcPmvsazFhq8yvd82aVhWl+99luu8+dpe5FWc3VF1ZppKSEnXZOzYu3F3rPjpFeY8XVbqb9XvVuUOIUmMM2YLQrTgkdH+7jdby35w1WKM9rVFZub/PeVu+D3+vEQyGpyXNgGBpQ4cO1ebNm/Xtt9/KOOABCLfeequ+++47bd68Wd26dVOHDh3kdrtVXt7wT1579uypbdu2KT8/n53FAAAAABBk132Yr992VGnxDV1qPeTu9s8L9eGaCq34W3JNS4m6DH86W6O6h+vZsxJqHT/xhRwlx4TorQsSJUn/XV6mOxcUacZpcfrzEfs3Fm0rdOr4Wbt169gY3Tg6pln38NsOh8797x4pwLuLP7g4QcO72QO6BmBly5cv17Bhw8yOYUnsLEazrFy5UqtWrVJJSYlGjBih4cOH13wsXLhQTqdTM2fOlORt/F9RUaHff/+93usVFxdr586dSkpKolAMAAAAACYYPyBSuWVufbbugB195S59srZCf+wbUatQvLXAqa0FtXtWnNbfroUbHdpVvH938Y9bHNqU79KEAftbTpzcz66IEOndVeVyH7B/7e0V3g1GxzejBcU+R3eL0PkDQwL+gLsNGzYEdgEAMAk9i9EsM2fOlMfj0f3336+EhASf89OnT9fcuXM1Y8YMTZgwQatXr9a///1vzZkzp87rPf7443K5XDrppJMCHR0AAAAAUIfxA+w6MjVMt35WqA15TsVH2vT672Vye6TJY2Jrjb3obe9bpRdd16Xm2A2jY/TJukpd8NYeXXlUtMqrPJq1uFSHJ4XqvLT9O4g7dwjRDaNj9MSPJbrsnXz96TC7MnZX660V5Zo4MFJDU8JbdB/XDZe+3WZTbrlbvJcaaJvS0tLMjmBZtKFAk7lcLnXp0kXR0dHaunVrnWOuueYazZ49W59//rmOOeYYDRw4ULm5uXrllVd06aWX1hq7cOFCTZw4USEhIVq+fLn69OkTjNsAAAAAABykqNKth74p1hfrK1Xp9GhocpjuOjFWRxxUwD3uuRxJtYvFkpSZW60Hvi7WbzurFGaTxvW165/jYpUUHVJrnMfj0WvLyvXaslJtL3QpKTpE5wyJ1M3HxSgspGXbgpcvX66CmMN1xbz8Qw9uphdPk04+IjVg1wesbu3atTr88MPNjmFJFIvRZK+//rouu+wyTZo0SbNmzapzzKJFizRmzBhNnDhR8+fP1y+//KLTTz9d+fn5Ov744zV27FiFhoZq8eLF+uKLLxQREaG33npLZ5xxRpDvBgAAAADQnuzrdXrzRwX6KKNCrgBUPV4/M1xjD0/0/4UBSKJnsZkoFqPJxo4dqx9++EE//PCDxowZU++41NRUFRYWKicnRzExMcrNzdW0adO0YMECZWVlye12KykpSX/4wx/04IMPsqMYAAAAANBi1dXVCgsLU365Sye8sFvFlR75u/Dx6DH5Ov+EIX6+KoB9Nm7cqL59+5odw5IoFgMAAAAAgHYjMzNT/fv3lyT9b02FbvqowO9rUCwGAquyslJ2u93sGJZkMzsAAAAAAACAv5SXl9d8fsZAu07sE6EWtkH20aNHD/9eEEAta9euNTuCZVEsBgAAAAAA7UZ0dHTN54Zh6OFT4hTu52pxfn7gHp4HAGaiWAwAAAAAANqNnj171nqdEhuiaSfF+nWN0tJSv14PQG3dunUzO4JlUSwGAAAAAADtxpo1a3yOXTg0Skd1DfNbO4rQ0FD/XAhAnVwul9kRLItiMQAAAAAAaNdshqFHx8fL5qdicZ8+ffxzIQB1ysrKMjuCZVEsBgAAAAAA7UZqamqdx/skhGrK8TF+WSMzM9Mv1wGA1oZiMQAAAAAAaDcMo/7tw38d2UEDk0L91o4CQGAMHjzY7AiWRbEYAAAAAAC0Gzt37qz3XKjN0OMT4uVp4RpxcXEtvAKAhmzevNnsCJZFsRgAAAAAAFjG4C5huvaYaLVkc3FkVKTf8gDwVV5ebnYEy6JYDAAAAAAA2o2BAwcecszNx8Wqe8eQZj/wLmsXD98CAik6OtrsCJZFsRgAAAAAALQb27dvP+QYe6ihxyfEyd3SfhQAAqJnz55mR7AsisUAAAAAAKDdKC0tbdS4kd0jdMmwqGbtLu7WvXvTJwFotDVr1pgdwbIoFgMAAAAAgHbDbrc3euztJ8SqU5Styf2Li4qKmjgDANoGisUAAAAAAKDd6NevX6PHxkTY9MhpcWpqN4qS4uImzgDQFKmpqWZHsCyKxQAAAAAAoN1IT09v0viT+to1caBdIU3YXmwLCWliKgBNYRjNfPokWoxiMQAAAAAAsLR7/9hR0eGNL07169s3gGkA7Ny50+wIlhVqdgAAAAAAAAB/SU5ObvKcTlEh+tepcXrul9JDtqToGhuiquy1UuoRzQsIAK2Y4fF4mtqaBwAAAAAAwLKWL1+uYcOGmR0DaLccDociIiLMjmFJtKEAAAAAAABogoSEBLMjAO3a9u3bzY5gWRSLAQAAAAAAmiAuLs7sCEC7VlpaanYEy6JYDAAAAAAA0ASbNm0yOwLQrtntdrMjWBbFYgAAAAAAAACtRr9+/cyOYFkUiwEAAAAAAJqgd+/eZkcA2rX09HSzI1gWxWIAAAAAAIAmKC4uNjsCAAQExWIAAAAAAIAmyMvLMzsC0K4lJyebHcGyKBYDAAAAAAA0gWEYZkcA2rWwsDCzI1gWxWIAAAAAAIAmGDp0qNkRgHZt+/btZkewrFCzAwAAAAAAAPiNxyO9+b20u7D+MeOPkgZ0bfYS6enpGjJkSLPnA0BrRbEYAAAAAAC0H7+sk657TgqxSXV1i3B7pHcXSd8/LIWGNGsJp9PZsowAGjRgwACzI1gWbSgAAAAAAED7UbW3kOtyS846PtweafU26ZlPmr1EXFycf7ICqFNWVpbZESyLYjEAAAAAALAWj6QH35E2NK8glZiY6N88AGopLi42O4JlUSwGAAAAAADW43JLNzwvud1Nnrphw4YABAKwT0REhNkRLItiMQAAAAAAsB6XW/p5nfTa12YnAXAQehabh2IxAAAAAACwrjtel3blN2lKr169ApMFgCRp5cqVZkewLIrFAAAAAADAuhzV0s0vSB5Po6eUlZUFMBAAmIdiMQAAAAAAsC6XW1rwu/T+z42ekpubG8BAADp37mx2BMuiWAwAAAAAAKzNkDT5JSmvxOwkACRFRkaaHcGyKBYDAAAAAABr80gqqZBuf61Rw4cOHRrYPIDFbd261ewIlkWxGAAAAAAAwOWW5v4ofbn8kEMzMjICnwcATECxGAAAAAAAQJJshnTDLO8u4wZUVVUFKRBgTYcddpjZESyLYjEAAAAAAIAkuT3S7kLp/rcbHBYbGxucPIBF8RBJ81AsBgAAAAAA2MftkWYvkH5dV++Q5OTkIAYCrKewsNDsCJZFsRgAAAAAAOBANkO65lmpsu52E5mZmUEOBFhLWFiY2REsi2IxAAAAAADAgVweafNu6dEPzE4CWNLgwYPNjmBZFIsBAAAAAAAO5vFIT8yX0rf6nOrRo4cJgQDrWLFihdkRLItiMQAAAAAAQH2ufVZyumodcjgcwc9RWCb9bbbU+69S8uXShPul5ZsbP3/dTunsh6WUy6UeV0t/fUbaU1z32E3Z0lUzpT6TpM6XSsP+fsiH/gH+5PF4zI5gWaFmBwAAAAAAAGiVXG5p5Vbpuc+km06vOZyTk6OUlJTg5XC7pfMe8e5y/tsZUqcY6cUvvQXj76ZL/Q6RZWeedOq9UmyUdPcFUlmlNPNjac126ZuHpPADykMrt3ivm5Ig3TRBSoiRtu/xXgMIksTERLMjWBY7i+FX8+bNk2EYMgxD55xzTp1jtm7dqtDQUBmGobS0tJrjaWlpstvtwYoKAAAAAEDj3Pe2d7dtoIy/z7uDuT4f/ir9mik9d510x7nSpFOkT++WQmzS9HcPff3HPpTKHdLH06TrTpOmni299ndp1Vbpv9/uH+d2S5P+Ix2W6i1CTz5Tunyc9M/zvWsDQRITE2N2BMuiWIyACAsL04IFC1ReXu5zbubMmfJ4PLLZ+OMHAAAAAGgDXG7phlnePsZSrY1PQTH/V6lzR2niyP3HEmOls0dJny6VHNUNz//fYunU4VL3A3Zrnpjm3ZH8wS/7jy1c6d1tfPs5UmS4t8Dscvv3XoBG2Ly5CS1W4FdU6xAQY8aMUVlZmV588UWfc++++65GjhypsLAwE5IBAAAAANBELre0KEOa840kaf369cFdf8UWaWhv6eBNVyP6egu6G7Lqn7srX8otko7s43tuRF/vtff5dpX314gw6Q93ensjd7lMuuIpKb+0pXcBoA2gWIyAGDZsmHr27Kk5c+bUOv75559r+/btuvLKK01KBgAAAABAM90+R8rKV2VlZXDXzSmQkuN8j3eJ9/6aVVD/3Oy957rUMT85Xioo3b8zeePeVhuXP+VtRfH6ZOnvE707k/88o2ZnNRBoffv2NTuCZVEsRsD8+c9/1rJly2r9xPW5555TbGysrrjiCvOCAQAAAADQHJVV0uSXFNOhQ/OvUe2U8oprf1S7JEcdx917W0BUVEnhdbw71x62P1dDmSXvbuGD7TtWsXdM2d4i+PA+0os3Smce4+1X/M/zvT2Tv01v+v0CzVBQ0MAPQBBQFIsRMH/7298UEhKip556SpJUUlKiL7/8UhMmTFB4eLjJ6QAAAAAAaCKXW/p0qboVtWCH7S/rpN6Tan/8mim995Pv8e17vHMiw6WqOvoSV+49Zm/ge+x95+rqa7zvWGR47bHnHld73Hl7X/+aeej7A/wgPz/f7AiWRbEYAdO1a1eNHj1a7733niRp9uzZqqio0E033eTXdfLz8+VwOGpel5aWqqSkpOZ1VVWV8vLyas3Jyspq8HV2drY8B7y9hjVYgzVYgzVYgzVYgzVYgzVYgzXaxhp1PWjdb0Jscp44RGuMFtzHkJ7Kf+U6eT68U5p/lzT/LjkP7yr3CUNqXle8fYvK35pc0zrC0zlOVdt3+14zZ+/uy5T4+n+vkr2tKso37/L5varenivFd5AiwlRVVaXK+Cjvyc4da+dOivXO2ZlT9xp7tec/V6wR3DVsB/Tnbsv34e81gsHwHJgaaKF58+bpvPPO0+TJk/XEE0/o1Vdf1ZVXXqkPP/xQd999tyoqKpSZ6f1JpN1u12GHHaZVq7wN9NPS0rR+/frg934CAAAAALQf36VLZzwYmGtHhUtLntDyPTs0bNgw/113/H1SjyTp+evrPn/Zv6Wf1kqZz9V+yN3fZkvvLJK2vlh3m4l9+kySjh8kvfb32seHT5a6JkgfTfO+fvkr6e8vSv+5Rrr0xP3jNudIQ2+W7v6zNPXsZt0igLaBncUIqIsvvljx8fG69957tWrVKl100UVmRwIAAAAAoHkevETqlqhu3boFd90zj5F2F3kfNLdPXrH04a/SqcNrF4o3ZXs/as0fKX2+TNqxZ/+xb1dJG7Kks0btPzbhKO+13vh2f79kSZrztffXE4/w2y0BDdm3sRDBF2p2ALRvYWFhmjhxol577TWFh4frxhtvNDsSAAAAAABNE2KTjuonXfVHSZLL5Qru+meNkp79TLr+eWntTqlTjPTiF94eynedV3vsxL27qtOf2X9sylnSB79KEx6QrjvN+yC7pz6SBveQLjlh/7gucdLUs6SH3pXOflg6/Wgpfav06tfSucdKI/oG9j6BvYL+dww1KBYj4G677TaFh4erX79+SkxMNDsOAAAAAABNYzOkZ6+taQGRlZWlLl26BG/9EJs07zZp2n+l5z+XKquk4X2k566TDks99PxuidJnd0t3vC7d+5YUHir96Uhp+iW+7Sv+8X9SXLQ0a4F0+2v7C8i3nxOIOwPqlJCQYHYEy6JYjIAbOHCgZs+ebXYMAAAAAACa567zG1eUba5P7zn0mPgO0jPXeD8acuCO4gMN7C59eOeh1zEM6ZpTvR+ASeLj482OYFn0LAYAAAAAAKhLiE0a1F26aUKtw4MHDzYpEGANGzduNDuCZbGzGH517rnnyuPxNGpsZWVlrdc0LwcAAAAAtCoej/T89VJY7fLJ5s2b1b9/f5NCAUDgsLMYAAAAAADgYIYh/e0MaVhvn1Pl5eUmBAKso3dv3793CA6KxQAAAAAAAAeyGVKPROmOc+s8HR0dHeRAgLWUlJSYHcGyKBYDAAAAAAAcyL23/URkeJ2ne/bsGeRAgLXs2bPH7AiWRbEYAAAAAABgH5shXXWSdNzAeoesWbMmiIEA6zEMw+wIlkWxGAAAAAAAQPIWihNjpfsvNjsJYGlDhw41O4JlUSwGAAAAAACQvO0nnp4kxUY1OCw1NTVIgQBrWr16tdkRLCvU7AAAAAAAAACmC7FJZ46UThtxyKG8RR4IrOrqarMjWBY7iwEAAAAAgLUZkqIjpEevbNTwnTt3BjYPYHFxcXFmR7AsisUAAAAAAMDaPJIeu0pK6mh2EgCSkpKSzI5gWRSLAQAAAACAdYXYpJOOkP48ptFTBg4cGMBAANavX292BMuiWAwAAAAAAKwrPFR66q9SE/oQb9++PYCBAMA8FIsBAAAAAIB13X+R1KNpb3kvLS0NUBgAktSzZ0+zI1gWxWIAAAAAAGA9ITbp6H7SX//U5Kl2uz0AgQDsU1FRYXYEy6JYDAAAAAAArMcwpOeuk2xNL43069cvAIEA7LN7926zI1gWxWIAAAAAAGAthqQ7zpX6d23W9PT0dP/mAYBWItTsAAAAAAAAAH4TFuL9NdRW90PrXG5vkfjvZwQ3F4BGO+KII8yOYFkUiwEAAAAAQPsx+nDtmHqquoV1qH/MxJFSWPNLIsnJyc2eC+DQ1q1bp4EDB5odw5IoFgMAAAAAgPbDMLRn4jB1GzYsYEtQLAYCy+FwmB3BsuhZDAAAAAAA2pWEhASzIwBogdjYWLMjWBbFYgAAAAAA0K7ExcWZHQFAC6SkpJgdwbIoFgMAAAAAgHZl06ZNZkcA0ALr1q0zO4JlUSwGAAAAAAAAAFAsBgAAAAAA7Uvv3r3NjgCgBbp37252BMuiWAwAAAAAANqV4uJisyMAaIHq6mqzI1gWxWIAAAAAANCu5OXlmR0BQAtkZ2ebHcGyKBYDAAAAAIB2xTAMsyMAQJtkeDwej9khAAAAAAAAAECSnE6nQkNDzY5hSewsBgAAAAAA7Up6enqz576XXq5z/5urX7c7/JgIQFNs2LDB7AiWRbEYAAAAAAC0K06ns1nzsopdumtBkX7bUa2Xf6HvMWCWyspKsyNYFsViAAAAAADQrsTFxTV5jsfj0e0LClXl8shmSBUVFKsAs3To0MHsCJZF8w8AAAAAANCuJCYmNnnO/zIq9O0mb+sJmyH6pQIm6t69u9kRLIudxQAAAAAAoF1par/T/HKX/vlFkYwDjkVHR/k3FIBGy8jIMDuCZVEsBgAAAAAAlnbvV0Uqq/LIc8CxoqJi0/IAgFl4TwUAAAAAAGhXevXq1eixX2+s1PwM+hMDrUnXrl3NjmBZ7CwGAAAAAADtSllZWaPGlTrcuu2zQhmG77nIyEg/pwLQWB6P59CDEBAUiwEAAAAAQLuSm5vbqHGPfFesPeVuUZcCWpddu3aZHcGyaEMBAAAAAAAs57cdDs35vbze8xUVFUFMAwCtAzuLAQAAAABAuzJ06NAGz1c6PZrySaFsdbSfAGC+QYMGmR3BsigWAwAAAACAdiUjI6PB8zMXFWtboUvuBtpPdOwY6+dUABpr69atZkewLIrFAAAAAACgXamqqqr33Jrd1Xru1zIdqk1xWVn9LSoABFZjH1IJ/6NYDAAAAAAA2pXY2Lp3BTvdHk35pECN6T7hdDr9GwpAo0VFRZkdwbJ4wB0AAAAAAGhXkpOT6zz+4m9lWrO7cUXgkJAQf0YC0AS9e/c2O4JlsbMYAAAAAAC0K5mZmT7HthQ49dj3xY2+RkxMB39GAvD/7d15XFV1/sfx973sq8iiiBuiuYSKWpalpTnlOqU1qZmWZuW0u2TTrzGbbHPSFtPqpznmlE6NZaNmalZq9stKzVLEDRfccEcRkB3O7w+GmxcucIELx7iv5+PBI+853+/5vg/dY7cPX77fSti5c6fZEdwWxWIAAAAAAFCnGYahp1allruhXUmpqRdqLhAAXKZYhgIAAAAAANQpzZo1s3v97+2Z2nys7E3vAFxeGjVqZHYEt0WxGAAAAAAA2LmQXahp36ZpTWK2svINxTXy0rM3BatDpLdT/fedzdOL69K05ViuvDyk3i19NaV3sML8y14HeOnOTI3/IlX+Xhbtnli9QlFOTo7tzyfTC/TCOueXnyjm5+dbrQwAqo41w83DMhQAAAAAAMCm0DB035IULd+VpVFdAvRMr2ClXCzUXR+nKOlcxZvDnUgr0NCPUnTofL7+cmOQxl4TqHUHsjVycYpyCxyvA3Ext6g47e9lcck9nDp1SlLR8hN/XZOqnPxKrD/xXxYLJRPALMeOHTM7gtvibz64xMmTJ+Xt7S2LxaLp06c7bBMRESGLxWL78vT0VHh4uAYOHKjdu3fXcmIAAAAAgCOr9mRra3KeXhsQovE9gjSqS4AW3x0mq0V64/v0Cvu//VO6MvMMfTw8TPddHajHrgvSu4NCtet0vpbsyHTYZ/YPGQr0tqrPFa6dzbtyT7bWHshRGTXqcmVmOs4KAHUZxWK4xKxZs5Sfn6+IiAgtWrSozHahoaGaMWOGZsyYocmTJ6tTp05avXq1rr/+eiUnJ9diYgAAAACAI6v2ZikiwKr+bX4r3Ib5e+iPbf309f7sCmfpfrk3W39o6aPGwb+tfNkj2kcxoR76Yk9WqfZJ5/I1/+cMPds7WJ4uqlJ06NBB57MKNfmrVLlmrjKA2tS2bVuzI7gtisVwiY8//lgdOnTQ/fffr4SEBG3fvt1hu4CAAE2aNEmTJk3S1KlT9c0332jo0KFKTU3VG2+8UcupAQAAAAAl7Tydp9iGXrJa7MuscY28lJVnKOl82UtRnEwv0NnMQnVs5FXqXFwjb+08lVfq+NS1F3RdMx/1bum6WcX79u3TC2svKD3HUBUmFUuSgoODXZYHQOUwodA8FItRbWvXrtWhQ4c0YsQIPfroo7JarXrrrbec7t+3b19J0v79+2sqIgAAAADASaczCtUgoPTmUg0Ci46dSi8op2/ROYf9A6xKzTbsZiavPZCt/zuUo2d7u7Yw+8OxQv1nZ1aVlp8olpXFMhSAWdLTK17yBjXDs+ImQPneeecd+fj4aOzYsQoJCVG3bt20fPlyFRQUOLV7ZWJioiSpfv36NR0VAAAAANxKoWEot+zarh0fD8lisSg735C3g2qBj2fRTOPscpahKD7n7VF68YdL+/t4WpRbYOjFtRc0olOAWoeXnolcVRdzC/X2znqyWqTCahSL8/Iq3swPQM3w9XXt+uVwHjOLUS0ZGRlas2aNevXqpZCQEEnSvffeq3Pnzjlcu7igoEDHjh3TsWPHlJCQoNdee02zZ8+W1WrVmDFjqpTh3LlzysnJsct06U+gcnNzlZKSYtfnxIkT5b4+efKkDOO3TxWMwRiMwRiMwRiMwRiMwRiMwRi/xzE2Hc1Vm9dPOPUVf/SCJMnX06Ls3IJSY5w8nWI7X9Z9+Px3vlBugVHqPtKzcu36z/3pglIyCzSxR5CtTWaW/ZrGVfle7TyWpnPZlmoViiXJarWWOcbl/O+cMRijLozRqlWrOnEfrh6jNliMS1MDlfTGG2/oySef1CeffKIhQ4ZIknJychQREaFOnTrpu+++s7WNiIjQ2bNnS10jMjJS06ZN0+jRo2srNgAAAAC4hdMZBdqQlFNxQ0l9W/sq2Meqnu+dUnR9T30wJMzu/L+3X9TTX17QmjERahvheCbwyfQCXfvuKT3TK0gPXRtkd278F+e1/kC2to9rpLScQnV795Tu6RygkZ39bW1eXpemb5Ny9PX9EfLztCjcwXIWznj4o/368ph/lQvGVot0a1tfzbottGoXAFAt27ZtU6dOncyO4ZZYhgLV8sEHHygoKEgtW7bUr7/+ajt+zTXXaMOGDTp27JiaNGliOx4REWFbzzg5OVnz589XUlKSvLxc9ytHAAAAAIAiDQI9NKSDf8UNL3FlAy9tOZarQsOw2+Ru24k8+XlZ1KJ+2aWEyCAPhflbFX+i9EZ220/k6sqGRf/vdyG7UBdzDc3ZlKE5mzJKte0x57T6XOGreXdUrVh7T+uL2no+UGcuFla5YJyamiqJYjEA90KxGFUWHx+vHTt2yDAMXXXVVQ7bzJo1S9OnT7e99vX11fDhw22vH3roIXXo0EFjx45Vt27d1LJlyxrPDQAAAAAo24A2flq1N1ur92ZrYFs/SdK5zAKt3JOlm1v62NYelqTD54vW9W1+SQG5f2tfLUnI0vG0AkUFF80M/v5Qjg6eK9D9VwdKksL9rXrv9tL71izYelG/HM/V7Fvr2zbUq4rW0Y01PTRQoz49V+VrADBPw4YNzY7gtigWo8pmzZolwzD0wgsvKDS09E9bX3nlFS1evNiuWFxSYGCgpk+frqFDh2r8+PFasWJFTUYGAAAAAFRgQBtfdY7y0lOrU7U/JV/1/axa+OtFFRrShB7Bdm3v/nfR+pobH/6tsPPodUFauTdbd318VvddHaDMXENzN2eobYSnbZazn5dVfVv7lRr7q33Z2n7C4vBcZRQUFKhXjK8GX+mnFbuzVFCF2cVssAWYx8fHx+wIbotiMaqkoKBAy5YtU7NmzTRlyhSHbeLj4/Xee+9pzZo16tu3b5nXGjJkiGJjY7V69WrFx8erY8eONRUbAAAAAFABD6tFHwwJ08vr07Rg60Vl5xuKi/TS6wNC1DKs4jJCVLCHPhkephfXpenVDenyskq9W/rq2d7BdrOSa9KJEyfUsGFDPX9zPa0/mK20bEOVrRd7eFhrJBuAih05csThxETUPDa4Q5UsXLhQ9957r8aOHau5c+c6bLNx40b16NFDt912m5YvX66IiAj5+fnpyJEjpdp+/PHHuvvuuzVgwACtXLmypuMDAAAAAOqwSzfHWrE7S499fr5S/a0W6YbIbH14b0wNpANQETa4Mw8/JkOVzJs3T5J0zz33lNmme/fuatSokb7++mulp6eXe73hw4erdevW+vLLL7Vt2zZXRgUAAAAAuJnY2Fjbn//Y1le9Y3zkUTuTmgG4QOvWrc2O4LaYWQwAAAAAAOqUxMREu2LTibQC9f7HaWXmOVcCsVqkga299PbgiJqKCKAcBw8eVEwMM/vNwMxiAAAAAABQp2RmZtq9bhTsoWd7B5fR2rGsrGxXRgJQCWlpaWZHcFsUiwEAAAAAQJ0SEBBQ6tjwOH91bezl9HIUeXl5Lk4FwFne3t5mR3BbFIsBAAAAAECd0rx581LHrBaLZgyoL6uTxWKrsw0BuFy7du3MjuC2KBYDAAAAAIA6ZdeuXQ6Ptwj11KQbg5y6Rr16IS5MBKAytm/fbnYEt0WxGAAAAAAAuI0HugaqXYRnhctRnD9/vnYCAcBlhGIxAAAAAACoU6Kioso852m16PWB9WXUYh4AlRMREWF2BLdFsRgAAAAAANQpFkv504ZjG3rpoWsDVF4rHx8f14YC4DRHm1SidlAsBgAAAAAAdUpycnKFbcZ1D1bTeh5lbnjn6enp4lQAnHXo0CGzI7gtisUAAAAAAMDt+Hpa9PrAEBWWsR7FxYsXazcQAFwGKBYDAAAAAIA6pV27dk61u6apj0Z29i9zdjEAc7Rq1crsCG6LYjEAAAAAAKhTjh496nTb/+kZrDB/q0oucxwUFOTiVACcdfbsWbMjuC2KxQAAAAAAoE7JyMhwum2Qj1Wv9g+RUWI5ipycHBenAuCs1NRUsyO4LYrFAAAAAACgTvH19a1U+z+09NVt7Xzlccns4tzcXBenAuAsNpg0D8ViAAAAAABQp1RlvdPnb66nAG+LiuvFlpLrUgCoNe3btzc7gtuiWAwAAAAAAOqUhISESvcJ8/fQi33qyZBUaEghISEuzwXAOdu3bzc7gtuiWAwAAAAAACBpUDs/9YrxkSR5ZaeYnAZwX0bJRcRRa1gABAAAAAAA1CmRkZFV6mexWDTr1vpKOpevgpO7XJwKgLPCwsLMjuC2KBYDAAAAAIA6parFYkmq52tVpyhvHckPdWEiAJURHBxsdgS3xTIUAAAAAAAAJbBmMWCepKQksyO4LYrFAAAAAAAAJRw8eNDsCABQ6ygWAwAAAAAAALhsxMTEmB3BbVEsBgAAAAAAKKFFixZmRwDcVmpqqtkR3BbFYgAAAAAAgBLS0tLMjgC4rXPnzpkdwW1RLAYAAAAAACghJSXF7AiA27JaKVmahe88AAAAAABACRaLxewIgNvq2LGj2RHclsUwDMPsEAAAAAAAAAAgSTt27FCHDh3MjuGWmFkMAAAAAABQQkJCQpX65RcyJw+oroKCArMjuC2KxQAAAAAAACXk5+dXus8Ph3N0zTundCqDQhdQHfXr1zc7gtuiWAwAAAAAAFBCSEhIpdoXFBoa9WmKUjILFX/wdM2EAtxEWFiY2RHcFsViAAAAAACAEsLDwyvVfnF8pnL/O6H43LmUGkgEuI/9+/ebHcFtUSwGAAAAAAAooTLFqvNZhXplfZrttZ+fX01EAoAaR7EYAAAAAACgGl7dkKaLeb9tbBfZsKGJaYDfv+joaLMjuC2KxQAAAAAAACU4W6zadjxX/96eqcLfasVKOnSoRjIB7iIjI8PsCG6LYjEAAAAAAEAJFy9erLBNQaGhv65JldVSC4EAN3L27FmzI7gtisUAAAAAAAAlnDlzpsI2i+MztfN0vgoM++MRERE1lAoAahbFYgAAAAAAgEo6l1lgt6kdANfp1KmT2RHcFsViAAAAAACAEuLi4so9X3JTu0s5MysZQNl27txpdgS3RbEYAAAAAACghN27d5d5btvxXC2Oz7Lb1A6A6+Tl5ZkdwW1RLAYAAAAAACghNzfX4XFnNrVrER1dM6EAN1GvXj2zI7gtisUAAAAAAAAlBAcHOzz+7zI2tbvUyVOnaigV4B4aNmxodgS3RbEYAAAAAACghMjIyFLHzmUWaJoTm9plZWXVRCTAbSQmJpodwW1RLAYAAAAAACjBUbGqvE3tLuXj41MTkQCgxnmaHQAAAAAAAOByV7ypnTN72jVp0qTG8wB1WbNmzcyO4LaYWQwAAAAAAFDCpcUqZza1u9SBAwdqKBXgHrKzs82O4LaYWQwAAAAAAFzqQnahpn2bpjWJ2crKNxTXyEvP3hSsDpHeTvXfdzZPL65L05ZjufLykHq39NWU3sEK8/cos8/SnZka/0Wq/L0s2j2xUbXvIScnx/bn4k3tANSO06dPKyoqyuwYbomZxQAAAAAAwGUKDUP3LUnR8l1ZGtUlQM/0ClbKxULd9XGKks5VXHA9kVagoR+l6ND5fP3lxiCNvSZQ6w5ka+TiFOUWOF4E4mJuUXHa38vJqb9OOHXqlCTnN7W7VFhYmMtyAEBtolhcQ06ePClvb29ZLBZNnz69zHYRERGyWCy2L09PT4WHh2vgwIHavXt3reVdsmSJLBaLJk6cWGtjAgAAAADqnlV7srU1OU+vDQjR+B5BGtUlQIvvDpPVIr3xfXqF/d/+KV2ZeYY+Hh6m+64O1GPXBendQaHadTpfS3ZkOuwz+4cMBXpb1ecKX1ffjtOb2l3Kw6PsGdAAKtahQwezI7gtisU1ZNasWcrPz1dERIQWLVpUbtvQ0FDNmDFDM2bM0OTJk9WpUyetXr1a119/vZKTk2spMQAAAAAA1bdqb5YiAqzq3+a3wm2Yv4f+2NZPX+/PVk5++YXXL/dm6w8tfdQ4+LeVM3tE+ygm1ENf7Mkq1T7pXL7m/5yhZ3sHy9OFVY4OHTrYNrUrrFytWKdPn3ZdEMANJSYmmh3BbVEsriEff/yxOnTooPvvv18JCQnavn17mW0DAgI0adIkTZo0SVOnTtU333yjoUOHKjU1VW+88UYtpgYAAAAAoHp2ns5TbEMvWS32S0LENfJSVp6hpPNlL0VxMr1AZzML1bGRV6lzcY28tfNUXqnjU9de0HXNfNS7pWtnFe9J3FepTe0AuM6la4ajdlEsrgFr167VoUOHNGLECD366KOyWq166623KnWNvn37SpL2799fYdt169bJy8tLnTt3VmFhoe14Xl6eYmNj5ePjo40bN1buJsqxdOlSde7cWf7+/vL29lZMTIxeeumlUu06dOigiIgI7d+/X71791ZAQIB8fHx01VVX6eeff3ZZHgAAAADA5eN0RqEaBJRehqFBYNGxU+kF5fQtOuewf4BVqdmG3czktQey9X+HcvRs7+Dqxi5lxX5p5+l8lbFMcrmio6NdngdwJ0FBQWZHcFsUi2vAO++8Ix8fH40dO1ZNmjRRt27dtHz5chUUlP0fxJKKp9vXr1+/wra9e/fWpEmTtG3bNo0bN852/OGHH9auXbv0zDPPqHv37pW/EQfmz5+vO++8U4cPH9a9996rcePGydPTU1OmTNF9991Xqn1OTo569Oghq9WqJ598UkOGDFF8fLwGDRqkvLzSPxEGAAAAAFw+Cg1D2fnOfRlGUVU1O9+Qt2fpa/l4Wmzny1J8ztuj9HTekv1zCwy9uPaCRnQKUOvw0jORq+NcZoE+SKx6seoMy1AA1dK4cWOzI7gtB399ozoyMjK0Zs0a9erVSyEhIZKke++9V3/+85+1aNEijRo1qlSfgoICHTt2TJKUmpqqL7/8UrNnz5bVatWYMWOcGnfatGn69ttv9e6776p///7KzMzU+++/rx49euj55593yb3l5eXp6aeflo+PjzZv3qxWrVpJkl544QV16dJFH3zwgR5//HF16dLF1ic9PV1jxozRzJkzbcciIiI0c+ZMLV68WCNHjnRJNgAAAACA6206mqu7Pk5xqu3aByLUKsxLvp4W5TpYaaJ4RrCvZ9nrOhSfy3Uwnbdk//lbMnQuq1ATe7h+BuKrG9KUXVD19ScuZjreiA+Ac/bs2aNOnTqZHcMtMbPYxd577z1lZmbq/vvvtx0bNWqUgoKCNH/+fId9jh8/rqZNm6pp06bq0KGDnnrqKVv7G2+80emxP/vsM4WEhGj06NEaO3aswsLCtGTJkmrfU7G1a9cqJSVFt912m61QLEl+fn6aMGGCDMMotZmfxWIptUTFwIEDJUm7du1ySa5z587ZrWWTkZGh9PTfdtjNzc1VSor9h5sTJ06U+/rkyZO2n4ozBmMwBmMwBmMwBmMwBmMwBmO46xgtQz312oAQvTYgRM9eL9ufHb3WxbMyDEMNAq06fbGg1BhHU4oKqA2DPMq8DyPzrCTp9MWCUvdx+mKhgn0kbw8pLadQs3/M0O2trUpJz9bRC/k6eiFfF7LyZBiGjl7I19mLBVX+XtXztdp9vyrLarUvt/ye/p0zBmNcDmNc6vd8H64eozZYjOr87YdS4uLilJSUpG+//VaWSxbzf+qpp7RhwwYlJSWpSZMmtuMRERGyWCy2NY2Tk5M1f/58JSUlaf78+RoxYkSlxv/444919913S5KWL1+u2267zal+S5Ys0ZAhQzRhwoQyN9WbNWuWxo0bpxdffFHPPvus3blff/1VXbp00eDBg7V06VJJRWsWHz9+vNQbPSEhQR06dNDYsWM1d+7cSt0fAAAAAODy9vCyc9pyLFebH21ot8nd/3yZqmW7srT9iUjbkhKOdJl9Ut2aeuvdwaF2x2+ad0qRQR76+K5wHb2Qrx5zyl/qoc8Vvpp3R2i5bcpyMbdQ17+TrAu5HqpK0eQ/I0J1VRPXbrgHuJOzZ88qPDzc7BhuiWUoXCg+Pl47duyQYRi66qqrHLaZNWuWpk+fbnfM19dXw4cPt71+6KGHbMXUbt26qWXLlk5n+M9//mP78+bNm50uFteUkj9NvRQ/pwAAAACAumdAGz+t2put1XuzNbCtn6SiNYBX7snSzS197ArFh88XrVfRvP5v5Yn+rX21JCFLx9MKFBVcNAv5+0M5OniuQPdfHShJCve36r3bS+/xs2DrRf1yPFezb61v21CvKgK8rXq6u7eeWe/83kOX2r9/v65q0r7K4wPuLj/fwVo2qBUUi11o1qxZMgxDL7zwgkJDS//08pVXXtHixYtLFYtLCgwM1PTp0zV06FCNHz9eK1ascGr8efPmacmSJerXr5+OHDmi6dOnq1+/furRo0eV7qekNm3aSCqaGVzSzz//LElq0aKFS8YCAAAAAPw+DWjjq85RXnpqdar2p+Srvp9VC3+9qEJDmtAj2K7t3f8u+k3UjQ83tB179Logrdybrbs+Pqv7rg5QZq6huZsz1DbCU0M6+EuS/Lys6tvar9TYX+3L1vYTFofnKqt3M0Pdmnpry7FcOVhCGUANOnnypCIjI82O4ZYoFrtIQUGBli1bpmbNmmnKlCkO28THx+u9997TmjVr1Ldv33KvN2TIEMXGxmr16tWKj49Xx44dy22/b98+TZw4UY0bN9bixYt1/PhxXX311Ro+fLh27dqloKDqL/jfu3dvhYWFacWKFTp48KBiYmIkSTk5OZo5c6YsFkuVN6zLycnR9u3bFRQUpHbt2lU7KwAAAADAHB5Wiz4YEqaX16dpwdaLys43FBfppdcHhKhlWMVliKhgD30yPEwvrkvTqxvS5WWVerf01bO9g8tdvsLVTp48qZf6xKrP+2cq3Te0ftWWvwAAs1EsdpGPPvpIKSkp+tOf/lRmm3vvvVfvvfee3n333QqLxZI0efJk3X333XrmmWe0cuXKMtsVFBTojjvuUE5Ojv79738rODhYwcHBeu211/Twww9rxIgR+vzzz526j++++06PPPJIqeMRERGaOnWqXn31VY0dO1Zdu3bV0KFDFRQUpOXLlysxMVGjR49Wly5dnBqnpH379unaa69V+/bttWPHjipdAwAAAABweajna9X0/iGa3r/8dpfOKL5U6wgvLRwWVulxXx9YX68PrHS3Ml0R7qUHuwZo3paimdHO8vbxdl0IwA21b88yLmahWOwi8+bNkyTdc889Zbbp3r27GjVqpK+//lrp6ekVzvYdPny4nn/+eX355Zfatm2bOnXq5LDdo48+qoSEBE2ZMsVuyYmHHnpIX331lZYuXap3333XYRG4pK1bt2rr1q2ljkdFRWnq1Km6//77FRISopdeekn//Oc/lZ+fryZNmjjc9A4AAAAAgN+r2NhYSdK47kH6bGeWUi4WOr3Z3cmTJ6W2bM4FVNWBAwdsy6GidlkMdhkDAAAAAACwk5iYqNatW0uSvtidpUc/P+903+nXntOwXsyMBKqqvEmTqFlWswMAAAAAAABcbjIzM21/HtjWV92aesvDySWTmzVrVkOpAPcQEBBgdgS3RbEYAAAAAACghEuLVRaLRS/3red033PnztVEJMBt8AMX81AsBgAAAAAAKKF58+Z2r1uFeemBrgGyOjG7OCMjo4ZSAe5h9+7dZkdwWxSLAQAAAAAASti1a1epY+O6BynU36qK6sWenp41EwoAahjFYgAAAAAAACcEeFv1ws31ZFTQLiYmplbyAHVVVFSU2RHcFsViAAAAAACAEsoqVg1oU/Fmd4mJiTWUCgBqFsViAAAAAACAEiwWx9Xgym52B6Dyjh8/bnYEt0WxGAAAAAAAoITk5OQyz7UK89KD15S92V1ISEjNhAKAGkaxGAAAAAAAoJKeuD5IYWVsdufn51freYC6pF27dmZHcFsUiwEAAAAAAEqoqFgV4G3V1DI2uztx4kTNhALcxJEjR8yO4LYoFgMAAAAAAJRw9OjRCtsMaOOr65qVv9kdgMq7ePGi2RHcFsViAAAAAACAEjIyMipsY7FY9FKf0pvdNW3SpCYiAW6DpVzMQ7EYAAAAAACgBF9fX6faOdrs7kJaWg2lAtxDy5YtzY7gtigWAwAAAAAAlNCqVSun2xZvdlcsjWIxUC0JCQlmR3BbFIsBAAAAAABKqEyxqnizu2IeHh41EQkAahzFYgAAAAAAgGoa0MZX4f+dXdwihl+hB6ojMjLS7Ahui2IxAAAAAABACZUtVlksFi0aFqb2Db2UdWJvDaUC3IOnp6fZEdwWxWIAAAAAAIASqjKzsV0DL60cHaFAz4IaSAS4j2PHjpkdwW1RLAYAAAAAAHCh0NBQsyMAQJVYDMMwzA4BAAAAAABQV6SlpSk4ONjsGMDvVnZ2tnx9fc2O4ZaYWQwAAAAAAOBCBw8eNDsC8LuWnJxsdgS3RbEYAAAAAAAAwGUjPT3d7Ahui2IxAAAAAACAC7Vo0cLsCMDvmo+Pj9kR3BbFYgAAAAAAABdKS0szOwLwu9a6dWuzI7gtisUAAAAAAAAulJKSYnYE4Hdtx44dZkdwWxSLAQAAAAAAXMhisZgdAQCqxGIYhmF2CAAAAAAAAACQpOPHjysqKsrsGG6JmcUAAAAAAACStClRWr5JOnm+WpdJSEhwUSDAPfn6+podwW15mh0AAAAAAADAdHuOSX2ekwxJN8ZKK56VqricRH5+vmuzAW7myJEjCg0NNTuGW2JmMQAAAAAAQFpWUaFYkr7bKX20ocqXCgkJcUkkAKhtFIsBAAAAAABK+ssH0qnUKnUNDw93bRbAzbRu3drsCG6LYjEAAAAAAEBJmTnSk+9Xqev+/ftdHAZwL6dOnTI7gtuiWAwAAAAAAFBSQaH0+WZpxWazkwBu58KFC2ZHcFsUiwEAAAAAAByxSBr3Dyn1YqW6RUdH10gcwF14eXmZHcFtUSwGAAAAAABwxJB0LkN6dlGlul28WLniMgB7sbGxZkdwWxSLAQAAAAAAylJYKH24XtqQ4HSXM2fO1GAgoO7btm2b2RHcFsViAAAAAACA8lgt0sP/W7TpHQDUYRSLAQAAAAAAylNoSMfPSS994lTzuLi4Gg4E1G3h4eFmR3BbFIsBAAAAAAAqUmhI76ySth6osOnu3btrIRBQdwUGBpodwW1RLAYAAAAAAHCG1SI99K6Um19us9zc3FoKBNRNhw4dMjuC26JYDAAAAAAA4IyCQikxWZr5ebnNgoODaykQALgWxWIAAAAAAABnGZL+/pm0N7nMJpGRkbWXB6iDWrVqZXYEt0WxGAAAAAAAoDIMQ3r4f6XCQoenExMTazkQULekpKSYHcFtUSwGAAAAAACojIJC6ef90ryvzE4C1Ennz583O4LbolgMAAAAAABQFVP+JR05U+pws2bNTAgD1B0eHh5mR3BbFIsBAAAAAACqIq9Aevy9omUpLpGTk1P7WVIvSk+8J7V4UIocJQ18QdqW5Hz/vcnS7dOkRqOkZvdLD74tnU0rv8/i76Xgu4r6AC7UoUMHsyO4LbcpFvfr108Wi8XsGHamTJmixo0by8vLSxaLRQkJCWZHAgAAAAAAzioolNbvkP79f3aHT506Vbs5CgulIa9Kn26UxvaVXrhbOpNWVDDef6Li/skpUr/npYMnpefukp74o7TmV2nQy1JuvuM+GdnSc/+SAnxceiuAJMXHx5sdwW1Vqlj8888/64EHHlCbNm0UHBwsX19ftWjRQo8++qhSU1NLtbdYLOV+Pfroo666D0nSe++9p7Fjx7r0mjXl008/1UsvvaTmzZtr6tSpmjFjhpo0aVJj461fv15jx46lIA0AAAAAgKs9tUA6c6Hmrj9gqvTQu2WfX7ZJ2pQo/e/D0jN3FhWMVz0neVilVz6t+PqvLZMyc6QvpkgP95cm3S59MF7acVj617eO+8z4jxToJw3sWoUbAspXWMbmkah5npVpPGvWLH3yySfq0aOH7rjjDnl7e2vDhg169913tXLlSu3YsUNBQUG29jNmzHB4nddee02nTp3SsGHDqpe+hP/85z9as2aN3nvvPZdetyasXLlSkrRkyRJFRUXV+Hg//fST5s2bpz59+qh9+/Y1Ph4AAAAAAG7jYo40aUFRgVUm/Ar98k1Sg3rSbdf8diw8WLq9W9FSETl5ko9X2f0/3yz16yI1Df/t2E0dpFaNpKU/SffdbN9+/wnpnVXSv56Ulv7o2nsBJIWGhpodwW1Vqlh8zz336PXXX1dERITd8TFjxmjBggWaNm2aXnnlFdvxSZMmlbrG3r179Ze//EUtW7bUjTfeWMXYl7+UlBSFhYWVeb74V1Jqo1BcGyq6XwAAAAAA6qyCwqKi6rCfpQFXa9++fWrbtm3tjb/9kBTXQrKW+AXyq1pKC9YWFXdjy9h07/i5olnRnWNKn7uqpfTVttLH/+dD6YZYqW9nisWoESEhIWZHcFuVWobilltuKVUoloqKxZK0c+fOCq8xc+ZMGYahkSNHOj3ud999p+7duyswMFBeXl5q0qSJxo8fr7y8PFubDh06aM2aNZLsl7+YNm2a3bXOnDmjwYMHKzg4WF5eXmrXrp1Wr15daszCwkI999xzatmypXx8fOTr66uOHTvq00/tf30jISFBFotFY8eO1axZs9SyZUt5e3trxIgRDu+luP2XX35pl/XSnzoeOHBAgwcPVnh4uDw9PVW/fn3deuutOnz4sN219u/fr+HDh6tFixYKCAiwfW/GjRtn970ZO3as/vrXv0qShgwZYhuzX79+tvNlrZkcERFR6ieixX0XL16sK6+8Ur6+vurVq5ft/Ndff63u3bsrKChIXl5eioqK0qOPPqrc3Fy76/zwww+68cYbFRoaKi8vL4WEhKhjx45asGCBw+8dAAAAAACXLYulaLO7C5nKzs6u3bFPnZciQ0ofb1i/6J8nzpfd9+R/zzV00D+yvnQ+o2hmcrEvf5HWxUvT7qlqWqBCBw8eNDuC26rUzOKyHDhwQJLUoEGDctsVFhbqs88+k4+Pjx577DGnrv3111/rj3/8ozw8PDRs2DBFRkZqzZo1euutt5SQkKBvvvlGkvTMM8/o5Zdf1q5du+yWv7jlllvsrtejRw+FhIToscceU0pKihYuXKihQ4fq0KFDdjNj+/Tpo3Xr1unGG2/UsGHDlJOTo6VLl+quu+5SamqqHnzwwVI5P/roIw0ZMkQtWrQo8ycgTZo00YwZM7RgwQK7rMUzjHfv3q3u3bsrPz9fgwcPVqtWrbRv3z4tWbJE3bp1U3x8vK1g/+OPP2rt2rXq3bu3WrVqpdzcXK1du1azZs1SUlKSPv/8c0nSyJEjdfLkSa1YsUKjR49WbGysJKldu3ZO/TtwZNeuXRo1apQGDx6su+66y3Z8wYIFGjt2rCIjIzV69GiFhYXpp59+0v/+7/9qx44d+u677yRJycnJ6t+/vyRp6NChio6O1pkzZ/Trr79q48aNuu+++6qcDQAAAACAWmcYUkq69Ny/FPRE76pfJy9fSssscaxAysmXUtLsj9cPLJpNnJUreTtYZsL3v8eyc0ufK1Z8ztEyFcXHsnKL/pybLz3zoTTmZqltze27BMA81S4W5+Xladq0abJarRVuLvfpp5/qzJkz6tevn8LDw8ttW+yJJ55Qfn6+vv76a9uyFS+//LJuuukmrV27VosXL9awYcN0991368MPP9SuXbscLn9R7Morr9TSpUttrzt06KDHH39cs2fP1vPPPy9JmjNnjtauXavnn39ef/vb32xtp02bpiuvvFKTJ0/W/fffL+slv95x5MgRbdy4Ud26dSv3fkJCQjRp0iR98803DrOOGTNG+fn52rJli9q0aWM7fu+996pfv36aPHmybU3mwYMHa8SIEXY5pKIC+RdffKEDBw7YlvvYuHGjVqxYoYEDB+rOO+8sN6Mzjh49qo8++kjDhw+3HcvIyNCECRPUunVr/frrr/L29rade+qpp/Taa69pyZIluvPOO7Vq1SqlpaXprbfe0hNPPFHtPAAAAAAAmK7QkBasVZPRN1X9Gj/tlQa+WPr4pkTpsx/sj+2YJTVvIPl5S7l5pftk//eYr3fpc8WKz+U46F98zO+/bd5ZWVQQ/+uQ8u8BqKYWLVqYHcFtVWoZCkeGDx+uvXv36pFHHlHXruXvgDl37lxJ0kMPPeTUtQ8fPqw9e/bouuuus1vf2Gq16oUXXpAkffLJJ5XKO2XKFLvXt99+uyQpMTHRdmzRokXy9fXV6NGjdezYMdvX6dOn9Yc//EFnzpzRL7/8Yneda6+9tsJCcUXOnDmjTZs26YYbblBAQIDd2O3atVNkZKRtZq4kBQUF2QrFWVlZOn78uI4dO6a+ffvKMAx9++231cpTnujoaLtCsSQtXrxYFy5c0IgRI3T69Gm7/EOHDpUkffHFF5J+W6h89erVOnv2bLWynDt3Tjk5ObbXGRkZSk9Pt73Ozc1VSkqKXZ8TJ06U+/rkyZMyDIMxGIMxGIMxGIMxGIMxGIMxGIMx3GyMavGwSnEttDM/tdwxyr2P9s2V9e+Jyvx4grR8srR8sgpjmyr3hna211o+WSkLHvpt6YiG9ZV9+FTpMYqXmGhUv+zvVWTRUhX5ySmlvleZSceLZi/7eEkXMlX46n+k0b2l9Ezp8Gmd+XmnjIxsyZB0+LTOJx7+Xf47Z4zLb4wLFy7Uiftw9Ri1wWJcmrqS7r//fr3//vu69dZbbUselOX48eNq3ry5GjRooOTkZKeuv3r1ag0YMEBjxozR/Pnz7c5lZWUpICBAV111lbZs2SJJ6tevn9asWSNHt1R8Ljc3V15e9r9aUbwGb/HaxU2aNKkw49KlSzV48GAlJCSoQ4cOGjFihBYtWuTUfZWV9csvv7QtzVCWBg0a2DbHy83N1fjx47V06VKdOnWq1H2/+uqr+stf/iKpaFb0X//6V3366aelZhaPHTtW8+bN044dO9S+fXu7cxEREYqMjNSOHTtsxywWi2688UZt2LDBru348eP11ltvlZt/wIABWrlypSSpb9+++uqrr+Th4aErrrhCPXr00JgxY3TdddeVew0AAAAAAFxu8z7p5ikVtyuPh1X6/u/alndOnTp1ckksSdKAqVKzCGnOI47P3/um9MMeKfF/7Te5e+I96ZON0uF/OF5moljMWOmGK6UPxtsf7zJBahwqrZgiHT4tdajgN4MHXi19XPZvewPO2rZtm2ufITitystQjB07Vu+//7769eunZcuWVdh+9uzZys/P17Bhw6o6pEuULBQXu7TQahiGgoKCbDOhHSk5i9jf37/a2Yoz3HzzzbZNA0sKCAiw/XnEiBFasmSJevXqpfHjxysyMlLe3t7atGmT3nrrLRUUFDg1rsViKfNcWdfw8/MrM/+ECRPKnGUeHR1t+/OaNWu0ceNGLVmyRD/++KMWLlyo999/X08//bReeeUVp7IDAAAAAHBZsFikSYOl2GZqcrb6NYJKGXSttGyT9PlmafB/6xUpaUXH+nWxLxQfPFn0z5jIS/pfI330nXTsrNTkv8uGfrtD2n9CenRA0euIetJHT5Yee86X0uZE6f0nHG+SB1RBebUq1KwqFYuLZ6L27dtXX3zxRak1cx3597//LQ8PD40bN87pca688kpJ0t69e0ud27JliwzDULNmzWzHXPVGatq0qTZv3qx+/fqpfv36LrmmMzp27CiLxaK8vLxSSzw4smrVKsXGxmr9+vV2x/fs2VOqbXn/joqXhDh16pTdzOKMjAylpqaqcePGTuVv27atJCkwMNCp/JLUvXt3de/e3TZ+586d9cYbb+ill15y6n0FAAAAAIDpPKxSdANpUtFSl85O3nKZwd2kd1dLj8yR9iRLYUHSP76SCgqlySXWF77tpaJ/Jrz927EnB0tLNxWtlfxwf+litvTWCim2mTSyV1Ebfx/pjw4mhn2xRdpqdXwOqKK4uDizI7itSlfjHnroIc2bN0+33HKLVq5cKQ8Pjwr7fP311zp06JC6deum5s2bOz1W8+bN1bZtW/3444/auHGj7XhhYaFtM7ritXCl32bdHj9+3OkxHLnnnntkGIYefPBBh+eTkpKqdf2yNG7cWF27dtX//d//adWqVaXOFxYW6siRI7bXVqu11NITqampmjdvXqm+QUFBkorWRS4pNjZWkrRixQq7488884zDJT3KMnz4cAUHB+vdd991+O8gPT3dtvbK8ePHS/3Hs2HDhmrUqJFyc3N18eJFp8cFAAAAAMBUhYVFS0T8dwZvra8z6mGVljwt3XFd0UzfKf8qKhiveFa6Iqri/k3CpdXPSS0aSs9/XFQo7tNZWv7X8pevAGpIQkKC2RHcVqVmFj/77LOaO3euwsLCdPPNN+vNN9+0Ox8VFaW77767VL933nlHksosvpZn1qxZ+uMf/6g+ffpo2LBhioyM1Jo1a/TLL7/oD3/4g92yFtddd50+++wzjRgxQv3795e3t7d69+6tjh07VmrMRx99VF988YU+++wztWvXTjfffLMiIiJ09OhRbd261bbZXU344IMP1KNHD912223q27evOnfurIKCAh08eFDr16/X4MGD9d5770mSevfurc8//1y9evVS7969dfLkSS1ZskTBwcGlrnvTTTfJYrHotddeU0pKigIDA9WmTRv1799fw4YN09NPP6133nlHKSkpiomJ0caNG5WQkGArMjsjJCRE77zzjsaMGaO2bdtq0KBBuuKKK3T+/HklJibq22+/1QcffKA777xTM2fO1Pvvv6/evXurVatW8vb21nfffadffvlFPXv2rNS4AAAAAACYxmqRxvaVrm1dc2Os+lvFbeoHSm//ueirPJfOKL5Uu6bSsr9WPtucR8peSxmoovz8fLMjuK1KFYt//vlnSVJKSoqefvrpUufbt29fqlicnp6ur776SmFhYRo5cmSlA95yyy366quv9Mwzz+iTTz5RTk6OGjRooHHjxmnGjBl2bcePH6+tW7fqyy+/1IYNG2QYhl555ZVKF4ulos31pk+frg8++ED/+Mc/lJ+fr5CQELVp00bPPvtspa/nrLZt22rbtm16+umntW7dOn311Vfy8vJSeHi4evXqpfvuu8/WduHChXr44Ydta/+Gh4frrrvuUvfu3XXXXXfZXbddu3aaNm2aZs+ereeff14FBQXq27ev+vfvLy8vLy1fvlx//vOf9cknn8jDw8M2w/n666+vVP6RI0eqRYsW+tvf/qaVK1cqLS1NAQEBatSoke69917b9fr376/t27fru+++0/Lly2W1WtWwYUNNnDhRL774YvW/kQAAAAAA1DSrpWid3ufs/x+8+Dd4AVRNSEiI2RHclsWozDoDAAAAAAAAddHmfdLNUyrfb+kz0h/s11dNTExU69Y1ONMYqOMyMjIUGBhodgy3xA5iAAAAAAAAleVhlYbfUKpQLEmZmZkmBALqjv3795sdwW1RLAYAAAAAAKgMi6Rgf2naKIenAwICajcPALgIxWIAAAAAAIDKMCTNfEAKdfxr8s2bN6/dPEAdEx0dbXYEt0WxGAAAAAAAwFkeVql/F2nwtWU22bVrVy0GAuqeixcvmh3BbVEsBgAAAAAAcJavd9GsYovF7CRAnXXmzBmzI7gtisUAAAAAAADOmnaP1Ci03CZRUVG1FAYAXMvT7AAAAAAAAACXPQ+r1K2NNKp3hU0tzDoGqiUuLs7sCG6LmcUAAAAAAAAV8bBKb//ZqeUnkpOTayEQUHft3r3b7Ahui2IxAAAAAABAeSySnhsmtYw0OwngFnJzc82O4LZYhgIAAAAAAKAsHlbpyqbSIwOc7tKuXbsaDATUfcHBwWZHcFvMLAYAAAAAACjPnEckTw+nmx89erQGwwB1X2Qks/jNQrEYAAAAAADAEYtFmnCb1KF5pbplZGTUUCDAPSQmJpodwW2xDAUAAAAAAEBJHhapeQPpL3dUuquvr28NBAKAmsfMYgAAAAAAgJIKjaLlJ3y9K921VatWNRAIcB/NmjUzO4LbolgMAAAAAABwKatFeqCP1K1NlbonJCS4OBDgXnJycsyO4LYoFgMAAAAAABSzWKQG9aTnh5udBHBbp06dMjuC22LNYgAAAAAAgC4xOjXyOjXM85BG9pKC/Kp8qcjISNflAoBaZDEMwzA7BAAAAAAAgNkKCgrk4eFhdgzA7fEsmodlKAAAAAAAACTt27fP7AgAxLNoJorFAAAAAAAAkrKzs82OAEA8i2aiWAwAAAAAACApKCjI7AgAxLNoJtYsBgAAAAAAUNFsRl9fX7NjAG6PZ9E8zCwGAAAAAACQtGfPHrMjABDPopkoFgMAAAAAAAAAKBYDAAAAAABIUpMmTcyOAEA8i2aiWAwAAAAAACCpoKDA7AgAxLNoJorFAAAAAAAAkk6cOGF2BADiWTQTxWIAAAAAAAAAgCyGYRhmhwAAAAAAADBbXl6evLy8zI4BuD2eRfMwsxgAAAAAAEBSUlKS2REAiGfRTBSLAQAAAAAAJGVmZpodAYB4Fs1EsRgAAAAAAEBSQECA2REAiGfRTKxZDAAAAAAAICk3N1fe3t5mxwDcHs+ieZhZDAAAAAAAIGnXrl1mRwAgnkUzUSwGAAAAAAAAAFAsBgAAAAAAkKSoqCizIwAQz6KZKBYDAAAAAABIslgsZkcAIJ5FM1EsBgAAAAAAkJScnGx2BADiWTQTxWIAAAAAAAAAgCyGYRhmhwAAAAAAADBbTk6OfHx8zI4BuD2eRfMwsxgAAAAAAEDS0aNHzY4AQDyLZqJYDAAAAAAAICkjI8PsCADEs2gmisUAAAAAAACSfH19zY4AQDyLZmLNYgAAAAAAAEn5+fny9PQ0Owbg9ngWzcPMYgAAAAAAAEkJCQlmRwAgnkUzUaLH71pBQYESExPNjgEAAAAAqAMOHjwoHx8fs2MAbo9n0bHWrVvLw8OjRsegWIzftcTERF155ZVmxwAAAAAAAABq1K5du9SuXbsaHYM1i/G75uzM4oyMDF1zzTXavHmzAgMDayEZcHnhGYC74xmAu+MZgLvjGYAzTp48qd69e2vdunWKjIw0O45L8QzA3dWVZ6A2ZhZTLIZbSEtLU7169XThwgUFBwebHQeodTwDcHc8A3B3PANwdzwDcMaxY8fUtGlTHT16VE2aNDE7jkvxDMDd8Qw4jw3uAAAAAAAAAAAUiwEAAAAAAAAAFIvhJnx8fPS3v/2NnTThtngG4O54BuDueAbg7ngG4Izg4GD17NmzTv6KOs8A3B3PgPNYsxgAAAAAAAAAwMxiAAAAAAAAAADFYgAAAAAAAACAKBYDAAAAAAAAAESxGAAAAAAAAAAgisWoo+bOnasRI0aobdu28vDwkMViqfQ1evXqJYvF4vDr559/roHUgOu44hmQpFWrVun6669XQECAQkNDNWTIECUlJbk4LVAzPvzwQ3Xu3Fl+fn5q2LChHnjgAZ05c8bp/tHR0WX+d+Ds2bM1mBxwTmFhod588021bdtWvr6+atq0qZ588kldvHixVvoDZqvue7isv+MDAwNrODngGtOmTdOQIUMUExMji8Wi6OjoKl2nup+ZALO44hngM39pFsMwDLNDAK4WHR2tlJQUde7cWUlJSTp27Jgq+1bv1auXdu7cqTfffLPUuQEDBig0NNRVcQGXc8Uz8J///Ed33nmn4uLi9OCDD+rChQuaOXOmPDw89PPPPysqKqqG0gPV9+abb2rixInq2bOn7r77bh07dkxvvPGGmjdvrs2bNysgIKDCa0RHR8vPz0+TJ08udW7IkCHy8fGpieiA08aNG6dZs2bp9ttvV//+/bV7927Nnj1bN9xwg7755htZreXPC6luf8Bs1X0PWywW3XDDDRo7dqzdcS8vLw0bNqwmowMuYbFYFBoaqi5dumjr1q0KDg7WoUOHKnUNV3xmAsziimeAz/wOGEAdlJSUZBQUFBiGYRgDBw40qvJW79mzp9G8eXMXJwNqR3WfgdzcXCMqKspo1qyZkZ6ebjv+66+/Glar1XjwwQddmhdwpTNnzhj+/v5G165djfz8fNvxzz//3JBkvPzyy05dp3nz5kbPnj1rKCVQPQkJCYbFYjHuuOMOu+OzZs0yJBn/+te/arQ/YDZXvIclGaNGjaqhhEDNO3DggO3PsbGxlf7/V1d9ZgLMUt1nwDD4zO8I0wVQJ0VHR7tsNkxhYaHS0tIqPSsTMFN1n4ENGzbo+PHjeuCBB+x+FbNTp07q1auXFi9erLy8PFdEBVxu2bJlyszM1OOPPy4PDw/b8VtvvVUxMTFatGhRpa6Xn5+vtLQ0V8cEquXjjz+WYRgaP3683fEHH3xQ/v7+Fb7Pq9sfMJsr38O5ubnKyMhwcUKg5sXExFSrv6s/MwG1rbrPwKX4zP8bisVAOZKTkxUYGKh69eopMDBQd9xxh/bs2WN2LKDGbdmyRZJ03XXXlTrXrVs3paWlKTExsbZjAU6p6P27Z88ep4sCmzZtkr+/v+rVq6eQkBCNGjVKx48fd2leoCq2bNkiq9Wqa665xu64r6+vOnXqZHsOaqo/YDZXvYeXLFkif39/BQUFqUGDBnr88cd14cKFmogMXHZc+ZkJ+D3jM789T7MDAJerFi1aqHv37urYsaM8PDy0adMmvf3221q7dq2+//57dejQweyIQI0p/g9j48aNS50rPpacnKzY2NhazQU4o6L3r2EYOn78uFq3bl3udWJjY/XAAw+oXbt2ysvL07fffqt//OMfWrt2rTZv3sy63TDV8ePHFR4e7nAdvcaNG+uHH35Qbm6uvL29a6Q/YDZXvIevueYaDRkyRK1atVJaWppWrVqlt99+Wxs2bNAPP/zARneo81z1mQn4PeMzf2kUi3HZSk1N1cyZM51u/8QTT7h007kFCxbYvb7zzjt12223qVevXpo4caK+/vprl40FOGLmM5CZmSlJDv8HzNfX164NUFOq+gy46v27cuVKu9d33XWXbrzxRo0YMUJ/+9vfNG/ePKezAa6WmZlZ5oYrl77PyyqUVbc/YDZXvIc3bdpk9/ree+9Vx44dNXnyZL311lsONzsC6hI+8wN85neEYjEuW6mpqZo6darT7UeOHOnSYrEjN9xwg2688UatX79eWVlZ8vPzq9Hx4N7MfAb8/f0lSTk5OaXOZWdn27UBakpVn4FL378l/56u7vv37rvv1uTJk0t9qARqm7+/v06fPu3wnDPv8+r2B8xWU+/hp556SlOnTtXKlSspFqPOq8nPTMDvmbt/5mfNYly2oqOjZRiG01+tWrWqtVwFBQU6f/58rYwH92XmM1D8qzbJycmlzhUfc/TraoArVfUZqOj9a7FYqvXrZNHR0Tp79myV+wOuEBUVpbNnzzr8oV5ycrLCw8PLnVFZ3f6A2WrqPezl5WW7NlDX1fRnJuD3zJ0/81MsBipp37598vT0rPFZzICZunbtKkn68ccfS5376aefFBwczNpluGxV9P5t06ZNtdah3L9/vxo2bFjl/oArdO3aVYWFhdq8ebPd8ezsbG3btk1XX311jfYHzFZT7+Hs7GwdO3aMv+fhFmr6MxPwe+bOn/kpFsPtnThxQnv27LFbi+nChQsqKCgo1XblypXauHGjbrnlFtsaTsDvnaNnoGfPnmrUqJH+8Y9/2O2AvH37dn377bcaMmSIvLy8zIgLVGjQoEHy8/PT22+/bfd3+YoVK3Tw4EGNGDHCrv2RI0e0Z88e5eXl2Y6dO3fO4bXfeecdHTt2TLfeemvNhAecNGzYMFksllLres+bN0+ZmZl27/MDBw5oz549Ve4PXI6q+wykpKQ4vO6UKVOUn5/P3/Oocxx93qnsZybg94zP/M6zGIZhmB0CcLUVK1Zo+/btkqRFixZp7969evHFFyVJISEheuyxx2xtR48erQ8++EDr169Xr169JEnLli3TxIkTdeuttyomJkaenp7avHmzFi1apNDQUG3cuJFZlbisVfcZkKRPP/1Uw4YNU1xcnB588EGlpaXpzTfflMVi0datW1mGApe1119/XZMmTVKvXr00fPhwJScn6/XXX1fTpk21ZcsWu1kyvXr10oYNG5SUlKTo6GhJ0syZMzV//nz169dP0dHRys/P17fffqtly5apZcuW+vHHHxUREWHS3QFFHn/8cb399tu6/fbbNWDAAO3evVuzZs1S9+7dtW7dOlmtRfNCoqOjdfjwYZX82O9sf+ByVZ1nYMKECfrpp5900003qVmzZsrIyNCqVau0fv16XXvttVq/fj37k+Cyt3DhQh0+fFiSNHv2bOXm5urJJ5+UJDVv3lz33HOPra2jzztS5T4zAZeb6j4DfOYvgwHUQaNGjTIkOfxq3ry5w7br16+3Hdu1a5cxZMgQIyYmxggICDC8vb2NmJgY45FHHjGOHTtWuzcDVEF1n4FiK1asMK699lrDz8/PCAkJMf70pz8Z+/fvr52bAKppwYIFRseOHQ0fHx8jIiLCuO+++4xTp06VatezZ09DkpGUlGQ79v333xu33nqr0bRpU8PX19fw8fEx2rZtazz99NPG+fPna+8mgHLk5+cbr732mtG6dWvD29vbiIqKMiZMmGCkp6fbtWvevLnh6GO/s/2By1V1noFly5YZffr0MaKiogwfHx/D39/fiIuLM15++WUjKyurNm8DqLLizzCOvnr27Omw7aWfd4o5+5kJuNxU9xngM79jzCwGAAAAAAAAALBmMQAAAAAAAACAYjEAAAAAAAAAQBSLAQAAAAAAAACiWAwAAAAAAAAAEMViAAAAAAAAAIAoFgMAAAAAAAAARLEYAAAAAAAAACCKxQAAAAAAAAAASZ5mBwAAAAAAAHCV0aNH64MPPpAkxcbGKiEhwe58YWGhXnnlFS1YsEBHjhxRs2bNdODAAU2fPl3vv/++du3aJau18nPr5syZo1deeUX79u2Tj4+P3bmZM2dqwoQJttdnzpxReHh4Fe6uagoKCvTzzz9r3759ysnJUWhoqLp27aomTZpU2PfChQvasmWLTp06pezsbAUGBqpVq1aKi4uTp+dvZaXjx4/riy++cHiNQYMGqWHDhrbXZ86csV1Tkho0aKBrr722Vr8nABxjZjEAAAAAAPhdWLNmjSwWS5lfH374oSQpPDxcCxcu1N///vdS13j33Xf13HPP6Y477tD777+vuXPnKi0tTa+++qqefvrpUoXiqVOnymq1avfu3aWuNWbMGHl4eGjlypUaPXq0cnNzNXfu3FLt+vXrp4ULF+r222930Xeicr799lvFx8erVatWuv7662W1WrV69WqdPHmy3H4ZGRlaunSpTp8+rdjYWF1//fVq2LChtm7dqrVr1zrs0759e9100012X/Xq1bOdP3v2rD7//HOlp6frqquuUpcuXZSWlqYVK1YoNTXVlbcNoAqYWQwAAAAAAH4Xtm/fLkmaNWuW6tevX+p83759tW7dOgUEBGjkyJEOr7FgwQLdcsstmjFjhu3YzJkzlZ+fr+HDh5dq//DDD+vvf/+7Zs6caVcInj17thYsWKCXXnpJAwcOlCSNGjVKb7zxhh5//HFZLBZb27Zt26pt27bav3+/li5dWrWbr6LTp0/rwIEDuvbaaxUXFydJuuKKK7RkyRJt2rRJgwYNKrPvvn37lJubq9tuu02hoaGSpHbt2skwDNss5ZKzqCMjIxUTE1PmNbds2SJPT08NGjRIvr6+tjyLFy/W5s2b1adPn+reMoBqoFgMAAAAAAB+F+Lj41WvXj099thjdsVYZ2VnZ2v79u2aOnWq3fEFCxbotttusxUvL9WgQQONGDFCCxcu1Msvv6zw8HBt2LBBEydO1J/+9CdNnjzZ1nbo0KGaPn261q9fr969e1f+BmvAwYMHZbFY1K5dO9sxT09PtWnTRlu2bFFGRoYCAwMd9s3NzZUk+fv72x339/eXxWIpc7mO3NxceXp6Ojx/8uRJNW3a1O577e/vr0aNGunIkSPKy8uTl5dXpe8TgGuwDAUAAAAAAPhd2L59uzp37lylQvH9998vPz8/FRQU6Nlnn5XFYtF1112npKQkxcfH6+abby6z74QJE5SVlaU5c+bo6NGjGjp0qNq2bat//vOfdu2uuuoqhYaGavny5ZXO50hhYaGys7Od+jIMw+E1UlJSVK9ePXl7e9sdb9Cgge18WaKioiRJGzZs0NmzZ5WRkaEDBw5o165dio2NdVjU3bBhg/75z39q/vz5WrFihc6cOWN3vqCgQB4eHqX6eXp6qrCwUOfOnSv/mwKgRjGzGAAAAAAAXPZyc3O1d+9e9ejRQ2fPni11vl69euXOSB0xYoS8vLw0d+5cvfXWWwoNDVXz5s31ww8/SJK6dOlSZt/Y2Fj16dNH77zzjpYtW6a8vDwtW7bM4YzcLl26aOPGjVW4w9JOnjxZ5qZxJQ0fPlxBQUGljmdmZpaaGSz9Nlv44sWLZV6zadOmuvrqq/Xrr7/q8OHDtuOdO3dW165d7dparVa1aNHCNms4NTVV27dv1+eff65BgwbZNq8LCQnR6dOnVVhYaJt5XFBQoNOnT1eYB0DNo1gMAAAAAAAue7t27VJeXp7mzJmjOXPmlDq/d+9etW7dusz+vXv31tq1axUQEKDHHnvMVqicMmWKJKlFixbljj9x4kT169dPp0+f1qpVq9SyZUuH7WJiYrRw4UJnb6tcYWFhGjBggFNt/fz8HB7Pz893OJO3+FhBQUG51w0KClKjRo3UokUL+fr66siRI/r111/l5+en9u3b29pFRkYqMjLSrm+LFi20ZMkSbd682XYfV155pb7//nt99913iouLk2EY+uWXX5SZmelUHgA1i2IxAAAAAAC47MXHx0uS/vnPf6px48alzl9xxRVOXSM2NtZuLd2UlBR5enqWuW5vsd27d0sqKgb37du3zHb169dXVlZWmTN6K8PHx0dNmjSp1jU8PT0dFmCLjzkqJBfbv3+/vvvuOw0bNsz2/WnRooUMw9DmzZvVqlUrh+s8F6tXr56io6OVlJRkm0l85ZVXKiMjQ/Hx8UpMTJQkRUREKC4uTr/++ivrFQMmo1gMAAAAAAAue9u3b5enp6eGDx9eav3dylyjvEJvWb755htNmjRJV1xxhfbt26evvvpKffr0cdi2eO3gqqyrXFJBQYFycnKcauvr6+twQzl/f3+HSzsUz+QNCAgo85q7du1SeHh4qUJ68+bNlZiYqLNnz1ZYzA4ICFBhYaHy8/Nt/96uueYaxcXF6fz58/L29lZoaKg2b94sqajADMA8FIsBAAAAAMBlLz4+Xi1atKhyoTg1NVVHjx5Vhw4d7I6HhYUpPz9f6enpDtf8PXjwoIYNG6bOnTvrm2++UevWrfXmm2+WWSw+f/68/P39y1wWojJOnTpV7TWLw8LCdPz4ceXm5tp974rXCA4LCyvzmllZWfLx8Sl1vLCwUJLK3FTvUunp6fLw8Cg1Y9jHx8du2Yrk5GQFBAQoJCSkwmsCqDkUiwEAAAAAwGUvPj5e3bp1q1Z/SerYsaPd8bZt20qSkpKSSp3LyMjQoEGD5OXlpaVLl6pevXp65JFHNHXqVO3evVvt2rUrNU5SUpLD41XhijWLY2JiFB8fr927dysuLk5S0YzlvXv3qkGDBrZZw/n5+crIyJCvr69taYl69erp2LFjSk1NtSviHjhwQBaLRaGhobZjWVlZpTKkpKTo8OHDatq0abkzrQ8cOKAzZ86oW7duLpmRDaDqKBYDAAAAAIDL2smTJ3X69GlbYbcqtm/fLql0sfi6666TJP3888925wzD0D333KO9e/dq/fr1tuUWHnnkEf3973/XzJkzNXfu3FLj/PLLLxoxYkSVc17KFWsWN2jQQDExMdq8ebOysrJUr149JSYmKj09XT179rS1O336tL744gt16dJFV199tSQpLi5OR48e1YoVKxQbGysfHx8dOXJER48eVdu2be2WsFi7dq08PDzUsGFD+fn56fz589qzZ488PT11zTXX2NqdOHFCv/zyixo3bixfX1+dPn1ae/fuVdOmTe02zANgDorFAAAAAADgslZc6D1z5owWLVpU6nxcXFyp5SVKio+PV+PGje1mw0pFM2/bt2+vb775RmPGjLEdf/7557Vs2TLNnTtX3bt3tx2PiIjQyJEjtXDhQr3yyit2yzhs3bpV586d06BBg6p0nzWlV69eCgwM1L59+5Sbm6vQ0FD169dPjRo1Krdfo0aNNGjQIG3dulU7d+5UTk6OgoKC1LVrV9ss5WLR0dHat2+fduzYodzcXPn5+Sk6OlpXXXWV3TrEAQEBslgsio+PV15enu16HTp0cLjmMoDaRbEYAAAAAABc1oqXkFiwYIEWLFhQ6vyHH37oVLG45KziYmPGjNFzzz1nW0ph6dKlevHFF/XQQw9p7NixpdpPmDBB8+fP15w5czR58mTb8U8//VTNmjVT7969K3N7Nc7T01PdunUrdxmPqKgoh/faoEED9e/fv8Ix2rdv79TM4ODgYKeX1gBQ+yyGM6uRAwAAAAAA/A6MHj1a69at0y+//CJPT0+nNky7cOGCYmJiNH36dN1///1VGjcnJ0fR0dH6n//5H40bN87uXHZ2tjIyMjR9+nTNmDFDZ86cUXh4eJXGAYCaxPx+AAAAAABQpxw9elQRERHq0aOHU+3r1aunv/zlL5oxY4YKCwurNOaCBQvk5eWlhx56qNS5OXPmKCIiQjNmzKjStQGgtjCzGAAAAAAA1Bm7du3S8ePHJUmBgYHlLr1QW44ePaq9e/faXvfs2VNeXl4mJgIAxygWAwAAAAAAAABYhgIAAAAAAAAAQLEYAAAAAAAAACCKxQAAAAAAAAAAUSwGAAAAAAAAAIhiMQAAAAAAAABAFIsBAAAAAAAAAKJYDAAAAAAAAAAQxWIAAAAAAAAAgCgWAwAAAAAAAAAk/T9aX6HgrPSbSwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1570x850 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer\n",
+    "\n",
+    "explainer = get_nori_imputation_explainer(nori, X_ctx.values)\n",
+    "sv = explainer.explain(X_test.values[0:1], budget=128)\n",
+    "\n",
+    "print(\"Explaining prediction for row:\")\n",
+    "print(X_test.iloc[0])\n",
+    "sv.plot_waterfall(feature_names=list(X.columns))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "waterfall-explanation-md",
+   "metadata": {},
+   "source": [
+    "### How to read the waterfall plot\n",
+    "\n",
+    "The plot starts at Nori's **baseline prediction** and shows how each feature moves the prediction for this one row:\n",
+    "\n",
+    "- A **positive** contribution pushes the prediction higher than the baseline.\n",
+    "- A **negative** contribution pushes the prediction lower than the baseline. It does **not** mean the feature is bad or should be ignored.\n",
+    "- A longer bar means a larger effect on this prediction; a near-zero bar means little effect for this row.\n",
+    "- The baseline plus all feature contributions equals the final prediction.\n",
+    "\n",
+    "These are **local explanations**: the direction and size can change for another row. Consider ignoring a feature only after checking that it is consistently unimportant across representative data—not merely because its contribution is negative here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "closing-md",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- **One-shot helper:** skip the object entirely with `from synthefy_nori import predict; predict(X_train, y_train, X_test, task=\"regression\")`.\n",
+    "- **Your own checkpoint:** `NoriRegressor(model_path=\"path/to/checkpoint.pt\")`.\n",
+    "- **More interpretability:** partial-dependence plots and sequential feature selection live in `synthefy_nori.interpretability` — see [`examples/interpretability_regression.py`](../interpretability_regression.py).\n",
+    "- **Docs & benchmarks:** [docs.synthefy.com/nori](https://docs.synthefy.com/nori/) and the [model card on Hugging Face](https://huggingface.co/Synthefy/Nori).\n",
+    "\n",
+    "Questions? Join the [Discord](https://discord.gg/rTCCJkht4)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds `examples/notebooks/Nori_Demo_Local.ipynb` — the end-to-end hands-on demo (install → fit/predict → intervals → baseline comparison → interpretability).

Why: the notebook's own Colab badge and the docs sidebar (synthefy-docs PR #49) already point at
`colab.research.google.com/github/Synthefy/synthefy-nori/blob/main/examples/notebooks/Nori_Demo_Local.ipynb` — this makes that link live.

Checked before publishing: no secrets/keys, no internal paths, installs from public PyPI (`synthefy-nori[eval,interpretability]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)