### PR TITLE
Promote staging to public + release 0.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv sync --extra dev
-      - run: uv run pytest -m slow tests/test_inference_e2e.py
+      - run: uv run pytest -m slow tests/test_inference_e2e.py tests/test_memory_policy_e2e.py
 
   # Merge gate (part 2): one real training step from scratch on CPU (data-gen ->
   # loss -> optimizer step -> checkpoint write). Offline; no checkpoint download.

--- a/README.md
+++ b/README.md
@@ -438,8 +438,10 @@ for details, including the current RelBench submission status.
 
 The speedups below are **on by default** and **deterministic** — identical results
 run-to-run with the same settings — and the published [Results](#results) were
-produced with them on. The **KV cache** is exactly result-identical to the
-un-cached path (`cache==chunked`). The **preprocessing speedups** are **R²-neutral**:
+produced with them on. The **KV cache** is **R²-equivalent** to the un-cached path,
+not bit-identical: the two paths reduce in a different order, so predictions differ by
+mixed-precision noise (max abs diff ~3e-3, measured below) at identical R². The
+**preprocessing speedups** are **R²-neutral**:
 toggling them shifts individual predictions by a tiny, R²-equivalent amount (below
 cross-environment noise), not bit-for-bit. For the exact un-accelerated path, set
 each to its off value (see below).
@@ -450,9 +452,115 @@ each to its off value (see below).
 | `SYNTHEFY_CAP_QUANTILES` | `1` (on) | Cap quantile-transform resolution + subsample its fit. Acts on large context (>2000 rows); set `0` to disable. |
 | `SYNTHEFY_QUANTILE_MAX` / `SYNTHEFY_QUANTILE_SUBSAMPLE` | — | Tune the cap above (max quantiles / fit-subsample size). |
 | `SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE` | `2000` | Fit preprocessing on at most this many rows, apply to all rows. Acts on large context; set `0` to fit on all rows. |
-| `SYNTHEFY_ENABLE_CACHED_INFERENCE` | `1` (on) | Reuse the train-side attention K/V across test chunks (KV cache); ~2-3x faster on large test sets that chunk. Set `0` to disable. |
-| `SYNTHEFY_CACHE_MAX_GB` | `6.0` | Skip the KV cache if its estimated footprint would exceed this. |
-| `SYNTHEFY_MAX_ELEMENTS_BUDGET` | `2000000` | Inference element budget; raise on large GPUs for full-context inference. |
+| `SYNTHEFY_ENABLE_CACHED_INFERENCE` | `1` (on) | Reuse the train-side attention K/V across test chunks (KV cache); ~2-3x faster on large test sets that chunk. Set `0` to disable (or `SYNTHEFY_DISABLE_CACHED_INFERENCE=1`). |
+| `SYNTHEFY_MAX_ELEMENTS_BUDGET` | VRAM-aware | Inference element budget; raise on large GPUs for full-context inference. Prefer `memory_policy={"elements_budget": N}`. |
+
+> ⚠️ **`SYNTHEFY_CACHE_MAX_GB` has been removed** and now raises if set. It used to
+> *skip* the KV cache above a fixed 6 GB; the cache is now **offloaded to host RAM**
+> instead of skipped, so the old value does not translate. Use
+> `memory_policy={"gpu_budget_frac": 0.4}` for a share of VRAM (portable across GPUs) or
+> `memory_policy={"gpu_budget_absolute_gb": N}` for a hard cap on a shared GPU — see
+> [Serving memory on large tables](#serving-memory-on-large-tables). Memory is
+> configured through `memory_policy=` now, not environment variables; the only env vars left
+> on this path are the kill switches above.
+
+### Serving memory on large tables
+
+Nori does in-context regression: your table is *input*, not weights. So one `predict`
+call keeps a per-layer key/value cache over every context row, and that cache — not the
+model — is what runs you out of GPU memory on a big table.
+
+`memory_policy=` decides what to do about it. Omit it and you get the defaults, which handle
+the common cases:
+
+```python
+from synthefy_nori import NoriRegressor, MemoryPolicy
+
+NoriRegressor(model="nori-6m")                                   # the defaults
+NoriRegressor(model="nori-6m", memory_policy="exact")                   # never quantize
+NoriRegressor(model="nori-6m", memory_policy="max_context")             # fit the biggest table
+NoriRegressor(model="nori-6m", memory_policy="off")                     # no cache at all
+NoriRegressor(model="nori-6m", memory_policy={"gpu_budget_frac": 0.25}) # e.g. from a config file
+```
+
+Under the hood it walks a ladder, using the cheapest rung that can serve the request:
+
+| rung | what it does | exact? |
+|---|---|---|
+| `resident_bf16` | cache fits VRAM at full precision | **yes** |
+| `resident_int8` | quantize to stay on the GPU instead of streaming | ~6e-6 R² |
+| `offload_int8` | cache lives in host RAM, streamed per layer | quantized |
+| `context_row_chunk` | after an OOM: also cap rows per build step | **yes** |
+| `plain_loop` | no cache; several times slower, may drop context rows | **yes** |
+
+**Only the int8 rungs cost accuracy, and `resident_int8` is only reached when full
+precision would not fit.** A table that serves correctly today keeps bit-exact
+predictions — accuracy is spent only to avoid a fallback that is slower or fatal. Use
+`memory_policy="exact"` to forbid quantizing outright (it offloads instead).
+
+Budgets are **fractions of your hardware**, so one setting travels from a laptop GPU to
+an H200:
+
+| field | default | meaning |
+|---|---|---|
+| `gpu_budget_frac` | `0.4` | share of total VRAM the resident cache may use |
+| `host_budget_frac` | `0.25` | share of total RAM an offloaded cache may use |
+| `gpu_budget_absolute_gb` / `host_budget_absolute_gb` | — | hard caps, for a shared GPU |
+| `cache_dtype` | `"bf16"` | precision the cache **starts** at |
+| `allow_quantization` | `True` | may bf16 drop to int8 to stay resident? |
+| `offload_to_host` | `True` | may the cache move to host RAM? |
+| `context_row_chunk` | `None` | cap context rows per build step (auto after an OOM) |
+| `elements_budget` | auto | per-forward element cap; drives chunking + subsampling |
+| `allow_subsample` | `True` | may context rows be dropped to fit? `False` = raise |
+
+> **Host offload needs RAM > 1.6 × VRAM at these defaults.** Offload only engages once
+> the cache exceeds the GPU budget, and it can only succeed within the host budget — so
+> `0.25 × RAM` has to exceed `0.4 × VRAM`. Below that ratio the offload rung is
+> unreachable and a spilling request goes straight to `plain_loop`. Concretely, a 143 GB
+> H200 needs more than ~229 GB of RAM; an 80 GB card needs more than ~128 GB. If your
+> box is under the ratio, raise `host_budget_frac` (Nori warns, naming this, the first
+> time a request actually needs the fallback and cannot get it).
+>
+> The default is deliberately conservative rather than higher: the fraction is of
+> *total* RAM, your own input table is already resident in it, and overshooting host RAM
+> gets the process OOM-killed by the kernel — unlike overshooting VRAM, which raises a
+> catchable error and degrades to the next rung.
+
+**Which rung ran** is on the estimator after `predict`:
+
+```python
+model.predict(X_test)
+model.memory_report_
+# {'rung': 'resident_bf16', 'cache_dtype': 'bf16', 'est_cache_gb': 30.5,
+#  'gpu_budget_absolute_gb': 57.2, 'dropped_context_rows': 0, ...}
+MemoryPolicy(**model.memory_report_).is_bit_exact      # -> True
+```
+
+Fallbacks are logged (`logging.getLogger("synthefy_nori.inference.predictor")`), and
+dropping to `plain_loop` also emits a `RuntimeWarning` — it is the one rung that may
+subsample your context, which otherwise looks like an unexplained accuracy loss.
+
+**Incoherent settings fail instead of being ignored.** Asking for something that cannot
+take effect raises rather than silently doing nothing:
+
+```python
+model = NoriRegressor(memory_policy={"cache": False, "context_row_chunk": 2048})
+model.fit(X, y)
+# ValidationError: ... 'row chunking without KV caching' is not a reachable
+# configuration.  (the chunk caps the K/V *build*; with no cache there is no build)
+```
+
+The check runs in `fit`, not `__init__` — scikit-learn requires `__init__` to store
+parameters verbatim so `clone` works — but it does run before any inference, so a bad
+config fails in seconds rather than minutes into a job.
+
+Settings that are merely redundant warn instead — e.g. setting both a fraction and an
+absolute budget tells you the fraction is ignored, rather than refusing a layered
+config. Unknown keys always raise.
+
+**Known limit:** at large row counts × many columns, the first thing to run out of
+memory is the transductive preprocessing (RBF + polynomial expansion over the whole
+table), *upstream* of the transformer. None of the above helps with that.
 
 ### Preprocessing speedups (on by default)
 
@@ -473,13 +581,13 @@ layers reusing that cache, instead of recomputing the train K/V for every test
 chunk — measured **~2-3x faster** on multi-chunk inference (the win scales with
 the number of chunks). It only activates when the test set is large enough that
 inference is already chunking (`n_test > chunk_size`), so it does not change the
-chunking and therefore does not change the result. We verified `cache == chunked`
-directly: identical R² and a max prediction difference of ~1e-5 on CPU and exactly
-0 R² difference on GPU (floating-point reduction-order noise). The cache is skipped
-automatically if its estimated footprint exceeds `SYNTHEFY_CACHE_MAX_GB` (falling
-back to the identical chunked path). Disable it with
+chunking and therefore does not change R². We verified `cache == chunked` directly:
+identical R², with per-prediction differences at mixed-precision scale (the two paths
+reduce in a different order). When the cache will not fit VRAM it is **offloaded to
+host RAM or quantized rather than skipped** — see
+[Serving memory on large tables](#serving-memory-on-large-tables). Disable it with
 `SYNTHEFY_ENABLE_CACHED_INFERENCE=0` or the `SYNTHEFY_DISABLE_CACHED_INFERENCE=1`
-kill switch.
+kill switch, or `memory_policy={"cache": False}`.
 
 On the 1024-feature QSAR-TID-11 set (single H200), `predict` wall-clock vs.
 test-set size with the cache OFF vs. ON shows the OFF time grows linearly

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -38,6 +38,55 @@ The default checkpoint exposes a 999-quantile pinball head; quantiles come back
 in original-`y` units, sorted per row. `"quantiles"`/`"full"` require the
 pinball checkpoint — a `bar_distribution` checkpoint raises `NotImplementedError`.
 
+## Large tables and memory (`memory_policy=`)
+
+Nori predicts in context, so your table is *input*: every call reads all of
+`X_train` and keeps a per-layer key/value cache over those rows. That cache — not
+the ~6M parameters — is what fills a GPU on a big table.
+
+Omit `memory_policy` and nothing changes. The defaults cache at full precision,
+drop to int8 only if that is what keeps the cache on the GPU, spend at most 40% of
+VRAM on it, offload to host RAM rather than give up, and shrink the context only as
+a last resort.
+
+```python
+from synthefy_nori import MemoryPolicy, NoriRegressor
+
+reg = NoriRegressor(model="nori-6m", memory_policy="exact")        # never trade accuracy
+reg = NoriRegressor(model="nori-6m", memory_policy="max_context")  # fit the largest table
+reg = NoriRegressor(model="nori-6m", memory_policy="off")          # no cache at all
+reg = NoriRegressor(model="nori-6m", memory_policy=MemoryPolicy(cache_dtype="int8"))
+
+reg.fit(X_train, y_train)
+y_pred = reg.predict(X_test)
+print(reg.memory_report_["rung"])          # which fallback actually ran
+```
+
+When the cache does not fit, inference takes the cheapest step that works:
+
+| Rung | What happens | Accuracy |
+| --- | --- | --- |
+| `resident_bf16` | full-precision cache in GPU memory | exact |
+| `resident_int8` | quantized so it stays resident | ~1.9x smaller, \|ΔR²\| ≈ 6e-6 |
+| `offload_bf16` | full precision in host RAM, streamed per layer | exact, slower |
+| `offload_int8` | quantized *and* in host RAM | as int8 |
+| `context_row_chunk` | cache built in row chunks after an OOM retry | not bit-identical |
+| `plain_loop` | no cache; the context is re-read per batch | exact, much slower |
+| `no_cache` | the cached path did not apply | exact |
+
+Only the int8 rungs trade accuracy, and they are reached only when full precision
+will not fit; offloading moves bytes rather than approximating. The cache is built
+only when the query set spans more than one batch, so a small `X_test` reports
+`no_cache` — that is normal, not a degradation.
+
+`memory_report_["dropped_context_rows"]` is the one number here that is a real
+accuracy loss rather than a rounding-level effect: it counts context rows discarded
+to fit. Set `allow_subsample=False` to make that case an error instead of a silent
+shrink.
+
+Field-by-field reference, the budget knobs, and the measured saving per lever:
+[README, "Serving memory on large tables"](../README.md#serving-memory-on-large-tables).
+
 ## Categorical / ordinal targets (`discretize=` / `categorical_levels=`)
 
 When the target only takes a small set of discrete values (ratings, counts,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.12.1"
+version = "0.13.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "numba>=0.60",
     "numpy>=2.0",
     "pandas>=2.0",
+    "pydantic>=2.0",
     "scikit-learn>=1.4",
     "scipy>=1.13",
     "torch>=2.8,<2.14",

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -13,7 +13,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 
 __all__ = [
     "ContextTooLargeError",

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from synthefy_nori import discretize
+from synthefy_nori.inference.memory_policy import ContextTooLargeError, MemoryPolicy
 from synthefy_nori.api import (
     NoriRegressor,
     config_path,
@@ -15,6 +16,8 @@ from synthefy_nori.pricing import billable_price
 __version__ = "0.12.1"
 
 __all__ = [
+    "ContextTooLargeError",
+    "MemoryPolicy",
     "NoriRegressor",
     "discretize",
     "NoriEmbedding",

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 from sklearn.base import BaseEstimator, RegressorMixin
 
+from synthefy_nori.inference.memory_policy import MemoryPolicy
 from synthefy_nori.discretize import (
     DEFAULT_DISCRETIZE_METHOD,
     DISCRETIZE_METHODS,
@@ -55,6 +56,26 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
     ``synthefy_nori.interpretability``. The ``__init__`` arguments are stored
     verbatim (the only normalizations applied are idempotent), so ``clone`` round
     trips correctly.
+
+    Memory on large tables (``memory_policy=``)
+        Nori does in-context regression, so your table is *input*: one ``predict``
+        keeps a per-layer key/value cache over every context row, and that cache --
+        not the model -- is what exhausts GPU memory on a big table. ``memory_policy=``
+        decides what to do about it. Omit it for defaults that handle the common
+        cases, or pass:
+
+        * a preset name -- ``"exact"`` (never quantize; offload instead),
+          ``"max_context"`` (fit the largest table you can), ``"off"`` (no cache)
+        * a dict of individual fields, e.g. ``{"gpu_budget_frac": 0.25}``, which is
+          the shape a YAML/JSON config lands in
+        * a :class:`~synthefy_nori.inference.memory_policy.MemoryPolicy`
+
+        Budgets are fractions of your hardware, so one setting travels from a laptop
+        GPU to an H200. Settings that cannot take effect raise rather than being
+        ignored, and redundant ones warn. Validated in :meth:`fit`; afterwards
+        :attr:`memory_report_` says which fallback rung ran, at what precision, and
+        whether any context rows had to be dropped. Full field table and the rung
+        ladder: README, "Serving memory on large tables".
     """
 
     def __init__(
@@ -74,6 +95,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         discretize: str | None = None,
         categorical_levels=None,
         text_columns=None,
+        memory_policy: "MemoryPolicy | dict | str | None" = None,
         svd_dim: int | None = 128,
         embedder="minilm",
         text_max_cardinality: int = 128,
@@ -174,10 +196,32 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         self.embedder = embedder
         self.text_max_cardinality = int(text_max_cardinality)
         self.text_normalize = text_normalize
+        # Serving-memory policy: a preset name ("exact", "max_context", "off"), a
+        # dict, or a MemoryPolicy. Stored VERBATIM and coerced lazily in
+        # _get_predictor(); transforming it here would break sklearn clone(), whose
+        # identity check requires the stored attribute to be the object handed in.
+        self.memory_policy = memory_policy
         self._predictor = None
         # Fitted text preprocessor (embed -> SVD -> extra columns), built by fit()
         # when text_columns is not None; None = numeric-only.
         self._text_preprocessor = None
+
+    @property
+    def memory_report_(self) -> dict | None:
+        """What the last ``predict`` call did about memory, or None before one.
+
+        A ``MemoryPolicy.model_dump()``: the ladder rung taken, the cache precision
+        and placement chosen, the budgets used, and how many context rows (if any)
+        had to be dropped to fit. Reconstruct the object with
+        ``MemoryPolicy(**estimator.memory_report_)`` for derived facts such as
+        ``is_bit_exact``.
+
+        Forwards to the underlying predictor so callers never have to reach through
+        ``._predictor``, which is private.
+        """
+        if self._predictor is None:
+            return None
+        return self._predictor.memory_report_
 
     def fit(self, X, y):
         """Fit the in-context regressor on ``(X, y)``.
@@ -189,6 +233,11 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         train), and appended; the encoder and Nori stay frozen. ``predict`` replays
         the transform, so its ``X`` must be a DataFrame with these columns.
         """
+        # Validate memory_policy= HERE rather than in __init__ (sklearn requires __init__ to
+        # store params verbatim, and clone() depends on it) and rather than lazily at
+        # predict time, where an incoherent config would only surface minutes into a
+        # job. The coerced policy is discarded: this call exists for its errors.
+        MemoryPolicy.coerce(self.memory_policy)
         if self.text_columns is not None:
             self._text_preprocessor = MultimodalPreprocessor(
                 self.text_columns, svd_dim=self.svd_dim, embedder=self.embedder,
@@ -219,6 +268,22 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         return np.asarray(X, dtype=np.float32)
 
     def _get_predictor(self):
+        """The cached predictor, with ``memory_policy=`` re-read from this estimator.
+
+        The predictor is built once -- it owns the loaded checkpoint -- and reused, so
+        every *other* constructor argument here is effectively frozen at first use.
+        That is right for those: they choose the weights and the inference config,
+        neither of which can change without a reload. It is wrong for ``memory_policy``,
+        which is a per-call resource decision that says nothing about the model.
+
+        So re-declare it on every call. ``NoriPredictor.__init__`` stores ``memory_policy``
+        verbatim and ``_memory_policy()`` coerces it afresh inside each ``predict``,
+        which is what makes this single assignment sufficient -- nothing downstream
+        caches the resolved policy. Without it the FIRST predict's policy would stick
+        for the estimator's lifetime, so ``est.memory_policy = "off"; est.predict(X)`` would
+        be silently ignored, and a long-lived server that re-declares the policy per
+        request would serve every caller the first caller's setting.
+        """
         if self._predictor is None:
             from synthefy_nori.inference.predictor import NoriPredictor
 
@@ -232,7 +297,10 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 bar_temperature=self.bar_temperature,
                 bar_point_estimator=self.bar_point_estimator,
                 discrete_y_snap_max_unique=self.discrete_y_snap_max_unique,
+                memory_policy=self.memory_policy,
             )
+        else:
+            self._predictor.memory_policy = self.memory_policy
         return self._predictor
 
     def predict(

--- a/src/synthefy_nori/inference/memory_policy.py
+++ b/src/synthefy_nori/inference/memory_policy.py
@@ -1,0 +1,1028 @@
+"""How much memory inference may use, and where the K/V cache lives.
+
+Nori does in-context regression: the context table is *input*, not weights, so one
+``predict`` call reads all N context rows and keeps a per-layer key/value cache that
+every query row then attends to. That cache is O(nlayers x N) and stays resident for
+the whole decode phase, which makes it the dominant serving cost at large N.
+
+:class:`MemoryPolicy` is the single object describing what to do about that.
+:meth:`MemoryPolicy.resolve` measures the request and returns **another
+MemoryPolicy** with the decided fields concrete — same type in, same type out, so
+there is no second "decision" type to keep straight.
+
+Every field's declared default is its **real value**, not a sentinel: reading the
+signature tells you what happens without looking anything up. The adaptive part is
+expressed as *permissions* (``allow_quantization``, ``offload_to_host``) rather than
+an opaque ``"auto"``, so "what is the default precision" and "may it change under
+pressure" are two separate, individually readable questions.
+
+The ladder, cheapest rung first. Each rung is used only when the one above it cannot
+serve the request:
+
+=================  ========================================================
+rung               meaning
+=================  ========================================================
+no_cache           the cached path does not apply (e.g. the query set is small
+                   enough that inference never chunks). Not a degradation.
+resident_bf16      the full-precision cache fits the GPU budget. BIT-EXACT.
+resident_int8      bf16 would not fit but int8 does, so the cache stays on the
+                   fast on-GPU path instead of paying PCIe streaming. Costs
+                   |dR2| ~ 6e-6 (per-(row, head) absmax quantization).
+                   Requires ``allow_quantization``.
+offload_bf16       cannot stay resident and quantizing is not allowed -> the
+                   full-precision cache lives in host RAM. Bit-exact, slower.
+offload_int8       cannot stay resident at any precision -> quantized cache in
+                   host RAM, each layer's slice streamed back on demand.
+context_row_chunk  an actual OOM happened -> re-run bounding the prefill
+                   working set too (bit-exact; see layer.py).
+plain_loop         nothing above worked. **No cache at all: every query chunk
+                   recomputes the context K/V, so this is several times slower,
+                   and if the context alone exceeds the element budget the
+                   caller must SUBSAMPLE it — silently losing rows unless
+                   ``allow_subsample=False`` turns that into an error.** The
+                   predictor logs a warning naming the rung and, when rows are
+                   dropped, how many.
+=================  ========================================================
+
+**Only the int8 rungs are lossy, and ``resident_int8`` is reached only when the
+full-precision cache does not fit.** That ordering is the point: a table that serves
+correctly today keeps bit-exact predictions, and accuracy is spent only to avoid a
+fallback that would otherwise be slower or fatal. A measured cost for int8
+(|dR2| = 5.8e-6) is not a licence to charge it to requests that had no memory
+problem in the first place.
+
+``context_row_chunk`` and ``plain_loop`` are *reactions* to an OutOfMemoryError, so the
+caller escalates into them via :meth:`MemoryPolicy.escalated`; :meth:`resolve` picks
+the opening rung.
+
+Budgets are **fractions of the hardware** rather than absolute GB so one setting is
+portable from a 24 GB laptop card to a 143 GB H200. The ``*_absolute_gb`` overrides
+exist for the one case a fraction cannot express: a co-tenanted GPU, where what
+matters is a hard ceiling rather than a share.
+
+**This module reads no environment variables.** Configuration comes from
+``NoriPredictor(memory_policy=...)`` / ``NoriRegressor(memory_policy=...)``; the only env var in
+the whole path is the ``SYNTHEFY_DISABLE_CACHED_INFERENCE`` kill switch, handled by
+the predictor. Resolution is pure arithmetic — no torch allocations, no device calls
+— so every rung boundary is unit-testable on CPU rather than only exercised by
+whoever happens to run a 500k-row table on a big card.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+import warnings
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+#: Named starting points, for callers who do not want to set fields individually.
+#: Each one CHANGES something. There is deliberately no "auto"/"default" preset:
+#: omitting ``memory_policy=`` already means the defaults, so naming that would just be a
+#: second spelling of nothing.
+MemoryPreset = Literal["exact", "max_context", "off"]
+MEMORY_PRESETS: tuple[str, ...] = ("exact", "max_context", "off")
+
+CacheDtype = Literal["bf16", "int8"]
+CACHE_DTYPE_CHOICES: tuple[str, ...] = ("bf16", "int8")
+
+RUNGS: tuple[str, ...] = (
+    "no_cache", "resident_bf16", "resident_int8", "offload_bf16", "offload_int8",
+    "context_row_chunk", "plain_loop",
+)
+
+# --- unit + shape constants (no bare numbers in the arithmetic below) ---------
+
+#: Bytes per GiB, for every GB figure in this module.
+BYTES_PER_GIB = 1024 ** 3
+
+#: The cache stores one key AND one value vector per (layer, group, row).
+KV_TENSORS_PER_ROW = 2
+
+#: int8 payload width.
+INT8_BYTES_PER_ELEMENT = 1
+
+#: Width of the fp32 absmax scale int8 quantization adds, one per head_dim vector.
+#: Counting it keeps the resident threshold honest: against bf16 the real saving is
+#: ~1.9x, not the 4x that holds only against fp32.
+INT8_SCALE_BYTES = 4
+
+# --- policy defaults ---------------------------------------------------------
+
+#: Share of TOTAL VRAM the resident cache may occupy before we offload. 0.4 is the
+#: aggressive ceiling: the co-resident non-cache working set measures ~0.72x the bf16
+#: cache, which puts a resident peak near full VRAM at this fraction.
+DEFAULT_GPU_BUDGET_FRAC = 0.4
+
+#: Share of total physical RAM the offloaded cache may occupy.
+DEFAULT_HOST_BUDGET_FRAC = 0.25
+
+#: Fit-time row chunk engaged automatically after an OOM on the cached path.
+FIT_ROW_CHUNK_ON_OOM = 2048
+
+#: Fields that only mean anything while the cached path is in use. Asking for any of
+#: them with ``cache=False`` is incoherent, so it is rejected rather than silently
+#: dropped — the failure mode where a caller spells everything correctly and still
+#: gets none of what they asked for.
+CACHE_ONLY_FIELDS: tuple[str, ...] = (
+    "cache_dtype", "allow_quantization", "offload_to_host", "context_row_chunk",
+    # adaptive_query_chunk is passed only to forward_cached_regression, so it is
+    # inert on the plain loop as well -- it belongs here for the same reason.
+    "adaptive_query_chunk",
+    # The budgets bound where the CACHE is placed. With no cache to place, tuning
+    # them does nothing, which is the same silent no-op as the levers above.
+    "gpu_budget_frac", "gpu_budget_absolute_gb",
+    "host_budget_frac", "host_budget_absolute_gb",
+)
+
+#: Stand-in when the device cannot be introspected (CPU inference, or a device string
+#: torch will not describe). Conservative on purpose; the OOM fallback is the real
+#: safety net regardless of how good this estimate is.
+ASSUMED_VRAM_GB = 24.0
+
+#: Config warnings already emitted this process. These describe a *configuration*, not
+#: a request, so saying it once is enough -- and the alternative is genuine spam:
+#: resolve() runs once per inference pipeline (16 on the default config), and because
+#: ``stacklevel`` attributes the warning to a varying caller frame, Python's own
+#: per-location de-duplication never engages. Measured 32 copies of one warning from
+#: two predict() calls before this existed.
+_WARNED_ONCE: set[str] = set()
+
+
+def warn_once(message: str) -> None:
+    """Emit ``message`` as a UserWarning the first time it is seen this process.
+
+    Args:
+        message: the full warning text; identical text is emitted only once.
+    """
+    if message in _WARNED_ONCE:
+        return
+    _WARNED_ONCE.add(message)
+    # Prefixed because these fire inside pydantic validation, so Python attributes them
+    # to pydantic/main.py rather than to the caller's line. The prefix keeps it obvious
+    # whose warning this is; the text is self-contained about which fields are involved.
+    warnings.warn(f"Nori memory policy: {message}", UserWarning, stacklevel=3)
+
+
+class ContextTooLargeError(RuntimeError):
+    """The context does not fit the element budget and may not be subsampled.
+
+    A **caller** condition, not a server fault: the context size, ``elements_budget`` and
+    ``allow_subsample`` are all things the caller chose, and changing any one of them
+    makes the same request work. The message names which setting forbade the shrink and
+    what to raise.
+
+    Typed so that a server can tell it apart from the other ``RuntimeError`` that reaches
+    the same place -- a CUDA OOM, which really is a server condition. Without the
+    distinction a server has to choose between turning its own faults into 4xx or
+    reporting a caller's own configuration back to them as a 500 with the remedy buried
+    in it.
+
+    Subclasses ``RuntimeError`` because that is what this used to raise, so code already
+    catching ``RuntimeError`` keeps working.
+    """
+
+
+#: The one field family a shared server must bound rather than honour verbatim, named
+#: here beside the fields themselves so a serving target cannot go stale: adding a
+#: budget field means editing this tuple, not every server.
+HOST_BUDGET_FIELDS: tuple[str, ...] = ("host_budget_frac", "host_budget_absolute_gb")
+
+#: Field a shared server must FLOOR rather than honour verbatim. Unlike the budgets above,
+#: whose cost is memory, this one's cost is TIME: it is the step size of the prefill loop
+#: that builds the K/V cache, so ``context_row_chunk=1`` turns one request into O(N) kernel
+#: launches per layer over the caller's own context rows. That runs while holding the
+#: inference lock, so it delays every other caller rather than only its own -- which is
+#: exactly the "hurts nobody else" premise the other fields rely on, and the reason this
+#: one cannot ride along with them.
+CONTEXT_ROW_CHUNK_FIELD = "context_row_chunk"
+
+#: Guards the warning capture in :func:`capture_policy_notes`.
+#: ``warnings.catch_warnings`` swaps process-global filter state, so two callers
+#: capturing at once would otherwise cross-attribute each other's notes.
+#:
+#: Reentrant because a caller legitimately nests: a server holds one capture across a
+#: whole request and :meth:`MemoryPolicy.coerce_for_service` opens its own inside that.
+#: A plain Lock deadlocks on that nesting -- and it deadlocks while holding the
+#: inference lock, so the replica stops answering rather than failing one request.
+_WARNING_CAPTURE_LOCK = threading.RLock()
+
+
+@contextlib.contextmanager
+def capture_policy_notes():
+    """Collect the policy warnings emitted in this block, instead of logging them.
+
+    A memory-policy warning is *advice to whoever set the policy*. In a script that is
+    the person reading stderr, so :func:`warn_once` is right. In a server the person
+    who set it is on the other end of an HTTP request and never sees stderr, so the
+    warnings have to be captured and returned -- as ``memory_report.notes``.
+
+    Yields the list the notes accumulate into, so a caller reads it after the block:
+
+        with capture_policy_notes() as notes:
+            ...
+        return tuple(notes)
+
+    Two things this handles that an inline ``catch_warnings`` does not:
+
+    - **Per-request de-duplication.** :func:`warn_once` suppresses repeats for the
+      life of the process, which is right for a script and wrong for a server: the
+      first caller to misconfigure something absorbs the only warning and everyone
+      after them is told nothing about their own policy. So the registry is cleared
+      on entry.
+    - **Serialisation.** The filter state this swaps is process-global, so overlapping
+      captures cross-attribute. Note the lock alone is NOT sufficient for a server:
+      it serialises captures against each other, but not a capture against a
+      concurrent forward pass, which also emits warnings. A server must therefore
+      hold this INSIDE its inference lock -- see ``serving/nori_serving/engine.py``.
+
+    Yields:
+        The list of warning messages, filled as the block runs.
+    """
+    with _WARNING_CAPTURE_LOCK:
+        forget_emitted_warnings()
+        notes: list = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                yield notes
+            finally:
+                # In the finally so a raising block still reports the warnings that
+                # preceded it: an incoherent policy is exactly the case where the
+                # notes explain the error.
+                notes.extend(str(entry.message) for entry in caught)
+
+
+def _as_pydantic_would_coerce(value) -> "float | None":
+    """The float pydantic's lax mode will produce for ``value``, or None if it will not.
+
+    Exists because clamping has to reason about the value that ENDS UP in the model, and
+    an ``isinstance(value, (int, float))`` test does not: pydantic v2 without
+    ``strict=True`` accepts ``"0.95"`` and ``True`` and turns them into ``0.95`` and
+    ``1.0``. Bools are deliberately included rather than skipped -- ``True`` became 100%
+    of host RAM, unclamped and reported as honoured.
+    """
+    if value is None or isinstance(value, (list, tuple, dict, set)):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def forget_emitted_warnings() -> None:
+    """Clear the once-per-process registry behind :func:`warn_once`.
+
+    Process-lifetime de-duplication is right for a script or a notebook: one copy of
+    "this budget cannot bite", not one per inference chunk. It is wrong for a
+    **long-lived server**, where each request carries a different caller's config —
+    the first caller to make a mistake absorbs the only warning, and every caller
+    after them is told nothing about their own. Worse, the warning goes to the
+    server's log, not to the caller who could act on it.
+
+    So a server calls this once per request, captures the warnings that follow, and
+    returns them to that request. ``serving/nori_serving/engine.py`` does exactly
+    that, surfacing them as ``memory_report.notes``. Tests use it for the same reason
+    in miniature: without it, a ``pytest.warns`` assertion passes or fails depending
+    on what an earlier test in the session already emitted.
+
+    Safe to call at any time; it only forgets what has been *said*, never any
+    configuration.
+    """
+    _WARNED_ONCE.clear()
+
+
+def estimate_cache_gb(
+    *,
+    n_context_rows: int,
+    n_groups: int,
+    nlayers: int,
+    embed_dim: int,
+    bytes_per_element: int,
+) -> float:
+    """Estimate the stored key/value cache footprint in GiB at full precision.
+
+    Args:
+        n_context_rows: context (train) rows; the N the cache scales in.
+        n_groups: feature groups the model splits the columns into.
+        nlayers: transformer layers, each keeping its own cache.
+        embed_dim: model embedding width.
+        bytes_per_element: 2 under mixed precision, 4 in fp32.
+
+    Returns:
+        Footprint in GiB.
+    """
+    elements = nlayers * n_groups * n_context_rows * KV_TENSORS_PER_ROW * embed_dim
+    return (elements * bytes_per_element) / BYTES_PER_GIB
+
+
+def int8_footprint_gb(est_cache_gb: float, *, bytes_per_element: int, head_dim: int) -> float:
+    """Footprint of the same cache stored int8, including its scale tensor.
+
+    Args:
+        est_cache_gb: full-precision footprint from :func:`estimate_cache_gb`.
+        bytes_per_element: bytes per element in that full-precision figure.
+        head_dim: ``embed_dim // nhead``; the vector length each scale covers.
+
+    Returns:
+        Footprint in GiB.
+    """
+    payload_gb = est_cache_gb * (INT8_BYTES_PER_ELEMENT / max(bytes_per_element, 1))
+    scale_ratio = INT8_SCALE_BYTES / max(head_dim, 1)
+    return payload_gb * (1.0 + scale_ratio)
+
+
+#: cgroup v2 then v1. A container's memory ceiling lives here and NOWHERE that
+#: ``sysconf`` can see.
+_CGROUP_LIMIT_PATHS = (
+    "/sys/fs/cgroup/memory.max",                     # v2
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",   # v1
+)
+
+#: v1 spells "unlimited" as a huge sentinel rather than a word. Anything at or above
+#: this is "no limit set", not a 8-exabyte container.
+_CGROUP_UNLIMITED_SENTINEL = 1 << 62
+
+
+def _physical_ram_gb() -> float:
+    """What the KERNEL reports, which inside a container is the whole node's RAM."""
+    if not hasattr(os, "sysconf"):
+        return 0.0
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        page_count = os.sysconf("SC_PHYS_PAGES")
+    except (ValueError, OSError):
+        return 0.0
+    if not page_size or not page_count or page_size < 0 or page_count < 0:
+        return 0.0
+    return (page_size * page_count) / BYTES_PER_GIB
+
+
+def _cgroup_memory_limit_gb() -> float:
+    """The container's own memory ceiling in GiB, or 0.0 if there is not one.
+
+    Read because ``sysconf("SC_PHYS_PAGES")`` derives from the host's ``MemTotal`` and
+    is **not** namespaced by any container runtime — so a process in a 234 GiB cgroup on
+    a 2 TiB node sees 2 TiB. Budgeting against that number is how you get SIGKILLed: the
+    cgroup limit is the one the kernel actually enforces, and exceeding it is not a
+    catchable error.
+    """
+    for path in _CGROUP_LIMIT_PATHS:
+        try:
+            raw = open(path).read().strip()
+        except (OSError, ValueError):
+            continue
+        if raw == "max":            # v2's "no limit"
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        if value <= 0 or value >= _CGROUP_UNLIMITED_SENTINEL:
+            continue
+        return value / BYTES_PER_GIB
+    return 0.0
+
+
+def total_host_ram_gb() -> float:
+    """Host RAM this process may actually use, in GiB, or 0.0 if unknowable.
+
+    The **smaller** of what the kernel reports and what the container's cgroup allows.
+    Both are needed: `sysconf` alone over-reports inside a container (it is not
+    namespaced), and the cgroup limit alone is absent when there is no limit set.
+
+    Returns 0.0 rather than raising, so an unknown platform degrades to "no host
+    budget" — never offload — instead of inventing a number and getting OOM-killed.
+    """
+    physical = _physical_ram_gb()
+    limit = _cgroup_memory_limit_gb()
+    if physical and limit:
+        return min(physical, limit)
+    return limit or physical
+
+
+class MemoryPolicy(BaseModel):
+    """What inference may spend on memory, and where the K/V cache goes.
+
+    One object covers the whole ladder (see the module docstring)::
+
+        MemoryPolicy()                                        # the defaults below
+        MemoryPolicy.coerce("exact")                          # never quantize
+        MemoryPolicy.coerce({"gpu_budget_frac": 0.25})        # e.g. parsed from YAML
+        MemoryPolicy(cache_dtype="int8", context_row_chunk=2048)
+
+    ``extra="forbid"`` is deliberate: a mistyped key on a knob whose whole job is "do
+    not lose accuracy" must fail loudly rather than be ignored forever.
+    ``frozen=True`` makes instances hashable and safe to share — :meth:`resolve`
+    returns a new object rather than mutating.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    cache: bool = Field(
+        True,
+        description="Build a key/value cache over the context rows at all. False re-reads "
+                    "the whole context for every batch of query rows instead: correct, but "
+                    "several times slower on a large query set, and it may have to drop "
+                    "context rows to fit.",
+    )
+    cache_dtype: CacheDtype = Field(
+        "bf16",
+        description="Precision the K/V cache STARTS at. bf16 is bit-exact and is the "
+                    "default; set 'int8' to quantize from the outset (~1.9x smaller, "
+                    "|dR2| ~ 6e-6) when you would rather trade that for context. "
+                    "Whether bf16 may be downgraded under memory pressure is a "
+                    "separate question — see allow_quantization.",
+    )
+    allow_quantization: bool = Field(
+        True,
+        description="May the cache be quantized to int8 when full precision would "
+                    "NOT stay resident? This is the only way int8 gets used by "
+                    "default, and it is strictly better than offloading (which costs "
+                    "40-175% latency). False keeps every rung bit-exact — the "
+                    "'exact' preset — at the cost of offloading sooner.",
+    )
+    gpu_budget_frac: float = Field(
+        DEFAULT_GPU_BUDGET_FRAC, gt=0, le=1,
+        description="Share of TOTAL VRAM the resident cache may occupy before we "
+                    "offload. A fraction so one setting is portable across GPUs. "
+                    "Total rather than free VRAM: free is racy, and budgeting against "
+                    "it would make the same call take different rungs on different "
+                    "runs.",
+    )
+    gpu_budget_absolute_gb: float | None = Field(
+        None, ge=0,
+        description="Hard VRAM ceiling in GiB, overriding gpu_budget_frac. For a "
+                    "co-tenanted GPU, where a fixed cap is the requirement and a "
+                    "share of the card is the wrong unit. None = use the fraction; "
+                    "0 = never keep the cache in GPU memory. 0 is deliberately "
+                    "legal, not a typo guard: it is a real request, and it is also "
+                    "the value the resolved budget can take.",
+    )
+    offload_to_host: bool = Field(
+        True,
+        description="May the cache be moved to host RAM (streamed back per layer) "
+                    "when it cannot stay resident? Bit-exact transport, but 40-175% "
+                    "slower. False reproduces the legacy behaviour of skipping the "
+                    "cache entirely instead, which is slower still.",
+    )
+    host_budget_frac: float = Field(
+        DEFAULT_HOST_BUDGET_FRAC, gt=0, le=1,
+        description="Share of total physical RAM the offloaded cache may occupy. A "
+                    "fraction because a flat GB default is a latent bug: 128 GB "
+                    "'fits' on a 32 GB laptop by arithmetic, so offload proceeds and "
+                    "the kernel OOM-kills the process instead of the policy falling "
+                    "to the plain loop.",
+    )
+    host_budget_absolute_gb: float | None = Field(
+        None, ge=0,
+        description="Hard host-RAM ceiling in GiB, overriding host_budget_frac. "
+                    "None = use the fraction; 0 = never offload. 0 is deliberately "
+                    "legal: it is also what a platform that will not report its RAM "
+                    "resolves to, and that case has to degrade to 'no offload' rather "
+                    "than fail.",
+    )
+    context_row_chunk: int | None = Field(
+        None,
+        gt=0,
+        description="Bound the fit-time build working set to this many context rows "
+                    f"(bit-exact). None = off, with {FIT_ROW_CHUNK_ON_OOM} engaged "
+                    "automatically after an OOM. Pinning a value uses it from the "
+                    "first attempt — which also costs you that escalation, since "
+                    "there is then nothing left to escalate to.",
+    )
+    adaptive_query_chunk: bool = Field(
+        True,
+        description="On a decode OOM, halve the QUERY chunk and retry instead of "
+                    "raising. Distinct from context_row_chunk, which caps CONTEXT rows "
+                    "during prefill.",
+    )
+    elements_budget: int | None = Field(
+        None,
+        gt=0,
+        description="Per-forward element cap driving query chunk size and context "
+                    "subsampling. None = derive it from available VRAM. Upstream of "
+                    "everything else here: the cached path engages only when the "
+                    "query set exceeds the chunk size this implies, so raising it far "
+                    "enough disables the cache knobs by making inference stop "
+                    "chunking at all.",
+    )
+    allow_subsample: bool = Field(
+        True,
+        description="Permit dropping context rows when the request will not fit "
+                    "otherwise. False makes that an error instead of a silent "
+                    "accuracy loss.",
+    )
+
+    # --- populated by resolve(); None on an unresolved policy ----------------
+    rung: str | None = Field(
+        None,
+        description="Which fallback the server used, in decreasing memory cost: "
+                    "resident_bf16 (cache in GPU memory, exact), resident_int8 (quantized), "
+                    "offload_bf16 / offload_int8 (cache in host RAM, streamed back per layer, "
+                    "exact transport), context_row_chunk (cache built in row chunks), "
+                    "plain_loop (no cache; the context re-read per query batch), no_cache "
+                    "(the cached path did not apply). Decided per request, not requestable.")
+    est_cache_gb: float | None = Field(
+        None, ge=0,
+        description="Full-precision cache footprint for this request's context, in GiB. Reported, not set.")
+    resident_gb: float | None = Field(
+        None, ge=0,
+        description="Footprint at the chosen precision (GiB) — the figure actually "
+                    "compared against the budget. Reported, not set.")
+    query_chunk: int | None = Field(
+        None, gt=0,
+        description="Query rows per decode forward, as the cached path was entered "
+                    "with. Reported, not set. NOTE: a decode OOM may halve this "
+                    "further inside the model, and that further reduction is not "
+                    "currently reported here.")
+    dropped_context_rows: int = Field(
+        0, ge=0,
+        description="Context rows the caller had to subsample away to fit. Non-zero "
+                    "only on the plain_loop rung; recorded so a shrunk context is "
+                    "visible in memory_report_ rather than inferred from the score.")
+
+    @model_validator(mode="after")
+    def _check_rung(self) -> "MemoryPolicy":
+        """Reject an unrecognised rung so a typo cannot masquerade as a decision."""
+        if self.rung is not None and self.rung not in RUNGS:
+            raise ValueError(f"rung must be one of {RUNGS}, got {self.rung!r}")
+        return self
+
+    @model_validator(mode="after")
+    def _check_coherent(self) -> "MemoryPolicy":
+        """Reject a request that asks for cache-only levers with the cache off.
+
+        Only applies BEFORE resolution. While ``rung is None`` these fields are a
+        *request* the caller wrote, and ``cache=False`` plus (say) ``context_row_chunk``
+        is a contradiction: fit-time row chunking bounds the prefill build, which only
+        happens on the cached path, so the request could never be honoured. Once
+        :meth:`resolve` has run the same fields are *outputs* — a ``plain_loop``
+        policy legitimately reports ``cache=False`` alongside a concrete dtype — so
+        the check is skipped.
+
+        Uses ``model_fields_set`` so only levers the caller EXPLICITLY set count:
+        ``offload_to_host`` defaults to True, and ``MemoryPolicy(cache=False)`` (the
+        ``"off"`` preset) must stay legal.
+
+        Returns:
+            ``self`` when coherent.
+
+        Raises:
+            ValueError: naming every field that could not be honoured.
+        """
+        if self.rung is not None or self.cache:
+            return self
+        requested = sorted(f for f in CACHE_ONLY_FIELDS if f in self.model_fields_set)
+        if requested:
+            raise ValueError(
+                f"cache=False cannot be combined with {requested}: those only affect "
+                f"the cached path, so nothing would honour them. In particular "
+                f"context_row_chunk caps the K/V build, which only runs when "
+                f"the cache is on — 'row chunking without KV caching' is not a "
+                f"reachable configuration. Either drop {requested}, or set cache=True "
+                f"and use memory_policy={{'context_row_chunk': N}} to cap the build."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _check_no_dead_settings(self) -> "MemoryPolicy":
+        """Warn where one setting makes another unreachable.
+
+        These are WARNINGS, not errors, unlike :meth:`_check_coherent`. The split
+        follows one rule: **error when we cannot know what the caller meant, or when
+        guessing wrong would cost accuracy; warn when intent is clear and the extra
+        setting is merely inert.** A layered config (base YAML sets a fraction, a
+        per-run override sets an absolute) reaches these innocently, and refusing it
+        would make layering unusable for no safety gain.
+
+        Same principle as :meth:`_check_coherent`, for pairs rather than the cache
+        switch: a value that cannot take effect is rejected instead of silently
+        ignored. Skipped after resolution, where these fields are outputs.
+
+        Returns:
+            ``self`` when every setting can take effect.
+
+        Raises:
+            ValueError: naming the pair and which of the two to drop.
+        """
+        if self.rung is not None:
+            return self
+        given = self.model_fields_set
+        for frac, absolute in (("gpu_budget_frac", "gpu_budget_absolute_gb"),
+                               ("host_budget_frac", "host_budget_absolute_gb")):
+            if frac in given and absolute in given:
+                warn_once(
+                    f"{frac} is ignored because {absolute} is also set and takes "
+                    f"precedence. Set only one: the fraction for a config that travels "
+                    f"between GPUs, the absolute for a hard cap on a shared one.",
+                )
+        if "offload_to_host" in given and not self.offload_to_host:
+            dead = sorted(f for f in ("host_budget_frac", "host_budget_absolute_gb")
+                          if f in given)
+            if dead:
+                warn_once(
+                    f"{dead} is ignored because offload_to_host=False disables host "
+                    f"offload entirely, so no host budget is ever consulted.",
+                )
+        # A cache that is configured never to be usable: statically decidable, so say
+        # so rather than letting every call quietly take the slowest rung.
+        if (self.cache and not self.offload_to_host
+                and self.gpu_budget_absolute_gb == 0):
+            warn_once(
+                "cache=True but gpu_budget_absolute_gb=0 with offload_to_host=False "
+                "means the cache can never be placed, so every call will take the "
+                "plain_loop rung (several times slower, and it may subsample "
+                "context). Raise the GPU budget or allow host offload.",
+            )
+        # Rule 6, the half that is decidable without hardware: when BOTH budgets are
+        # absolute, we can compare them now. Offload only engages above the GPU budget
+        # and only succeeds within the host budget, so a host budget at or below the
+        # GPU budget makes offload unreachable. The fractional case depends on the
+        # box, so resolve() carries the same check for it.
+        if (self.offload_to_host
+                and self.gpu_budget_absolute_gb is not None
+                and self.host_budget_absolute_gb is not None
+                and self.host_budget_absolute_gb <= self.gpu_budget_absolute_gb):
+            warn_once(
+                f"offload_to_host=True cannot engage: host_budget_absolute_gb="
+                f"{self.host_budget_absolute_gb} is not above gpu_budget_absolute_gb="
+                f"{self.gpu_budget_absolute_gb}, so any cache too big to stay resident "
+                f"is also too big to offload. Raise the host budget above the GPU "
+                f"budget for offload to be reachable.",
+            )
+        if ("allow_quantization" in given and not self.allow_quantization
+                and self.cache_dtype == "int8"):
+            raise ValueError(
+                "allow_quantization=False with cache_dtype='int8' is contradictory: "
+                "the first forbids quantizing, the second asks for a quantized cache "
+                "outright. Use cache_dtype='bf16' with allow_quantization=False to "
+                "stay bit-exact, or cache_dtype='int8' alone to start quantized."
+            )
+        return self
+
+    def _revalidated_copy(self, **update) -> "MemoryPolicy":
+        """Copy with ``update`` applied, re-running validation.
+
+        ``model_copy(update=...)`` does NOT re-validate, so writing a bad rung or a
+        negative budget through it would succeed silently and the validators above
+        would be decorative on the only path that actually uses them.
+
+        Args:
+            **update: field values to overwrite.
+
+        Returns:
+            The validated copy.
+        """
+        return type(self).model_validate({**self.model_dump(), **update})
+
+    # ------------------------------------------------------------------ build
+
+    @classmethod
+    def coerce(cls, value: "MemoryPreset | dict | MemoryPolicy | None") -> "MemoryPolicy":
+        """Build a policy from a preset name, a dict, an instance, or None.
+
+        Args:
+            value: ``None`` for the defaults; ``"exact"``, ``"max_context"`` or
+                ``"off"`` for a named starting point; a dict of field values (e.g.
+                parsed from a config file); or an existing policy, returned unchanged.
+
+        Returns:
+            The policy.
+
+        Raises:
+            ValueError: on an unknown preset name.
+            TypeError: on any other type.
+            pydantic.ValidationError: on an unknown or invalid dict key.
+        """
+        if isinstance(value, MemoryPolicy):
+            if value.rung is not None:
+                raise ValueError(
+                    f"memory_policy= was given an already-RESOLVED policy (rung="
+                    f"{value.rung!r}). Its decided outputs would be re-used as inputs, "
+                    f"and a policy carrying a rung skips every coherence check. Pass a "
+                    f"fresh MemoryPolicy with only the fields you want to set; "
+                    f"memory_report_ is for inspection, not for feeding back in."
+                )
+            return value
+        if value is None:
+            return cls()
+        if isinstance(value, dict):
+            if value.get("rung") is not None:
+                raise ValueError(
+                    f"memory_policy= was given a resolved report (rung={value['rung']!r}), "
+                    f"probably a memory_report_ dict. Those are outputs; feeding them "
+                    f"back in re-uses decided values as configuration and skips every "
+                    f"coherence check. Pass only the fields you want to set."
+                )
+            return cls(**value)
+        if isinstance(value, str):
+            if value not in MEMORY_PRESETS:
+                raise ValueError(
+                    f"unknown memory preset {value!r}; expected one of "
+                    f"{MEMORY_PRESETS}, a dict, or a MemoryPolicy"
+                )
+            if value == "exact":
+                # Never trade accuracy: offload (bit-exact) rather than quantize.
+                return cls(allow_quantization=False)
+            if value == "max_context":
+                # Fit the largest table possible; start quantized to free VRAM at once.
+                return cls(cache_dtype="int8")
+            return cls(cache=False)     # "off"
+        raise TypeError(
+            f"memory must be a preset name, dict, MemoryPolicy or None, "
+            f"got {type(value).__name__}"
+        )
+
+    @classmethod
+    def coerce_for_service(
+        cls,
+        value: "MemoryPreset | dict | MemoryPolicy | None",
+        *,
+        max_host_budget_frac: float,
+        min_context_row_chunk: int | None = None,
+        total_ram_gb: float | None = None,
+    ) -> "tuple[MemoryPolicy | None, tuple[str, ...], tuple[str, ...]]":
+        """Coerce a policy that arrived from a caller who does not own this process.
+
+        :meth:`coerce` is enough when the policy was written by whoever runs the
+        process: a bad value is their own problem, and a warning goes to a terminal
+        they are looking at. A **server** taking policies from requests needs three
+        more things, and all three depend on this module's own fields — which is why
+        they live here rather than in each serving target:
+
+        1. **Bound the host-RAM budgets** (:data:`HOST_BUDGET_FIELDS`). Every other
+           field spends only the requesting caller's GPU memory, so overspending is
+           self-inflicted and passed through. Host RAM is different in kind:
+           exceeding the container's cgroup limit is a SIGKILL, not a catchable
+           error, so it takes down the replica and charges the *next* caller a cold
+           start. Clamped values are returned by name so the server can report them
+           instead of applying them silently.
+        2. **Clamp before validating**, so the coherence rules below run against the
+           numbers that will actually be used — a warning about a budget that cannot
+           bite is only true of the clamped figure.
+        3. **Capture the warnings for this caller.** :func:`warn_once` de-duplicates
+           for the life of the process, so on a long-lived server the first caller to
+           make a given mistake absorbs the only copy and everyone after them is told
+           nothing — and it goes to the server's log either way, never to the person
+           who could act on it. The registry is cleared and the warnings collected
+           per call, for the server to return in its response.
+
+        Args:
+            value: what the request carried, unchanged. ``None`` means the request
+                said nothing, and is returned as ``None`` rather than as the default
+                policy, so a server can tell "not asked for" from "asked for the
+                defaults" and keep its response unchanged in the first case.
+            max_host_budget_frac: the largest share of host RAM this deployment will
+                grant. A deployment-shaped decision (it depends on what else lives in
+                the container), so it has no default here.
+            min_context_row_chunk: the smallest prefill step this deployment will run.
+                ``None`` leaves it unbounded, which is right in-process and wrong on a
+                shared server: a tiny value costs TIME rather than memory, and it spends
+                that time holding the inference lock. Also deployment-shaped, hence no
+                default.
+            total_ram_gb: host RAM to size an absolute budget against.
+                ``None`` measures it with :func:`total_host_ram_gb`, which is
+                cgroup-aware — a container sees its limit, not the machine's.
+
+        Returns:
+            ``(policy, clamped_field_names, notes)``. ``policy`` is None only when
+            ``value`` was. ``notes`` are the coherence warnings, already formatted.
+
+        Raises:
+            ValueError, TypeError: exactly as :meth:`coerce` — the caller maps them
+                onto its own status code, keeping the message, which already names
+                the offending field.
+        """
+        if value is None:
+            return None, (), ()
+
+        clamped: list[str] = []
+        ceilings = {
+            "host_budget_frac": max_host_budget_frac,
+            "host_budget_absolute_gb": max_host_budget_frac * (
+                total_host_ram_gb() if total_ram_gb is None else total_ram_gb
+            ),
+        }
+        if isinstance(value, dict):
+            value = dict(value)  # never mutate the caller's parsed request body
+            for field in HOST_BUDGET_FIELDS:
+                numeric = _as_pydantic_would_coerce(value.get(field))
+                # Compare what VALIDATION will produce, not what the JSON happens to look
+                # like. An isinstance check here let `"0.95"` and `true` straight through:
+                # pydantic runs in lax mode, so it coerces both to floats AFTER the clamp
+                # has already skipped them -- and `clamped` then came back empty, which the
+                # response documents as "honoured verbatim". A quote mark defeated the rail.
+                if numeric is None:
+                    continue                    # not numeric at all -> pydantic's error
+                if numeric > ceilings[field]:
+                    value[field] = ceilings[field]
+                    clamped.append(field)
+
+            if min_context_row_chunk is not None:
+                # A FLOOR, not a ceiling: small is the dangerous direction here, because
+                # the cost is one prefill step per `context_row_chunk` rows and the loop
+                # holds the lock. Same reporting as the budgets -- capped, never silent.
+                given = _as_pydantic_would_coerce(value.get(CONTEXT_ROW_CHUNK_FIELD))
+                if given is not None and given < min_context_row_chunk:
+                    value[CONTEXT_ROW_CHUNK_FIELD] = min_context_row_chunk
+                    clamped.append(CONTEXT_ROW_CHUNK_FIELD)
+        # A preset needs no clamping: none of them sets a host budget (they set
+        # allow_quantization / cache_dtype / cache), so the safe default fraction
+        # applies. Asserted by a test, so a new preset cannot quietly break it.
+
+        # Construction-time warnings only -- coherence checks that pydantic runs during
+        # validation. The ones resolve() emits fire later, during predict, and a server
+        # that wants those too holds its own capture across the whole request.
+        with capture_policy_notes() as notes:
+            policy = cls.coerce(value)
+        return policy, tuple(clamped), tuple(notes)
+
+    # --------------------------------------------------------------- resolve
+
+    def gpu_budget(self, total_vram_gb: float) -> float:
+        """GPU budget in GiB: the absolute override if set, else the fraction."""
+        if self.gpu_budget_absolute_gb is not None:
+            return self.gpu_budget_absolute_gb
+        return self.gpu_budget_frac * total_vram_gb
+
+    def host_budget(self, total_ram_gb: float) -> float:
+        """Host budget in GiB: the absolute override if set, else the fraction."""
+        if self.host_budget_absolute_gb is not None:
+            return self.host_budget_absolute_gb
+        return self.host_budget_frac * total_ram_gb
+
+    @property
+    def is_resolved(self) -> bool:
+        """Whether a rung has been chosen for a specific request."""
+        return self.rung is not None
+
+    @property
+    def is_bit_exact(self) -> bool:
+        """Whether the cache is stored losslessly.
+
+        Offload moves bytes without changing them, so only precision decides this.
+        """
+        return self.cache_dtype != "int8"
+
+    @property
+    def is_degraded(self) -> bool:
+        """Whether this rung is a fallback rather than the intended fast path.
+
+        ``no_cache`` is not degraded — it means the request never needed a cache.
+        Used by the predictor to decide whether to log at warning level.
+        """
+        return self.rung in ("offload_bf16", "offload_int8", "context_row_chunk", "plain_loop")
+
+    def resolve(
+        self,
+        *,
+        est_cache_gb: float,
+        bytes_per_element: int,
+        head_dim: int,
+        total_vram_gb: float | None = None,
+        total_ram_gb: float | None = None,
+        cache_eligible: bool = True,
+    ) -> "MemoryPolicy":
+        """Decide the opening rung for one request, returning a concrete policy.
+
+        Args:
+            est_cache_gb: full-precision cache footprint, from
+                :func:`estimate_cache_gb`.
+            bytes_per_element: bytes per element behind ``est_cache_gb``.
+            head_dim: ``embed_dim // nhead``, for the int8 scale overhead.
+            total_vram_gb: total VRAM; defaults to :data:`ASSUMED_VRAM_GB` when the
+                device cannot be introspected.
+            total_ram_gb: total host RAM; defaults to a probe that yields 0.0 — and
+                therefore no offload — when the platform will not say.
+            cache_eligible: False when the cached path cannot apply at all (for
+                example the query set is small enough that inference never chunks),
+                giving rung ``no_cache``.
+
+        Returns:
+            A new :class:`MemoryPolicy` with ``rung``, ``cache``, ``cache_dtype``,
+            ``offload_to_host``, both absolute budgets, ``est_cache_gb`` and
+            ``resident_gb`` concrete.
+        """
+        vram = ASSUMED_VRAM_GB if total_vram_gb is None else total_vram_gb
+        ram = total_host_ram_gb() if total_ram_gb is None else total_ram_gb
+        gpu_budget_gb = self.gpu_budget(vram)
+        host_budget_gb = self.host_budget(ram)
+        bf16_gb = est_cache_gb
+        int8_gb = int8_footprint_gb(
+            est_cache_gb, bytes_per_element=bytes_per_element, head_dim=head_dim)
+
+        def decided(rung: str, dtype: str, offload: bool, resident: float,
+                    cache: bool, budgets: bool = True) -> "MemoryPolicy":
+            return self._revalidated_copy(
+                cache=cache, cache_dtype=dtype, offload_to_host=offload,
+                gpu_budget_absolute_gb=gpu_budget_gb if budgets else None,
+                host_budget_absolute_gb=host_budget_gb if budgets else None,
+                rung=rung, est_cache_gb=est_cache_gb, resident_gb=resident,
+            )
+
+        if not self.cache or not cache_eligible:
+            # Not eligible, or switched off: nothing to place, and no budget was
+            # consulted. Report the budgets as None rather than a number computed
+            # from a VRAM figure nobody looked at -- a diagnostic that states
+            # "budget 9.6 GiB" on an 80 GB card is worse than one that says nothing.
+            return decided("no_cache", self.cache_dtype, False, 0.0, cache=False,
+                           budgets=False)
+
+        # Precisions this request may use, cheapest-accuracy-cost first. Starting at
+        # int8 means bf16 is not a candidate at all — the caller asked for the smaller
+        # cache; allow_quantization only governs DOWNGRADING from bf16.
+        if self.cache_dtype == "int8":
+            candidates = [("int8", int8_gb)]
+        elif self.allow_quantization:
+            candidates = [("bf16", bf16_gb), ("int8", int8_gb)]
+        else:
+            candidates = [("bf16", bf16_gb)]
+
+        for dtype, footprint in candidates:
+            if footprint <= gpu_budget_gb:
+                return decided(f"resident_{dtype}", dtype, False, footprint, cache=True)
+
+        if self.offload_to_host:
+            # Offload the LARGEST (i.e. most precise) candidate host RAM can hold, not
+            # the smallest. Offload transport is bit-exact at either precision, so
+            # quantizing here buys only PCIe bandwidth -- and spending accuracy for
+            # speed is exactly what this ladder exists not to do. int8 is used only
+            # when bf16 will not fit host either. Callers who would rather have the
+            # faster stream ask for it: cache_dtype="int8" or memory_policy="max_context".
+            for dtype, footprint in candidates:
+                if footprint <= host_budget_gb:
+                    return decided(f"offload_{dtype}", dtype, True, footprint, cache=True)
+
+        # Rule 6: we needed a fallback and offload could not provide one. Warn HERE
+        # rather than up-front: a host budget below the GPU budget makes offload
+        # unreachable, but that only matters once a request actually overflows VRAM.
+        # Warning at the top of resolve() fired on untouched defaults for anyone whose
+        # RAM is under ~1.6x their VRAM, for a fallback their request never reached.
+        # Do not repeat what construction already said. When BOTH budgets are absolute,
+        # rule 6a compared them at construction time and warned there; saying it again
+        # here makes one root cause produce two warnings.
+        already_warned_at_construction = (
+            self.gpu_budget_absolute_gb is not None
+            and self.host_budget_absolute_gb is not None
+        )
+        if (self.offload_to_host and host_budget_gb <= gpu_budget_gb
+                and not already_warned_at_construction):
+            warn_once(
+                f"This request needed to spill out of VRAM, but offload_to_host could "
+                f"not help: the host budget ({host_budget_gb:.1f} GiB) is not larger "
+                f"than the GPU budget ({gpu_budget_gb:.1f} GiB), so a cache too big to "
+                f"stay resident is also too big to offload. Falling back to the plain "
+                f"loop. Raise host_budget_frac / host_budget_absolute_gb above the GPU "
+                f"budget to make offload reachable.",
+            )
+        worst_dtype, worst_footprint = candidates[-1]
+        return decided("plain_loop", worst_dtype, False, worst_footprint, cache=False)
+
+    def escalated(self, rung: str, *, context_row_chunk: int | None = None,
+                  dropped_context_rows: int | None = None,
+                  query_chunk: int | None = None) -> "MemoryPolicy":
+        """Return a copy recording an escalation the caller made after an OOM.
+
+        Args:
+            rung: the rung reached, e.g. ``"context_row_chunk"`` or ``"plain_loop"``.
+            context_row_chunk: the chunk actually used, when applicable.
+            dropped_context_rows: context rows subsampled away, when applicable.
+            query_chunk: query rows per decode forward, when applicable.
+
+        Returns:
+            The updated policy.
+        """
+        updates: dict[str, object] = {"rung": rung}
+        if context_row_chunk is not None:
+            updates["context_row_chunk"] = context_row_chunk
+        if dropped_context_rows is not None:
+            updates["dropped_context_rows"] = dropped_context_rows
+        if query_chunk is not None:
+            updates["query_chunk"] = query_chunk
+        if rung == "plain_loop":
+            updates["cache"] = False
+        return self._revalidated_copy(**updates)
+
+    def describe(self) -> str:
+        """One-line human-readable summary, for logs and warnings.
+
+        Returns:
+            e.g. ``"resident_int8 (cache 48.8 GiB -> 25.9 GiB int8, GPU budget
+            31.8 GiB, host budget 503.9 GiB)"``.
+        """
+        if not self.is_resolved:
+            return "unresolved"
+        parts = [self.rung]
+        if self.est_cache_gb and self.gpu_budget_absolute_gb is not None:
+            parts.append(
+                f"(cache {self.est_cache_gb:.1f} GiB -> {self.resident_gb:.1f} GiB "
+                f"{self.cache_dtype}, GPU budget {self.gpu_budget_absolute_gb:.1f} GiB, "
+                f"host budget {self.host_budget_absolute_gb:.1f} GiB)"
+            )
+        if self.context_row_chunk:
+            parts.append(f"context_row_chunk={self.context_row_chunk}")
+        if self.dropped_context_rows:
+            parts.append(f"DROPPED {self.dropped_context_rows} context rows")
+        return " ".join(parts)

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -12,6 +12,13 @@ from synthefy_nori.inference.preprocess import (
     MADWinsorizer,
     PolynomialInteractionGenerator,
     SubSampleData)
+from synthefy_nori.inference.memory_policy import (
+    FIT_ROW_CHUNK_ON_OOM,
+    ContextTooLargeError,
+    MemoryPolicy,
+    estimate_cache_gb,
+    total_host_ram_gb,
+)
 from synthefy_nori.utils.loading import load_model
 import torch
 from typing import List, Literal
@@ -25,7 +32,11 @@ import pandas as pd
 import einops
 import json
 import os
+import logging
+import warnings
 
+
+logger = logging.getLogger(__name__)
 
 NA_PLACEHOLDER = "__MISSING__"
 
@@ -48,7 +59,8 @@ class NoriPredictor:
                  quantile_collapse: str = 'mean',
                  bar_temperature: float = 1.0,
                  bar_point_estimator: str = 'mean',
-                 discrete_y_snap_max_unique: int = 0):
+                 discrete_y_snap_max_unique: int = 0,
+                 memory_policy: "MemoryPolicy | dict | str | None" = None):
         """
         init NoriPredictor
 
@@ -104,6 +116,11 @@ class NoriPredictor:
         # Set to 0 to disable. Default 30 covers all standard discrete-y
         # benchmarks while leaving continuous y untouched.
         self.discrete_y_snap_max_unique = int(discrete_y_snap_max_unique)
+        # Stored verbatim (a preset name, dict, MemoryPolicy or None) and coerced
+        # lazily in _memory_policy(). Transforming it here would break sklearn's
+        # clone(), whose identity check requires the stored attribute to be the
+        # object it was handed.
+        self.memory_policy = memory_policy
         self.inference_with_DDP=inference_with_DDP
         # Optional inference-time augmentations. Currently supports:
         #   'yj': Yeo-Johnson target transform ensemble — fit PowerTransformer
@@ -462,8 +479,52 @@ class NoriPredictor:
             if len(np.unique(col)) < self.min_unique_num_for_numerical_infer:
                 categorical_idx.append(idx)
         return categorical_idx
-        
-    
+
+    def _warn_once_per_call(self, key: str, message: str, category) -> None:
+        """Emit ``message`` at most once per public ``predict`` call.
+
+        The runtime warnings (plain-loop fallback, context subsampling) describe the
+        REQUEST, so once per request is right -- but they are raised inside
+        ``_predict_reg_single``, which runs once per inference pipeline (16 on the
+        default config). Emitting there directly produced 16 identical copies per
+        predict, and Python's per-location de-duplication does not help because
+        ``stacklevel`` attributes them to a varying frame.
+
+        Args:
+            key: stable identifier for this warning kind.
+            message: the full warning text.
+            category: warning class to raise.
+        """
+        seen = getattr(self, "_warned_this_call", None)
+        if seen is None:
+            seen = self._warned_this_call = set()
+        if key in seen:
+            return
+        seen.add(key)
+        warnings.warn(message, category, stacklevel=4)
+
+    def _log_once_per_call(self, key: str, level: int, message: str) -> None:
+        """Log ``message`` at most once per public ``predict`` call.
+
+        Same reason as :meth:`_warn_once_per_call`, for the logger: these sites run once
+        per inference pipeline, and Python's logging has no de-duplication at all. With
+        no handler configured, logging's handler-of-last-resort writes WARNING to
+        stderr, so a user saw 16 identical lines per predict (measured 32 across two
+        calls) before this.
+
+        Args:
+            key: stable identifier for this log kind.
+            level: logging level.
+            message: the full text.
+        """
+        seen = getattr(self, "_logged_this_call", None)
+        if seen is None:
+            seen = self._logged_this_call = set()
+        if key in seen:
+            return
+        seen.add(key)
+        logger.log(level, "%s", message)
+
     def predict(self, x_train:np.ndarray, y_train:np.ndarray, x_test:np.ndarray,
                 return_distribution: bool = False) -> np.ndarray:
         """
@@ -481,6 +542,11 @@ class NoriPredictor:
             and the Yeo-Johnson point ensemble are skipped — the raw decoder
             output is the predictive distribution callers want for scoring.
         """
+        # Reset the per-call de-duplication sets. The runtime warnings and logs
+        # below are raised once per inference pipeline (16 on the default
+        # config); these make them once per user-visible predict instead.
+        self._warned_this_call = set()
+        self._logged_this_call = set()
         if return_distribution:
             return self._predict_reg(x_train, y_train, x_test, return_distribution=True)
         preds = self._predict_reg(x_train, y_train, x_test)
@@ -809,13 +875,97 @@ class NoriPredictor:
         return base
 
     def _resolve_max_elements_budget(self) -> int:
-        """Per-forward element budget: ``SYNTHEFY_MAX_ELEMENTS_BUDGET`` when set,
-        else the VRAM-aware default. Single source of truth shared by the predict
-        (``_predict_reg_single``) and embedding (``get_embeddings``) paths, which
-        had duplicated — and drifted on — this resolution.
+        """Per-forward element budget: the policy's value, else the VRAM-aware default.
+
+        Single source of truth shared by the predict (``_predict_reg_single``) and
+        embedding (``get_embeddings``) paths, which had duplicated — and drifted on
+        — this resolution. Routed through :class:`MemoryPolicy` so
+        ``memory_policy={"elements_budget": N}`` and the legacy
+        ``SYNTHEFY_MAX_ELEMENTS_BUDGET`` land in the same place; this budget is
+        upstream of the cache knobs, since the cached path engages only when the
+        query set exceeds the chunk size it implies.
         """
+        budget = self._coerced_memory_policy().elements_budget
+        if budget is not None:
+            return int(budget)
+        # Legacy, still supported: SYNTHEFY_MAX_ELEMENTS_BUDGET shipped on main long
+        # before this policy existed, is documented in public/README.md, and is how
+        # the eval CLI's --max-elements-budget reaches inference
+        # (evaluation/cli.py sets it, evaluation/harness.py records it). It is NOT
+        # part of the MemoryPolicy surface; prefer memory_policy={"elements_budget": N}.
         env_budget = os.environ.get("SYNTHEFY_MAX_ELEMENTS_BUDGET")
         return int(env_budget) if env_budget else self._default_max_elements_budget()
+
+    #: Set by ``predict`` to the resolved :class:`MemoryPolicy` for the last call (as
+    #: ``model_dump()``): which ladder rung ran, the precision chosen, the budgets
+    #: used, and any context rows dropped. None until a prediction has run.
+    #:
+    #: Exists because the fallback ladder is otherwise invisible — a request that
+    #: quietly dropped to ``plain_loop``, the one rung that may subsample the context,
+    #: is indistinguishable from a fast one except by its numbers.
+    memory_report_: dict | None = None
+
+    def _coerced_memory_policy(self) -> MemoryPolicy:
+        """This predictor's :class:`MemoryPolicy`.
+
+        No environment variables feed the policy: it is configured through
+        ``NoriPredictor(memory_policy=...)`` alone. The two env vars still honoured are
+        pre-existing, shipped, and documented in ``public/README.md`` — the
+        ``SYNTHEFY_DISABLE_CACHED_INFERENCE`` / ``SYNTHEFY_ENABLE_CACHED_INFERENCE``
+        kill switches, applied here because an operator must be able to turn the
+        cached path off in production without a redeploy.
+
+        Returns:
+            The still-unresolved policy for this predictor.
+
+        Raises:
+            RuntimeError: if ``SYNTHEFY_CACHE_MAX_GB`` is set. That variable shipped
+                on main with a *different* meaning (skip the cache above this size,
+                measured against the full-precision footprint) and no longer has an
+                equivalent. Silently ignoring a memory-safety knob could turn a
+                working job into an OOM, so this fails loudly instead.
+        """
+        if os.environ.get("SYNTHEFY_CACHE_MAX_GB") is not None:
+            raise RuntimeError(
+                "SYNTHEFY_CACHE_MAX_GB is no longer supported. It used to SKIP the "
+                "KV cache when the full-precision footprint exceeded it; the cache "
+                "is now OFFLOADED to host RAM instead of skipped, so the old value "
+                "does not translate. Use memory_policy={'gpu_budget_frac': 0.4} for a share "
+                "of VRAM (portable across GPUs) or "
+                "memory_policy={'gpu_budget_absolute_gb': N} for a hard cap on a "
+                "co-tenanted GPU. Unset the variable to continue."
+            )
+        policy = MemoryPolicy.coerce(self.memory_policy)
+        disabled = (
+            os.environ.get("SYNTHEFY_DISABLE_CACHED_INFERENCE", "0") == "1"
+            or os.environ.get("SYNTHEFY_ENABLE_CACHED_INFERENCE", "1") != "1"
+        )
+        if disabled and policy.cache:
+            logger.info("Nori KV cache disabled by environment kill switch")
+            # Rebuild rather than model_copy(cache=False): flipping cache off while the
+            # caller's cache-only levers are still set is precisely the state rule 1
+            # rejects, and model_copy would smuggle it past validation -- the
+            # inconsistency this branch removed everywhere else. Carry over only the
+            # settings that still mean something without a cache.
+            policy = MemoryPolicy(
+                cache=False,
+                elements_budget=policy.elements_budget,
+                allow_subsample=policy.allow_subsample,
+            )
+        return policy
+
+    def _total_vram_gb(self) -> float | None:
+        """Total VRAM in GiB for this predictor's device, or None if unknowable.
+
+        None rather than a guess, so :meth:`MemoryPolicy.resolve` applies its own
+        documented fallback instead of this method inventing a number.
+        """
+        try:
+            props = torch.cuda.get_device_properties(self.device)
+        except Exception:
+            # CPU inference, or a device string torch will not describe.
+            return None
+        return props.total_memory / (1024 ** 3)
 
     @staticmethod
     def _chunk_size(max_elements: int, budget_n_features: int, n_train: int) -> int:
@@ -1174,9 +1324,46 @@ class NoriPredictor:
         # model never sees the raw count when the config reduces dimensionality.
         budget_n_features = self._effective_budget_n_features(n_features, x_train)
         base_elements = (n_samples_train + 1) * budget_n_features
+        dropped_context_rows = 0
         if base_elements > MAX_ELEMENTS_BUDGET:
+            # Guard: SYNTHEFY_FORBID_SUBSAMPLE=1 makes context subsampling FAIL LOUDLY
+            # instead of silently shrinking the training set. Use for full-context
+            # evaluation where any subsampling must be visible, never silent.
+            _forbid_env = os.environ.get("SYNTHEFY_FORBID_SUBSAMPLE") == "1"
+            if not self._coerced_memory_policy().allow_subsample or _forbid_env:
+                # Name whichever setting actually forbade it. Reporting the env var to
+                # someone who set memory_policy={"allow_subsample": False} sends them hunting
+                # a variable they never set.
+                _source = ("SYNTHEFY_FORBID_SUBSAMPLE=1" if _forbid_env
+                           else "memory_policy={'allow_subsample': False}")
+                _remedy = ("Raise memory_policy={'elements_budget': N} for full context, or "
+                           "allow subsampling.")
+                raise ContextTooLargeError(
+                    f"{_source}: context subsampling required but forbidden "
+                    f"(n_train={n_samples_train}, eff_features={budget_n_features}, "
+                    f"base_elements={base_elements} > budget={MAX_ELEMENTS_BUDGET}). "
+                    f"{_remedy}"
+                )
             # If even the train set + 1 row is too big, we must subsample the training set
             max_train_samples = max(10, MAX_ELEMENTS_BUDGET // (2 * budget_n_features))
+            # Not forbidden, so we proceed — but never SILENTLY: warn so a trimmed
+            # context is always visible. Raise SYNTHEFY_MAX_ELEMENTS_BUDGET to keep
+            # full context, or set SYNTHEFY_FORBID_SUBSAMPLE=1 to make this an error.
+            # Never SILENTLY: both warn and log, with the exact row counts, so a
+            # trimmed context is visible whichever channel the caller watches. The
+            # count is also carried into memory_report_["dropped_context_rows"]
+            # below, so it survives past the warning.
+            dropped_context_rows = n_samples_train - max_train_samples
+            _subsample_msg = (
+                f"Nori: context subsampled {n_samples_train} -> {max_train_samples} rows "
+                f"({dropped_context_rows} dropped) to fit an element budget of "
+                f"{MAX_ELEMENTS_BUDGET} (base_elements={base_elements}, "
+                f"eff_features={budget_n_features}). Raise "
+                f"memory_policy={{'elements_budget': N}} for full context, or set "
+                f"memory_policy={{'allow_subsample': False}} to make this an error."
+            )
+            self._log_once_per_call("subsample", logging.WARNING, _subsample_msg)
+            self._warn_once_per_call("subsample", _subsample_msg, UserWarning)
             # Randomly subsample the training data
             rng = np.random.default_rng(self.seed)
             idx = rng.choice(n_samples_train, max_train_samples, replace=False)
@@ -1281,47 +1468,173 @@ class NoriPredictor:
                 # multi-chunk (large test) inference, scaling with the chunk count.
                 # Disable with SYNTHEFY_ENABLE_CACHED_INFERENCE=0 or the
                 # SYNTHEFY_DISABLE_CACHED_INFERENCE=1 kill switch.
-                bare_model = self.model.module if hasattr(self.model, "module") else self.model
+                # Unwrap the DDP wrapper so the cached-KV fast path (an
+                # attribute on the backbone) is reachable.
+                bare_model = self._bare_model()
+                # Gate on the MODEL's mask_prediction, not the predictor's flag.
+                # forward_cached_regression hard-requires mask_prediction=False;
+                # NoriPredictor.mask_prediction defaults to False but a training-
+                # style checkpoint builds the model with mask_prediction=True, so
+                # keying off self.mask_prediction wrongly enters the cached path
+                # and the model raises NotImplementedError under chunking. Use the
+                # model's real flag so such ckpts fall to the plain chunked loop.
+                model_mask_pred = bool(getattr(bare_model, "mask_prediction",
+                                               self.mask_prediction))
+                # Serving-memory policy. The ladder and the reasoning behind its
+                # ORDER live in ``synthefy_nori.inference.memory_policy``; here we
+                # only supply the measurements it needs and record what it picked.
+                #
+                # By default the cache stays bit-exact while it fits VRAM,
+                # quantizes to int8 only to keep it resident, and offloads to host
+                # only when it cannot be resident at any precision. So a table that
+                # serves correctly today keeps bit-exact predictions: accuracy is
+                # spent only to avoid a fallback that would otherwise be slower or
+                # fatal.
+                #
+                # Configure via NoriPredictor(memory_policy=...) — omit it for the
+                # defaults, or pass a preset name ("exact", "max_context", "off"), a
+                # dict, or a MemoryPolicy. No env var configures this; only the
+                # SYNTHEFY_DISABLE_CACHED_INFERENCE kill switch is honoured.
+                policy = self._coerced_memory_policy()
                 use_cached = (
                     hasattr(bare_model, "forward_cached_regression")
                     and not self.mask_prediction
                     and n_samples_test > chunk_size
-                    and os.environ.get("SYNTHEFY_ENABLE_CACHED_INFERENCE", "1") == "1"
-                    and os.environ.get("SYNTHEFY_DISABLE_CACHED_INFERENCE", "0") != "1"
+                    and policy.cache
                 )
                 if use_cached:
-                    # Skip the cache if its train K/V footprint would be too large.
                     fpg = max(int(getattr(bare_model, "features_per_group", 2)), 1)
                     n_groups = (budget_n_features + fpg - 1) // fpg
                     embed_dim = int(getattr(bare_model, "embed_dim", 128))
                     nlayers = int(getattr(bare_model, "nlayers", 16))
+                    nhead = max(int(getattr(bare_model, "nhead", 2)), 1)
                     bytes_per = 2 if self.mix_precision else 4
-                    est_cache_gb = (
-                        nlayers * n_groups * n_samples_train * 2 * embed_dim * bytes_per
-                    ) / (1024 ** 3)
-                    max_cache_gb = float(os.environ.get("SYNTHEFY_CACHE_MAX_GB", "6.0"))
-                    use_cached = est_cache_gb <= max_cache_gb
+                    policy = policy.resolve(
+                        est_cache_gb=estimate_cache_gb(
+                            n_context_rows=n_samples_train,
+                            n_groups=n_groups,
+                            nlayers=nlayers,
+                            embed_dim=embed_dim,
+                            bytes_per_element=bytes_per,
+                        ),
+                        bytes_per_element=bytes_per,
+                        head_dim=max(embed_dim // nhead, 1),
+                        total_vram_gb=self._total_vram_gb(),
+                        total_ram_gb=total_host_ram_gb(),
+                    )
+                    use_cached = policy.cache
+                else:
+                    policy = policy.resolve(
+                        est_cache_gb=0.0, bytes_per_element=1, head_dim=1,
+                        cache_eligible=False,
+                    )
+                # Announce the opening rung. WARNING when it is already a fallback
+                # (offload / plain loop), because that is a real slowdown the caller
+                # should see by default; INFO on the fast rungs so a normal run stays
+                # quiet but is still explainable after the fact.
+                self._log_once_per_call(
+                    "rung", logging.WARNING if policy.is_degraded else logging.INFO,
+                    f"Nori serving-memory rung: {policy.describe()}")
 
                 cached_done = False
                 if use_cached:
                     self.model.to(self.device)
-                    try:
-                        with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
-                            output = bare_model.forward_cached_regression(
-                                x=x_.unsqueeze(0),
-                                y=y_.unsqueeze(0),
-                                eval_pos=len(y_train),
-                                row_chunk_size=chunk_size,
+                    # Sequential fallback. Attempt 1 uses the resolved rung; on an
+                    # OOM, escalate to fit-time row chunking (bit-exact — it bounds
+                    # the O(N*groups) build working set, which offload alone cannot)
+                    # before dropping to the plain loop.
+                    #
+                    # A policy that PINS context_row_chunk uses it from attempt 1, which
+                    # also means there is nothing left to escalate to. That is the
+                    # documented cost of pinning it.
+                    pinned = policy.context_row_chunk
+                    fit_chunk_attempts = [pinned]
+                    if pinned is None:
+                        fit_chunk_attempts.append(FIT_ROW_CHUNK_ON_OOM)
+                    for attempt_fit_chunk in fit_chunk_attempts:
+                        try:
+                            with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
+                                output = bare_model.forward_cached_regression(
+                                    x=x_.unsqueeze(0),
+                                    y=y_.unsqueeze(0),
+                                    eval_pos=len(y_train),
+                                    row_chunk_size=chunk_size,
+                                    offload_kv_cache=policy.offload_to_host,
+                                    cache_dtype=policy.cache_dtype,
+                                    fit_row_chunk=attempt_fit_chunk,
+                                    adaptive_query_chunk=policy.adaptive_query_chunk,
+                                )
+                            output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
+                            if not torch.isfinite(output).all():
+                                output = torch.nan_to_num(output, nan=0.0, posinf=0.0, neginf=0.0)
+                            outputs.append(output)
+                            cached_done = True
+                            if attempt_fit_chunk is not None and pinned is None:
+                                policy = policy.escalated(
+                                    "context_row_chunk",
+                                    context_row_chunk=attempt_fit_chunk)
+                                logger.warning(
+                                    "Nori recovered on rung %s", policy.describe())
+                            policy = policy.escalated(
+                                policy.rung, dropped_context_rows=dropped_context_rows,
+                                query_chunk=chunk_size)
+                            self.memory_report_ = policy.model_dump()
+                            break
+                        except NotImplementedError as exc:
+                            # This checkpoint cannot do context-row chunking (serial
+                            # sequence attention). If the CALLER pinned it, that is
+                            # their error and it propagates. If we chose it ourselves
+                            # as an OOM escalation, degrade quietly to the next rung.
+                            if pinned is not None:
+                                raise
+                            logger.warning(
+                                "Nori cannot escalate to context_row_chunk on this "
+                                "checkpoint (%s); falling back to the plain loop",
+                                exc,
                             )
-                        output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
-                        if not torch.isfinite(output).all():
-                            output = torch.nan_to_num(output, nan=0.0, posinf=0.0, neginf=0.0)
-                        outputs.append(output)
-                        cached_done = True
-                    except torch.cuda.OutOfMemoryError:
-                        torch.cuda.empty_cache()
-                        cached_done = False
-                
+                            cached_done = False
+                            break
+                        except torch.cuda.OutOfMemoryError:
+                            torch.cuda.empty_cache()
+                            cached_done = False
+                            # Name the OOM and what happens next, or the escalation is
+                            # invisible in the logs and a slow run looks inexplicable.
+                            next_step = (
+                                f"retrying with fit_row_chunk={FIT_ROW_CHUNK_ON_OOM}"
+                                if attempt_fit_chunk is None and pinned is None
+                                else "falling back to the plain chunked loop"
+                            )
+                            logger.warning(
+                                "Nori OOM on rung %s (fit_row_chunk=%s); %s",
+                                policy.rung, attempt_fit_chunk, next_step,
+                            )
+                if not cached_done:
+                    # Every cached rung failed, or the policy never chose one. This
+                    # is the plain chunked loop: much slower, and the only rung that
+                    # may have to subsample the context. Say so — a silent drop here
+                    # reads as an unexplained accuracy regression to whoever is
+                    # looking at the numbers later.
+                    if policy.rung != "no_cache":
+                        policy = policy.escalated(
+                            "plain_loop", dropped_context_rows=dropped_context_rows)
+                        msg = (
+                            f"Nori fell back to the plain chunked loop: "
+                            f"{policy.describe()}. Every query chunk now recomputes "
+                            f"the context K/V, several times slower"
+                            + (f"; {dropped_context_rows} context rows were DROPPED "
+                               f"to fit" if dropped_context_rows else "")
+                            + ". Raise memory_policy={'gpu_budget_frac': ...} / "
+                            "'host_budget_frac' / 'elements_budget', or read "
+                            "predictor.memory_report_ for what was chosen."
+                        )
+                        self._log_once_per_call("plain_loop", logging.WARNING, msg)
+                        self._warn_once_per_call("plain_loop", msg, RuntimeWarning)
+                    else:
+                        policy = policy.escalated(
+                            policy.rung, dropped_context_rows=dropped_context_rows)
+                    self.memory_report_ = policy.model_dump()
+
+
                 # Chunk the test data (skipped entirely if the cached path ran)
                 all_outputs = []
                 for i in ([] if cached_done else range(0, n_samples_test, chunk_size)):

--- a/src/synthefy_nori/model/kv_cache_scaling.py
+++ b/src/synthefy_nori/model/kv_cache_scaling.py
@@ -1,0 +1,180 @@
+"""WS1 (memory engineering): make Nori's cached-regression KV cache RAM-efficient
+so dense/isab/delta serving scales to far more context rows on a fixed GPU.
+
+The train-side sequence-attention K/V cache is O(N_train) — one K/V per training
+row per layer — and is the resident-memory bottleneck at large row counts. This
+module lets that cache be:
+  * int8-quantized  (per-(row,head) absmax scale -> ~1.9x smaller than bf16/fp16,
+    ~3.8x than fp32: one byte per element plus one fp32 scale per head_dim
+    vector, which is ~+6% at head_dim 64 — count it or the resident budget
+    reads optimistic), and/or
+  * host-offloaded  (kept in CPU RAM; streamed to the GPU on demand),
+dequantizing + staging to the compute device lazily when the attention code reads
+``cache["kv"]`` — so it is transparent to ``MultiheadAttention.forward_with_kv_cache``.
+
+This mirrors TabPFN-3's serving recipe (int8 KV + host offload + chunked prefill):
+GPU high-water-mark stays ~flat in N (weights + per-chunk activations + a staged
+slice), while the O(N) cache lives in host RAM. Compute is unchanged; this is a
+memory lever only.
+"""
+from __future__ import annotations
+
+import torch
+
+
+def quantize_int8(t: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-vector (last-dim) absmax int8 quantization. Returns (int8, scale).
+
+    scale has t's shape with the last dim = 1; dequant is q.float() * scale.
+    Per-(…, head_dim-vector) scaling keeps error low without a big scale tensor.
+    """
+    scale = t.abs().amax(dim=-1, keepdim=True).clamp_min(1e-12) / 127.0
+    q = torch.clamp(torch.round(t / scale), -127, 127).to(torch.int8)
+    return q, scale.to(torch.float32)
+
+
+def dequantize_int8(q: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    return (q.to(torch.float32) * scale).to(dtype)
+
+
+class ScalableSeqKV:
+    """Dict-like drop-in for the ``{"kv","batch","groups"}`` seq-attn cache.
+
+    Stores ``kv`` int8-quantized and/or on host RAM; ``self["kv"]`` returns the
+    full-precision tensor on ``device`` (dequantized + moved), computed lazily so
+    the GPU copy is transient. ``self["batch"]``/``self["groups"]`` are plain ints.
+    """
+
+    def __init__(self, kv: torch.Tensor, batch: int, groups: int, *,
+                 quantize: bool = False, offload: bool = False,
+                 device: torch.device | None = None):
+        self.batch = int(batch)
+        self.groups = int(groups)
+        self.device = torch.device(device) if device is not None else kv.device
+        self.dtype = kv.dtype
+        self.quantized = quantize
+        self.offloaded = offload
+        store_dev = torch.device("cpu") if offload else self.device
+        if quantize:
+            q, scale = quantize_int8(kv)
+            self._q = q.to(store_dev, non_blocking=False)
+            self._scale = scale.to(store_dev, non_blocking=False)
+            self._kv = None
+        else:
+            self._q = self._scale = None
+            self._kv = kv.to(store_dev, non_blocking=False)
+
+    def __getitem__(self, key: str):
+        if key == "batch":
+            return self.batch
+        if key == "groups":
+            return self.groups
+        if key == "kv":
+            if self.quantized:
+                q = self._q.to(self.device, non_blocking=True) if self.offloaded else self._q
+                scale = self._scale.to(self.device, non_blocking=True) if self.offloaded else self._scale
+                return dequantize_int8(q, scale, self.dtype)
+            kv = self._kv
+            return kv.to(self.device, non_blocking=True) if self.offloaded else kv
+        raise KeyError(key)
+
+    @classmethod
+    def from_row_slices(cls, slices, batch: int, groups: int, *,
+                        quantize: bool = False, offload: bool = False,
+                        device: torch.device | None = None,
+                        dtype: torch.dtype | None = None) -> "ScalableSeqKV":
+        """Build from row-axis slices, folding each one in as it arrives.
+
+        ``__init__`` takes the finished tensor, which means the fit-time row-chunked
+        build (``layer.py``) would have to assemble it at full precision first — so at
+        the ``torch.cat`` the slice list *and* its copy are both resident: two
+        full-precision copies of the whole cache, on the one code path entered
+        *because* memory was already tight. This consumes an iterator instead and
+        quantizes/moves each slice immediately, so full precision never exists beyond
+        one slice.
+
+        Safe because quantization is per-(row, head) absmax over the LAST axis: a
+        row's scale depends on that row alone, so quantizing slices and concatenating
+        the int8 payloads is bit-identical to quantizing the concatenation.
+        ``test_kv_cache_scaling.py`` pins that equivalence, so if quantization ever
+        became per-tensor (as TabPFN-3 does it) the test fails rather than this build
+        silently changing meaning.
+
+        Args:
+            slices: iterable of ``kv`` tensors, row axis at dim 1, in row order.
+            batch: batch size the cache was built for.
+            groups: feature-group count the cache was built for.
+            quantize: store int8 rather than full precision.
+            offload: store on host RAM rather than the compute device.
+            device: compute device reads are staged back to.
+            dtype: dtype to dequantize back to on read; inferred from the first slice
+                when omitted.
+
+        Returns:
+            The assembled cache.
+
+        Raises:
+            ValueError: if ``slices`` is empty — a cache with no rows is a bug
+                upstream, not something to represent.
+        """
+        store = torch.device("cpu") if offload else None
+        q_parts: list[torch.Tensor] = []
+        scale_parts: list[torch.Tensor] = []
+        kv_parts: list[torch.Tensor] = []
+        for kv_slice in slices:
+            if dtype is None:
+                dtype = kv_slice.dtype
+            if device is None:
+                device = kv_slice.device
+            if quantize:
+                q, scale = quantize_int8(kv_slice)
+                q_parts.append(q if store is None else q.to(store))
+                scale_parts.append(scale if store is None else scale.to(store))
+            else:
+                kv_parts.append(kv_slice if store is None else kv_slice.to(store))
+        if not (q_parts or kv_parts):
+            raise ValueError("from_row_slices got no slices; nothing to cache")
+
+        obj = cls.__new__(cls)
+        obj.batch = int(batch)
+        obj.groups = int(groups)
+        obj.device = device if device is not None else torch.device("cpu")
+        obj.dtype = dtype
+        obj.quantized = bool(quantize)
+        obj.offloaded = bool(offload)
+        if quantize:
+            obj._q = torch.cat(q_parts, dim=1)
+            obj._scale = torch.cat(scale_parts, dim=1)
+            obj._kv = None
+        else:
+            obj._q = obj._scale = None
+            obj._kv = torch.cat(kv_parts, dim=1)
+        return obj
+
+
+    def resident_gpu_bytes(self) -> int:
+        """Bytes this cache holds resident on the GPU (0 if offloaded)."""
+        if self.offloaded:
+            return 0
+        if self.quantized:
+            return self._q.numel() + self._scale.numel() * 4
+        return self._kv.numel() * self._kv.element_size()
+
+
+def scale_caches(caches: list[dict], *, quantize: bool = False, offload: bool = False,
+                 device: torch.device | None = None) -> list[dict]:
+    """Wrap each layer cache's ``seq_kv`` in a ScalableSeqKV (in place). No-op
+    when quantize=offload=False. Returns the same list for convenience."""
+    if not (quantize or offload):
+        return caches
+    for layer_cache in caches:
+        skv = layer_cache.get("seq_kv")
+        if skv is None or isinstance(skv, ScalableSeqKV):
+            continue
+        if "kv" not in skv:   # delta/isab cache is the O(M) landmark memory, already tiny
+            continue
+        layer_cache["seq_kv"] = ScalableSeqKV(
+            skv["kv"], skv["batch"], skv["groups"],
+            quantize=quantize, offload=offload, device=device,
+        )
+    return caches

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -739,17 +739,155 @@ class EncoderBaseLayer(nn.Module):
                 out = out[0]
         return layer_norm(out + residual)
 
+    def _project_kv_cache_rowchunked(self, attn_mod, x_kv_src, copy_kv, row_chunk,
+                                     *, norm=None, offload=False, quantize=False,
+                                     device=None):
+        """Build attn_mod's K/V cache over the row axis in chunks.
+
+        Mirrors ``project_kv_cache(full)`` bit-for-bit (K/V are per-row
+        independent), but never materialises the full-N projection transient
+        (the fp32 einsum spike that OOMs at large N*groups) -- it projects
+        ``row_chunk`` rows at a time.
+
+        Each slice is quantized and/or moved to host **as it is produced**
+        (``ScalableSeqKV.from_row_slices``), so the full-precision cache is
+        never resident in whole -- neither as a slice list nor as a
+        concatenated copy. That matters because this path is entered precisely
+        when memory is already tight: assembling at full precision and
+        quantizing afterwards would peak at two full copies of the cache.
+
+        Args:
+            attn_mod: the attention module whose K/V projection to run.
+            x_kv_src: source activations, ``[B, N, groups, E]``.
+            copy_kv: forwarded to ``project_kv_cache`` as ``copy_first_head_kv``.
+            row_chunk: context rows to project per step.
+            norm: optional layer norm applied per-slice before projecting (the
+                ``pre_norm`` path); applied inside the loop so normalising does
+                not itself materialise all N rows.
+            offload: store the finished cache on host RAM.
+            quantize: store the finished cache int8.
+            device: compute device reads are staged back to.
+
+        Returns:
+            A ``ScalableSeqKV`` when quantizing/offloading, else the plain
+            ``{"kv", "batch", "groups"}`` dict.
+        """
+        from synthefy_nori.model.kv_cache_scaling import ScalableSeqKV
+
+        N = x_kv_src.shape[1]
+        B, groups = x_kv_src.shape[0], x_kv_src.shape[2]
+
+        def _row_slices():
+            """Yield each row-slice's projected K/V, one at a time.
+
+            A generator so the consumer folds each slice in and drops it before the
+            next is projected -- the whole point of this path.
+            """
+            for r0 in range(0, N, row_chunk):
+                sl = slice(r0, min(r0 + row_chunk, N))
+                rows = x_kv_src[:, sl]
+                if norm is not None:
+                    rows = norm(rows)
+                yield attn_mod.project_kv_cache(
+                    rows.transpose(1, 2), copy_first_head_kv=copy_kv)["kv"]
+
+        if not (quantize or offload):
+            # Nothing to fold in; the plain dict is what the uninstrumented path uses.
+            return {"kv": torch.cat(list(_row_slices()), dim=1),
+                    "batch": B, "groups": groups}
+        return ScalableSeqKV.from_row_slices(
+            _row_slices(), B, groups, quantize=quantize, offload=offload,
+            device=device or x_kv_src.device, dtype=x_kv_src.dtype,
+        )
+
+    def _forward_train_cache_memsaving(
+            self, x_train, feature_atten_mask, pre_seq_steps, seq_step,
+            post_seq_steps, index1, index2, row_chunk, quantize, offload, device):
+        """Memory-bounded fit-time cache build (TabPFN-3-style, non-serial only).
+
+        Keeps only ONE full-N K/V tensor resident: the self-attention cache.
+        Everything else -- queries, attention output, MLP hidden, and the
+        stored test cache -- is processed / built in row-chunks and written
+        back into ``x_train`` in place, so the peak is ~ K/V + input instead of
+        the ~4-5x working set the monolithic path materialises. Bit-exact: the
+        self-attention becomes project-once + chunked cached-query reads (each
+        query row attends to the full K/V), and the per-row MLP/feature-attn
+        steps are unchanged."""
+        seq_attn_train = self.sequence_attentions[index1]
+        seq_attn_test = self.sequence_attentions[index2]
+        seq_norm = self.layer_norms[seq_step]
+        N = x_train.shape[1]
+
+        def _rows_inplace(steps):
+            for r0 in range(0, N, row_chunk):
+                sl = slice(r0, min(r0 + row_chunk, N))
+                xc = x_train[:, sl]
+                for st in steps:
+                    xc = self._run_non_sequence_step(
+                        xc, step_idx=st, feature_atten_mask=feature_atten_mask,
+                        eval_pos=xc.shape[1])
+                x_train[:, sl] = xc
+
+        # pre-seq per-row steps (fmfmsm) -- must finish for all rows before we
+        # project K/V from the post-pre-step activations.
+        _rows_inplace(pre_seq_steps)
+
+        # Build the self-attention cache (resident) and the stored test cache
+        # (quantized/offloaded during build). Non-serial => both read the same
+        # source. The norm, when this layer is pre_norm, is applied per-slice
+        # inside the projector so it does not materialise all N rows either.
+        norm = seq_norm if self.pre_norm else None
+
+        def _proj(mod, copy_kv, **scale):
+            return self._project_kv_cache_rowchunked(
+                mod, x_train, copy_kv, row_chunk, norm=norm, device=device, **scale)
+
+        train_cache = _proj(seq_attn_train, self.self_share_all_kv_heads)
+        test_cache = _proj(seq_attn_test, self.cross_share_all_kv_heads,
+                           quantize=quantize, offload=offload)
+
+        # Self-attention as chunked cached-query reads + post steps, in place.
+        for r0 in range(0, N, row_chunk):
+            sl = slice(r0, min(r0 + row_chunk, N))
+            xr = x_train[:, sl]
+            if self.pre_norm:
+                attn_r = seq_attn_train.forward_with_kv_cache(
+                    seq_norm(xr).transpose(1, 2), train_cache)[0].transpose(1, 2)
+                xr = self._residual_add(xr, attn_r)
+            else:
+                attn_r = seq_attn_train.forward_with_kv_cache(
+                    xr.transpose(1, 2), train_cache)[0].transpose(1, 2)
+                xr = seq_norm(attn_r + xr)
+            for st in post_seq_steps:
+                xr = self._run_non_sequence_step(
+                    xr, step_idx=st, feature_atten_mask=feature_atten_mask,
+                    eval_pos=xr.shape[1])
+            x_train[:, sl] = xr
+        del train_cache
+        return x_train, {"seq_kv": test_cache}
+
     def forward_train_cache(
             self,
             x_train: torch.Tensor,
             feature_atten_mask: torch.Tensor | None = None,
+            fit_row_chunk: int | None = None,
+            quantize_kv_cache: bool = False,
+            offload_kv_cache: bool = False,
+            device=None,
     ) -> tuple[torch.Tensor, dict[str, dict[str, torch.Tensor | int]]]:
         """Run the train rows through one layer and cache train K/V for tests.
 
         This mirrors forward(..., eval_pos=n_train) for the train side, but it
         also stores projected K/V for the subsequent test cross-attention. It
         is intentionally inference-only; training still uses the standard path.
+
+        fit_row_chunk switches to a
+        memory-bounded build (TabPFN-3-style: chunked queries + in-place
+        residual + chunked/offloaded cache projection) that keeps only the
+        resident K/V tensor full-size. Supported for non-serial seq attention;
+        serial falls back to the standard monolithic path.
         """
+
         if self.layer_arch == 'fmfmsm':
             pre_seq_steps = (0, 1, 2, 3)
             seq_step = 4
@@ -765,13 +903,35 @@ class EncoderBaseLayer(nn.Module):
                 "Cached inference currently supports layer_arch='fmfmsm' and 'smf'"
             )
 
+        index1 = seq_index * 2 if self.seq_attn_isolated else seq_index
+        index2 = index1 + 1 if self.seq_attn_isolated else index1
+
+        # Memory-bounded fit build (TabPFN-3-style). Non-serial only: the serial
+        # variant's test cache reads the self-attention OUTPUT, which the chunked
+        # path would have to fully materialise -- defeating the purpose.
+        #
+        # Raise rather than fall through to the monolithic path. Silently ignoring a
+        # requested memory lever is how a caller ends up believing the cap applied
+        # while the build still peaks at O(N); the predictor catches this to decide
+        # whether to escalate elsewhere.
+        if fit_row_chunk and self.seq_attn_serial:
+            raise NotImplementedError(
+                "context_row_chunk is not supported for serial sequence attention: "
+                "the serial variant's test cache reads the self-attention output, so "
+                "the chunked build would have to materialise all rows anyway. Use "
+                "memory={'context_row_chunk': None} on this checkpoint."
+            )
+        if fit_row_chunk:
+            return self._forward_train_cache_memsaving(
+                x_train, feature_atten_mask, pre_seq_steps, seq_step,
+                post_seq_steps, index1, index2, fit_row_chunk,
+                quantize_kv_cache, offload_kv_cache, device)
+
         eval_pos = x_train.shape[1]
         for step_idx in pre_seq_steps:
             x_train = self._run_non_sequence_step(
                 x_train, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos)
 
-        index1 = seq_index * 2 if self.seq_attn_isolated else seq_index
-        index2 = index1 + 1 if self.seq_attn_isolated else index1
         seq_attn_train = self.sequence_attentions[index1]
         seq_attn_test = self.sequence_attentions[index2]
         seq_norm = self.layer_norms[seq_step]
@@ -935,13 +1095,40 @@ class LayerStack(nn.Module):
         return x,feature_attention,sample_attention
 
     def build_train_cache(self, x_train, **kwargs):
+        """Build the per-layer train K/V caches for chunked inference.
+
+        WS1 Stage 2 memory lever: with quantize/offload set, each layer's O(N)
+        seq-K/V cache is int8-quantized and/or moved to host RAM *immediately*
+        after that layer produces it — before the next layer runs. This is what
+        actually bounds the GPU high-water-mark: otherwise all len(layers) caches
+        accumulate full-precision on the GPU and the prefill peak is O(L*N), so a
+        post-hoc offload (after the whole build) can't lower it. Doing it in the
+        loop keeps at most ~one layer's cache resident during the build.
+        """
         caches = []
         feature_atten_mask = kwargs.get("feature_atten_mask", None)
+        quantize = kwargs.get("quantize_kv_cache", False)
+        offload = kwargs.get("offload_kv_cache", False)
+        device = kwargs.get("device", None)
+        fit_row_chunk = kwargs.get("fit_row_chunk", None)
+        if quantize or offload:
+            from synthefy_nori.model.kv_cache_scaling import scale_caches
         for layer in self.layers:
             x_train, layer_cache = layer.forward_train_cache(
                 x_train,
                 feature_atten_mask=feature_atten_mask,
+                fit_row_chunk=fit_row_chunk,
+                quantize_kv_cache=quantize,
+                offload_kv_cache=offload,
+                device=device,
             )
+            if quantize or offload:
+                # Scale in place, per layer: the full-precision GPU tensor is
+                # dropped as soon as the CPU/int8 copy is stored, so the next
+                # layer builds against a freed allocator slot. (No-op if the
+                # fit_row_chunk path already offloaded it -- scale_caches skips
+                # an already-wrapped ScalableSeqKV.)
+                scale_caches([layer_cache], quantize=quantize, offload=offload, device=device)
             caches.append(layer_cache)
         return x_train, caches
 

--- a/src/synthefy_nori/model/transformer.py
+++ b/src/synthefy_nori/model/transformer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import torch
 import torch.nn as nn
 from synthefy_nori.model.layer import EncoderBaseLayer, MLP, LayerStack, RMSNorm
@@ -526,6 +527,12 @@ class FeaturesTransformer(nn.Module):
             eval_pos: int,
             *,
             row_chunk_size: int | None = None,
+            cache_dtype: str = "bf16",
+            offload_kv_cache: bool = False,
+            fit_row_chunk: int | None = None,
+            adaptive_query_chunk: bool = True,
+            quantize_kv_cache: bool | None = None,
+            adaptive_oom_chunk: bool | None = None,
     ) -> torch.Tensor:
         """Regression-only cached prediction path for chunked inference.
 
@@ -533,7 +540,48 @@ class FeaturesTransformer(nn.Module):
         are computed once. Test rows are then streamed through the same layers
         using those train caches. Preprocessing still sees the full transductive
         X table once, preserving the existing inference semantics.
+
+        Args:
+            x: inputs, ``[batch, seq, feature]``.
+            y: targets, ``[batch, label]``.
+            eval_pos: index separating context rows from query rows.
+            row_chunk_size: query rows per decode forward.
+            cache_dtype: precision the stored K/V cache is kept at — ``"bf16"``
+                (bit-exact, the default) or ``"int8"``. This method takes a
+                CONCRETE precision: it does not know the device budget, so it
+                cannot decide when quantizing is worth it. That decision belongs
+                to :class:`~synthefy_nori.inference.memory_policy.MemoryPolicy`,
+                which ``NoriPredictor.predict`` resolves before calling here.
+            offload_kv_cache: keep the cache in host RAM, streaming slices back.
+            fit_row_chunk: bound the fit-time build working set to this many
+                context rows (bit-exact). ``None`` = off.
+            adaptive_query_chunk: on a decode OOM, halve the query chunk and
+                retry rather than raising.
+            quantize_kv_cache: alias for ``cache_dtype``, accepted so the WS1
+                benchmark harnesses (``internal/delta_isab/*``) run unmodified
+                against both this branch and #257 — which is what makes the
+                before/after memory comparison apples-to-apples. Prefer
+                ``cache_dtype`` in new code.
+            adaptive_oom_chunk: alias for ``adaptive_query_chunk``, same reason.
+
+        Returns:
+            Predictions for the query rows.
         """
+        # Aliases: honour them, but let the new names win when both are given, so a
+        # caller migrating one call site cannot end up with the old value silently
+        # applied.
+        if quantize_kv_cache is not None and cache_dtype == "bf16":
+            cache_dtype = "int8" if quantize_kv_cache else "bf16"
+        if adaptive_oom_chunk is not None:
+            adaptive_query_chunk = bool(adaptive_oom_chunk)
+        if cache_dtype not in ("bf16", "int8"):
+            raise ValueError(
+                "forward_cached_regression takes a concrete cache_dtype of "
+                f"'bf16' or 'int8', got {cache_dtype!r}. Deciding which one is "
+                "worth it needs the device budget, so it belongs to "
+                "MemoryPolicy.resolve() (synthefy_nori.inference.memory_policy) — "
+                "go through NoriPredictor(memory=...) rather than guessing here."
+            )
         if self.mask_prediction:
             raise NotImplementedError("forward_cached_regression requires mask_prediction=False")
         if x is None or y is None:
@@ -578,31 +626,62 @@ class FeaturesTransformer(nn.Module):
             eval_pos=eval_pos,
         )
         train_tokens = torch.cat((x_train, embedded_y[:, :eval_pos].unsqueeze(2)), dim=2)
+        # WS1 Stage 2 memory lever: int8-quantize and/or host-offload the
+        # O(N_train) seq K/V cache. Threaded INTO build_train_cache so each layer's
+        # cache is scaled the moment it's produced -- otherwise all L layers'
+        # full-precision caches accumulate on the GPU and the prefill peak is
+        # O(L*N) regardless of any post-hoc offload.
+        #
+        # Arguments only: this path reads no environment variables. Callers configure
+        # it through NoriPredictor(memory=MemoryPolicy(...)), which resolves the rung
+        # and passes the concrete decision down.
+        quantize_kv_cache = cache_dtype == "int8"
         _, caches = self.transformer_encoder.build_train_cache(
             train_tokens,
             feature_atten_mask=None,
+            quantize_kv_cache=quantize_kv_cache,
+            offload_kv_cache=offload_kv_cache,
+            fit_row_chunk=fit_row_chunk,
+            device=data_tensor.device,
         )
 
         n_test = total_rows - eval_pos
         if row_chunk_size is None or row_chunk_size <= 0:
             row_chunk_size = n_test
-        outputs = []
-        for start in range(eval_pos, total_rows, row_chunk_size):
-            end = min(start + row_chunk_size, total_rows)
+
+        def _run_chunk(start: int, end: int) -> torch.Tensor:
             x_test = self._encode_x_rows(
-                preprocessed_x,
-                slice(start, end),
-                total_rows=total_rows,
-                feature_pos_emb=feature_pos_emb,
+                preprocessed_x, slice(start, end),
+                total_rows=total_rows, feature_pos_emb=feature_pos_emb,
             )
             test_tokens = torch.cat((x_test, embedded_y[:, start:end].unsqueeze(2)), dim=2)
             test_out = self.transformer_encoder.forward_test_with_cache(
-                test_tokens,
-                caches,
-                feature_atten_mask=None,
+                test_tokens, caches, feature_atten_mask=None,
             )
             test_out = self.encoder_out_norm(test_out)
-            outputs.append(self.reg_y_decoder(test_out[:, :, -1]))
+            return self.reg_y_decoder(test_out[:, :, -1])
+
+        outputs = []
+        start = eval_pos
+        chunk = row_chunk_size
+        while start < total_rows:
+            end = min(start + chunk, total_rows)
+            try:
+                outputs.append(_run_chunk(start, end))
+                start = end
+            except torch.cuda.OutOfMemoryError:
+                # Adaptive halving: degrade the query chunk instead of dying.
+                # The reduced chunk is deliberately NOT restored for later
+                # chunks: whatever made this one not fit is a property of the
+                # request, so restoring would re-OOM on the next chunk and
+                # thrash. Cost is throughput for the rest of the table.
+                # memory_report_["query_chunk"] records the chunk this path was
+                # ENTERED with; the further halving below is internal to this loop and
+                # is not currently surfaced.
+                if not adaptive_query_chunk or chunk <= 1:
+                    raise
+                torch.cuda.empty_cache()
+                chunk = max(1, chunk // 2)
         return torch.cat(outputs, dim=1)
 
     def apply_target_aware_embedding(

--- a/tests/test_kv_cache_scaling.py
+++ b/tests/test_kv_cache_scaling.py
@@ -1,0 +1,108 @@
+"""Standalone tests for WS1 KV-cache scaling (torch-only, CPU-runnable)."""
+import torch
+
+# A normal package import. The internal tier co-locates this file next to the module and
+# loads it by path; here it lives in tests/ with the rest of this tier's suite, where a
+# path-relative load would point at the wrong directory -- and the module is importable
+# anyway, so the path hack bought nothing.
+from synthefy_nori.model.kv_cache_scaling import (
+    ScalableSeqKV,
+    dequantize_int8,
+    quantize_int8,
+    scale_caches,
+)
+
+def test_quant_roundtrip():
+    t = torch.randn(4, 100, 2, 3, 16)
+    q, s = quantize_int8(t)
+    assert q.dtype == torch.int8 and s.shape[-1] == 1
+    rel = (dequantize_int8(q, s, t.dtype) - t).abs().max() / t.abs().max()
+    assert rel < 0.02, f"int8 rel err too high: {rel}"
+
+def test_identity_when_off():
+    kv = torch.randn(2, 50, 2, 4, 8)
+    c = ScalableSeqKV(kv, 2, 5, quantize=False, offload=False, device=torch.device("cpu"))
+    assert c["batch"] == 2 and c["groups"] == 5
+    assert torch.equal(c["kv"], kv)
+
+def test_quantized_close():
+    kv = torch.randn(2, 50, 2, 4, 8)
+    c = ScalableSeqKV(kv, 2, 5, quantize=True, offload=False, device=torch.device("cpu"))
+    rel = (c["kv"] - kv).abs().max() / kv.abs().max()
+    assert rel < 0.02, rel
+
+def test_offload_transparent():
+    kv = torch.randn(2, 50, 2, 4, 8)
+    c = ScalableSeqKV(kv, 2, 5, quantize=False, offload=True, device=torch.device("cpu"))
+    assert torch.equal(c["kv"], kv) and c.resident_gpu_bytes() == 0
+
+def test_scale_caches_inplace_and_noop():
+    mk = lambda: [{"seq_kv": {"kv": torch.randn(1, 10, 2, 2, 4), "batch": 1, "groups": 1}}]
+    c0 = mk(); assert scale_caches(c0, quantize=False, offload=False) is c0
+    assert isinstance(c0[0]["seq_kv"], dict)  # untouched
+    c1 = mk(); scale_caches(c1, quantize=True, offload=True, device=torch.device("cpu"))
+    assert isinstance(c1[0]["seq_kv"], ScalableSeqKV) and c1[0]["seq_kv"]["kv"].shape == (1,10,2,2,4)
+
+def _chunks(kv, size):
+    """Split kv along the row axis (dim 1) the way the fit-time build does."""
+    return [kv[:, i:i + size] for i in range(0, kv.shape[1], size)]
+
+def test_rowchunked_int8_is_bit_identical_to_quantizing_the_whole_tensor():
+    """Quantizing per row-slice must equal quantizing after the concat.
+
+    This is what licenses the memory win: the builder never holds a
+    full-precision copy of the whole cache, and it is allowed to do that only
+    because the absmax scale is taken over the LAST axis (head_dim), so a row's
+    scale depends on that row alone. If quantization ever became global -- or
+    per-tensor, as TabPFN-3 does it -- this test fails and the row-chunked build
+    would have to change with it.
+    """
+    kv = torch.randn(3, 257, 2, 4, 16)      # 257 rows: deliberately not a multiple
+    whole_q, whole_scale = quantize_int8(kv)
+    built = ScalableSeqKV.from_row_slices(
+        iter(_chunks(kv, 64)), 3, 4, quantize=True, offload=False,
+        device=torch.device("cpu"), dtype=kv.dtype)
+    assert torch.equal(built._q, whole_q), "int8 payload differs from whole-tensor quant"
+    assert torch.equal(built._scale, whole_scale), "scales differ from whole-tensor quant"
+    # ...and therefore the dequantized read is identical too.
+    assert torch.equal(built["kv"], dequantize_int8(whole_q, whole_scale, kv.dtype))
+
+def test_rowchunked_bf16_reassembles_exactly():
+    kv = torch.randn(2, 100, 2, 3, 8)
+    out = ScalableSeqKV.from_row_slices(
+        iter(_chunks(kv, 32)), 2, 3, quantize=False, offload=False,
+        device=torch.device("cpu"), dtype=kv.dtype)
+    assert torch.equal(out["kv"], kv)
+
+def test_rowchunked_offload_keeps_nothing_resident():
+    kv = torch.randn(2, 100, 2, 3, 8)
+    out = ScalableSeqKV.from_row_slices(
+        iter(_chunks(kv, 32)), 2, 3, quantize=True, offload=True,
+        device=torch.device("cpu"), dtype=kv.dtype)
+    assert out.resident_gpu_bytes() == 0
+    assert out["kv"].shape == kv.shape
+
+def test_rowchunked_matches_the_unchunked_scalable_cache():
+    """One slice == no chunking: the builder and ScalableSeqKV must agree."""
+    kv = torch.randn(2, 64, 2, 3, 8)
+    direct = ScalableSeqKV(kv, 2, 3, quantize=True, offload=False,
+                           device=torch.device("cpu"))
+    built = ScalableSeqKV.from_row_slices(
+        iter([kv]), 2, 3, quantize=True, offload=False,
+        device=torch.device("cpu"), dtype=kv.dtype)
+    assert torch.equal(built["kv"], direct["kv"])
+
+if __name__ == "__main__":
+    for n, f in sorted(globals().items()):
+        if n.startswith("test_") and callable(f):
+            f(); print("PASS", n)
+    print("all kv-cache-scaling tests passed")
+
+def test_from_row_slices_rejects_an_empty_iterator():
+    # A cache with no rows is an upstream bug, not a state worth representing.
+    try:
+        ScalableSeqKV.from_row_slices(iter([]), 1, 1, quantize=True,
+                                      device=torch.device("cpu"), dtype=torch.float32)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on an empty slice iterator")

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -1,0 +1,777 @@
+"""Tests for MemoryPolicy — the ladder, the budgets, and the config surface.
+
+Deliberately GPU-free: resolution is pure arithmetic, so every rung boundary can be
+pinned in CI on every PR rather than only being exercised by whoever happens to run
+a 500k-row table on a big card.
+
+The load-bearing test is
+:func:`TestAutoLadder.test_small_table_stays_bit_exact_even_though_int8_would_fit` —
+it encodes the decision that int8 is *not* charged to requests with no memory
+problem. That is exactly the kind of default that regresses silently a year later,
+because "int8 is basically free" is true per-request and wrong as a policy.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from synthefy_nori.inference import memory_policy as _mp
+from synthefy_nori.inference.memory_policy import (
+    DEFAULT_GPU_BUDGET_FRAC,
+    MEMORY_PRESETS,
+    MemoryPolicy,
+    estimate_cache_gb,
+    int8_footprint_gb,
+    total_host_ram_gb,
+)
+
+# The deployed ~5.87M checkpoint's shape, as used by the WS1 Stage 2 matrix.
+NORI_6M = dict(nlayers=16, embed_dim=128, bytes_per_element=2)
+H100_80GB_VRAM = 79.6
+H100_BUDGET = DEFAULT_GPU_BUDGET_FRAC * H100_80GB_VRAM          # ~31.8 GiB at the default fraction
+HEAD_DIM = 64                                # embed_dim 128 / nhead 2
+BIG_RAM = 1024.0
+
+
+@pytest.fixture(autouse=True)
+def _forget_emitted_warnings():
+    """Clear the once-per-process warning registry between tests.
+
+    Config warnings are de-duplicated process-wide (see memory_policy.warn_once), so
+    without this a `pytest.warns` assertion would pass or fail depending on whether an
+    earlier test in the same session already emitted the same text — order-dependent
+    flakiness, which pytest-randomly would surface eventually.
+    """
+    _mp._WARNED_ONCE.clear()
+    yield
+    _mp._WARNED_ONCE.clear()
+
+
+def cache_gb(n_rows: int, n_groups: int) -> float:
+    """Full-precision cache footprint for the 6M model at this shape."""
+    return estimate_cache_gb(n_context_rows=n_rows, n_groups=n_groups, **NORI_6M)
+
+
+def resolve(est_gb: float, policy: MemoryPolicy | None = None, **kwargs) -> MemoryPolicy:
+    """Resolve a policy for the 6M model on an 80 GB H100 with ample host RAM."""
+    kwargs.setdefault("total_vram_gb", H100_80GB_VRAM)
+    kwargs.setdefault("total_ram_gb", BIG_RAM)
+    return (policy or MemoryPolicy()).resolve(
+        est_cache_gb=est_gb, bytes_per_element=2, head_dim=HEAD_DIM, **kwargs
+    )
+
+
+class TestFootprintArithmetic:
+    def test_cache_scales_with_layers_rows_groups_and_width(self):
+        # One key and one value vector of width embed_dim per (layer, group, row)
+        # -> the factor 2.
+        expected = (16 * 8 * 50_000 * 2 * 128 * 2) / (1024 ** 3)
+        assert cache_gb(50_000, 8) == pytest.approx(expected)
+
+    def test_int8_saves_about_1_9x_against_bf16_not_4x(self):
+        # 4x holds only against fp32. Against bf16 it is 2x minus the fp32 absmax
+        # scale (one per head_dim vector) -> ~1.9x. Over-claiming here is exactly
+        # what makes a resident budget optimistic.
+        int8_gb = int8_footprint_gb(8.0, bytes_per_element=2, head_dim=HEAD_DIM)
+        assert int8_gb == pytest.approx(4.25)          # 4.0 payload + 0.25 scale
+        assert 8.0 / int8_gb == pytest.approx(1.88, abs=0.01)
+
+    def test_scale_overhead_shrinks_as_head_dim_grows(self):
+        wide = int8_footprint_gb(8.0, bytes_per_element=2, head_dim=256)
+        narrow = int8_footprint_gb(8.0, bytes_per_element=2, head_dim=16)
+        assert wide < narrow
+
+    def test_host_ram_probe_is_positive_or_a_declared_unknown(self):
+        # 0.0 means "cannot tell" and must disable offload rather than invent a
+        # number -- guessing gets the process OOM-killed instead of degrading.
+        assert total_host_ram_gb() >= 0.0
+
+
+class TestBudgets:
+    def test_fraction_is_relative_to_the_card(self):
+        # The whole point of a fraction: one setting, portable across hardware.
+        policy = MemoryPolicy()
+        assert policy.gpu_budget(79.6) == pytest.approx(31.84)
+        assert policy.gpu_budget(143.0) == pytest.approx(57.2)
+
+    def test_absolute_override_wins_for_a_co_tenanted_gpu(self):
+        policy = MemoryPolicy(gpu_budget_absolute_gb=20.0)
+        assert policy.gpu_budget(143.0) == 20.0
+
+    def test_host_budget_is_also_a_fraction(self):
+        # A flat 128 GB "fits" on a 32 GB laptop by arithmetic; offload then
+        # proceeds and the kernel OOM-kills the process. A fraction cannot.
+        laptop = MemoryPolicy().host_budget(32.0)
+        assert laptop == pytest.approx(8.0)
+        assert laptop < 128.0
+
+    def test_unknown_host_ram_yields_no_host_budget(self):
+        assert MemoryPolicy().host_budget(0.0) == 0.0
+
+    def test_out_of_range_fractions_are_rejected(self):
+        with pytest.raises(ValidationError):
+            MemoryPolicy(gpu_budget_frac=40)        # 40x VRAM, surely a typo
+        with pytest.raises(ValidationError):
+            MemoryPolicy(gpu_budget_frac=0)
+        with pytest.raises(ValidationError):
+            MemoryPolicy(host_budget_absolute_gb=-5)
+
+
+class TestAutoLadder:
+    def test_small_table_stays_bit_exact_even_though_int8_would_fit(self):
+        """The decision: never spend accuracy on a request that fits anyway.
+
+        6M at 50k rows x 16 features is ~3 GiB of cache against a ~32 GiB budget on
+        an 80 GB H100. Both precisions fit comfortably, so the tie must break toward
+        bit-exact. Under the previous default this shape was quantized and returned
+        a max prediction difference of 0.046875 versus the un-quantized path.
+        """
+        policy = resolve(cache_gb(50_000, 8))
+        assert policy.rung == "resident_bf16"
+        assert policy.cache_dtype == "bf16"
+        assert policy.is_bit_exact
+        assert policy.cache and not policy.offload_to_host
+
+    def test_quantizes_only_to_keep_the_cache_resident(self):
+        # bf16 overflows the budget, int8 does not -> quantize rather than pay PCIe
+        # streaming. The one lossy rung, reached only because the rung above it
+        # could not serve the request.
+        policy = resolve(H100_BUDGET * 1.5)
+        assert policy.rung == "resident_int8"
+        assert policy.cache_dtype == "int8"
+        assert not policy.is_bit_exact
+        assert not policy.offload_to_host
+
+    def test_offloads_at_full_precision_when_host_ram_can_hold_it(self):
+        # Offload transport is bit-exact at either precision, so quantizing here
+        # would buy only PCIe bandwidth -- accuracy is not spent for speed.
+        policy = resolve(H100_BUDGET * 4)
+        assert policy.rung == "offload_bf16"
+        assert policy.is_bit_exact
+        assert policy.offload_to_host and policy.cache
+
+    def test_offloads_quantized_only_when_bf16_will_not_fit_host(self):
+        # bf16 = 127 GiB exceeds a 100 GiB host budget; int8 (~68 GiB) fits.
+        policy = resolve(H100_BUDGET * 4, total_ram_gb=400.0)
+        assert policy.rung == "offload_int8"
+        assert not policy.is_bit_exact
+
+    def test_falls_to_plain_loop_when_host_cannot_take_it_either(self):
+        with pytest.warns(UserWarning, match="could not help"):
+            policy = resolve(H100_BUDGET * 4, total_ram_gb=4.0)
+        assert policy.rung == "plain_loop"
+        assert not policy.cache
+
+    def test_unknown_host_ram_disables_offload_rather_than_guessing(self):
+        with pytest.warns(UserWarning, match="could not help"):
+            policy = resolve(H100_BUDGET * 4, total_ram_gb=0.0)
+        assert policy.rung == "plain_loop"
+        assert not policy.cache
+
+    def test_offload_to_host_false_reproduces_legacy_skip_the_cache(self):
+        policy = resolve(H100_BUDGET * 4, MemoryPolicy(offload_to_host=False))
+        assert policy.rung == "plain_loop"
+        assert not policy.cache and not policy.offload_to_host
+
+    def test_rungs_are_monotonic_in_table_size(self):
+        # Growing the table may only move us down the ladder, never back up. These
+        # four row counts walk every rung in order on an 80 GB card.
+        expected = ["resident_bf16", "resident_int8", "offload_bf16", "plain_loop"]
+        seen = [resolve(cache_gb(n, 8)).rung
+                for n in (10_000, 655_000, 2_000_000, 20_000_000)]
+        assert seen == expected
+
+    def test_ineligible_request_reports_no_cache(self):
+        policy = resolve(0.0, cache_eligible=False)
+        assert policy.rung == "no_cache"
+        assert not policy.cache and policy.is_bit_exact
+
+    def test_resolved_policy_is_fully_concrete(self):
+        for est in (0.1, H100_BUDGET * 1.5, H100_BUDGET * 4):
+            policy = resolve(est)
+            assert policy.is_resolved
+            assert policy.cache_dtype in ("bf16", "int8")
+            assert isinstance(policy.offload_to_host, bool)
+            assert policy.gpu_budget_absolute_gb is not None
+            assert policy.host_budget_absolute_gb is not None
+
+    def test_resolve_returns_a_memory_policy_not_a_second_type(self):
+        # One type in, one type out: a resolved policy is just one with no "auto"
+        # left, which is why there is no separate decision object to keep straight.
+        assert isinstance(resolve(1.0), MemoryPolicy)
+
+
+class TestPinnedPrecision:
+    def test_exact_preset_offloads_rather_than_quantizing(self):
+        # "exact" must stay exact: when it will not fit the GPU the answer is host
+        # RAM (bit-exact transport), never a silent downgrade to int8.
+        policy = resolve(H100_BUDGET * 4, MemoryPolicy.coerce("exact"))
+        assert policy.rung == "offload_bf16"
+        assert policy.cache_dtype == "bf16" and policy.is_bit_exact
+
+    def test_int8_pinned_quantizes_even_when_bf16_would_fit(self):
+        policy = resolve(cache_gb(50_000, 8), MemoryPolicy(cache_dtype="int8"))
+        assert policy.rung == "resident_int8"
+
+    def test_max_context_starts_quantized(self):
+        # It does not force offload: starting int8 already frees the VRAM, and the
+        # ladder will offload only if even that will not fit.
+        policy = resolve(cache_gb(50_000, 8), MemoryPolicy.coerce("max_context"))
+        assert policy.rung == "resident_int8"
+        assert policy.cache_dtype == "int8"
+
+    def test_off_preset_never_caches(self):
+        policy = resolve(cache_gb(50_000, 8), MemoryPolicy.coerce("off"))
+        assert policy.rung == "no_cache"
+        assert not policy.cache
+
+
+class TestConfigSurface:
+    def test_presets_cover_the_documented_names(self):
+        assert set(MEMORY_PRESETS) == {"exact", "max_context", "off"}
+        for name in MEMORY_PRESETS:
+            assert isinstance(MemoryPolicy.coerce(name), MemoryPolicy)
+
+    def test_none_means_the_defaults(self):
+        # There is deliberately no "auto" preset: omitting memory_policy= already means
+        # the defaults, so a name for it would be a second spelling of nothing.
+        assert MemoryPolicy.coerce(None) == MemoryPolicy()
+        with pytest.raises(ValueError, match="unknown memory preset"):
+            MemoryPolicy.coerce("auto")
+
+    def test_dict_config_is_accepted(self):
+        # The config-file path: parsed YAML/JSON lands here.
+        assert MemoryPolicy.coerce({"gpu_budget_frac": 0.25}).gpu_budget_frac == 0.25
+
+    def test_a_policy_passes_through_unchanged(self):
+        policy = MemoryPolicy(cache_dtype="bf16")
+        assert MemoryPolicy.coerce(policy) is policy
+
+    def test_typos_are_rejected_not_ignored(self):
+        # The failure mode this guards: a silently-ignored key on a knob whose whole
+        # job is "do not lose accuracy" would be wrong forever with no signal.
+        with pytest.raises(ValidationError):
+            MemoryPolicy.coerce({"int_8": False})
+        with pytest.raises(ValidationError):
+            MemoryPolicy.coerce({"gpu_budget": 20})
+        with pytest.raises(ValidationError):
+            MemoryPolicy.coerce({"offload": True})       # renamed to offload_to_host
+
+    def test_unknown_preset_and_wrong_type_are_rejected(self):
+        with pytest.raises(ValueError, match="unknown memory preset"):
+            MemoryPolicy.coerce("fastest")
+        with pytest.raises(TypeError):
+            MemoryPolicy.coerce(3.5)
+
+    def test_unknown_rung_is_rejected(self):
+        with pytest.raises(ValidationError):
+            MemoryPolicy(rung="resident_fp8")
+
+    def test_policy_is_frozen_and_hashable(self):
+        policy = MemoryPolicy()
+        assert hash(policy) is not None
+        with pytest.raises(ValidationError):
+            policy.cache_dtype = "int8"
+
+    def test_every_field_documents_itself(self):
+        # These descriptions are the user-facing documentation for the knobs and
+        # become the JSON Schema if the preset is ever exposed over the API.
+        for name, field in MemoryPolicy.model_fields.items():
+            assert field.description, f"{name} has no description"
+
+
+class TestEscalation:
+    def test_context_row_chunk_escalation_is_recorded(self):
+        policy = resolve(cache_gb(50_000, 8)).escalated("context_row_chunk", context_row_chunk=2048)
+        assert policy.rung == "context_row_chunk"
+        assert policy.context_row_chunk == 2048
+        assert policy.cache
+
+    def test_plain_loop_escalation_turns_the_cache_off(self):
+        policy = resolve(cache_gb(50_000, 8)).escalated("plain_loop")
+        assert policy.rung == "plain_loop"
+        assert not policy.cache
+
+    def test_subsample_count_is_recorded(self):
+        # The reviewer's question: where does a dropped context show up? Here, so it
+        # survives past the log line into memory_report_.
+        policy = resolve(cache_gb(50_000, 8)).escalated(
+            "plain_loop", dropped_context_rows=1234)
+        assert policy.dropped_context_rows == 1234
+        assert "DROPPED 1234 context rows" in policy.describe()
+
+    def test_describe_names_the_rung_and_the_numbers(self):
+        text = resolve(cache_gb(50_000, 8)).describe()
+        assert text.startswith("resident_bf16")
+        assert "GPU budget" in text and "host budget" in text
+
+    def test_report_round_trips_through_a_dict(self):
+        # predictor.memory_report_ is exactly this dump, so it must reconstruct.
+        policy = resolve(cache_gb(50_000, 8))
+        assert MemoryPolicy(**policy.model_dump()) == policy
+
+
+class TestPermissionsInsteadOfSentinels:
+    """Every default is a literal value; adaptivity is expressed as permissions."""
+
+    def test_declared_defaults_are_real_values_not_sentinels(self):
+        # The reviewer's point: reading the signature should tell you what happens
+        # without looking anything up. No field defaults to "auto".
+        policy = MemoryPolicy()
+        assert policy.cache_dtype == "bf16"          # a precision, not "auto"
+        assert policy.allow_quantization is True
+        assert policy.offload_to_host is True
+        assert policy.context_row_chunk is None          # off, plainly
+        assert policy.gpu_budget_frac == DEFAULT_GPU_BUDGET_FRAC
+        for field in MemoryPolicy.model_fields.values():
+            assert field.default != "auto", "an 'auto' sentinel crept back in"
+
+    def test_allow_quantization_false_keeps_every_rung_bit_exact(self):
+        for est in (cache_gb(50_000, 8), H100_BUDGET * 1.5, H100_BUDGET * 4):
+            policy = resolve(est, MemoryPolicy(allow_quantization=False))
+            assert policy.is_bit_exact, policy.rung
+            assert policy.cache_dtype == "bf16"
+
+    def test_starting_at_int8_never_considers_bf16(self):
+        # Asking for int8 outright must not be silently upgraded to bf16 even when
+        # bf16 would fit -- the caller wanted the smaller cache.
+        policy = resolve(cache_gb(50_000, 8), MemoryPolicy(cache_dtype="int8"))
+        assert policy.rung == "resident_int8"
+
+    def test_int8_with_quantization_forbidden_is_contradictory(self):
+        # One forbids quantizing, the other asks for a quantized cache. Reading them
+        # together tells you nothing, so it is rejected rather than resolved by a
+        # precedence rule nobody would remember.
+        with pytest.raises(ValidationError, match="contradictory"):
+            MemoryPolicy(cache_dtype="int8", allow_quantization=False)
+
+    def test_offload_prefers_the_smallest_candidate_that_host_can_hold(self):
+        # bf16 (128 GiB) will not fit a 100 GiB host budget but int8 (~68 GiB) will.
+        est = H100_BUDGET * 4
+        policy = resolve(est, total_ram_gb=400.0)     # host budget = 100 GiB
+        assert policy.rung == "offload_int8"
+
+    def test_offload_stays_bf16_when_quantization_is_forbidden(self):
+        est = H100_BUDGET * 2
+        policy = resolve(est, MemoryPolicy(allow_quantization=False))
+        assert policy.rung == "offload_bf16"
+        assert policy.is_bit_exact
+
+
+class TestPredictorEnvSurface:
+    """The policy itself reads no env vars; only the kill switch survives."""
+
+    def _policy_of(self, memory_policy=None):
+        # _coerced_memory_policy() touches only self.memory_policy and the environment, so a bare
+        # instance is enough — no checkpoint load required.
+        from synthefy_nori.inference.predictor import NoriPredictor
+        predictor = NoriPredictor.__new__(NoriPredictor)
+        predictor.memory_policy = memory_policy
+        return predictor._coerced_memory_policy()
+
+    def test_no_env_var_configures_the_policy(self, monkeypatch):
+        for name in ("SYNTHEFY_KV_CACHE_DTYPE", "SYNTHEFY_KV_INT8",
+                     "SYNTHEFY_KV_OFFLOAD", "SYNTHEFY_KV_GPU_BUDGET_FRAC",
+                     "SYNTHEFY_CACHE_HOST_MAX_GB", "SYNTHEFY_FIT_ROW_CHUNK"):
+            monkeypatch.setenv(name, "int8" if "DTYPE" in name else "1")
+        policy = self._policy_of()
+        assert policy == MemoryPolicy(), "an env var leaked into the policy"
+
+    def test_disable_kill_switch_is_honoured(self, monkeypatch):
+        monkeypatch.setenv("SYNTHEFY_DISABLE_CACHED_INFERENCE", "1")
+        assert self._policy_of().cache is False
+
+    def test_legacy_enable_zero_also_disables(self, monkeypatch):
+        # Shipped and documented in public/README.md, so it keeps working.
+        monkeypatch.setenv("SYNTHEFY_ENABLE_CACHED_INFERENCE", "0")
+        assert self._policy_of().cache is False
+
+    def test_removed_cache_max_gb_fails_loudly(self, monkeypatch):
+        # It shipped with a DIFFERENT meaning (skip vs offload), so silently ignoring
+        # it could turn a working job into an OOM. Fail instead.
+        monkeypatch.setenv("SYNTHEFY_CACHE_MAX_GB", "6.0")
+        with pytest.raises(RuntimeError, match="no longer supported"):
+            self._policy_of()
+
+    def test_preset_and_dict_reach_the_policy(self):
+        assert self._policy_of("exact").allow_quantization is False
+        assert self._policy_of({"gpu_budget_frac": 0.25}).gpu_budget_frac == 0.25
+
+
+class TestIncoherentConfigsAreRejected:
+    """A correctly-spelled request that cannot be honoured must fail, not be dropped.
+
+    `extra="forbid"` catches typos. This catches the worse case: every key spelled
+    right, and the caller still gets none of what they asked for.
+    """
+
+    def test_row_chunking_without_caching_is_rejected(self):
+        # The headline case. context_row_chunk bounds the fit-time K/V build, which only
+        # runs on the cached path, so "row chunking, no KV cache" is unreachable.
+        with pytest.raises(ValidationError, match="not a\n?\\s*reachable configuration"):
+            MemoryPolicy(cache=False, context_row_chunk=2048)
+
+    @pytest.mark.parametrize("lever", [
+        {"context_row_chunk": 2048},
+        {"cache_dtype": "int8"},
+        {"offload_to_host": True},
+        {"allow_quantization": False},
+    ])
+    def test_every_cache_only_lever_is_rejected_with_cache_off(self, lever):
+        with pytest.raises(ValidationError, match="cache=False cannot be combined"):
+            MemoryPolicy(cache=False, **lever)
+
+    def test_the_error_names_every_unhonourable_field(self):
+        with pytest.raises(ValidationError) as exc:
+            MemoryPolicy(cache=False, context_row_chunk=2048, cache_dtype="int8")
+        for name in ("cache_dtype", "context_row_chunk"):
+            assert name in str(exc.value)
+
+    def test_off_preset_stays_legal(self):
+        # cache=False alone is the "off" preset and must not trip the check --
+        # offload_to_host defaults to True, so only EXPLICITLY set levers count.
+        assert MemoryPolicy.coerce("off").cache is False
+        assert MemoryPolicy(cache=False).cache is False
+
+    def test_every_combination_either_works_or_raises_clearly(self):
+        """Sweep the field space: no combination may silently drop a lever."""
+        from itertools import product
+        checked = rejected = 0
+        for cache, dtype, allow_q, offload, chunk in product(
+                [True, False], ["bf16", "int8"], [True, False], [True, False],
+                [None, 2048]):
+            kwargs = dict(cache=cache, cache_dtype=dtype,
+                          allow_quantization=allow_q, offload_to_host=offload)
+            if chunk is not None:
+                kwargs["context_row_chunk"] = chunk
+            checked += 1
+            contradictory = dtype == "int8" and not allow_q
+            try:
+                policy = MemoryPolicy(**kwargs)
+            except ValidationError:
+                rejected += 1
+                # Every rejection must have one of the two documented reasons.
+                assert (not cache) or contradictory, (
+                    f"unexplained rejection: {kwargs}")
+                continue
+            assert cache and not contradictory, f"should have been rejected: {kwargs}"
+            # Accepted => the cache is on, so every lever can actually take effect.
+            resolved = resolve(cache_gb(50_000, 8), policy)
+            assert resolved.is_resolved
+        assert checked == 32
+        # 16 with cache=False (each sets cache-only levers explicitly here), plus the
+        # 4 cache=True ones pairing cache_dtype="int8" with allow_quantization=False.
+        assert rejected == 20, f"expected 20 rejections, got {rejected}"
+
+
+class TestResolutionIsValidated:
+    """model_copy does not re-validate; the copies used by resolve/escalated must."""
+
+    def test_escalated_rejects_an_unknown_rung(self):
+        with pytest.raises(ValidationError, match="rung must be one of"):
+            MemoryPolicy().escalated("resident_fp8")
+
+    def test_escalated_rejects_a_negative_row_count(self):
+        with pytest.raises(ValidationError):
+            resolve(cache_gb(50_000, 8)).escalated("plain_loop",
+                                                   dropped_context_rows=-5)
+
+    def test_resolved_policy_may_report_cache_false_with_a_concrete_dtype(self):
+        # The coherence check must NOT fire on outputs: plain_loop legitimately has
+        # cache=False alongside a concrete cache_dtype.
+        policy = resolve(H100_BUDGET * 4, MemoryPolicy(offload_to_host=False))
+        assert policy.rung == "plain_loop"
+        assert policy.cache is False and policy.cache_dtype in ("bf16", "int8")
+
+    def test_escalating_a_resolved_policy_round_trips(self):
+        policy = resolve(cache_gb(50_000, 8)).escalated("context_row_chunk",
+                                                        context_row_chunk=2048)
+        assert MemoryPolicy(**policy.model_dump()) == policy
+
+
+class TestNoCacheReportsNoBudget:
+    def test_no_cache_does_not_invent_a_budget(self):
+        # Previously reported 9.6 GiB (0.4 x ASSUMED_VRAM_GB) even on an 80 GB card,
+        # for a decision where no budget was consulted at all.
+        policy = MemoryPolicy().resolve(
+            est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
+        assert policy.rung == "no_cache"
+        assert policy.gpu_budget_absolute_gb is None
+        assert policy.host_budget_absolute_gb is None
+
+    def test_describe_survives_absent_budgets(self):
+        policy = MemoryPolicy().resolve(
+            est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
+        assert policy.describe() == "no_cache"
+
+    def test_a_real_rung_still_reports_both_budgets(self):
+        policy = resolve(cache_gb(50_000, 8))
+        assert policy.gpu_budget_absolute_gb is not None
+        assert policy.host_budget_absolute_gb is not None
+
+
+class TestDeadSettingsWarn:
+    """A setting another makes unreachable WARNS -- it is not silent, not fatal.
+
+    The error/warn split follows one rule: error when we cannot know what the caller
+    meant, or when guessing wrong would cost accuracy; warn when intent is clear and
+    the extra setting is merely inert. Both of these have an obvious precedence AND a
+    legitimate way to be reached innocently (a base config sets the fraction, a
+    per-run override sets the absolute), so refusing them would break config layering
+    for no safety gain.
+    """
+
+    def test_both_gpu_budget_forms_warns_and_absolute_wins(self):
+        with pytest.warns(UserWarning, match="gpu_budget_frac is ignored"):
+            policy = MemoryPolicy(gpu_budget_frac=0.3, gpu_budget_absolute_gb=20)
+        assert policy.gpu_budget(100.0) == 20.0
+
+    def test_both_host_budget_forms_warns_and_absolute_wins(self):
+        with pytest.warns(UserWarning, match="host_budget_frac is ignored"):
+            policy = MemoryPolicy(host_budget_frac=0.3, host_budget_absolute_gb=64)
+        assert policy.host_budget(1000.0) == 64.0
+
+    def test_host_budget_with_offload_disabled_warns(self):
+        with pytest.warns(UserWarning, match="offload_to_host=False"):
+            MemoryPolicy(offload_to_host=False, host_budget_absolute_gb=64)
+
+    def test_cache_that_can_never_be_placed_warns(self):
+        with pytest.warns(UserWarning, match="can never be placed"):
+            MemoryPolicy(gpu_budget_absolute_gb=0.0, offload_to_host=False)
+
+    def test_either_budget_form_alone_is_fine(self):
+        assert MemoryPolicy(gpu_budget_frac=0.3).gpu_budget(100.0) == 30.0
+        assert MemoryPolicy(gpu_budget_absolute_gb=20).gpu_budget(100.0) == 20.0
+
+    def test_resolved_policies_carry_both_forms_without_tripping_the_check(self):
+        # resolve() writes the decided absolute budget while the fraction is still
+        # set, which is legal precisely because rung is no longer None.
+        policy = resolve(cache_gb(50_000, 8), MemoryPolicy(gpu_budget_frac=0.3))
+        assert policy.gpu_budget_frac == 0.3
+        assert policy.gpu_budget_absolute_gb is not None
+
+
+class TestOffloadReachability:
+    """Rule 6: offload_to_host is dead when the host budget is not the larger one.
+
+    Found by the differential prober (`scratchpad/probe_inert.py`), not by reading the
+    code -- offload only engages above the GPU budget, so a host budget at or below it
+    can never rescue anything.
+    """
+
+    def test_warns_only_when_a_request_actually_needed_the_dead_fallback(self):
+        # 200 GiB cache against a 70 GiB GPU budget and a 50 GiB host budget: the
+        # request needs to spill and offload cannot help, so say so.
+        policy = MemoryPolicy(gpu_budget_absolute_gb=70.0)
+        with pytest.warns(UserWarning, match="offload_to_host could not help"):
+            policy.resolve(est_cache_gb=200.0, bytes_per_element=2, head_dim=HEAD_DIM,
+                           total_vram_gb=H100_80GB_VRAM, total_ram_gb=200.0)
+
+    def test_silent_on_untouched_defaults_even_when_ram_is_small(self):
+        # The regression this replaced: warning up-front fired for anyone whose RAM is
+        # under ~1.6x their VRAM, on a request that never left the GPU.
+        import warnings as _w
+        with _w.catch_warnings():
+            _w.simplefilter("error")
+            MemoryPolicy().resolve(est_cache_gb=0.2, bytes_per_element=2,
+                                   head_dim=HEAD_DIM, total_vram_gb=80.0,
+                                   total_ram_gb=128.0)
+
+    def test_silent_when_offload_can_actually_rescue_something(self):
+        import warnings as _w
+        with _w.catch_warnings():
+            _w.simplefilter("error")            # any warning fails the test
+            resolve(cache_gb(50_000, 8))        # host 256 GiB > gpu 31.8 GiB
+
+    def test_no_warning_when_offload_is_disabled(self):
+        import warnings as _w
+        with _w.catch_warnings():
+            _w.simplefilter("error")
+            MemoryPolicy(offload_to_host=False).resolve(
+                est_cache_gb=1.0, bytes_per_element=2, head_dim=HEAD_DIM,
+                total_vram_gb=H100_80GB_VRAM, total_ram_gb=200.0)
+
+
+class TestOffloadReachabilityAtConstruction:
+    """Rule 6a: the half of the offload-reachability check pydantic can do alone."""
+
+    def test_both_absolute_budgets_are_compared_at_construction(self):
+        with pytest.warns(UserWarning, match="cannot engage"):
+            MemoryPolicy(gpu_budget_absolute_gb=70.0, host_budget_absolute_gb=50.0)
+
+    def test_equal_budgets_also_warn(self):
+        # Equal is still unreachable: offload needs a footprint ABOVE the GPU budget
+        # that is at or below the host budget, and there is none.
+        with pytest.warns(UserWarning, match="cannot engage"):
+            MemoryPolicy(gpu_budget_absolute_gb=50.0, host_budget_absolute_gb=50.0)
+
+    def test_host_above_gpu_is_silent(self):
+        import warnings as _w
+        with _w.catch_warnings():
+            _w.simplefilter("error")
+            MemoryPolicy(gpu_budget_absolute_gb=20.0, host_budget_absolute_gb=200.0)
+
+    def test_fraction_case_is_deferred_to_resolve(self):
+        # Cannot be decided here: 0.25 x RAM vs 0.4 x VRAM depends on the box.
+        import warnings as _w
+        with _w.catch_warnings():
+            _w.simplefilter("error")
+            MemoryPolicy(gpu_budget_frac=0.9, host_budget_frac=0.05)
+
+
+class TestEstimatorRedeclaresMemory:
+    """``memory_policy=`` must not be frozen by the first predict.
+
+    ``NoriRegressor`` caches its predictor because the predictor owns the loaded
+    checkpoint. Every other constructor argument is therefore fixed at first use,
+    which is correct for them and wrong for ``memory_policy``: it is a per-call resource
+    decision, and a long-lived server (``serving/nori_serving/engine.py``) sets it
+    per request on one reused estimator. If the cached predictor kept the first
+    value, request 2 would silently run request 1's policy.
+
+    No checkpoint is loaded here: the re-declaration path is the branch taken when
+    ``_predictor`` already exists, so a stand-in is enough and the test stays fast.
+    """
+
+    class _PredictorStub:
+        """Just enough of NoriPredictor: it only has to hold the attribute."""
+
+        def __init__(self):
+            self.memory_policy = "the-first-call's-policy"
+
+    def _regressor_with_stub(self, memory_policy):
+        from synthefy_nori import NoriRegressor
+
+        estimator = NoriRegressor(model="nori-6m", memory_policy=memory_policy)
+        estimator._predictor = self._PredictorStub()
+        return estimator
+
+    def test_a_later_memory_change_reaches_the_cached_predictor(self):
+        estimator = self._regressor_with_stub(None)
+        estimator.memory_policy = "off"
+        assert estimator._get_predictor().memory_policy == "off"
+
+    def test_it_tracks_every_change_not_just_the_first(self):
+        estimator = self._regressor_with_stub(None)
+        for value in ("off", "exact", {"cache_dtype": "int8"}, None):
+            estimator.memory_policy = value
+            assert estimator._get_predictor().memory_policy == value
+
+    def test_the_value_is_passed_through_verbatim_not_coerced(self):
+        # sklearn's contract: params round-trip unchanged. Coercion happens inside
+        # predict, so clone()/get_params() keep seeing what the caller passed.
+        estimator = self._regressor_with_stub(None)
+        estimator.memory_policy = {"gpu_budget_frac": 0.3}
+        assert estimator._get_predictor().memory_policy == {"gpu_budget_frac": 0.3}
+
+
+class TestCoerceForService:
+    """``coerce_for_service`` — the entry point a server uses instead of ``coerce``.
+
+    It lives here, not in a serving target, because everything it does depends on this
+    module's own fields: which budgets to bound, and which warnings belong to the caller.
+    A serving-side copy would go stale the moment the policy gains a field, with every
+    test on both sides still passing.
+    """
+
+    CEILING = 0.5
+
+    def _coerce(self, value, **kwargs):
+        kwargs.setdefault("max_host_budget_frac", self.CEILING)
+        kwargs.setdefault("total_ram_gb", 200.0)
+        return MemoryPolicy.coerce_for_service(value, **kwargs)
+
+    def test_none_stays_none_so_a_server_can_tell_it_was_not_asked_for(self):
+        # Distinct from coerce(None), which returns the default policy: a server needs
+        # "the request said nothing" to leave its response untouched.
+        assert self._coerce(None) == (None, (), ())
+
+    def test_host_budget_frac_over_the_ceiling_is_clamped_and_named(self):
+        policy, clamped, _ = self._coerce({"host_budget_frac": 0.95})
+        assert policy.host_budget_frac == self.CEILING
+        assert clamped == ("host_budget_frac",)
+
+    def test_host_budget_absolute_gb_is_clamped_against_the_ram_it_is_given(self):
+        policy, clamped, _ = self._coerce({"host_budget_absolute_gb": 10_000.0})
+        assert policy.host_budget_absolute_gb == self.CEILING * 200.0
+        assert clamped == ("host_budget_absolute_gb",)
+
+    def test_a_budget_under_the_ceiling_is_honoured_verbatim(self):
+        policy, clamped, _ = self._coerce({"host_budget_absolute_gb": 40.0})
+        assert (policy.host_budget_absolute_gb, clamped) == (40.0, ())
+
+    def test_only_the_host_budgets_are_bounded(self):
+        # The point of the asymmetry: everything else spends the caller's own GPU
+        # memory, so overspending is self-inflicted and passed through.
+        policy, clamped, _ = self._coerce({"gpu_budget_frac": 0.99})
+        assert (policy.gpu_budget_frac, clamped) == (0.99, ())
+
+    def test_the_callers_dict_is_never_mutated(self):
+        sent = {"host_budget_frac": 0.95}
+        self._coerce(sent)
+        assert sent == {"host_budget_frac": 0.95}
+
+    def test_a_non_numeric_budget_is_left_for_pydantic_to_reject(self):
+        # Not compared against the ceiling (that would raise TypeError from the
+        # comparison); pydantic's message names the field, which is more useful.
+        with pytest.raises(ValidationError):
+            self._coerce({"host_budget_frac": "lots"})
+
+    def test_notes_are_returned_to_every_caller_not_just_the_first(self):
+        # warn_once de-duplicates for the life of the process, which on a server means
+        # the first caller to make a mistake absorbs the only copy. The registry is
+        # cleared per call so each caller hears about their own config.
+        both = {"gpu_budget_frac": 0.6, "gpu_budget_absolute_gb": 10.0}
+        first = self._coerce(dict(both))[2]
+        second = self._coerce(dict(both))[2]
+        assert first and first == second
+        assert any("gpu_budget_frac" in note for note in first)
+
+    def test_an_unambiguous_policy_produces_no_notes(self):
+        assert self._coerce({"cache_dtype": "int8"})[2] == ()
+
+    @pytest.mark.parametrize("preset", MEMORY_PRESETS)
+    def test_no_preset_sets_a_host_budget_so_none_needs_clamping(self, preset):
+        """Backs the claim that presets skip clamping.
+
+        ``coerce_for_service`` only bounds dicts. That is safe exactly while no preset
+        sets a host budget itself — so if a future preset does, this fails rather than
+        letting an unbounded budget through under a friendly name.
+        """
+        policy, clamped, _ = self._coerce(preset)
+        assert clamped == ()
+        assert policy.host_budget_frac == _mp.DEFAULT_HOST_BUDGET_FRAC
+        assert policy.host_budget_absolute_gb is None
+
+    def test_measures_host_ram_when_none_is_given(self):
+        # The default path a server actually takes; cgroup-aware, so a container sees
+        # its own limit rather than the machine's.
+        policy, clamped, _ = MemoryPolicy.coerce_for_service(
+            {"host_budget_absolute_gb": 10_000_000.0}, max_host_budget_frac=self.CEILING
+        )
+        assert clamped == ("host_budget_absolute_gb",)
+        assert 0 < policy.host_budget_absolute_gb < 10_000_000.0
+
+    def test_rejections_pass_through_unchanged_for_the_caller_to_map(self):
+        with pytest.raises(ValueError, match="unknown memory preset"):
+            self._coerce("aggressive")
+        with pytest.raises(TypeError, match="preset name"):
+            self._coerce(["exact"])
+        with pytest.raises(ValidationError):
+            self._coerce({"int8": True})
+
+
+class TestContextTooLargeError:
+    """The typed error that lets a server tell a caller's budget from its own OOM."""
+
+    def test_it_is_a_runtime_error_so_existing_handlers_keep_working(self):
+        # It replaced a bare RuntimeError; anything already catching that must still catch.
+        assert issubclass(_mp.ContextTooLargeError, RuntimeError)
+
+    def test_it_is_importable_from_the_package_root(self):
+        # A caller who can trigger it must be able to catch it by name without reaching
+        # into a private module path.
+        import synthefy_nori
+
+        assert synthefy_nori.ContextTooLargeError is _mp.ContextTooLargeError
+        assert "ContextTooLargeError" in synthefy_nori.__all__

--- a/tests/test_memory_policy_e2e.py
+++ b/tests/test_memory_policy_e2e.py
@@ -1,0 +1,275 @@
+"""End-to-end: does ``memory_policy=`` actually reach inference and change what happens?
+
+``src/synthefy_nori/inference/test_memory_policy.py`` covers the policy in isolation
+(pure arithmetic, no GPU). This file covers the wiring nothing else does — the path a
+real user takes:
+
+    NoriRegressor(memory_policy=...) -> NoriPredictor -> resolve() -> forward_cached_regression
+
+Without this, the whole public surface could be inert and every other test would still
+pass, because the policy unit tests never construct an estimator.
+
+Needs a checkpoint, so it skips when one is not reachable (no network / no HF cache).
+Runs on CPU; slow but not GPU-bound.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthefy_nori.inference.memory_policy import MemoryPolicy
+
+pytestmark = pytest.mark.slow
+
+N_TRAIN, N_TEST, N_FEATURES = 600, 400, 8
+
+# The cached path engages only when n_test exceeds chunk_size, and
+# chunk_size = max(256, budget / features - n_train). At 50_000 that is 5650 for this
+# table -- larger than N_TEST, so the cache never engaged and most assertions below
+# were vacuously true against rung "no_cache". 5_000 drives chunk_size to its 256-row
+# floor, so 400 query rows really do stream through a cache.
+SMALL_ELEMENTS_BUDGET = 5_000
+
+
+@pytest.fixture(scope="module")
+def table():
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(N_TRAIN + N_TEST, N_FEATURES)).astype(np.float32)
+    y = np.sin(x[:, 0] * 2) - x[:, 1] + 0.1 * rng.normal(size=len(x))
+    return x[:N_TRAIN], y[:N_TRAIN], x[N_TRAIN:]
+
+
+@pytest.fixture(scope="module")
+def regressor_cls():
+    """NoriRegressor, or skip when no checkpoint is reachable."""
+    from synthefy_nori.api import NoriRegressor
+    try:
+        NoriRegressor(model="nori-6m", device="cpu")._get_predictor()
+    except Exception as exc:                                   # noqa: BLE001
+        pytest.skip(f"no reachable Nori checkpoint: {type(exc).__name__}: {exc}")
+    return NoriRegressor
+
+
+def _predict(regressor_cls, table, memory_policy):
+    """Fit + predict under one memory policy, returning (predictions, report)."""
+    x_train, y_train, x_test = table
+    model = regressor_cls(
+        model="nori-6m", device="cpu",
+        memory_policy={**({} if memory_policy is None else memory_policy),
+                "elements_budget": SMALL_ELEMENTS_BUDGET},
+    )
+    model.fit(x_train, y_train)
+    return np.asarray(model.predict(x_test), dtype=np.float64), model.memory_report_
+
+
+class TestPolicyReachesInference:
+    def test_report_is_none_before_predicting(self, regressor_cls):
+        model = regressor_cls(model="nori-6m", device="cpu")
+        assert model.memory_report_ is None
+
+    def test_default_lands_on_a_bit_exact_rung(self, regressor_cls, table):
+        _, report = _predict(regressor_cls, table, None)
+        assert report is not None, "memory_policy= never reached the predictor"
+        assert report["rung"] == "resident_bf16", (
+            f'expected the cached path to engage; got {report["rung"]}. If this is '
+            f'"no_cache", SMALL_ELEMENTS_BUDGET is too large for this table and the '
+            f'rest of this suite is testing nothing.')
+        assert MemoryPolicy(**report).is_bit_exact
+
+    def test_report_round_trips_into_the_policy_type(self, regressor_cls, table):
+        _, report = _predict(regressor_cls, table, None)
+        assert MemoryPolicy(**report).rung == report["rung"]
+
+    def test_requesting_int8_changes_the_reported_rung(self, regressor_cls, table):
+        # The load-bearing assertion: a different memory_policy= must produce a different
+        # decision, or the parameter is decorative.
+        _, default_report = _predict(regressor_cls, table, None)
+        _, int8_report = _predict(regressor_cls, table, {"cache_dtype": "int8"})
+        assert int8_report["cache_dtype"] == "int8"
+        assert not MemoryPolicy(**int8_report).is_bit_exact
+        assert default_report["rung"] == "resident_bf16"
+        assert int8_report["rung"] == "resident_int8"
+
+    def test_off_preset_disables_the_cache(self, regressor_cls, table):
+        _, report = _predict(regressor_cls, table, {"cache": False})
+        assert report["cache"] is False
+        assert report["rung"] == "no_cache"
+
+    def test_no_cache_reports_no_budget(self, regressor_cls, table):
+        # It consulted no budget, so it must not state one.
+        _, report = _predict(regressor_cls, table, {"cache": False})
+        assert report["gpu_budget_absolute_gb"] is None
+        assert report["host_budget_absolute_gb"] is None
+
+    def test_tiny_gpu_budget_forces_a_fallback_rung(self, regressor_cls, table):
+        _, report = _predict(regressor_cls, table, {"gpu_budget_absolute_gb": 0.0})
+        assert report["rung"] != "resident_bf16"
+
+
+class TestPredictionsAgreeAcrossPolicies:
+    def test_cached_and_uncached_agree_within_mixed_precision_tolerance(
+            self, regressor_cls, table):
+        # NOT bit-identical: the two paths reduce in a different order, which the
+        # README documents at ~1.5e-3. Asserting equality here would be wrong.
+        cached, cached_report = _predict(regressor_cls, table, None)
+        uncached, _ = _predict(regressor_cls, table, {"cache": False})
+        if cached_report["rung"] == "no_cache":
+            pytest.skip("cached path not eligible on this shape; nothing to compare")
+        assert np.abs(cached - uncached).max() < 5e-3
+
+    def test_same_policy_twice_is_deterministic(self, regressor_cls, table):
+        first, _ = _predict(regressor_cls, table, None)
+        second, _ = _predict(regressor_cls, table, None)
+        assert np.array_equal(first, second)
+
+
+class TestIncoherentConfigFailsAtFit:
+    def test_row_chunking_without_caching_raises_before_any_compute(
+            self, regressor_cls, table):
+        # Must fail before inference, not silently do nothing at predict time.
+        from pydantic import ValidationError
+        x_train, y_train, x_test = table
+        model = regressor_cls(
+            model="nori-6m", device="cpu",
+            memory_policy={"cache": False, "context_row_chunk": 2048},
+        )
+        # fit(), not predict(): the point is to fail before any inference runs.
+        with pytest.raises(ValidationError, match="not a\n?\\s*reachable configuration"):
+            model.fit(x_train, y_train)
+
+    def test_unknown_key_raises(self, regressor_cls, table):
+        from pydantic import ValidationError
+        x_train, y_train, x_test = table
+        model = regressor_cls(model="nori-6m", device="cpu",
+                              memory_policy={"gpu_budget": 20})
+        with pytest.raises(ValidationError):
+            model.fit(x_train, y_train)
+
+
+class TestSklearnContract:
+    def test_clone_round_trips_every_memory_form(self, regressor_cls):
+        from sklearn.base import clone
+        for policy in (None, "exact", {"gpu_budget_frac": 0.25},
+                       MemoryPolicy(cache_dtype="bf16")):
+            estimator = regressor_cls(model="nori-6m", memory_policy=policy)
+            # sklearn's param name follows the constructor argument, so the rename moves
+            # this key too -- get_params()["memory"] would silently KeyError-free to nothing.
+            assert clone(estimator).get_params()["memory_policy"] == policy
+
+    def test_set_params_accepts_a_preset(self, regressor_cls):
+        estimator = regressor_cls(model="nori-6m")
+        estimator.set_params(memory_policy="max_context")
+        assert estimator.memory_policy == "max_context"
+
+
+class TestSubsamplingIsNeverSilent:
+    """`allow_subsample=False` must raise rather than quietly shrink the context.
+
+    Promoted with #257 and untested anywhere until now -- including in the internal tier,
+    where `allow_subsample` appears in no test file at all. It is the one setting in this
+    feature whose failure mode is a *wrong answer* rather than an error: a silently trimmed
+    context still returns confident, plausible predictions computed from a fraction of the
+    data the caller supplied. Nothing downstream can detect that.
+    """
+
+    def test_forbidding_the_shrink_raises_instead_of_trimming(self, regressor_cls):
+        from synthefy_nori.inference.memory_policy import ContextTooLargeError
+
+        rng = np.random.default_rng(0)
+        x_train = rng.normal(size=(3000, 8)).astype(np.float32)
+        y_train = (0.5 + 0.4 * (x_train[:, 0] - x_train[:, 1])).astype(np.float64)
+        x_test = rng.normal(size=(64, 8)).astype(np.float32)
+
+        model = regressor_cls(
+            model="nori-6m", device="cpu",
+            # A budget this context cannot fit, with the shrink forbidden.
+            memory_policy={"elements_budget": 2000, "allow_subsample": False},
+        )
+        model.fit(x_train, y_train)
+        with pytest.raises(ContextTooLargeError) as excinfo:
+            model.predict(x_test)
+        message = str(excinfo.value)
+        # The message must name the setting that forbade it and how to proceed -- the caller
+        # cannot act on "context too large" alone.
+        assert "allow_subsample" in message
+        assert "elements_budget" in message
+
+    def test_permitting_the_shrink_serves_and_reports_what_it_dropped(self, regressor_cls):
+        rng = np.random.default_rng(0)
+        x_train = rng.normal(size=(3000, 8)).astype(np.float32)
+        y_train = (0.5 + 0.4 * (x_train[:, 0] - x_train[:, 1])).astype(np.float64)
+        x_test = rng.normal(size=(64, 8)).astype(np.float32)
+
+        model = regressor_cls(model="nori-6m", device="cpu",
+                              memory_policy={"elements_budget": 2000})
+        model.fit(x_train, y_train)
+        with pytest.warns(UserWarning, match="context subsampled"):
+            predictions = model.predict(x_test)
+
+        assert len(predictions) == len(x_test)
+        # The count is the point: it is the only signal that the answer used less data than
+        # was supplied, and it has to survive past the warning.
+        assert model.memory_report_["dropped_context_rows"] > 0
+
+
+class TestWarningVolume:
+    """One user-visible predict must not emit N copies of the same warning.
+
+    `_predict_reg_single` runs once per inference pipeline (16 on the default config),
+    so a warning raised there fires 16 times per predict. Python's own per-location
+    de-duplication does not save us, because `stacklevel` attributes the warning to a
+    varying caller frame, and logging has no de-duplication at all. Measured 36 stderr
+    lines from two predict() calls before this was fixed.
+    """
+
+    def _broken_config_predict(self, regressor_cls, table, n_calls):
+        """Predict under a config guaranteed to hit the plain-loop fallback."""
+        x_train, y_train, x_test = table
+        model = regressor_cls(
+            model="nori-6m", device="cpu",
+            # BOTH budgets capped: capping only the GPU lets offload succeed against
+            # this box's real RAM, which never reaches the plain-loop rung.
+            memory_policy={"elements_budget": SMALL_ELEMENTS_BUDGET,
+                    "gpu_budget_absolute_gb": 0.001,
+                    "host_budget_absolute_gb": 0.0005},
+        )
+        model.fit(x_train, y_train)
+        for _ in range(n_calls):
+            model.predict(x_test)
+        return model
+
+    def test_fallback_warns_once_per_call_not_once_per_pipeline(
+            self, regressor_cls, table):
+        import warnings as _w
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")          # defeat dedup, so we count raw emissions
+            model = self._broken_config_predict(regressor_cls, table, n_calls=1)
+        if model.memory_report_["rung"] != "plain_loop":
+            pytest.skip("config did not reach the plain-loop rung on this shape")
+        fallbacks = [w for w in caught
+                     if "fell back to the plain chunked loop" in str(w.message)]
+        assert len(fallbacks) == 1, (
+            f"one predict emitted {len(fallbacks)} copies of the fallback warning; "
+            f"it must be de-duplicated per call, not per inference pipeline")
+
+    def test_a_second_call_warns_again(self, regressor_cls, table):
+        # Per-CALL, not per-process: each request is a fact about that request, so a
+        # second predict that also falls back must say so again.
+        import warnings as _w
+        with _w.catch_warnings(record=True) as caught:
+            _w.simplefilter("always")
+            model = self._broken_config_predict(regressor_cls, table, n_calls=2)
+        if model.memory_report_["rung"] != "plain_loop":
+            pytest.skip("config did not reach the plain-loop rung on this shape")
+        fallbacks = [w for w in caught
+                     if "fell back to the plain chunked loop" in str(w.message)]
+        assert len(fallbacks) == 2, f"expected one per call, got {len(fallbacks)}"
+
+    def test_log_lines_are_deduplicated_too(self, regressor_cls, table, caplog):
+        import logging
+        with caplog.at_level(logging.INFO, logger="synthefy_nori.inference.predictor"):
+            self._broken_config_predict(regressor_cls, table, n_calls=1)
+        rung_lines = [r for r in caplog.records if "serving-memory rung" in r.message]
+        assert len(rung_lines) == 1, (
+            f"one predict logged the rung {len(rung_lines)} times; logging has no "
+            f"de-duplication of its own, so it must be done at the call site")

--- a/uv.lock
+++ b/uv.lock
@@ -3781,7 +3781,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },

--- a/uv.lock
+++ b/uv.lock
@@ -48,9 +48,9 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "idna" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "idna", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -72,9 +72,9 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "idna", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.10' and python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -86,7 +86,7 @@ name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "argon2-cffi-bindings" },
+    { name = "argon2-cffi-bindings", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
 wheels = [
@@ -98,7 +98,7 @@ name = "argon2-cffi-bindings"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
 wheels = [
@@ -130,11 +130,11 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' and sys_platform == 'win32'" },
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-    { name = "tomli" },
+    { name = "colorama", marker = "python_full_version < '3.10' and os_name == 'nt' and sys_platform == 'win32'" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pyproject-hooks", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tomli", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
 wheels = [
@@ -156,11 +156,11 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' and sys_platform == 'win32'" },
-    { name = "importlib-metadata", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10.2'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and os_name == 'nt' and sys_platform == 'win32'" },
+    { name = "importlib-metadata", version = "9.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.10.2' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.10.2' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pyproject-hooks", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tomli", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
@@ -181,8 +181,8 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
-    { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and implementation_name != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.10' and implementation_name != 'PyPy' and sys_platform == 'win32')" },
+    { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and implementation_name != 'PyPy' and sys_platform == 'linux') or (python_full_version >= '3.10' and implementation_name != 'PyPy' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -380,7 +380,7 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -402,7 +402,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
@@ -436,7 +436,7 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -501,7 +501,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -564,7 +564,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -659,7 +659,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -845,10 +845,10 @@ name = "galois"
 version = "0.4.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/84/996f1c4a7e8fe973a7f8e4d7901e125a91d0abb62615e35076ff47e9383a/galois-0.4.11.tar.gz", hash = "sha256:f5055546c4b39d1e36decae9d4f21f3d66d9c6c7c9aec39189cb5d2284e9022f", size = 7402587, upload-time = "2026-05-02T18:21:28.615Z" }
 wheels = [
@@ -860,7 +860,7 @@ name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "smmap" },
+    { name = "smmap", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
 wheels = [
@@ -872,8 +872,8 @@ name = "gitpython"
 version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gitdb" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "gitdb", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
@@ -920,8 +920,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "certifi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "h11", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -933,11 +933,11 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "certifi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpcore", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "idna", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -953,15 +953,15 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.23.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "hf-xet", marker = "(python_full_version < '3.10' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.10' and platform_machine == 'AMD64' and sys_platform == 'win32') or (python_full_version < '3.10' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version < '3.10' and platform_machine == 'amd64' and sys_platform == 'win32') or (python_full_version < '3.10' and platform_machine == 'arm64' and sys_platform == 'win32') or (python_full_version < '3.10' and platform_machine == 'x86_64' and sys_platform == 'win32')" },
+    { name = "httpx", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "typer", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839, upload-time = "2026-03-25T16:01:28.152Z" }
 wheels = [
@@ -983,15 +983,15 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer", version = "0.25.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "hf-xet", marker = "(python_full_version >= '3.10' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'amd64' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'arm64' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.10' and platform_machine == 'AMD64' and sys_platform == 'win32') or (python_full_version >= '3.10' and platform_machine == 'aarch64' and sys_platform == 'win32') or (python_full_version >= '3.10' and platform_machine == 'amd64' and sys_platform == 'win32') or (python_full_version >= '3.10' and platform_machine == 'arm64' and sys_platform == 'win32') or (python_full_version >= '3.10' and platform_machine == 'x86_64' and sys_platform == 'win32')" },
+    { name = "httpx", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "typer", version = "0.25.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
 wheels = [
@@ -1016,7 +1016,7 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1032,7 +1032,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1044,7 +1044,7 @@ name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -1088,7 +1088,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -1109,17 +1109,17 @@ name = "kditransform"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numba", version = "0.60.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numba", version = "0.60.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/11/0ada6dc28526d5c292bc7385b43d94ae17206c8891153db19984d888c2a9/kditransform-1.2.0-py3-none-any.whl", hash = "sha256:d8102c1091bc835620d96adc009e66abf4bd4581430aa90097690dfa0d949bbf", size = 20315, upload-time = "2025-10-23T17:26:37.999Z" },
@@ -1392,7 +1392,7 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -1414,7 +1414,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1510,16 +1510,16 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "importlib-resources" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "cycler", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "importlib-resources", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pyparsing", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "python-dateutil", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -1566,17 +1566,17 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging" },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "cycler", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pyparsing", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "python-dateutil", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1632,12 +1632,12 @@ name = "minio"
 version = "7.2.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "argon2-cffi" },
-    { name = "certifi" },
-    { name = "pycryptodome" },
-    { name = "typing-extensions" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "argon2-cffi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "certifi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pycryptodome", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
 wheels = [
@@ -1701,10 +1701,10 @@ name = "nltk"
 version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "joblib" },
-    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
 wheels = [
@@ -1720,8 +1720,8 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "llvmlite", version = "0.43.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "llvmlite", version = "0.43.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/93/2849300a9184775ba274aba6f82f303343669b0592b7bb0849ea713dabb0/numba-0.60.0.tar.gz", hash = "sha256:5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16", size = 2702171, upload-time = "2024-06-13T18:11:19.869Z" }
 wheels = [
@@ -1754,9 +1754,9 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
 wheels = [
@@ -1960,7 +1960,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1971,7 +1971,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1998,9 +1998,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2011,7 +2011,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2055,27 +2055,27 @@ name = "openml"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "liac-arff" },
-    { name = "minio" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tqdm" },
-    { name = "xmltodict" },
+    { name = "liac-arff", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "minio", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "python-dateutil", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "xmltodict", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/9b/729dc6377bbfdbf0828d5567a335670d4e7c2866065ca4593ab525a5809c/openml-0.15.1.tar.gz", hash = "sha256:58ae3840b6ea736bb6c69bcbb30d587b817f64db070dc691adb9e09b99018816", size = 146141, upload-time = "2025-01-25T10:56:28.351Z" }
 wheels = [
@@ -2102,11 +2102,11 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.10.*'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "python-dateutil", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pytz", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "tzdata", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2163,9 +2163,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "tzdata", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2646,10 +2646,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic-core", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-inspection", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -2661,7 +2661,7 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -2802,13 +2802,13 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pluggy", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pygments", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tomli", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -2830,13 +2830,13 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pluggy", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pygments", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tomli", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -2848,7 +2848,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -3160,10 +3160,10 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "certifi", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "charset-normalizer", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "idna", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -3185,10 +3185,10 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "certifi", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "charset-normalizer", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "idna", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/b8/7a707d60fea4c49094e40262cc0e2ca6c768cca21587e34d3f705afec47e/requests-2.34.0.tar.gz", hash = "sha256:7d62fe92f50eb82c529b0916bb445afa1531a566fc8f35ffdc64446e771b856a", size = 142436, upload-time = "2026-05-11T19:29:51.717Z" }
 wheels = [
@@ -3200,9 +3200,9 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pygments" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pygments", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -3237,10 +3237,10 @@ name = "sacremoses"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "joblib" },
-    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/51/fbdc4af4f6e85d26169e28be3763fe50ddfd0d4bf8b871422b0788dcc4d2/sacremoses-0.1.1.tar.gz", hash = "sha256:b6fd5d3a766b02154ed80b962ddca91e1fd25629c0978c7efba21ebccf663934", size = 883188, upload-time = "2023-10-30T15:56:20.187Z" }
 wheels = [
@@ -3278,10 +3278,10 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "threadpoolctl", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
 wheels = [
@@ -3313,10 +3313,10 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "threadpoolctl", marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -3353,10 +3353,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "threadpoolctl", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -3395,7 +3395,7 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -3426,7 +3426,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3470,7 +3470,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3521,16 +3521,16 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nltk" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "sentencepiece" },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers", version = "4.12.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "nltk", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "sentencepiece", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "torch", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "torchvision", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "transformers", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/9c/f07bd70d128fdb107bc02a0c702b9058b4fe147d0ba67b5a0f4c3cf15a54/sentence-transformers-2.2.2.tar.gz", hash = "sha256:dbc60163b27de21076c9a30d24b5b7b6fa05141d68cf2553fa9a77bf79a29136", size = 85953, upload-time = "2022-06-26T19:50:11.137Z" }
 
@@ -3549,17 +3549,17 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "torch" },
-    { name = "tqdm" },
-    { name = "transformers", version = "5.14.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "torch", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "transformers", version = "5.14.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
 wheels = [
@@ -3611,9 +3611,9 @@ name = "sentry-sdk"
 version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "certifi", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
@@ -3638,15 +3638,15 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colour" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "colour", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/52/efce67a5be4661e716ba450eff16efdc306e518f1b28060e02cd40a7ffdc/shapiq-1.2.1.tar.gz", hash = "sha256:bd8cf707104e56ce22c34c587b433a430da10d3e91cb9441c84a7fd2d0c0e28b", size = 191239, upload-time = "2025-02-17T22:15:09.438Z" }
 wheels = [
@@ -3664,24 +3664,24 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colour" },
-    { name = "galois" },
-    { name = "joblib" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" } },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sparse-transform" },
-    { name = "tqdm" },
+    { name = "colour", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "galois", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "sparse-transform", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/20/8e7bf8e1d2ad5e50c5ddb884760fe67657eee38b0ebe9d9996a0ab227221/shapiq-1.4.1.tar.gz", hash = "sha256:7f612c84fcfe4746ff826db72efa2944f9aa693c5c00c6e17a882613471534f8", size = 5781786, upload-time = "2025-11-10T19:43:31.882Z" }
 wheels = [
@@ -3699,17 +3699,17 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "colour" },
-    { name = "joblib" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" } },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "colour", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "joblib", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/bb/940b6af2c90238873b4f22011a2f2f924111bde12abeac83294d32111a94/shapiq-1.5.2.tar.gz", hash = "sha256:6336d764ce27836b69a1d3283392d69c8c2f4dcd3f52e19d2ad037d5aac1708c", size = 15210062, upload-time = "2026-06-12T22:37:09.726Z" }
 wheels = [
@@ -3753,14 +3753,14 @@ name = "sparse-transform"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "galois" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "tqdm" },
+    { name = "galois", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/da/82132137fdc207c4a14abb52fedcd8cc3dd697175f548cfb8689bd2afab8/sparse_transform-0.2.1.tar.gz", hash = "sha256:470d54c884600d97254469a3d85fac775480d18a8aa2c43574350695e1015c66", size = 24803, upload-time = "2025-04-03T08:11:39.47Z" }
 wheels = [
@@ -3772,7 +3772,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -3784,56 +3784,57 @@ name = "synthefy-nori"
 version = "0.12.1"
 source = { editable = "." }
 dependencies = [
-    { name = "einops" },
-    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "kditransform" },
-    { name = "numba", version = "0.60.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "torch" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "kditransform", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "numba", version = "0.60.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "pydantic", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tqdm", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
 dev = [
-    { name = "build", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "build", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "ruff" },
+    { name = "build", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "build", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "ruff", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 eval = [
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "openml" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "openml", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 interpretability = [
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "shapiq", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "shapiq", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
-    { name = "shapiq", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version >= '3.10' and python_full_version < '3.12' and sys_platform == 'win32')" },
+    { name = "shapiq", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
 ]
 text = [
-    { name = "sentence-transformers", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sentence-transformers", version = "5.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sentence-transformers", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "sentence-transformers", version = "5.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 train = [
-    { name = "wandb" },
-    { name = "xgboost", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "wandb", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "xgboost", version = "2.1.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 
 [package.metadata]
@@ -3848,6 +3849,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0" },
     { name = "openml", marker = "extra == 'eval'" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-learn", specifier = ">=1.4" },
@@ -3901,7 +3903,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -3977,32 +3979,32 @@ name = "torch"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform != 'win32'" },
-    { name = "typing-extensions" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/28/110f7274254f1b8476c561dada127173f994afa2b1ffc044efb773c15650/torch-2.8.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0be92c08b44009d4131d1ff7a8060d10bafdb7ddcb7359ef8d8c5169007ea905", size = 102052793, upload-time = "2025-08-06T14:53:15.852Z" },
@@ -4030,9 +4032,9 @@ name = "torchvision"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torch" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "torch", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/44/ddd56d1637bac42a8c5da2c8c440d8a28c431f996dd9790f32dd9a96ca6e/torchvision-0.23.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:31c583ba27426a3a04eca8c05450524105c1564db41be6632f7536ef405a6de2", size = 2394251, upload-time = "2025-08-06T14:58:01.725Z" },
@@ -4076,16 +4078,16 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "sacremoses" },
-    { name = "tokenizers", version = "0.10.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "regex", version = "2026.1.15", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "sacremoses", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tokenizers", version = "0.10.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/6b/7fe2e21dc2b3e8098979e20940e6e045af66d74498da9ad2d81578ef2d69/transformers-4.12.2.tar.gz", hash = "sha256:98de2b57d8ac933579a851254aa4575d7035b9135f724c1de4a3ea581edd04ed", size = 2559986, upload-time = "2021-10-29T18:49:54.73Z" }
 wheels = [
@@ -4107,16 +4109,16 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "regex", version = "2026.7.19", source = { registry = "https://pypi.org/simple" } },
-    { name = "safetensors" },
-    { name = "tokenizers", version = "0.22.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
-    { name = "typer", version = "0.25.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pyyaml", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "regex", version = "2026.7.19", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "safetensors", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tokenizers", version = "0.22.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "tqdm", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "typer", version = "0.25.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
 wheels = [
@@ -4128,8 +4130,8 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "setuptools" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ee/0ee5f64a87eeda19bbad9bc54ae5ca5b98186ed00055281fd40fb4beb10e/triton-3.4.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ff2785de9bc02f500e085420273bb5cc9c9bb767584a4aa28d6e360cec70128", size = 155430069, upload-time = "2025-07-30T19:58:21.715Z" },
@@ -4149,10 +4151,10 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "rich", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "shellingham", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/93d16574e66dfe4c2284ffdaca4b0320ade32858cb2cc586c8dd79f127c5/typer-0.23.2.tar.gz", hash = "sha256:a99706a08e54f1aef8bb6a8611503808188a4092808e86addff1828a208af0de", size = 120162, upload-time = "2026-02-16T18:52:40.354Z" }
 wheels = [
@@ -4174,10 +4176,10 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "rich", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "shellingham", marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
@@ -4198,7 +4200,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -4251,21 +4253,21 @@ name = "wandb"
 version = "0.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
-    { name = "gitpython" },
-    { name = "packaging" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "protobuf", version = "7.34.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "sentry-sdk" },
-    { name = "typing-extensions" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "eval-type-backport", marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "gitpython", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "protobuf", version = "7.34.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "pydantic", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform == 'linux') or (python_full_version >= '3.10' and sys_platform == 'win32')" },
+    { name = "sentry-sdk", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/a4/72a6640e1f566e81f184a426e3e45298d4c6672664de41adb7eb6f64370a/wandb-0.26.1.tar.gz", hash = "sha256:eef2dbaea06f0b1c0cdc5d76f544ae4c2b8848fc512442a00bd59f0502fc8aa1", size = 42159814, upload-time = "2026-04-23T16:27:34.033Z" }
 wheels = [
@@ -4287,9 +4289,9 @@ resolution-markers = [
     "python_full_version < '3.10' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine != 'aarch64' and sys_platform != 'win32'" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.10' and platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/5e/860a1ef13ce38db8c257c83e138be64bcffde8f401e84bf1e2e91838afa3/xgboost-2.1.4.tar.gz", hash = "sha256:ab84c4bbedd7fae1a26f61e9dd7897421d5b08454b51c6eb072abc1d346d08d7", size = 1091127, upload-time = "2025-02-06T18:18:20.192Z" }
 wheels = [
@@ -4315,11 +4317,11 @@ resolution-markers = [
     "python_full_version == '3.10.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform != 'win32'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.10' and sys_platform == 'linux'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
 wheels = [


### PR DESCRIPTION
Promote staging to public + release 0.13.0.

Two commits: the promotion (byte-identical to what landed as staging#13), then the release commit.

| | |
|---|---|
| `1814943` | int8 KV cache, host offload, fit-time row chunking, and `memory_policy=` |
| `2b7247a` | `0.13.0`, `docs/inference.md` |

The first is a byte-for-byte copy of staging's merged diff, so the cascade de-duplicates it on rebase rather than colliding.

## What ships

`NoriRegressor(memory_policy=...)` — a preset (`"exact"`, `"max_context"`, `"off"`), a dict, or a `MemoryPolicy`. Omit it and behaviour is unchanged.

Nori predicts in context, so the table is *input*: every call reads all of `X_train` and keeps a per-layer key/value cache over those rows. That cache — not the ~6M parameters — is what fills a GPU on a big table. When it does not fit, inference takes the cheapest step that works:

`resident_bf16 → resident_int8 → offload_bf16 → offload_int8 → context_row_chunk → plain_loop`

Only the int8 rungs trade accuracy (|ΔR²| ≈ 6e-6), and they are reached only when full precision will not fit; offloading moves bytes to host RAM rather than approximating, so it is bit-identical. `memory_report_["rung"]` reports which one ran.

Two fixes ride along:
- The cached predictor was built once and never re-read the policy, so `est.memory_policy = "off"` after the first `predict` was silently ignored.
- `allow_subsample=False` now raises `ContextTooLargeError` naming both the setting and the remedy, instead of quietly shrinking the context. That path had **no test anywhere**, including in the internal tier; it has two now, mutation-verified.

## Scope

Library only. The serving layer — `serving/`, `baseten/`, `sagemaker/`, the `thinking/` module, and `synthefy_nori/testing/rung_cases.py` (the serving rung spec, written for the hosted-API smoke suite) — does not exist in this tier and is not created here.

`inference/memory_policy.py` is **byte-identical to the internal tier**. An earlier revision stripped ~190 lines of server-only helpers (`coerce_for_service`, `capture_policy_notes`, the clamp constants) since nothing here calls them; that was reverted deliberately. Forking a file both tiers edit would make every future cascade rebase conflict on it and ask someone to re-derive the split. Carrying unused-but-harmless helpers is the cheaper mistake. Their tests come with them — shipping untested code is the thing this release has been removing.

## `pydantic` is a new runtime dependency

Measured, not assumed: installing every other declared dependency into a clean venv leaves no pydantic — nothing pulls it transitively — and `import synthefy_nori` then fails at `inference/memory_policy.py:78`, at package import, before any predict.

## One CI line

`tests/test_memory_policy_e2e.py` is appended to the existing slow inference step. It is `slow`-marked and was named by no job, so its 18 tests would have shipped and never run. That job is `ubuntu-latest`, so it was verified on CPU as well as GPU before being added — 18 passed in 3m56s with `CUDA_VISIBLE_DEVICES=""`, the one CUDA-gated assertion skipping itself. On staging's CI that step reported **21 passed in 12m25s**, so it demonstrably executes rather than silently skipping.

`gpu-ci.yml` is untouched here: this tier has the Modal secrets, the gate is real, and it stays on.

## Verification

- **207 passed / 2 skipped**, ruff clean
- wheel builds as `synthefy_nori-0.13.0-py3-none-any.whl`
- **installed from that wheel into a clean venv**: `__version__` 0.13.0, `MemoryPolicy` has its 17 fields, `NoriRegressor` takes `memory_policy=`, unknown fields raise `ValidationError`, `pydantic 2.13.4` resolved automatically
- version set in **both** `pyproject.toml` and `src/synthefy_nori/__init__.py` — CI enforces tag == wheel but not `__init__.py`
- 18 slow tests pass on GPU (3m02s) and CPU (3m56s)
- **eval equivalence gate: 322/322 datasets exactly equal** (TabArena + TALENT), same checkpoint, old code vs new — identical, not merely insignificant, as expected for a change provably off the numeric path

## Nothing here publishes

No PyPI upload on merge. That needs a GitHub Release for `v0.13.0` plus approval of the `pypi` environment reviewer gate — both deliberately left to a human. `RELEASING.md` has the runbook.

## The cascade is still broken

`rebase-sync` hop 2 (internal → staging) has failed nightly since at least 2026-07-25; internal is at 0.11.1 while staging and this tier are at 0.12.1, so `public ⊆ staging ⊆ internal` does not hold. The conflict is 4 hunks in `api.py`/`layer.py` — a stale internal commit re-adding `compile_model=True` against newer text-features work.

That commit, `5ead4c4`, also turned out to be the source of a 46-line dead function (`chunked_caculate_attention_score`, called by nothing in internal) that leaked into an earlier revision of this promotion via conflict resolution and was removed. Worth knowing when the cascade is repaired: this promotion is a hand-port and will need reconciling.
