### PR TITLE
docs: state the Nori base parameter count as ~6M everywhere (nori-monorepo#118)

### DIFF
--- a/.claude/skills/nori-regression/SKILL.md
+++ b/.claude/skills/nori-regression/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 
 ## What this is and when to use it
 
-A playbook for regression with **Nori** (`synthefy-nori` on PyPI), a ~5.5M-param
+A playbook for regression with **Nori** (`synthefy-nori` on PyPI), a ~6M-param
 tabular foundation model that predicts by **in-context learning**: `fit()` just
 stores your training rows as context, and `predict()` conditions the frozen
 model on them. No training loop, no hyperparameters to tune, and the full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ repo. Keep it accurate — update it when commands, layout, or conventions chang
 
 ## What this is
 
-`synthefy-nori` is a small (~5.5M-parameter) tabular foundation model
+`synthefy-nori` is a small (~6M-parameter) tabular foundation model
 (`FeaturesTransformer`) for **regression** via in-context
 learning. Given a few labeled context rows, it predicts on query rows in a
 single forward pass — no task-specific training. It is trained entirely on

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ needed at all.
 
 ### Architecture
 
-Nori is a **FeaturesTransformer (~5.9M parameters)** that alternates
+Nori is a **FeaturesTransformer (~6M parameters)** that alternates
 two kinds of attention:
 
 - **Feature attention** learns relationships between columns.

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Training: tier 1 (from scratch).
 #
 # Architecture: 16 layers, E=128, H=384, nhead=2, model_v2_lite,
-# column_specific_y_aware, ~5.5M params. Regression via a 999-quantile pinball
+# column_specific_y_aware, ~6M params. Regression via a 999-quantile pinball
 # loss with a monotonicity penalty.
 #
 # Trains to completion on synthetic data: no real-data validation, no early


### PR DESCRIPTION
Part of [nori-monorepo#118](https://github.com/Synthefy/nori-monorepo/issues/118). Prose only, 4 lines.

## TL;DR

This repo advertised **three different sizes for the same base model**. Everything now says `~6M`.

| file:line | Was | Now |
|---|---|---|
| `README.md:250` (Architecture) | `~5.9M parameters` | `~6M parameters` |
| `AGENTS.md:8` | `~5.5M-parameter` | `~6M-parameter` |
| `.claude/skills/nori-regression/SKILL.md:19` | `~5.5M-param` | `~6M-param` |
| `scripts/train.sh:7` | `~5.5M params` | `~6M params` |

`README.md` already said `~6M` at `:21` (benchmark section) and `:346` (quickstart), so the Architecture line contradicted its own file two screens up.

## Why `~6M` and not `~5.9M`

The measured count is **5,868,069** (~5.87M), which rounds most precisely to ~5.9M. `~6M` is nonetheless the published value, deliberately, so the advertised size matches the **`nori-6m` gateway slug**. Copy and API identifier then cannot drift apart. Policy: `nori-monorepo/.claude/skills/nori-release/SKILL.md` §A.6.

Ground truth for the integer: `nori-monorepo/experiments/nori-architecture/README.md:4`, corroborated by `postmortems/2026-07-10-retrieval-filtered-inference.md:20` and `synthefy-nori-internal/internal/EVAL_PORT_PLAN.md:149` — three independent records agreeing to the digit.

Worth knowing if anyone later argues for `~5.9M`: the website spells it out as "6 million parameters" in a live blog post, plots parameter count on an x-axis in `speed-size.svg` with labels baked as vector paths plus a committed `.png` twin, and bakes `6M` into an OpenGraph share image cached by Slack and LinkedIn. The slug itself encodes the number. `~6M` is the cheap value to keep.

## Why this can't break anything

The parameter count is **never a source literal**. `FeaturesTransformer` takes `nlayers`, `nhead`, `embed_dim`, `hid_dim` as constructor args, and `build_model` reads them from the config that ships *inside* `nori.pt`. The count only ever exists as a runtime `sum(p.numel() for p in model.parameters())`.

So all four lines are prose or a shell comment. No code, no numeric literal, no test assertion in this repo depends on them. Verified: `grep -riE '5\.5M|5\.9M'` over the repo now returns **nothing**.

## Not changed

- **`~29M` / `~29.2M`** (the `nori-30m` variant) is a separate, out-of-scope number. There is a minor `~29M` vs `~29.2M` rounding inconsistency across repos; that deserves its own issue, not this PR.
- No architecture claim is touched. `README.md:250-260` still correctly describes 16 layers, E=128, H=384, nhead=2, v2-lite.

## Release

No version bump needed: no code changes. The corrected README reaches PyPI as the `long_description` on the next scheduled release. The `nori-regression` skill ships to end users, so that line is user-visible immediately on merge.

## Siblings

Two other repos carried the same drift and have their own PRs, since a monorepo PR cannot touch submodule files:

- `synthefy-nori-internal` — the buyer-visible AWS Marketplace `ModelPackageDescription` said `~5.9M` while `marketplace_listing.md` says 6M in four places, plus 4 training-recipe headers.
- `nori-monorepo` — the release skill wrongly claimed #118 was already reconciled, and gains a cross-repo sweep command for this fact.

#118 also asked about two surfaces nobody had checked. Both are resolved and need no change: **`synthefy-website`** already says 6M in ~20 places with zero occurrences of 5.5M/5.9M, and the **"churn notebook"** is `nori-monorepo/pocs/servicenow/notebooks/nori_inference_walkthrough.ipynb`, which already said `~6M` — the issue misfiled it as one of the three conflicting numbers.
