### PR TITLE
Fix expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs](https://img.shields.io/badge/Docs-docs.synthefy.com-2ea44f?logo=readthedocs&logoColor=white)](https://docs.synthefy.com/nori/)
 [![Hugging Face](https://img.shields.io/badge/Hugging%20Face-Synthefy%2FNori-blue?logo=huggingface&logoColor=FFD21E)](https://huggingface.co/Synthefy/Nori)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20710462.svg)](https://doi.org/10.5281/zenodo.20710462)
-[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/rTCCJkht4)
+[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/jpsXMXGza)
 
 Nori is a tabular foundation model for **regression**
 via in-context learning (ICL). Given a few labeled rows as context, it predicts on

--- a/examples/notebooks/Nori_Demo_Local.ipynb
+++ b/examples/notebooks/Nori_Demo_Local.ipynb
@@ -413,7 +413,7 @@
     "- **More interpretability:** partial-dependence plots and sequential feature selection live in `synthefy_nori.interpretability` — see [`examples/interpretability_regression.py`](../interpretability_regression.py).\n",
     "- **Docs & benchmarks:** [docs.synthefy.com/nori](https://docs.synthefy.com/nori/) and the [model card on Hugging Face](https://huggingface.co/Synthefy/Nori).\n",
     "\n",
-    "Questions? Join the [Discord](https://discord.gg/rTCCJkht4)."
+    "Questions? Join the [Discord](https://discord.gg/jpsXMXGza)."
    ]
   }
  ],


### PR DESCRIPTION
The Discord invite `discord.gg/rTCCJkht4` has **expired** (verified via Discord's invite API). Repointed to the current invite `discord.gg/jpsXMXGza` (guild "Synthefy-Nori").

Files:
- `README.md` — Discord community badge
- `examples/notebooks/Nori_Demo_Local.ipynb` — "Questions? Join the Discord" link

Fixing this in **public** (the cascade root); the same dead link in `staging` and `internal` README/notebook will be carried up automatically by rebase-sync, so no separate PRs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)