### PR TITLE
configs: default to svd48 everywhere, resolved from one DEFAULT_CONFIG_NAME

### DIFF
--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from importlib.resources import files
+from .configs import DEFAULT_CONFIG_NAME
+from .configs import config_path as _config_path
 from typing import Literal
 
 import numpy as np
@@ -24,7 +25,7 @@ Task = Literal["regression", "reg"]
 
 def config_path(filename: str) -> str:
     """Return an absolute path for a bundled inference config."""
-    return str(files("synthefy_nori.configs").joinpath(filename))
+    return _config_path(filename)
 
 
 def _default_device():
@@ -148,9 +149,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         self.model = model
         self.device = device
         self.token = token
-        self.inference_config = inference_config or config_path(
-            "reg_allordinal_poly10_adaptive_svd256.json"
-        )
+        self.inference_config = inference_config or config_path(DEFAULT_CONFIG_NAME)
         self.augmentations = tuple(augmentations) if augmentations else ()
         self.yj_skew_threshold = float(yj_skew_threshold)
         self.quantile_collapse = quantile_collapse

--- a/src/synthefy_nori/configs/__init__.py
+++ b/src/synthefy_nori/configs/__init__.py
@@ -1,3 +1,28 @@
-"""Bundled inference configuration files."""
+"""Bundled inference configuration files.
+
+``DEFAULT_CONFIG_NAME`` is the config every entry point falls back to — the public
+``NoriRegressor``, the eval CLI and the eval model wrapper all resolve to the same file,
+so evaluation measures what inference actually does.
+
+It pins ``svd_components=48``. The ``HighDimFeatureSelector`` gate fires only above 256
+features, and on those tables a rank of 48 beats the 256 previously pinned here:
++0.020 mean R² over 109 wide tables (p=0.025) and ~2.9x faster inference. At or below
+256 features the selector is a passthrough, so the change is a no-op for most tables.
+
+``reg_allordinal_poly10_adaptive_svd256.json`` is still bundled: pass it explicitly to
+reproduce numbers produced before this became the default.
+"""
 
 from __future__ import annotations
+
+from importlib.resources import files
+
+DEFAULT_CONFIG_NAME = "reg_allordinal_poly10_adaptive_svd48.json"
+LEGACY_SVD256_CONFIG_NAME = "reg_allordinal_poly10_adaptive_svd256.json"
+
+__all__ = ["DEFAULT_CONFIG_NAME", "LEGACY_SVD256_CONFIG_NAME", "config_path"]
+
+
+def config_path(filename: str) -> str:
+    """Return an absolute path for a bundled config file."""
+    return str(files("synthefy_nori.configs").joinpath(filename))

--- a/src/synthefy_nori/configs/reg_allordinal_poly10_adaptive_svd48.json
+++ b/src/synthefy_nori/configs/reg_allordinal_poly10_adaptive_svd48.json
@@ -1,0 +1,306 @@
+[
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "quantile_uniform_all_data"
+   ],
+   "discrete_flag": false,
+   "original_flag": true,
+   "svd_tag": "svd"
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "quantile_uniform_all_data"
+   ],
+   "discrete_flag": false,
+   "original_flag": true,
+   "svd_tag": "svd"
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "quantile_uniform_all_data"
+   ],
+   "discrete_flag": false,
+   "original_flag": true,
+   "svd_tag": "svd"
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "quantile_uniform_all_data"
+   ],
+   "discrete_flag": false,
+   "original_flag": true,
+   "svd_tag": "svd"
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "adaptive"
+   ],
+   "discrete_flag": false,
+   "original_flag": false,
+   "svd_tag": null
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "adaptive"
+   ],
+   "discrete_flag": false,
+   "original_flag": false,
+   "svd_tag": null
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "adaptive"
+   ],
+   "discrete_flag": false,
+   "original_flag": false,
+   "svd_tag": null
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ },
+ {
+  "MaxFeatureSubsampler": {
+   "max_features": 500
+  },
+  "PolynomialInteractionGenerator": {
+   "max_interaction_features": 10
+  },
+  "CategoricalFeatureEncoder": {
+   "encoding_strategy": "ordinal_strict_feature_shuffled"
+  },
+  "FeatureShuffler": {
+   "mode": "shuffle"
+  },
+  "RebalanceFeatureDistribution": {
+   "worker_tags": [
+    "adaptive"
+   ],
+   "discrete_flag": false,
+   "original_flag": false,
+   "svd_tag": null
+  },
+  "retrieval_config": {
+   "use_retrieval": false,
+   "retrieval_before_preprocessing": false,
+   "calculate_feature_attention": false,
+   "calculate_sample_attention": false,
+   "subsample_ratio": 0.7,
+   "subsample_type": "sample",
+   "use_type": "mixed"
+  },
+  "FingerprintFeatureEncoder": true,
+  "HighDimFeatureSelector": {
+   "strategy": "svd_all",
+   "svd_components": 48,
+   "n_features_threshold": 256,
+   "binary_threshold": 1.01
+  }
+ }
+]

--- a/src/synthefy_nori/evaluation/cli.py
+++ b/src/synthefy_nori/evaluation/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from synthefy_nori.api import config_path
+from ..configs import DEFAULT_CONFIG_NAME, config_path
 
 
 def _parse_checkpoint(raw: str) -> tuple[str, str]:
@@ -28,7 +28,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--download-benchmarks", action="store_true",
                         help="Download the TabArena and TALENT regression CSV caches from OpenML first")
     parser.add_argument("--custom-reg-dir", default=None)
-    parser.add_argument("--reg-config", default=config_path("reg_allordinal_poly10_adaptive_svd256.json"))
+    parser.add_argument("--reg-config", default=config_path(DEFAULT_CONFIG_NAME))
     parser.add_argument("--sources", nargs="+", default=None)
     parser.add_argument("--max-train-samples", type=int, default=50000)
     parser.add_argument("--max-predict-samples", type=int, default=50000)

--- a/src/synthefy_nori/evaluation/models.py
+++ b/src/synthefy_nori/evaluation/models.py
@@ -11,7 +11,7 @@ import os
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from importlib.resources import files
+from ..configs import DEFAULT_CONFIG_NAME, config_path
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -20,7 +20,7 @@ import torch
 
 
 def package_config_path(filename: str) -> str:
-    return str(files("synthefy_nori.configs").joinpath(filename))
+    return config_path(filename)
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +74,7 @@ class NoriWrapper(BaseModelWrapper):
         self.model_path = model_path
         self.device = torch.device(device)
         self.reg_config_path = reg_config_path or package_config_path(
-            "reg_allordinal_poly10_adaptive_svd256.json"
+            DEFAULT_CONFIG_NAME
         )
         self.base_config_path = base_config_path
         self.augmentations = tuple(augmentations) if augmentations else ()

--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from importlib.resources import files
+from ..configs import config_path
 
 
 def package_config_path(filename: str) -> str:
-    return str(files("synthefy_nori.configs").joinpath(filename))
+    return config_path(filename)
 
 
 @dataclass

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -3,10 +3,11 @@ from pathlib import Path
 import pytest
 
 from synthefy_nori import NoriRegressor, config_path
+from synthefy_nori.configs import DEFAULT_CONFIG_NAME, LEGACY_SVD256_CONFIG_NAME
 
 
 def test_config_path_points_to_bundled_file():
-    path = Path(config_path("reg_allordinal_poly10_adaptive_svd256.json"))
+    path = Path(config_path(LEGACY_SVD256_CONFIG_NAME))
     assert path.name == "reg_allordinal_poly10_adaptive_svd256.json"
     assert path.exists()
 
@@ -14,7 +15,9 @@ def test_config_path_points_to_bundled_file():
 def test_regressor_uses_default_regression_config():
     model = NoriRegressor(model_path="local.pt")
     assert model.model_path == "local.pt"
-    assert model.inference_config.endswith("reg_allordinal_poly10_adaptive_svd256.json")
+    assert model.inference_config.endswith(DEFAULT_CONFIG_NAME)
+    # the default is rank 48; svd256 stays bundled for reproducing older numbers
+    assert DEFAULT_CONFIG_NAME == "reg_allordinal_poly10_adaptive_svd48.json"
 
 
 def test_regressor_stores_model_variant_verbatim():

--- a/tests/test_default_config.py
+++ b/tests/test_default_config.py
@@ -1,0 +1,63 @@
+"""One default config, resolved from one constant, used by every entry point.
+
+The public ``NoriRegressor``, the eval CLI and the eval model wrapper all fall back to
+``DEFAULT_CONFIG_NAME``, so evaluation measures what inference actually does. Keeping
+those in sync is the point of these tests.
+"""
+import json
+from pathlib import Path
+
+from synthefy_nori.configs import (
+    DEFAULT_CONFIG_NAME,
+    LEGACY_SVD256_CONFIG_NAME,
+    config_path,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src" / "synthefy_nori"
+
+
+def _selectors(name):
+    return [m["HighDimFeatureSelector"] for m in json.load(open(config_path(name)))]
+
+
+def test_default_config_is_bundled_and_pins_rank_48():
+    assert DEFAULT_CONFIG_NAME == "reg_allordinal_poly10_adaptive_svd48.json"
+    assert Path(config_path(DEFAULT_CONFIG_NAME)).is_file()
+    sels = _selectors(DEFAULT_CONFIG_NAME)
+    assert sels
+    for s in sels:
+        assert s["svd_components"] == 48
+        # Gate stays at 256: lowering it to 64 so the selector reaches 64 < p <= 256
+        # cost -0.069 across the 13 standard-suite tables in that band (12/13 lost).
+        assert s["n_features_threshold"] == 256
+
+
+def test_legacy_config_still_shipped_for_reproducing_older_numbers():
+    assert Path(config_path(LEGACY_SVD256_CONFIG_NAME)).is_file()
+    for s in _selectors(LEGACY_SVD256_CONFIG_NAME):
+        assert s["svd_components"] == 256
+
+
+def test_default_differs_from_legacy_only_in_rank():
+    a, b = _selectors(LEGACY_SVD256_CONFIG_NAME), _selectors(DEFAULT_CONFIG_NAME)
+    assert len(a) == len(b)
+    for x, y in zip(a, b):
+        assert {k: v for k, v in x.items() if k != "svd_components"} == \
+               {k: v for k, v in y.items() if k != "svd_components"}
+
+
+def test_no_module_hardcodes_a_config_filename():
+    """Every consumer must go through the constant."""
+    allowed = {SRC / "configs" / "__init__.py"}
+    offenders = [
+        str(py.relative_to(ROOT)) for py in SRC.rglob("*.py")
+        if py not in allowed
+        and (DEFAULT_CONFIG_NAME in py.read_text() or LEGACY_SVD256_CONFIG_NAME in py.read_text())
+    ]
+    assert not offenders, f"hardcoded config filename in: {offenders}"
+
+
+def test_every_entry_point_resolves_to_the_same_default():
+    for rel in ("api.py", "evaluation/cli.py", "evaluation/models.py"):
+        assert "DEFAULT_CONFIG_NAME" in (SRC / rel).read_text(), f"{rel} bypasses the constant"

--- a/tests/test_interpretability.py
+++ b/tests/test_interpretability.py
@@ -4,6 +4,7 @@ an end-to-end shapiq/PDP/feature-selection smoke test behind a stub predictor.""
 import numpy as np
 import pytest
 
+from synthefy_nori.configs import DEFAULT_CONFIG_NAME
 from synthefy_nori import NoriRegressor
 
 
@@ -16,7 +17,7 @@ def test_regressor_is_sklearn_estimator_and_clones():
     assert params["model_path"] == "local.pt"
     c = clone(m)                                 # required by SequentialFeatureSelector/cross_val
     assert c.get_params()["model_path"] == "local.pt"
-    assert c.inference_config.endswith("reg_allordinal_poly10_adaptive_svd256.json")
+    assert c.inference_config.endswith(DEFAULT_CONFIG_NAME)
 
 
 def test_imputation_explainer_requires_shapiq_or_runs():


### PR DESCRIPTION
## One default, used everywhere

The bundled default pinned `svd_components=256`. This makes **`reg_allordinal_poly10_adaptive_svd48.json`** the single default for every entry point — the public `NoriRegressor`, the eval CLI, and the eval model wrapper.

Deliberately *one* config rather than a separate eval default: a divergent eval config would make evaluation stop predicting production, which defeats the point of evaluating.

| | |
|---|---|
| `configs/__init__.py` | **owns** `DEFAULT_CONFIG_NAME`, `LEGACY_SVD256_CONFIG_NAME`, and the one `config_path` |
| `configs/reg_..._svd48.json` | **new** — the svd256 config at rank 48, nothing else changed |
| `api.py`, `evaluation/cli.py`, `evaluation/models.py` | resolve `DEFAULT_CONFIG_NAME` |
| `training/config.py` | helper delegates |
| `tests/test_default_config.py` | **new**, 5 tests |

## Why 256 was wrong

`svd256` isn't a reduction on the tables the gate fires on. With median n=190 vs p=1901, `fitted_k = min(256, p−1, n−1)` is **189**, and **67/109** tables keep *every* `min(n,p)−1` direction — it's a rotation into the full row space, not a truncation.

The retained noise tail then gets **whitened** by the downstream per-column quantile map: column-variance spread collapses **5.6e5 → 1.02**. So a direction 3–4 orders of magnitude below PC1 arrives at the model with PC1's dynamic range. That's why the fix has to be dropping components rather than rescaling them.

## Results

109 wide tables (>256 features: 107 RamanBench spectra + `topo_2_1` + `QSAR-TID-11`), Nori-100M full context, paired:

| config | mean R² | Δ | Wilcoxon | win/loss |
|---|---|---|---|---|
| svd256 (was) | +0.6491 | — | — | — |
| **svd48 (now)** | **+0.6687** | **+0.0197** | **0.025** | 60/45 |

Latency, 3 large-n wide tables (n 6234–7108):

| k | wall | vs svd256 |
|---|---|---|
| **48** | **171s** | **2.9× faster** |
| 64 | 201s | 2.4× |
| 256 | 491s | — |

## Blast radius is narrow, by construction

The gate is `(n_features > 256) OR (binary_frac >= binary_threshold)`, and `binary_threshold=1.01` is unreachable since `binary_frac <= 1`. So the gate is **exactly `n_features > 256`**, and the selector is a **passthrough** below it.

Of the 148 tables in the standard eval suite only **2** exceed 256 features → **146 are byte-identical**. That's analytic, and it was verified empirically on a p=53 table where predictions matched to **0.000e+00**.

The two that change:

| table | benchmark | p | svd256 | svd48 |
|---|---|---|---|---|
| `topo_2_1` | TALENT-100 | 266 | +0.0478 | +0.0483 |
| `QSAR-TID-11` | TabArena | 1024 | +0.7456 | **+0.7186** |

| scope | Δ |
|---|---|
| OpenML CTR23 (35) | 0.000000 |
| TALENT-100 (100) | +0.000005 |
| **TabArena (13)** | **−0.002072** |
| **Overall (148)** | **−0.000178** |

**A trade, not a free win.** `QSAR-TID-11` has the highest effective rank measured (erank 736) — precisely where truncation should hurt — so its −0.027 is mechanism-consistent, not noise.

## Reproducing older numbers

`reg_allordinal_poly10_adaptive_svd256.json` stays bundled as `LEGACY_SVD256_CONFIG_NAME`. Pass it explicitly (`--reg-config`, or `inference_config=`) to reproduce anything measured before this became the default. **Existing leaderboard baselines were computed at svd256** and are not comparable on the 2 gated tables; they are untouched here.

## Rejected alternatives — all measured

| option | result |
|---|---|
| centered SVD (real PCA) | **loses** 0.013–0.015 at three matched k — the mean/baseline direction carries signal |
| gate lowered to 64 | **−0.069** across the 13 suite tables at 64<p≤256, losing **12/13** (p=0.008) |
| `k = m · effective_rank` | no multiplicative rule beats a constant |
| `k = erank + 24` | beats k=64 (p=0.048) but **ties** k=48 (p=0.175) while costing +12–15% for an extra SVD per fit |
| `k` from an n/p size rule | +0.0075 (p=0.14) but buys no latency and puts k=16 on 45% of tables, one step from the k=8 collapse |
| k=8 | collapses, −0.1224 (p<0.001) |

k=48 vs k=64 is unresolvable on accuracy (p=0.25, below the study's 0.010–0.027 MDE). Latency breaks the tie, and 48 also has the better point estimate.

## Caveats

- **107 of the 109 wide tables are RamanBench spectra** in correlated families (32 bioprocess, 22 fuel, 14 microgel), so effective sample size is below 109 and the intervals above are optimistic. Well supported for spectroscopy; thinly supported for other wide data — the two non-spectral wide tables both moved the other way.
- The study is underpowered below ~0.02 R²; non-significant results there mean *underpowered*, not equivalent.

Full analysis, per-table CSVs and reproduction: **Synthefy/nori-monorepo PR #153**.

**Follow-up (not in this PR):** `internal/baseten/*.yaml` pin the config filename as a literal `INFERENCE_CONFIG` env value and can't import Python — they need a separate internal PR once this cascades, or serving keeps svd256.
