### PR TITLE
docs: warn Colab users to switch to a GPU runtime

### DIFF
--- a/examples/notebooks/Nori_Demo_Local.ipynb
+++ b/examples/notebooks/Nori_Demo_Local.ipynb
@@ -20,14 +20,14 @@
     "5. [Probabilistic output](#quantiles) — quantiles and prediction intervals\n",
     "6. [Interpretability](#interpretability) — Shapley values for a single prediction\n",
     "\n",
-    "Everything runs on a free Colab CPU; a GPU makes it faster but is not required."
+    "Use a GPU runtime (free-tier T4 is fine) — see the note below; CPU works but is much slower."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> ⚠️ **Use a GPU runtime.** Nori runs a forward pass per prediction call, and on CPU this notebook is painfully slow (minutes per cell instead of seconds). **On Colab, switch before running anything:** `Runtime → Change runtime type → Hardware accelerator → T4 GPU` → Save. The free tier's T4 is plenty — Nori is only 6M parameters. Running locally? Any CUDA GPU works; CPU works too but expect the benchmark cells to take a while."
+    "> ⚠️ **Use a GPU runtime.** Nori runs a forward pass per prediction call, and on CPU this notebook is painfully slow (minutes per cell instead of seconds). **On Colab, switch before running anything:** `Runtime → Change runtime type → Hardware accelerator → T4 GPU` → Save. The free tier's T4 is plenty. Running locally? Any CUDA GPU works; CPU works too but expect the benchmark cells to take a while."
    ]
   },
   {

--- a/examples/notebooks/Nori_Demo_Local.ipynb
+++ b/examples/notebooks/Nori_Demo_Local.ipynb
@@ -25,6 +25,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> ⚠️ **Use a GPU runtime.** Nori runs a forward pass per prediction call, and on CPU this notebook is painfully slow (minutes per cell instead of seconds). **On Colab, switch before running anything:** `Runtime → Change runtime type → Hardware accelerator → T4 GPU` → Save. The free tier's T4 is plenty — Nori is only 6M parameters. Running locally? Any CUDA GPU works; CPU works too but expect the benchmark cells to take a while."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "install-md",
    "metadata": {},
    "source": [
@@ -58,6 +65,28 @@
    "metadata": {},
    "source": [
     "> **Colab note:** if the install pulls a new PyTorch/CUDA build, restart the runtime once (**Runtime → Restart runtime**) before continuing so the fresh libraries load cleanly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GPU check — don't skip on Colab. CPU works but is ~10-100x slower for the cells below.\n",
+    "try:\n",
+    "    import torch\n",
+    "\n",
+    "    if torch.cuda.is_available():\n",
+    "        print(f\"GPU OK: {torch.cuda.get_device_name(0)}\")\n",
+    "    else:\n",
+    "        print(\n",
+    "            \"*** NO GPU DETECTED - this notebook will be VERY slow on CPU. ***\\n\"\n",
+    "            \"On Colab: Runtime -> Change runtime type -> Hardware accelerator -> T4 GPU,\\n\"\n",
+    "            \"then re-run from the top.\"\n",
+    "        )\n",
+    "except ImportError:\n",
+    "    print(\"torch not installed yet - run the install cell above first.\")"
    ]
   },
   {


### PR DESCRIPTION
CPU Colab is too slow for the demo notebook. Two additions:

1. **Warning cell right under the title**: switch to GPU before running anything (`Runtime → Change runtime type → T4 GPU`); notes the free-tier T4 is plenty for a 6M-param model.
2. **GPU-check code cell after install**: prints `GPU OK: <name>` when CUDA is available, or a loud *NO GPU DETECTED — this will be VERY slow* notice with the exact Colab steps.

No changes to the demo content itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)