### PR TITLE
fix(training): raise default NCCL_TIMEOUT to 3h so slow eval can't abort DDP runs

### DIFF
--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -436,10 +436,19 @@ def main():
     distributed = world_size > 1
 
     if distributed:
-        # Per-layer compile can take >10min per new shape on 14 layers.
-        # Default 600s NCCL timeout causes rank desync during compilation.
+        # NCCL collective timeout. Must exceed the longest interval any rank can
+        # spend OUTSIDE a collective while the others wait in one, else the
+        # waiters abort (SIGABRT: "Watchdog caught collective operation
+        # timeout ... BROADCAST"). Two known long gaps:
+        #   * per-layer compile: >10min per new shape (the original reason this
+        #     was raised from the 600s default);
+        #   * periodic validation: rank 0 runs the full eval suite while the
+        #     other ranks block on the post-eval broadcast (see Trainer's
+        #     _run_validation). A large eval set / big eval context easily
+        #     exceeds 60min, so the previous 3600s default crashed multi-GPU
+        #     training mid-eval. Default to 3h; override with NCCL_TIMEOUT.
         import datetime as _dt
-        nccl_timeout = int(os.environ.get('NCCL_TIMEOUT', '3600'))
+        nccl_timeout = int(os.environ.get('NCCL_TIMEOUT', '10800'))
         torch.distributed.init_process_group(
             backend='nccl',
             timeout=_dt.timedelta(seconds=nccl_timeout))


### PR DESCRIPTION
## Problem
Multi-GPU (DDP) training aborts **mid-validation** with an NCCL collective timeout:

```
Watchdog caught collective operation timeout: WorkNCCL(... OpType=BROADCAST ...)
ran for 3600001 ms before timing out  ->  Signal 6 (SIGABRT)
```

**Why:** validation runs on **rank 0 only** (`Trainer._run_validation`). The other ranks skip the eval block and immediately hit the post-eval `torch.distributed.broadcast(stop_tensor, src=0)`, where they **block for the entire eval duration**. `init_process_group` used a **3600s (60 min)** default timeout (`NCCL_TIMEOUT`), so any run whose eval suite exceeds ~60 min (large eval set / big eval context / many quantiles) trips NCCL's watchdog and the whole run dies — losing hours of training.

Observed concretely on a 4-GPU run: the eval suite (30 datasets) takes ~60 min; the dense arm crossed the 60-min line during eval and aborted, while a sibling arm that finished eval just under 60 min survived.

## Fix
Raise the default collective timeout **3600 → 10800s (3h)**, still overridable via `NCCL_TIMEOUT`. Updated the comment to document the eval-blocking gap (not just the pre-existing compile gap).

Purely a robustness change:
- runs whose eval fits the old 60-min window: **no behavioral change**;
- runs with slow eval: **no longer crash**;
- a genuinely hung collective still fails, just after 3h instead of 1h (acceptable — losing a run to a slow eval is the worse failure).

This is shared training code (`public ⊆ staging ⊆ internal`), so landing it in public fixes it for all tiers via the sync cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)