### PR TITLE
release: v0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.12.0"
+version = "0.12.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -12,7 +12,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 __all__ = [
     "NoriRegressor",

--- a/uv.lock
+++ b/uv.lock
@@ -3781,7 +3781,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Version bump `0.12.0` → `0.12.1` to **publish the widened torch pin from #90** (`torch>=2.8,<2.14`) to PyPI.

**Why:** #90 changed the published torch requirement on `main` but did not bump the version, and `0.12.0` is already on PyPI (with the old `torch>=2.8,<2.9`) — PyPI won't allow re-uploading it. Downstream integrations (notably `autogluon.tabular[nori]`) can't co-resolve their `torch>=2.10` until a release carries the wider range.

**Changes:** version bump only, in `pyproject.toml`, `src/synthefy_nori/__init__.py`, and the project's own entry in `uv.lock`. No code changes.

**Release steps (after merge):** trigger `publish.yml` (Actions → publish → Run workflow → target `pypi`, or `gh workflow run publish.yml --ref main -f target=pypi`), then approve the `pypi` environment gate.