### PR TITLE
Promote staging to public + release 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,53 @@ config. Unknown keys always raise.
 memory is the transductive preprocessing (RBF + polynomial expansion over the whole
 table), *upstream* of the transformer. None of the above helps with that.
 
+### Silent degradation
+
+Some fallbacks keep inference alive by handing the model **less than the configured
+pipeline promised**, then returning predictions anyway. In serving that is the right
+trade — a slightly worse answer beats an exception. In anything *scored* it is the wrong
+one: the run produces a plausible number that reads as "this config is weak" rather than
+"the pipeline broke", and nothing downstream can tell the two apart.
+
+So none of them are silent. Each warns under its own category, and escalating the
+category is how you forbid it:
+
+| warning | raised when | prevented outright by |
+|---|---|---|
+| `DegradedPipelineWarning` | base class — catch it to mean "any fidelity I did not ask for" | — |
+| ↳ `SvdFallbackWarning` | the high-dimensional feature SVD failed, so the model got the **raw** unprojected columns (a `fit` failure) or a **single all-zero column** (a `transform` failure) | — |
+| ↳ `ContextSubsampledWarning` | context rows were **dropped** to fit the element budget | `memory_policy={"allow_subsample": False}` |
+
+```python
+from synthefy_nori import NoriRegressor, SvdFallbackWarning, strict_pipeline
+
+model = NoriRegressor(model="nori-6m")
+model.fit(X_train, y_train)
+
+model.predict(X_test)                     # serving: keep answering, warn if degraded
+
+with strict_pipeline():                   # scored runs: a degraded pipeline raises
+    model.predict(X_test)                 # instead of reporting a number
+
+with strict_pipeline(SvdFallbackWarning):  # or just one fallback
+    model.predict(X_test)
+```
+
+`strict_pipeline()` restores the previous filters on exit, so one strict prediction does
+not harden the next one — safe inside a loop over datasets. It is a thin wrapper over
+`warnings.simplefilter("error", DegradedPipelineWarning)`, so `-W error::...`,
+`PYTHONWARNINGS`, and a `filterwarnings` line in `pytest.ini` work too.
+
+Because the categories form a tree, escalation is inherited: a new fallback adds one
+subclass and every caller who already asked for a strict pipeline gets it. **The eval
+runner (`synthefy_nori.evaluation`) already wraps every scored predict call in
+`strict_pipeline(SvdFallbackWarning)`** — a broken SVD is recorded as a failed row
+rather than scored. It deliberately does not escalate `ContextSubsampledWarning`, since
+trimming context to a budget is expected on large tables.
+
+Only an SVD inference config can raise `SvdFallbackWarning` at all — the bundled default
+and its lower-rank eval variant do; elsewhere the step is a no-op.
+
 ### Preprocessing speedups (on by default)
 
 `SYNTHEFY_GPU_SVD`, `SYNTHEFY_CAP_QUANTILES`, and `SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE`

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -159,3 +159,28 @@ Notes:
 
 The underlying lattice math is importable from `synthefy_nori.discretize`
 (`cell_masses`, `discretize_predictions`, `snap_to_levels`).
+
+## Silent degradation (`strict_pipeline`)
+
+Some fallbacks trade fidelity for staying alive and still return a prediction. None of
+them are silent — each warns under its own category, and escalating the category forbids
+it:
+
+| warning | raised when | also prevented by |
+|---|---|---|
+| `DegradedPipelineWarning` | base class, i.e. any of the below | — |
+| `SvdFallbackWarning` | the high-dimensional SVD failed: raw unprojected columns (`fit`) or one all-zero column (`transform`) | — |
+| `ContextSubsampledWarning` | context rows dropped to fit the element budget | `memory_policy={"allow_subsample": False}` |
+
+```python
+from synthefy_nori import strict_pipeline
+
+with strict_pipeline():          # evals / benchmarks: refuse to report a degraded run
+    y_pred = reg.predict(X_test)
+```
+
+Filters are restored on exit, so this is safe in a loop. Equivalent to
+`warnings.simplefilter("error", DegradedPipelineWarning)`, so `-W`, `PYTHONWARNINGS` and
+pytest's `filterwarnings` work as well. `synthefy_nori.evaluation`'s runner already
+wraps every scored predict call in `strict_pipeline(SvdFallbackWarning)`. Full rationale:
+README, "Silent degradation".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.13.0"
+version = "0.13.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 from synthefy_nori import discretize
+from synthefy_nori.inference.degradation import (
+    ContextSubsampledWarning,
+    DegradedPipelineWarning,
+    SvdFallbackWarning,
+    strict_pipeline,
+)
 from synthefy_nori.inference.memory_policy import ContextTooLargeError, MemoryPolicy
 from synthefy_nori.api import (
     NoriRegressor,
@@ -13,11 +19,15 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 __all__ = [
+    "ContextSubsampledWarning",
     "ContextTooLargeError",
+    "DegradedPipelineWarning",
     "MemoryPolicy",
+    "SvdFallbackWarning",
+    "strict_pipeline",
     "NoriRegressor",
     "discretize",
     "NoriEmbedding",

--- a/src/synthefy_nori/evaluation/runner.py
+++ b/src/synthefy_nori/evaluation/runner.py
@@ -32,6 +32,7 @@ except ImportError:
 
 from synthefy_nori.evaluation.datasets import DatasetEntry, DatasetRegistry
 from synthefy_nori.evaluation.models import ModelEntry, ModelRegistry
+from synthefy_nori.inference.degradation import SvdFallbackWarning, strict_pipeline
 
 
 # ---------------------------------------------------------------------------
@@ -442,11 +443,12 @@ class EvalRunner:
 
             # Warmup (for GPU timing stability)
             for _ in range(self.warmup_runs):
-                wrapper.predict_regression(
-                    X_train[:min(100, len(X_train))],
-                    y_train[:min(100, len(y_train))],
-                    ds.X_test[:min(10, ds.n_test)],
-                )
+                with strict_pipeline(SvdFallbackWarning):
+                    wrapper.predict_regression(
+                        X_train[:min(100, len(X_train))],
+                        y_train[:min(100, len(y_train))],
+                        ds.X_test[:min(10, ds.n_test)],
+                    )
 
             # Timed run — synchronize on the model's device, not the default device
             model_device = getattr(wrapper, 'device', None) or getattr(wrapper, '_device', None)
@@ -454,9 +456,10 @@ class EvalRunner:
                 torch.cuda.synchronize(model_device)
             t_start = time.perf_counter()
 
-            y_pred = wrapper.predict_regression(
-                X_train, y_train, ds.X_test
-            )
+            with strict_pipeline(SvdFallbackWarning):
+                y_pred = wrapper.predict_regression(
+                    X_train, y_train, ds.X_test
+                )
             if torch.cuda.is_available() and model_device is not None:
                 torch.cuda.synchronize(model_device)
             t_end = time.perf_counter()
@@ -472,6 +475,12 @@ class EvalRunner:
             # Aggressive cleanup on OOM so subsequent datasets can run
             gc.collect()
             torch.cuda.empty_cache()
+            if not self.skip_on_error:
+                raise
+            traceback.print_exc()
+
+        except SvdFallbackWarning as e:
+            result.error = f"{type(e).__name__}: {e}"
             if not self.skip_on_error:
                 raise
             traceback.print_exc()

--- a/src/synthefy_nori/inference/degradation.py
+++ b/src/synthefy_nori/inference/degradation.py
@@ -1,0 +1,89 @@
+"""Silent degradation: the one place that names it, and the one way to forbid it.
+
+Parts of inference keep going by handing the model **less than the configured
+pipeline promised** — a projection that fell back to raw columns, a context that
+was trimmed to fit. Predictions still come out, so the run reads as "this config
+is weak" rather than "the pipeline broke", and nothing downstream can tell the two
+apart. In serving that trade is right; in anything *scored* it is a fabricated
+number.
+
+Every such fallback therefore warns, and warns under a category from this module.
+That is the whole mechanism: no per-step argument to thread through the stack, no
+environment variable, nothing to keep in sync. A caller who must not be handed a
+degraded prediction escalates the category to an exception::
+
+    from synthefy_nori import strict_pipeline
+
+    with strict_pipeline():                 # every degradation is fatal
+        model.predict(X_test)
+
+    with strict_pipeline(SvdFallbackWarning):   # just this one
+        model.predict(X_test)
+
+or, equivalently, with the standard library::
+
+    warnings.simplefilter("error", DegradedPipelineWarning)
+
+Because the categories form a tree, escalation is inherited: a future fallback
+adds one subclass here and every caller who already asked for a strict pipeline
+gets it, with no other file to edit.
+
+``synthefy_nori.evaluation``'s runner runs every scored predict call inside
+``strict_pipeline(SvdFallbackWarning)``, so an eval records a failed row instead
+of scoring a broken projection. It deliberately does NOT escalate
+:class:`ContextSubsampledWarning`: trimming context to an element budget is
+expected on large tables, and ``memory_policy={"allow_subsample": False}`` is the knob
+for refusing it.
+"""
+
+from __future__ import annotations
+
+import warnings
+from contextlib import contextmanager
+
+
+class DegradedPipelineWarning(UserWarning):
+    """Nori gave the model less than the configured pipeline promised.
+
+    The prediction is still returned. Subclasses say which fallback ran; catch
+    this base class to mean "any loss of fidelity I did not ask for".
+
+    Subclasses ``UserWarning`` so callers who already filter that keep matching.
+    """
+
+
+class SvdFallbackWarning(DegradedPipelineWarning):
+    """The high-dimensional feature SVD failed and was worked around.
+
+    A ``fit`` failure passes the raw (unprojected) columns through; a
+    ``transform`` failure hands ``svd_all`` a single all-zero column — every
+    feature dropped — or ``svd_binary`` only its non-binary keep-columns. See
+    ``HighDimFeatureSelector``.
+    """
+
+
+class ContextSubsampledWarning(DegradedPipelineWarning):
+    """Context rows were dropped so the request would fit the element budget.
+
+    The declarative way to refuse this is ``memory_policy={"allow_subsample": False}``,
+    which raises before any prediction is computed.
+    """
+
+
+@contextmanager
+def strict_pipeline(*categories: type[Warning]):
+    """Make degradation warnings fatal for the duration of the block.
+
+    Args:
+        *categories: which to escalate; defaults to
+            :class:`DegradedPipelineWarning`, i.e. all of them. Pass a subclass
+            to escalate just that fallback.
+
+    The filter is restored on exit, so this is safe inside a library or a loop
+    over many datasets — one strict prediction does not silence or harden the
+    next one.
+    """
+    with warnings.catch_warnings():
+        for category in (categories or (DegradedPipelineWarning,)):
+            warnings.simplefilter("error", category)
+        yield

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -12,6 +12,7 @@ from synthefy_nori.inference.preprocess import (
     MADWinsorizer,
     PolynomialInteractionGenerator,
     SubSampleData)
+from synthefy_nori.inference.degradation import ContextSubsampledWarning, DegradedPipelineWarning
 from synthefy_nori.inference.memory_policy import (
     FIT_ROW_CHUNK_ON_OOM,
     ContextTooLargeError,
@@ -1299,6 +1300,12 @@ class NoriPredictor:
             if torch.is_tensor(base_pred):
                 return torch.as_tensor(ensembled, dtype=base_pred.dtype, device=base_pred.device)
             return ensembled
+        except DegradedPipelineWarning:
+            # A warning escalated to an exception is a caller DEMANDING to hear
+            # about degradation -- it is not a YJ failure to swallow. Warnings are
+            # Exceptions, so without this the blanket handler below would catch it
+            # and turn strict_pipeline() back into a silent degradation on this path.
+            raise
         except Exception as _e:
             print(f"  [YJ] augmentation failed ({type(_e).__name__}: {_e}), "
                   f"falling back to identity-only prediction")
@@ -1363,7 +1370,9 @@ class NoriPredictor:
                 f"memory_policy={{'allow_subsample': False}} to make this an error."
             )
             self._log_once_per_call("subsample", logging.WARNING, _subsample_msg)
-            self._warn_once_per_call("subsample", _subsample_msg, UserWarning)
+            # Same category tree as the SVD fallback: one escalation forbids every
+            # fallback that hands the model less than the config promised.
+            self._warn_once_per_call("subsample", _subsample_msg, ContextSubsampledWarning)
             # Randomly subsample the training data
             rng = np.random.default_rng(self.seed)
             idx = rng.choice(n_samples_train, max_train_samples, replace=False)

--- a/src/synthefy_nori/inference/preprocess.py
+++ b/src/synthefy_nori/inference/preprocess.py
@@ -21,6 +21,7 @@ from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.impute import SimpleImputer
 from sklearn.decomposition import TruncatedSVD
 from sklearn.utils.validation import check_is_fitted
+from synthefy_nori.inference.degradation import SvdFallbackWarning
 from synthefy_nori.utils.data_utils import NoriInferenceDataset
 from torch.cuda import OutOfMemoryError
 
@@ -1330,6 +1331,12 @@ class HighDimFeatureSelector(BasePreprocess):
     subsample_rows : int
         Cap rows when fitting MI / ExtraTrees (default 5000) to bound runtime
         on large train splits.
+
+    When the SVD itself throws, this step works around it rather than failing —
+    and always warns, under :class:`~synthefy_nori.SvdFallbackWarning`. Callers
+    who must not be handed a degraded prediction escalate that category to an
+    exception (``with strict_pipeline(): ...``); see
+    ``synthefy_nori.inference.degradation``.
     """
 
     def __init__(
@@ -1427,6 +1434,30 @@ class HighDimFeatureSelector(BasePreprocess):
         self.categorical_features_ = list(categorical_features)
         return list(categorical_features)
 
+    def _svd_degraded(self, stage: str, exc: Exception, fallback: str) -> None:
+        """Report an SVD failure that silently degrades the configured pipeline.
+
+        Both SVD fallbacks change what the model sees without changing the config:
+        a **fit** failure turns the projection into a passthrough of the RAW
+        (e.g. 1024) columns, and a **transform** failure feeds ``svd_all`` a single
+        zero column — every feature gone. Either one still returns predictions, so
+        the run completes with a plausible-looking bad R2 that reads as "this
+        config is weak" rather than "the SVD broke".
+
+        So it is never silent. Emitting :class:`SvdFallbackWarning` is also the
+        whole opt-out mechanism: escalating that category to an exception (see
+        ``synthefy_nori.inference.degradation``) makes the fallback fatal, with no
+        per-step argument to plumb through the predictor and the public API.
+        """
+        warnings.warn(
+            f"Nori: HighDimFeatureSelector(strategy={self.strategy!r}): SVD {stage} failed "
+            f"({type(exc).__name__}: {str(exc)[:120]}) -> {fallback}. Predictions are "
+            f"degraded, NOT the configured pipeline. Use "
+            f"synthefy_nori.strict_pipeline() to make this an error instead.",
+            SvdFallbackWarning,
+            stacklevel=3,
+        )
+
     @override
     def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, *, y=None, **kwargs) -> list[int]:
         x = np.asarray(x, dtype=np.float64)
@@ -1457,7 +1488,11 @@ class HighDimFeatureSelector(BasePreprocess):
             try:
                 self.svd_model_ = _TorchTruncatedSVD(n_components=n_components, random_state=seed_int)
                 self.svd_model_.fit(x_binary)
-            except Exception:
+            except Exception as exc:
+                self._svd_degraded(
+                    "fit", exc,
+                    f"passthrough of all {n_features} raw columns "
+                    f"({int(binary_mask.sum())} binary columns left unprojected)")
                 return self._activate_passthrough(categorical_features)
             self.svd_binary_mask_ = binary_mask
             self.svd_keep_idx_ = np.where(~binary_mask)[0]
@@ -1470,7 +1505,11 @@ class HighDimFeatureSelector(BasePreprocess):
             try:
                 self.svd_model_ = _TorchTruncatedSVD(n_components=n_components, random_state=seed_int)
                 self.svd_model_.fit(x_imp)
-            except Exception:
+            except Exception as exc:
+                self._svd_degraded(
+                    "fit", exc,
+                    f"passthrough of all {n_features} raw columns "
+                    f"(no reduction to {n_components} components)")
                 return self._activate_passthrough(categorical_features)
             self.svd_binary_mask_ = np.ones(n_features, dtype=bool)
             self.svd_keep_idx_ = np.array([], dtype=int)
@@ -1543,10 +1582,19 @@ class HighDimFeatureSelector(BasePreprocess):
             x_in = np.where(np.isnan(x_in), 0.0, x_in)
             try:
                 x_svd = self.svd_model_.transform(x_in)
-            except Exception:
-                # SVD test-time failure: fall back to keep cols (or zeros if svd_all)
+            except Exception as exc:
+                # SVD test-time failure: fall back to keep cols (or zeros if svd_all).
+                # Never silently — a zero column makes the model predict from nothing.
                 if self.strategy == 'svd_all':
+                    self._svd_degraded(
+                        "transform", exc,
+                        f"a single all-zero column for {x_arr.shape[0]} rows "
+                        f"(all {x_in.shape[1]} features dropped)")
                     return np.zeros((x_arr.shape[0], 1), dtype=np.float32), []
+                self._svd_degraded(
+                    "transform", exc,
+                    f"dropping the {x_in.shape[1]} SVD-projected columns, keeping the "
+                    f"{len(self.svd_keep_idx_)} non-binary ones")
                 return x_arr[:, self.svd_keep_idx_].astype(np.float32), self.categorical_features_
             if self.strategy == 'svd_all':
                 return x_svd.astype(np.float32), []

--- a/tests/test_svd_fallback_visibility.py
+++ b/tests/test_svd_fallback_visibility.py
@@ -1,0 +1,319 @@
+"""HighDimFeatureSelector's SVD fallbacks must never be silent.
+
+Both fallbacks keep inference alive by changing what the model sees: a **fit**
+failure degrades the projection to a passthrough of the raw columns, and a
+**transform** failure hands ``svd_all`` a single all-zero column (every feature
+gone). Both still return predictions, so a broken SVD reads as "this config
+scores badly" instead of "the SVD broke".
+
+These tests pin the guarantees: every fallback warns under ``SvdFallbackWarning``,
+one ``strict_pipeline()`` makes it fatal, the category tree lets a caller escalate
+all degradation or one kind, and the eval runner escalates the SVD fallback so no
+eval can score a degraded run.
+"""
+import inspect
+import warnings
+
+import numpy as np
+import pytest
+
+from synthefy_nori import (
+    ContextSubsampledWarning,
+    DegradedPipelineWarning,
+    SvdFallbackWarning,
+    strict_pipeline,
+)
+from synthefy_nori.inference import preprocess as pp
+from synthefy_nori.inference.preprocess import HighDimFeatureSelector
+
+SVD_BLOCK = {"strategy": "svd_all", "svd_components": 64,
+             "n_features_threshold": 256, "binary_threshold": 1.01}
+
+
+def _data(n=300, p=400, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, p))
+    return X, rng.standard_normal(n)
+
+
+def _selector(**kw):
+    return HighDimFeatureSelector(**SVD_BLOCK, **kw)
+
+
+def _break_fit(monkeypatch):
+    """Make the SVD blow up at fit time."""
+    class _Boom(pp._TorchTruncatedSVD):
+        def fit(self, X, y=None):
+            raise np.linalg.LinAlgError("synthetic fit failure")
+    monkeypatch.setattr(pp, "_TorchTruncatedSVD", _Boom)
+
+
+def _break_transform(sel):
+    """Make the already-fitted SVD blow up at transform time."""
+    def _boom(_X):
+        raise np.linalg.LinAlgError("synthetic transform failure")
+    sel.svd_model_.transform = _boom
+
+
+# --- transform-time failure (the all-zero column) ----------------------------
+
+def test_transform_failure_warns_and_zeros():
+    X, y = _data()
+    sel = _selector()
+    sel.fit(X, [], 0, y=y)
+    _break_transform(sel)
+    with pytest.warns(SvdFallbackWarning, match="all-zero column"):
+        out, cat = sel.transform(X[:5])
+    assert out.shape == (5, 1) and not out.any()   # fallback still taken
+    assert cat == []
+
+
+def test_transform_failure_is_fatal_under_strict_pipeline():
+    X, y = _data()
+    sel = _selector()
+    sel.fit(X, [], 0, y=y)
+    _break_transform(sel)
+    with strict_pipeline(), pytest.raises(SvdFallbackWarning, match="all-zero column"):
+        sel.transform(X[:5])
+
+
+def test_svd_binary_transform_failure_warns():
+    rng = np.random.default_rng(1)
+    X = (rng.random((300, 400)) < 0.3).astype(float)   # all-binary -> svd_binary
+    sel = HighDimFeatureSelector(strategy="svd_binary", n_features_threshold=256,
+                                 binary_threshold=0.5, svd_components=64)
+    sel.fit(X, [], 0, y=rng.standard_normal(300))
+    _break_transform(sel)
+    with pytest.warns(SvdFallbackWarning, match="SVD-projected columns"):
+        out, _ = sel.transform(X[:5])
+    assert out.shape[1] == len(sel.svd_keep_idx_)
+
+
+# --- fit-time failure (passthrough of the raw columns) -----------------------
+
+def test_fit_failure_warns_and_passes_through(monkeypatch):
+    X, y = _data()
+    _break_fit(monkeypatch)
+    sel = _selector()
+    with pytest.warns(SvdFallbackWarning, match="passthrough of all 400 raw columns"):
+        sel.fit(X, [], 0, y=y)
+    assert sel.passthrough_
+    out, _ = sel.transform(X[:5])
+    assert out.shape[1] == 400          # model sees the raw width, not 64
+
+
+def test_fit_failure_is_fatal_under_strict_pipeline(monkeypatch):
+    X, y = _data()
+    _break_fit(monkeypatch)
+    with strict_pipeline(), pytest.raises(SvdFallbackWarning, match="SVD fit failed"):
+        _selector().fit(X, [], 0, y=y)
+
+
+# --- the happy path stays quiet ---------------------------------------------
+
+def test_working_svd_is_silent_even_under_strict_pipeline():
+    """The guard must not fire on a healthy run, strict or not."""
+    X, y = _data()
+    sel = _selector()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sel.fit(X, [], 0, y=y)
+        out, _ = sel.transform(X[:5])
+    assert not [w for w in caught if issubclass(w.category, DegradedPipelineWarning)]
+    assert out.shape == (5, 64)
+
+    sel2 = _selector()                      # same run, now strict: still no raise
+    with strict_pipeline():
+        sel2.fit(X, [], 0, y=y)
+        out2, _ = sel2.transform(X[:5])
+    assert out2.shape == (5, 64)
+
+
+# --- the category tree is the whole mechanism --------------------------------
+
+def test_category_tree():
+    """One escalation covers every fallback; a subclass covers just one."""
+    assert issubclass(SvdFallbackWarning, DegradedPipelineWarning)
+    assert issubclass(ContextSubsampledWarning, DegradedPipelineWarning)
+    # UserWarning so callers who already filter that keep matching
+    assert issubclass(DegradedPipelineWarning, UserWarning)
+    assert not issubclass(SvdFallbackWarning, ContextSubsampledWarning)
+
+
+def test_strict_pipeline_can_escalate_one_kind_only(monkeypatch):
+    X, y = _data()
+    _break_fit(monkeypatch)
+    # escalating a sibling category leaves the SVD fallback merely warning
+    with strict_pipeline(ContextSubsampledWarning):
+        with pytest.warns(SvdFallbackWarning):
+            _selector().fit(X, [], 0, y=y)
+    # escalating the base class catches it
+    with strict_pipeline(DegradedPipelineWarning), pytest.raises(SvdFallbackWarning):
+        _selector().fit(X, [], 0, y=y)
+
+
+def test_strict_pipeline_restores_filters(monkeypatch):
+    """Safe in a loop: one strict prediction must not harden or silence the next."""
+    X, y = _data()
+    _break_fit(monkeypatch)
+    before = list(warnings.filters)
+    with strict_pipeline(), pytest.raises(SvdFallbackWarning):
+        _selector().fit(X, [], 0, y=y)
+    assert warnings.filters == before
+    with pytest.warns(SvdFallbackWarning):          # back to warning
+        _selector().fit(X, [], 0, y=y)
+
+
+def test_no_threaded_argument_survives():
+    """The knob is the warning category — not a parameter to plumb through the stack.
+
+    Guards against reintroducing the per-step argument (or the env var before it),
+    which had to be repeated in preprocess.py, predictor.py, api.py and the eval
+    wrapper and kept in sync in all four.
+    """
+    from synthefy_nori import api
+    from synthefy_nori.evaluation import models
+    from synthefy_nori.inference import predictor
+
+    for mod in (pp, predictor, api, models):
+        src = inspect.getsource(mod)
+        assert "on_svd_failure" not in src, f"{mod.__name__} threads on_svd_failure"
+        assert "FORBID_SVD_FALLBACK" not in src, f"{mod.__name__} reads an env var"
+    for cls in (HighDimFeatureSelector, predictor.NoriPredictor, api.NoriRegressor):
+        assert "on_svd_failure" not in inspect.signature(cls.__init__).parameters
+
+
+# --- an eval can never score a degraded run ---------------------------------
+
+class _WarningWrapper:
+    """A model whose predict degrades: warns ``category``, then predicts anyway."""
+
+    def __init__(self, category, name="degrader"):
+        self.category = category
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def device_str(self):
+        return "cpu"
+
+    def predict_regression(self, X_train, y_train, X_test):
+        warnings.warn(f"Nori: synthetic {self.category.__name__}", self.category)
+        return np.full(len(X_test), float(np.nanmean(y_train)), dtype=np.float64)
+
+    def cleanup(self):
+        pass
+
+
+def _run_runner_with(wrapper, tmp_path):
+    from synthefy_nori.evaluation.datasets import DatasetEntry
+    from synthefy_nori.evaluation.models import ModelEntry
+    from synthefy_nori.evaluation.runner import EvalRunner
+
+    class _Registry:
+        pass
+
+    ds = DatasetEntry(
+        name="d",
+        source="synth",
+        task_type="regression",
+        X_train=np.zeros((5, 2), np.float32),
+        y_train=np.arange(5, dtype=np.float64),
+        X_test=np.zeros((3, 2), np.float32),
+        y_test=np.arange(3, dtype=np.float64),
+    )
+    runner = EvalRunner(
+        _Registry(), _Registry(),
+        output_dir=tmp_path / "out",
+        cache_dir=tmp_path / "cache",
+        no_cache=True,
+        verbose=False,
+    )
+    entry = ModelEntry(name=wrapper.name, wrapper=wrapper, model_type="custom")
+    row = runner._eval_one(entry, ds, "[test]").to_dict()
+    row.setdefault("r2", None)
+    return row
+
+
+def test_runner_records_a_broken_svd_as_failed_not_scored(tmp_path):
+    """The guarantee: an eval can never report a degraded pipeline as a score."""
+    row = _run_runner_with(_WarningWrapper(SvdFallbackWarning), tmp_path)
+    assert row["r2"] is None or np.isnan(row["r2"])       # NOT scored
+    assert "SvdFallbackWarning" in (row["error"] or "")   # recorded instead
+
+
+def test_runner_still_scores_a_subsampled_context(tmp_path):
+    """Control: only the SVD fallback is escalated.
+
+    Trimming context to an element budget is expected on large tables, so
+    ContextSubsampledWarning must not fail the row — memory_policy=
+    {'allow_subsample': False} is the knob for refusing that.
+    """
+    with pytest.warns(ContextSubsampledWarning):        # warns, but does not fail
+        row = _run_runner_with(_WarningWrapper(ContextSubsampledWarning), tmp_path)
+    assert row["error"] is None
+    assert row["r2"] is not None and not np.isnan(row["r2"])
+
+
+class _DistPointDegrader:
+    """A second custom wrapper whose point prediction degrades."""
+    name = "dist-point-degrader"
+    device_str = "cpu"
+
+    def predict_regression(self, X_train, y_train, X_test):
+        warnings.warn("Nori: synthetic SvdFallbackWarning", SvdFallbackWarning)
+        return np.full(len(X_test), float(np.nanmean(y_train)), dtype=np.float64)
+
+    def cleanup(self):
+        pass
+
+
+def test_runner_guards_every_scored_predict(tmp_path):
+    """Every scored prediction is guarded by the strict SVD filter."""
+    row = _run_runner_with(_DistPointDegrader(), tmp_path)
+    assert "SvdFallbackWarning" in (row["error"] or "")   # recorded as failed
+    assert row["r2"] is None or np.isnan(row["r2"])       # NOT scored
+
+
+# --- an escalated warning must not be swallowed as a generic failure ---------
+
+def test_yj_ensemble_does_not_swallow_an_escalated_warning(monkeypatch):
+    """A Warning IS an Exception, so blanket handlers can eat the escalation.
+
+    ``_predict_reg``'s YJ ensemble wraps a second prediction pass in
+    ``except Exception`` and falls back to the identity pass. Escalated, the
+    warning must propagate instead of being printed as "[YJ] augmentation failed"
+    — otherwise strict_pipeline() silently degrades back to warn-and-continue.
+    """
+    from synthefy_nori.inference.predictor import NoriPredictor
+
+    calls = {"n": 0}
+
+    def _fake_single(self, x_train, y_train, x_test, return_distribution=False):
+        calls["n"] += 1
+        if calls["n"] == 2:                              # the YJ pass only
+            warnings.warn("Nori: synthetic SVD fit failure", SvdFallbackWarning)
+        return np.full(len(x_test), 1.0)
+
+    monkeypatch.setattr(NoriPredictor, "_predict_reg_single", _fake_single)
+    pred = NoriPredictor.__new__(NoriPredictor)          # no checkpoint needed
+    pred.augmentations = ["yj"]
+    pred.yj_skew_threshold = 0.0                         # force the YJ branch open
+    y = np.array([0.0, 0, 0, 0, 0, 0, 0, 0, 1, 40.0])    # skewed -> gate opens
+    x_train, x_test = np.zeros((10, 3)), np.zeros((4, 3))
+
+    with strict_pipeline(), pytest.raises(SvdFallbackWarning):
+        pred._predict_reg(x_train, y, x_test)
+    assert calls["n"] == 2, "the YJ pass must actually have run"
+
+    calls["n"] = 0                                       # default stays resilient
+    with pytest.warns(SvdFallbackWarning):
+        out = pred._predict_reg(x_train, y, x_test)
+    assert len(out) == 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/uv.lock
+++ b/uv.lock
@@ -3781,7 +3781,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

Promotes the reviewed SVD fallback visibility work from Synthefy/synthefy-nori-staging#15 (originating in Synthefy/synthefy-nori-internal#310) and bumps `synthefy-nori` from `0.13.0` to `0.13.1`.

- recoverable SVD fit/transform fallbacks emit `SvdFallbackWarning` with the exact degraded-pipeline action
- `strict_pipeline()` can promote all degradation warnings, or just `SvdFallbackWarning`, to exceptions
- scored evaluation records SVD degradation as a failed row rather than a plausible bad score
- exports/docs/tests cover the warning hierarchy and filter restoration
- `pyproject.toml`, `__version__`, and `uv.lock` agree on `0.13.1`

## Live release evidence

- Exact dev Baseten deployment returned HTTP 200 with predictions and a valid `usage` block for a normal 300-feature request.
- A deterministic SVD fit failure produced the exact `SvdFallbackWarning` category and full degradation message in deployment logs. The intentionally overflowing input later failed downstream, so this proves hosted warning visibility; the clean recoverable behavior is pinned by the test suite.
- Real `SynthefyNoriClient` → Frontier Gateway → `synthefy/nori-6m-dev` smoke passed with both a disposable key and a supplied dev key; disposable resources were deleted and no credential was persisted.
- Full evidence: Synthefy/synthefy-nori-internal#310, staging promotion: Synthefy/synthefy-nori-staging#15, client support: Synthefy/synthefy#48.

## Validation

- `uv run --frozen pytest -q tests/test_svd_fallback_visibility.py` — 14 passed
- `uv run --frozen pytest -q` — 243 passed, 2 skipped, 31 deselected
- `uv run --frozen ruff check src scripts tests`
- `uv build`
- `uvx twine check --strict dist/synthefy_nori-0.13.1.tar.gz dist/synthefy_nori-0.13.1-py3-none-any.whl`

After this package is published, a client `6.2.1` follow-up will raise the `synthefy[local]` dependency floor to `synthefy-nori>=0.13.1`; its lockfile cannot resolve correctly before this version exists on PyPI.