### PR TITLE
Promote staging to public + release 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,20 @@ It auto-detects the most recent tier-1 run, or point it at one with
 
 Training uses the **Muon** optimizer (EMA 0.999), a **pinball** loss with 999
 quantiles + a monotonicity penalty, and bf16 mixed precision with DDP. Pass
-`--seed` for reproducible runs. Full options: [docs/training.md](docs/training.md).
+`--seed` for reproducible runs.
+
+### Training acceleration
+
+The bundled launchers enable native RMSNorm, foreach EMA updates, and regional
+dynamic `torch.compile` by default. These preserve the natural shape curriculum;
+disable them per run with `NATIVE_RMS_NORM=0`, `EMA_FOREACH=0`, or
+`COMPILE_ENCODER_LAYERS=none`. Exact static-shape compilation is also available,
+but requires an explicit shape palette that changes the curriculum and must be
+validated separately.
+
+See [docs/training.md](docs/training.md) for the full training options and
+[the acceleration guide](docs/training_static_compile.md) for compiler modes,
+cache setup, measurements, and reproducibility controls.
 
 ## Evaluation
 
@@ -741,7 +754,8 @@ src/synthefy_nori/
   inference/        Sklearn-compatible predictor + preprocessing
   evaluation/       Benchmark runner over public benchmark suites
   hf.py             Hugging Face download / upload
-scripts/            train.sh, continue_training.sh, evaluate.sh
+scripts/            Training, precompile, and evaluation launchers
+benchmarks/         Reproducible performance and compiler harnesses
 docs/               training, inference, evaluation, huggingface guides
 examples/           Runnable inference / upload scripts
 ```

--- a/benchmarks/bench_training_compile.py
+++ b/benchmarks/bench_training_compile.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Build or benchmark exact-shape compiler artifacts for Nori training."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import time
+import types
+from pathlib import Path
+
+import torch
+
+from synthefy_nori.model.layer import RMSNorm
+from synthefy_nori.utils.loading import _safe_torch_load, build_model
+
+
+def parse_shapes(raw: str) -> list[tuple[int, int, float]]:
+    shapes = []
+    seen = set()
+    for item in raw.split(","):
+        try:
+            dims, ratio_raw = item.strip().split("@", maxsplit=1)
+            rows_raw, features_raw = dims.lower().split("x", maxsplit=1)
+            rows = int(rows_raw)
+            features = int(features_raw)
+            ratio = float(ratio_raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                "Shapes must use ROWSxFEATURES@CONTEXT_RATIO"
+            ) from exc
+        signature = (rows, features, ratio)
+        if rows <= 1 or features <= 0 or not 0 < ratio < 1:
+            raise argparse.ArgumentTypeError(f"Invalid shape signature: {item!r}")
+        if signature in seen:
+            raise argparse.ArgumentTypeError(f"Duplicate shape signature: {item!r}")
+        seen.add(signature)
+        shapes.append(signature)
+    if not shapes:
+        raise argparse.ArgumentTypeError("At least one shape signature is required")
+    return shapes
+
+
+def build_exact_model(
+    checkpoint: str,
+    device: torch.device,
+    native_rms_norm: bool,
+):
+    state = _safe_torch_load(checkpoint)
+    model = build_model(dict(state["model_config"]))
+    model.load_state_dict(state["model_state_dict"])
+    for name in (
+        "feature_decoder",
+        "cls_y_encoder",
+        "cls_y_decoder",
+        "cls_target_aware_embedding",
+    ):
+        module = getattr(model, name, None)
+        if module is not None:
+            module.requires_grad_(False)
+    model._skip_feature_decoder = True
+    if native_rms_norm:
+        for module in model.modules():
+            if isinstance(module, RMSNorm):
+                module.use_native = True
+    return model.to(device).train()
+
+
+def compile_model(model: torch.nn.Module, strategy: str, mode: str):
+    if strategy == "eager":
+        return model
+    compile_mode = None if mode == "default" else mode
+    if strategy in ("forward-dynamic", "forward-static"):
+        layers = model.transformer_encoder.layers
+        compiled_forward = torch.compile(
+            type(layers[0]).forward,
+            mode=compile_mode,
+            dynamic=strategy == "forward-dynamic",
+            fullgraph=False,
+        )
+        for layer in layers:
+            layer.forward = types.MethodType(compiled_forward, layer)
+        return model
+    if strategy in ("stack-dynamic", "stack-static"):
+        model.transformer_encoder = torch.compile(
+            model.transformer_encoder,
+            mode=compile_mode,
+            dynamic=strategy == "stack-dynamic",
+            fullgraph=False,
+        )
+        return model
+    raise ValueError(strategy)
+
+
+def make_batch(
+    batch: int,
+    rows: int,
+    features: int,
+    eval_pos: int,
+    device: torch.device,
+    seed: int,
+):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    x = torch.randn(batch, rows, features, generator=generator)
+    y = torch.randn(batch, rows, generator=generator)
+    query_mask = (
+        torch.rand(batch, rows - eval_pos, features, generator=generator) < 0.15
+    )
+    x[:, eval_pos:][query_mask] = float("nan")
+    context = y[:, :eval_pos]
+    y = (
+        (y - context.mean(-1, keepdim=True))
+        / context.std(-1, keepdim=True).clamp_min(1e-8)
+    )
+    return x.to(device), y.to(device)
+
+
+def clear_grads(model):
+    for parameter in model.parameters():
+        parameter.grad = None
+
+
+def counters_snapshot():
+    from torch._dynamo.utils import counters
+
+    return {
+        str(category): {
+            str(key): int(value)
+            for key, value in values.items()
+            if isinstance(value, int) and value
+        }
+        for category, values in counters.items()
+        if values
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--native-rms-norm", action="store_true")
+    parser.add_argument(
+        "--strategy",
+        choices=(
+            "eager",
+            "forward-dynamic",
+            "forward-static",
+            "stack-dynamic",
+            "stack-static",
+        ),
+        default="eager",
+    )
+    parser.add_argument(
+        "--compile-mode",
+        choices=("default", "reduce-overhead", "max-autotune-no-cudagraphs"),
+        default="default",
+    )
+    parser.add_argument("--compile-cache-limit", type=int, default=1024)
+    parser.add_argument("--disable-ddp-optimizer", action="store_true")
+    parser.add_argument(
+        "--shapes",
+        type=parse_shapes,
+        default=parse_shapes("256x64@0.5"),
+    )
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--cycles", type=int, default=2)
+    parser.add_argument(
+        "--shape-order",
+        choices=("interleaved", "grouped"),
+        default="interleaved",
+    )
+    parser.add_argument("--checkpoint-threshold", type=int, default=24576)
+    parser.add_argument(
+        "--checkpointing", choices=("auto", "on", "off"), default="auto"
+    )
+    parser.add_argument("--output")
+    args = parser.parse_args()
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    distributed = world_size > 1
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if distributed:
+        torch.cuda.set_device(local_rank)
+        torch.distributed.init_process_group(backend="nccl")
+        device = torch.device(f"cuda:{local_rank}")
+    else:
+        device = torch.device(args.device)
+    is_main = not distributed or local_rank == 0
+    torch.cuda.set_device(device)
+    torch.manual_seed(1234)
+    torch._dynamo.reset()
+    cache_limit = max(8, args.compile_cache_limit)
+    torch._dynamo.config.cache_size_limit = cache_limit
+    torch._dynamo.config.recompile_limit = cache_limit
+    torch._dynamo.config.accumulated_cache_size_limit = cache_limit
+    torch._dynamo.config.accumulated_recompile_limit = cache_limit
+    if args.disable_ddp_optimizer:
+        torch._dynamo.config.optimize_ddp = False
+
+    model = build_exact_model(args.checkpoint, device, args.native_rms_norm)
+    model = compile_model(model, args.strategy, args.compile_mode)
+    if distributed:
+        model = torch.nn.parallel.DistributedDataParallel(
+            model,
+            device_ids=[local_rank],
+            find_unused_parameters=False,
+            broadcast_buffers=False,
+            gradient_as_bucket_view=True,
+        )
+
+    records = []
+    started_all = time.perf_counter()
+    schedule = [
+        (cycle, shape_index)
+        for cycle in range(args.cycles)
+        for shape_index in range(len(args.shapes))
+    ]
+    if args.shape_order == "grouped":
+        schedule.sort(key=lambda item: (item[1], item[0]))
+
+    for cycle, shape_index in schedule:
+        rows, features, ratio = args.shapes[shape_index]
+        eval_pos = max(1, min(rows - 1, int(rows * ratio)))
+        x, y = make_batch(
+            args.batch_size,
+            rows,
+            features,
+            eval_pos,
+            device,
+            seed=cycle * 1000 + shape_index,
+        )
+        bare = model.module if distributed else model
+        bare = getattr(bare, "_orig_mod", bare)
+        if args.checkpointing == "auto":
+            checkpointed = rows * features >= args.checkpoint_threshold
+        else:
+            checkpointed = args.checkpointing == "on"
+        bare.transformer_encoder.gradient_checkpointing = checkpointed
+        clear_grads(model)
+        torch.cuda.reset_peak_memory_stats(device)
+        torch.cuda.synchronize(device)
+        started = time.perf_counter()
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            output = model(x=x, y=y, eval_pos=eval_pos, task_type="reg")
+            target = y[:, eval_pos:].unsqueeze(-1)
+            loss = (output["reg_output"].float() - target).square().mean()
+        loss.backward()
+        torch.cuda.synchronize(device)
+        record = {
+            "cycle": cycle,
+            "rows": rows,
+            "features": features,
+            "ratio": ratio,
+            "eval_pos": eval_pos,
+            "checkpointed": checkpointed,
+            "batch_size": args.batch_size,
+            "seconds": time.perf_counter() - started,
+            "peak_gib": torch.cuda.max_memory_allocated(device) / 1024**3,
+            "loss": float(loss.detach()),
+        }
+        records.append(record)
+        if is_main:
+            print(json.dumps(record), flush=True)
+        del x, y, output, loss
+
+    steady = [record["seconds"] for record in records if record["cycle"] > 0]
+    summary = {
+        "strategy": args.strategy,
+        "native_rms_norm": args.native_rms_norm,
+        "batch_size": args.batch_size,
+        "shape_count": len(args.shapes),
+        "shape_order": args.shape_order,
+        "total_seconds": time.perf_counter() - started_all,
+        "steady_mean_seconds": statistics.mean(steady) if steady else None,
+        "counters": counters_snapshot(),
+        "records": records,
+    }
+    if is_main:
+        print("SUMMARY " + json.dumps(summary), flush=True)
+    if args.output and is_main:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(summary, indent=2) + "\n")
+    gc.collect()
+    if distributed:
+        torch.distributed.barrier()
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -13,6 +13,21 @@ y_pred = reg.predict(X_test)
 If `model_path` is omitted, the default checkpoint is resolved from Hugging
 Face through `synthefy_nori.hf.download_checkpoint()`.
 
+## Execution defaults and exact reproducibility
+
+Standard inference loads checkpoints with PyTorch's native RMSNorm kernel and
+skips the feature decoder when its output cannot be observed. Decoder skipping
+is output-identical. Native RMSNorm follows the same equation but can move a
+mixed-precision result by one bf16 unit in the last place; controlled checks
+measured an R² shift no larger than `2e-5` and about a 1.3% end-to-end inference
+improvement, with preprocessing dominating total time.
+
+`NoriRegressor` uses these defaults automatically and does not add a new public
+switch. Advanced callers that need the exact historical execution path can pass
+`native_rms_norm=False` to lower-level `load_model()` or `NoriPredictor`, and
+`skip_unused_feature_decoder=False` to `NoriPredictor`. These controls change
+execution only; they do not select different weights.
+
 ## Output types
 
 `predict` selects what it returns via `output_type`:

--- a/docs/training.md
+++ b/docs/training.md
@@ -40,3 +40,23 @@ see the script header.
 Tiers 4 and 5 reach N = 56K rows, where dense O(N²) sample attention forces
 `batch=1` with large gradient accumulation. They can OOM or hang on smaller GPUs;
 smoke-probe them first (the script header shows a short-run probe).
+
+## Execution acceleration
+
+The bundled launchers enable three curriculum-neutral execution options by
+default: native RMSNorm, grouped foreach EMA updates, and regional dynamic
+`torch.compile`. The corresponding CLI flags remain opt-in when invoking
+`synthefy-nori-train` directly. Restore the previous eager launcher behavior
+per run with:
+
+```bash
+env NATIVE_RMS_NORM=0 EMA_FOREACH=0 COMPILE_ENCODER_LAYERS=none \
+  bash scripts/train.sh
+```
+
+Dynamic regional compilation keeps the natural shape sampler. Static regional
+compilation requires explicit shape and context-ratio palettes, so it changes
+the curriculum and should be treated as a data/quality decision rather than a
+drop-in compiler switch. See
+[Training acceleration and optional static-shape compilation](training_static_compile.md)
+for the controls, cache contract, benchmark caveats, and rollout procedure.

--- a/docs/training_static_compile.md
+++ b/docs/training_static_compile.md
@@ -1,0 +1,252 @@
+# Training acceleration and optional static-shape compilation
+
+This guide covers Nori's execution-only training speedups and the experimental
+static-shape path. The CLI controls remain opt-in. The bundled training
+launchers enable the curriculum-neutral subset by default: native RMSNorm,
+foreach EMA updates, and regional dynamic compilation. These options preserve
+the sampler, shape curriculum, and training hyperparameters; mixed-precision
+rounding can still differ at bf16 scale because the kernels reduce in a
+different order.
+
+Static compilation remains explicitly opt-in because it requires a bounded
+shape palette, which changes the data curriculum and therefore needs a separate
+quality validation.
+
+## Motivation
+
+Nori's axial transformer sees many table shapes. A Tier-1 curriculum with 62
+valid `(rows, features)` buckets and six context-ratio buckets can expose 372
+compiler signatures. An early generic dynamic-compile prototype was 6.4%
+slower than eager. The current implementation instead compiles the shared
+encoder-layer region and measured 15.6% faster end-to-end on the natural shape
+curriculum in one controlled run. Padding every episode to one maximum tensor
+would waste quadratic row- and feature-attention work.
+
+Exact static compilation is effective when the curriculum is projected onto a
+small, explicitly weighted shape palette. The compiler cache can then be built
+before training and reused by fresh models with the same architecture and
+execution contract.
+
+## Opt-in controls
+
+| Flag | Effect |
+|---|---|
+| `--shape-palette ROWSxFEATURES:WEIGHT,...` | Samples from an explicit weighted physical-shape set. |
+| `--context-ratio-palette RATIO,...` | Samples only the listed context fractions. |
+| `--compile-encoder-layers static` | Regionally compiles one shared encoder-layer forward with exact static signatures. |
+| `--compile-encoder-layers dynamic` | Regionally compiles shape-generic kernels. Needs **no** palette, so the data curriculum is unchanged. |
+| `--compile-mode MODE` | Selects the `torch.compile` mode. `default` is the tested choice. |
+| `--compile-cache-limit N` | Raises Dynamo's live variant limits for the bounded signature set. |
+| `--compile-disable-ddp-optimizer` | Disables DDPOptimizer graph splitting for the already-small regional compile unit. |
+| `--native-rms-norm` | Uses PyTorch's native RMSNorm kernel. |
+| `--skip-zero-feature-decoder` | Omits feature-decoder work when feature loss remains zero. |
+| `--ema-foreach` | Groups EMA updates into foreach kernels by device and dtype. |
+
+All flags are off by default **in the CLI**. The public training launchers
+(`scripts/train.sh` and `scripts/continue_training.sh`) turn on the
+curriculum-neutral subset — `--native-rms-norm`, `--ema-foreach`, and
+`--compile-encoder-layers dynamic` — through a `SPEEDUP_ARGS` block. Disable
+them per run with `NATIVE_RMS_NORM=0`, `EMA_FOREACH=0`, or
+`COMPILE_ENCODER_LAYERS=none`. The palette flags are never enabled there,
+because they change the data curriculum.
+
+`--skip-zero-feature-decoder` requires the feature
+loss to remain zero and unused-head freezing to remain enabled. It is
+deliberately NOT enabled by the scripts: `feature_loss_weight` defaults to 0.5,
+so a blanket enable would make the CLI reject the run.
+Static encoder compilation requires either `--shape-palette` or `--fixed-size`
+and also requires `--context-ratio-palette`; the CLI rejects an unbounded static
+compile configuration before model execution.
+
+## Validated 18-signature profile
+
+The initial profile uses three row counts, three feature counts, and two context
+fractions:
+
+```text
+rows:             128, 512, 1536
+features:         8, 48, 128
+context ratios:   0.4, 0.7
+```
+
+The weighted physical palette projects the measured Tier-1 sampler onto those
+nine shapes while keeping its cell-count distribution close to the control:
+
+```text
+128x8:0.240,128x48:0.135,128x128:0.126,
+512x8:0.115,512x48:0.064,512x128:0.061,
+1536x8:0.124,1536x48:0.079,1536x128:0.056
+```
+
+These weights are a tested experiment profile, not a universal default.
+
+## Choosing `static` vs `dynamic`
+
+`static` specializes on exact tensor shapes, so it can only run against a
+bounded signature set -- hence the palette requirement. `dynamic` emits
+shape-generic kernels and handles the natural sampler as-is.
+
+Measured on a separate 4xH200 box (8.5M/24-layer for compute,
+5.9M/16-layer for wall-clock):
+
+| | regional compute gain | real training wall-clock | cold build | palette required |
+|---|---:|---:|---:|:--:|
+| eager | - | 943 ms/step | - | - |
+| + native RMSNorm only | +10.2% | 876 ms/step (+7.7%) | - | no |
+| shape palette only, eager | - | 856 ms/step (+10.2%) | - | **yes** |
+| `dynamic` | +28.6% | 816 ms/step (+15.6%) | ~10 min | no |
+| `static` | +40.6% | 734 ms/step (+28.4%) | ~21 min | **yes** |
+
+Compute is roughly 77% of a real training step -- both the RMSNorm and the
+static-compile arms imply that independently -- so compute-side gains arrive at
+wall-clock discounted by about a quarter.
+
+End to end `static` is ahead, 734 vs 816 ms/step. But almost none of that gap is
+the compiler. Isolating each effect:
+
+| effect | gain |
+|---|---:|
+| `dynamic` compiler alone (natural shapes, A -> E) | +15.6% |
+| `static` compiler alone (curriculum held fixed, C -> D) | +16.6% |
+| shape palette alone, no compiler change (A -> C) | +10.2% |
+
+**The two compilers are within about one point of each other.** `static`'s
+12.8-point lead over `dynamic` is the palette sampling cheaper tables, which the
+eager palette-only arm demonstrates on its own.
+
+So the real choice is not which compiler but whether to accept the curriculum
+change. **`dynamic` is the default in `scripts/*.sh`**: it delivers essentially
+the whole compiler win with no change to what the model trains on. Enable
+`static` plus the palette when you have validated that the nine-shape curriculum
+does not cost model quality -- that is worth roughly another 10 points, and it is
+a data decision, not a performance one.
+
+Caveat: the wall-clock arms are single runs, not a multi-seed performance
+study. An earlier pass used the trainer's default `{:.1f}` throughput logging,
+which quantizes to ~+/-4.5% at 1.1 steps/s;
+those numbers were withdrawn.
+
+## Build the cache
+
+The cache builder loads a checkpoint only to recover architecture and parameter
+shapes. Compiled graphs do not contain those particular weights and can be used
+by a newly initialized model with the same architecture.
+
+```bash
+export TORCHINDUCTOR_CACHE_DIR="$PWD/cache/torchinductor/nori-training-static-b20"
+
+CUDA_VISIBLE_DEVICES=4,5,6,7 \
+COMPILE_TEMPLATE_CHECKPOINT=/path/to/checkpoint.pt \
+BATCH_SIZE=20 \
+GRAD_CKPT_THRESHOLD=24576 \
+bash scripts/precompile_training_shapes.sh
+```
+
+Override `COMPILE_SHAPES` for another signature set:
+
+```bash
+COMPILE_SHAPES='128x16@0.4,128x16@0.7,512x64@0.4,512x64@0.7' \
+bash scripts/precompile_training_shapes.sh
+```
+
+The precompiler runs under DDP because the cache must match the training graph
+boundary. It writes `precompile_manifest.json` into the cache directory.
+The wrapper
+delegates to `benchmarks/bench_training_compile.py`, which can also be run directly
+to compare eager, regional dynamic, and regional static execution.
+
+## Train with the cache
+
+Use the same cache directory, batch size, gradient-checkpoint threshold, native
+RMSNorm setting, architecture, PyTorch/CUDA stack, and GPU architecture. The
+snippet below prepares the cache environment and static-compile arguments;
+append the resulting arguments to your existing `synthefy-nori-train` or
+`torchrun` invocation. The public shell launchers deliberately do not enable a
+shape palette for you:
+
+```bash
+export TORCHINDUCTOR_CACHE_DIR="$PWD/cache/torchinductor/nori-training-static-b20"
+export TORCHINDUCTOR_FX_GRAPH_CACHE=1
+export TORCHINDUCTOR_AUTOGRAD_CACHE=1
+
+SHAPE_PALETTE='128x8:0.240,128x48:0.135,128x128:0.126,512x8:0.115,512x48:0.064,512x128:0.061,1536x8:0.124,1536x48:0.079,1536x128:0.056'
+
+STATIC_COMPILE_ARGS=(
+  --shape-palette "$SHAPE_PALETTE"
+  --context-ratio-palette 0.4,0.7
+  --native-rms-norm
+  --ema-foreach
+  --compile-encoder-layers static
+  --compile-mode default
+  --compile-cache-limit 1024
+  --compile-disable-ddp-optimizer
+)
+```
+
+Add `--skip-zero-feature-decoder` only when feature loss remains zero and
+unused-head freezing remains enabled.
+
+The first use in a new process still loads and attaches cached artifacts. It
+should not repeat cold code generation and autotuning.
+
+## Additional implementation measurements
+
+These earlier measurements used a 9.8M-parameter, 28-layer model with batch 20
+on four H200s. They characterize individual components and prototypes; use the
+matched wall-clock table above to choose the current regional compile mode.
+
+| Intervention | Measured result |
+|---|---:|
+| Native RMSNorm | 8.8% higher four-GPU throughput in the matched phase benchmark. |
+| Skip zero-loss feature decoder | About 1.6% end-to-end improvement. |
+| Exact static compile, fixed `256x64` | Model forward/backward improved from 359.9 ms to 291.3 ms (23.5% compute throughput). |
+| Exact static compile, fixed `256x64` | Full step improved from 542.9 ms to 472.6 ms (14.9% end-to-end throughput). |
+| Early generic dynamic-compile prototype | 6.4% slower than eager; superseded by the current regional dynamic path. |
+| Whole-stack static compile under DDP | Slower than regional compilation; not exposed by the training CLI. |
+
+The complete 18-signature cold build produced:
+
+```text
+18 successful signatures
+504 AOTAutograd entries (18 signatures x 28 layers)
+1.6 GiB persistent cache
+24.5 minutes total cold build time
+96.1 GiB maximum allocated GPU memory
+```
+
+Disabling Dynamo DDPOptimizer for regional compilation was about 10% faster in
+the exact DDP benchmark and allowed AOTAutograd disk-cache hits across fresh
+processes. Each regional layer is already smaller than a DDP bucket, so the
+extra graph splitting did not improve communication overlap in this model.
+
+## Scientific rollout
+
+The shape palette changes the data curriculum. Compilation and curriculum
+quality must therefore be evaluated separately:
+
+1. Compare eager and compiled runs using the identical explicit palette, seeds,
+   architecture, optimizer, and evaluation checkpoints. This isolates execution.
+2. Compare the best palette run against the unrestricted sampler. This measures
+   any quality impact from shape discretization.
+3. Require exact-step raw-evaluation parity before enabling the profile broadly.
+4. Retain eager fallback until multiple models, GPU types, and resume paths have
+   completed successfully.
+
+Do not interpret a faster compiled palette run as a pure systems ablation against
+an unrestricted-shape control.
+
+## Cache contract and limitations
+
+Treat compiled artifacts as disposable build products. Rebuild when any of the
+following changes:
+
+- model architecture or compiled layer code;
+- batch size, table shape, context split, or checkpointing state;
+- dtype or compiler flags;
+- QASS mode and attention-backend environment settings;
+- PyTorch, Triton, CUDA, driver, or GPU architecture.
+
+The cache is not committed to Git. If an expected signature is missing, Dynamo
+can compile it lazily, which may pause training for a minute or more. Monitor the
+first occurrence of every signature and keep the generated manifest with run
+provenance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.13.1"
+version = "0.14.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/continue_training.sh
+++ b/scripts/continue_training.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# --- Execution speedups -------------------------------------------------
+# Kernel/compiler options only. These do NOT change the sampler, the shape
+# curriculum, or any hyperparameter. Native RMSNorm can change bf16 rounding
+# because it reduces the same equation in a different order.
+# Dynamic regional compile measured +28.6% on forward/backward compute and
+# +15.6% end-to-end wall-clock in one controlled 4xH200 run. The static arm
+# (which needs a palette, so it is NOT enabled here) reached +28.4% wall-clock.
+# See docs/training_static_compile.md for the benchmark caveats.
+# Override any of them:
+#   NATIVE_RMS_NORM=0             restore the decomposed RMSNorm path
+#   EMA_FOREACH=0                 restore scalar EMA updates
+#   COMPILE_ENCODER_LAYERS=none   disable regional compilation
+#                         =static exact-shape kernels; ALSO requires
+#                                 --shape-palette + --context-ratio-palette,
+#                                 which DO change the curriculum, so it is
+#                                 never enabled by default here.
+# --skip-zero-feature-decoder is intentionally absent: the CLI rejects it
+# unless feature loss stays zero, and feature_loss_weight defaults to 0.5,
+# so enabling it blanket-wise would break these launchers. Opt in per run.
+SPEEDUP_ARGS=()
+if [[ "${NATIVE_RMS_NORM:-1}" != "0" ]]; then
+  SPEEDUP_ARGS+=(--native-rms-norm)
+fi
+if [[ "${EMA_FOREACH:-1}" != "0" ]]; then
+  SPEEDUP_ARGS+=(--ema-foreach)
+fi
+SPEEDUP_COMPILE="${COMPILE_ENCODER_LAYERS:-dynamic}"
+if [[ "${SPEEDUP_COMPILE}" != "none" ]]; then
+  SPEEDUP_ARGS+=(--compile-encoder-layers "${SPEEDUP_COMPILE}")
+  SPEEDUP_ARGS+=(--compile-cache-limit "${COMPILE_CACHE_LIMIT:-1024}")
+  SPEEDUP_ARGS+=(--compile-disable-ddp-optimizer)
+fi
+# ------------------------------------------------------------------------
+
 # Curriculum continuation: tiers 2 to 5, seeded from the tier-1 checkpoint
 # produced by train.sh.
 #
@@ -163,6 +197,7 @@ run_tier() {
 
   torchrun --nproc_per_node="${NPROC}" --master_port="${MASTER_PORT}" \
     -m synthefy_nori.training.cli \
+    "${SPEEDUP_ARGS[@]}" \
     "${SHARED_ARGS[@]}" \
     --resume "${seed}" --resume-model-only \
     --checkpoint-dir "${outdir}" \

--- a/scripts/precompile_training_shapes.sh
+++ b/scripts/precompile_training_shapes.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Populate a persistent Inductor/AOTAutograd cache under the same DDP boundary
+# used for training. Cached graphs are weight-independent but require the same
+# architecture, tensor signatures, compiler flags, and software/hardware stack.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -z "${COMPILE_TEMPLATE_CHECKPOINT:-}" ]]; then
+  echo "COMPILE_TEMPLATE_CHECKPOINT must point to a Nori training checkpoint" >&2
+  exit 2
+fi
+if [[ ! -f "${COMPILE_TEMPLATE_CHECKPOINT}" ]]; then
+  echo "Checkpoint does not exist: ${COMPILE_TEMPLATE_CHECKPOINT}" >&2
+  exit 2
+fi
+
+BATCH_SIZE="${BATCH_SIZE:-20}"
+COMPILE_SHAPES="${COMPILE_SHAPES:-128x8@0.4,128x8@0.7,128x48@0.4,128x48@0.7,128x128@0.4,128x128@0.7,512x8@0.4,512x8@0.7,512x48@0.4,512x48@0.7,512x128@0.4,512x128@0.7,1536x8@0.4,1536x8@0.7,1536x48@0.4,1536x48@0.7,1536x128@0.4,1536x128@0.7}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${REPO_ROOT}/cache/torchinductor/nori-training-static-b${BATCH_SIZE}}"
+export TORCHINDUCTOR_FX_GRAPH_CACHE="${TORCHINDUCTOR_FX_GRAPH_CACHE:-1}"
+export TORCHINDUCTOR_AUTOGRAD_CACHE="${TORCHINDUCTOR_AUTOGRAD_CACHE:-1}"
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+export MKL_NUM_THREADS="${MKL_NUM_THREADS:-1}"
+export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-1}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+# Match the public training launchers. These import-time settings affect the
+# graph and therefore belong to the compiler-cache contract.
+export SYNTHEFY_QASS_MODE="${SYNTHEFY_QASS_MODE:-log_only}"
+export SYNTHEFY_QASS_SDPA_SCALE="${SYNTHEFY_QASS_SDPA_SCALE:-1}"
+export SYNTHEFY_NORI_ALLOW_CUDNN_SDP="${SYNTHEFY_NORI_ALLOW_CUDNN_SDP:-1}"
+mkdir -p "${TORCHINDUCTOR_CACHE_DIR}"
+
+OUTPUT="${COMPILE_OUTPUT:-${TORCHINDUCTOR_CACHE_DIR}/precompile_manifest.json}"
+NPROC="${NPROC_PER_NODE:-4}"
+if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+  IFS=',' read -r -a _VISIBLE_DEVICES <<< "${CUDA_VISIBLE_DEVICES}"
+  NPROC="${#_VISIBLE_DEVICES[@]}"
+fi
+if [[ -z "${MASTER_PORT:-}" ]]; then
+  MASTER_PORT="$("${REPO_ROOT}/.venv/bin/python" -c "import socket; s=socket.socket(); s.bind(('', 0)); print(s.getsockname()[1]); s.close()")"
+fi
+
+NATIVE_RMS_ARGS=()
+if [[ "${NATIVE_RMS_NORM:-1}" != "0" ]]; then
+  NATIVE_RMS_ARGS+=(--native-rms-norm)
+fi
+SIGNATURE_COUNT=$(( $(tr -cd ',' <<< "${COMPILE_SHAPES}" | wc -c) + 1 ))
+
+echo "Precompiling ${SIGNATURE_COUNT} training signatures"
+echo "  checkpoint = ${COMPILE_TEMPLATE_CHECKPOINT}"
+echo "  cache      = ${TORCHINDUCTOR_CACHE_DIR}"
+echo "  output     = ${OUTPUT}"
+echo "  DDP ranks  = ${NPROC}"
+
+exec "${REPO_ROOT}/.venv/bin/torchrun" \
+  --nproc_per_node="${NPROC}" \
+  --master_port="${MASTER_PORT}" \
+  "${REPO_ROOT}/benchmarks/bench_training_compile.py" \
+  --checkpoint "${COMPILE_TEMPLATE_CHECKPOINT}" \
+  --device "${COMPILE_DEVICE:-cuda:0}" \
+  --strategy forward-static \
+  --compile-mode "${COMPILE_MODE:-default}" \
+  --compile-cache-limit "${COMPILE_CACHE_LIMIT:-1024}" \
+  --disable-ddp-optimizer \
+  "${NATIVE_RMS_ARGS[@]}" \
+  --shapes "${COMPILE_SHAPES}" \
+  --batch-size "${BATCH_SIZE}" \
+  --cycles 1 \
+  --shape-order grouped \
+  --checkpointing auto \
+  --checkpoint-threshold "${GRAD_CKPT_THRESHOLD:-24576}" \
+  --output "${OUTPUT}"

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# --- Execution speedups -------------------------------------------------
+# Kernel/compiler options only. These do NOT change the sampler, the shape
+# curriculum, or any hyperparameter. Native RMSNorm can change bf16 rounding
+# because it reduces the same equation in a different order.
+# Dynamic regional compile measured +28.6% on forward/backward compute and
+# +15.6% end-to-end wall-clock in one controlled 4xH200 run. The static arm
+# (which needs a palette, so it is NOT enabled here) reached +28.4% wall-clock.
+# See docs/training_static_compile.md for the benchmark caveats.
+# Override any of them:
+#   NATIVE_RMS_NORM=0             restore the decomposed RMSNorm path
+#   EMA_FOREACH=0                 restore scalar EMA updates
+#   COMPILE_ENCODER_LAYERS=none   disable regional compilation
+#                         =static exact-shape kernels; ALSO requires
+#                                 --shape-palette + --context-ratio-palette,
+#                                 which DO change the curriculum, so it is
+#                                 never enabled by default here.
+# --skip-zero-feature-decoder is intentionally absent: the CLI rejects it
+# unless feature loss stays zero, and feature_loss_weight defaults to 0.5,
+# so enabling it blanket-wise would break these launchers. Opt in per run.
+SPEEDUP_ARGS=()
+if [[ "${NATIVE_RMS_NORM:-1}" != "0" ]]; then
+  SPEEDUP_ARGS+=(--native-rms-norm)
+fi
+if [[ "${EMA_FOREACH:-1}" != "0" ]]; then
+  SPEEDUP_ARGS+=(--ema-foreach)
+fi
+SPEEDUP_COMPILE="${COMPILE_ENCODER_LAYERS:-dynamic}"
+if [[ "${SPEEDUP_COMPILE}" != "none" ]]; then
+  SPEEDUP_ARGS+=(--compile-encoder-layers "${SPEEDUP_COMPILE}")
+  SPEEDUP_ARGS+=(--compile-cache-limit "${COMPILE_CACHE_LIMIT:-1024}")
+  SPEEDUP_ARGS+=(--compile-disable-ddp-optimizer)
+fi
+# ------------------------------------------------------------------------
+
 # Training: tier 1 (from scratch).
 #
 # Architecture: 16 layers, E=128, H=384, nhead=2, model_v2_lite,
@@ -82,6 +116,7 @@ export PATH="${REPO_ROOT}/.venv/bin:${PATH}"
 
 torchrun --nproc_per_node="${NPROC}" --master_port="${MASTER_PORT}" \
   -m synthefy_nori.training.cli \
+  "${SPEEDUP_ARGS[@]}" \
   "${RESUME_ARGS[@]}" \
   --checkpoint-dir "${CKPT_DIR}" \
   --total-steps "${TOTAL_STEPS}" --run-steps "${TOTAL_STEPS}" \

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -19,7 +19,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -20,7 +20,9 @@ from synthefy_nori.inference.memory_policy import (
     estimate_cache_gb,
     total_host_ram_gb,
 )
+from synthefy_nori.model.layer import RMSNorm
 from synthefy_nori.utils.loading import load_model
+import contextlib
 import torch
 from typing import List, Literal
 import random
@@ -61,7 +63,9 @@ class NoriPredictor:
                  bar_temperature: float = 1.0,
                  bar_point_estimator: str = 'mean',
                  discrete_y_snap_max_unique: int = 0,
-                 memory_policy: "MemoryPolicy | dict | str | None" = None):
+                 memory_policy: "MemoryPolicy | dict | str | None" = None,
+                 skip_unused_feature_decoder: bool = True,
+                 native_rms_norm: bool | None = None):
         """
         init NoriPredictor
 
@@ -77,6 +81,20 @@ class NoriPredictor:
             inference_with_DDP: If using DDP to inference,
             seed: Random seed
             model: Pre-loaded model instance (skips load_model when provided)
+            skip_unused_feature_decoder: Skip the feature decoder when
+                mask_prediction is off, where its output is computed and then
+                discarded. Output-preserving, so it defaults to True. Only
+                reaches models built with mask_prediction=True — that is, the
+                model= path; load_model() already builds with it off.
+            native_rms_norm: Tri-state. None (default) inherits whatever the
+                model already has, which is the right thing in both directions:
+                load_model() turns the fused kernel on, and a training-built
+                model carries whatever the training run chose. True forces the
+                fused kernel on, False forces the decomposed path on for a
+                bit-for-bit match with history. Measured: R2 shift <= 2e-5,
+                largest per-row difference one bf16 ulp, ~+1.3% end-to-end
+                (preprocessing dominates inference, so the ~+10% kernel win
+                does not survive).
         """
         if isinstance(inference_config, str):
             if os.path.isfile(inference_config):
@@ -122,6 +140,29 @@ class NoriPredictor:
         # clone(), whose identity check requires the stored attribute to be the
         # object it was handed.
         self.memory_policy = memory_policy
+        # --- Execution-only options: same weights, same algorithm, different
+        # --- kernels. Applied per call and undone afterwards. (native_rms_norm
+        # --- does shift output by ~1 bf16 ulp; see below.)
+        # Skip the feature decoder when its output cannot be read. It is read
+        # only by the mask_prediction (imputation) branch of
+        # _predict_reg_single, so with mask_prediction=False the decoder runs
+        # and its result is dropped. Default ON: predictions are bit-identical
+        # either way, so this is pure removed work, not a trade-off.
+        self.skip_unused_feature_decoder = bool(skip_unused_feature_decoder)
+        # Use torch.nn.functional.rms_norm instead of the decomposed
+        # pow/mean/rsqrt/mul chain. None means "inherit the model's setting" so
+        # an explicit load_model(native_rms_norm=False) is not silently undone
+        # here. Controlled measurements show:
+        #   accuracy - R2 shift <= 2e-5 across 1k/4k/8k-row tables; the largest
+        #              per-row difference is 0.0078125, exactly one bf16 ulp,
+        #              i.e. the two formulations land on adjacent representable
+        #              values under autocast(bfloat16). Not an approximation.
+        #   speed    - only about +1.3% end-to-end on predict(). The kernel win
+        #              is ~+10% on forward+backward, but inference is dominated
+        #              by the 16 CPU preprocessing pipelines, so little of it
+        #              survives. Do NOT cite a large inference speedup here.
+        self.native_rms_norm = (
+            None if native_rms_norm is None else bool(native_rms_norm))
         self.inference_with_DDP=inference_with_DDP
         # Optional inference-time augmentations. Currently supports:
         #   'yj': Yeo-Johnson target transform ensemble — fit PowerTransformer
@@ -548,9 +589,10 @@ class NoriPredictor:
         # config); these make them once per user-visible predict instead.
         self._warned_this_call = set()
         self._logged_this_call = set()
-        if return_distribution:
-            return self._predict_reg(x_train, y_train, x_test, return_distribution=True)
-        preds = self._predict_reg(x_train, y_train, x_test)
+        with self._execution_overrides():
+            if return_distribution:
+                return self._predict_reg(x_train, y_train, x_test, return_distribution=True)
+            preds = self._predict_reg(x_train, y_train, x_test)
         # V12r3: discrete-y snap. If enabled (discrete_y_snap_max_unique > 0)
         # and training y has a low unique count (≤ the threshold), snap each
         # prediction to the nearest training-y value. OFF by default since
@@ -625,9 +667,48 @@ class NoriPredictor:
         model_ref = self.model
         if hasattr(model_ref, "module"):
             model_ref = model_ref.module
-        if hasattr(model_ref, "_orig_mod"):
-            model_ref = model_ref._orig_mod
+        # torch.compile wraps in an OptimizedModule; attributes set on the
+        # wrapper never reach the module whose forward actually reads them, so
+        # _skip_feature_decoder would silently do nothing.
+        model_ref = getattr(model_ref, "_orig_mod", model_ref)
         return model_ref
+
+    @contextlib.contextmanager
+    def _execution_overrides(self):
+        """Apply the execution-only speedups for the duration of one call.
+
+        Both settings live on the model object, and ``model=`` may hand us a
+        module the caller also trains with or uses for imputation elsewhere.
+        Mutating it permanently would be a silent action at a distance — a
+        leaked ``_skip_feature_decoder`` would zero the feature-reconstruction
+        loss of a subsequent training step. So every change is undone on exit,
+        including on exception.
+        """
+        model = self._bare_model()
+        undo = []
+
+        # Gate on mask_prediction at call time, not construction time: callers
+        # do flip the attribute on an existing predictor.
+        if self.skip_unused_feature_decoder and not self.mask_prediction:
+            previous = getattr(model, "_skip_feature_decoder", False)
+            if not previous:
+                model._skip_feature_decoder = True
+                undo.append(lambda: setattr(model, "_skip_feature_decoder", previous))
+
+        # None = inherit the model's current setting and touch nothing.
+        if self.native_rms_norm is not None:
+            want = self.native_rms_norm
+            for module in model.modules():
+                if isinstance(module, RMSNorm) and module.use_native != want:
+                    had = module.use_native
+                    module.use_native = want
+                    undo.append(lambda m=module, v=had: setattr(m, "use_native", v))
+
+        try:
+            yield
+        finally:
+            for revert in reversed(undo):
+                revert()
 
     @property
     def regression_head(self) -> str:
@@ -1063,6 +1144,19 @@ class NoriPredictor:
     def get_embeddings(self, x_train: np.ndarray, y_train: np.ndarray,
                        x_test: np.ndarray | None = None,
                        data_source: Literal["test", "train"] = "test") -> np.ndarray:
+        """Thin wrapper applying the execution overrides once for the call.
+
+        Entering the context manager per query chunk would walk model.modules()
+        on every chunk. Note the feature-decoder skip is inert here: the
+        embedding forwards pass return_embeddings=True and return before the
+        decode branch, so only native_rms_norm has any effect.
+        """
+        with self._execution_overrides():
+            return self._get_embeddings_impl(x_train, y_train, x_test, data_source)
+
+    def _get_embeddings_impl(self, x_train: np.ndarray, y_train: np.ndarray,
+                             x_test: np.ndarray | None = None,
+                             data_source: Literal["test", "train"] = "test") -> np.ndarray:
         """Extract per-row Nori embeddings for a context/query split.
 
         Runs each preprocessing pipeline (the inference ensemble) through the

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -52,12 +52,19 @@ class RMSNorm(nn.Module):
         self.normalized_shape = tuple(normalized_shape)
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        # Training can opt into PyTorch's fused native implementation without
+        # changing the checkpoint schema or default numerical path.
+        self.use_native = False
         if elementwise_affine:
             self.weight = nn.Parameter(torch.ones(self.normalized_shape, device=device, dtype=dtype))
         else:
             self.register_parameter('weight', None)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.use_native:
+            return nn.functional.rms_norm(
+                x, self.normalized_shape, weight=self.weight, eps=self.eps
+            )
         rms = x.pow(2).mean(-1, keepdim=True).add(self.eps).rsqrt()
         x = x * rms
         if self.weight is not None:

--- a/src/synthefy_nori/model/transformer.py
+++ b/src/synthefy_nori/model/transformer.py
@@ -354,7 +354,11 @@ class FeaturesTransformer(nn.Module):
                     test_encoder_out.shape[0], test_encoder_out.shape[1],
                     self.cls_y_decoder[-1].out_features)
                 reg_output = self.reg_y_decoder(test_encoder_out)
-            feature_pred = self.feature_decoder(encoder_out_4_feature)
+            feature_pred = (
+                None
+                if getattr(self, "_skip_feature_decoder", False)
+                else self.feature_decoder(encoder_out_4_feature)
+            )
             output_decoded = {
                 "cls_output": cls_output,
                 "reg_output": reg_output,

--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
+import types
 from datetime import datetime
 
 import torch
 
 from synthefy_nori.utils.loading import build_model
+from synthefy_nori.model.layer import RMSNorm
 from synthefy_nori.training.config import TrainingConfig, package_config_path
 from synthefy_nori.training.trainer import NoriTrainer
 
@@ -56,6 +59,63 @@ def parse_tags(raw: str | None) -> tuple[str, ...]:
     if raw is None:
         return ()
     return tuple(part.strip() for part in raw.split(',') if part.strip())
+
+
+def parse_shape_palette(raw: str | None) -> tuple[tuple[int, int, float], ...]:
+    # Parse and normalize ROWSxFEATURES:WEIGHT entries.
+    if not raw:
+        return ()
+    entries = []
+    seen = set()
+    for item in raw.split(','):
+        item = item.strip()
+        try:
+            dims, weight_raw = item.split(':', maxsplit=1)
+            rows_raw, features_raw = dims.lower().split('x', maxsplit=1)
+            rows = int(rows_raw)
+            features = int(features_raw)
+            weight = float(weight_raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                "Shape palette entries must be ROWSxFEATURES:WEIGHT"
+            ) from exc
+        if rows <= 1 or features <= 0 or weight <= 0 or not math.isfinite(weight):
+            raise argparse.ArgumentTypeError(
+                f"Shape palette values must be finite and positive "
+                f"(with rows > 1), got {item!r}"
+            )
+        shape = (rows, features)
+        if shape in seen:
+            raise argparse.ArgumentTypeError(
+                f"Duplicate shape palette entry: {dims}"
+            )
+        seen.add(shape)
+        entries.append((rows, features, weight))
+    total = sum(weight for _, _, weight in entries)
+    return tuple(
+        (rows, features, weight / total)
+        for rows, features, weight in entries
+    )
+
+
+def parse_context_ratio_palette(raw: str | None) -> tuple[float, ...]:
+    # Parse a finite list of context fractions in the open unit interval.
+    if not raw:
+        return ()
+    try:
+        ratios = tuple(float(part.strip()) for part in raw.split(',') if part.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "Context ratios must be comma-separated numbers"
+        ) from exc
+    if not ratios or any(
+        not math.isfinite(ratio) or ratio <= 0 or ratio >= 1
+        for ratio in ratios
+    ):
+        raise argparse.ArgumentTypeError("Context ratios must satisfy 0 < ratio < 1")
+    if len(set(ratios)) != len(ratios):
+        raise argparse.ArgumentTypeError("Context ratio palette contains duplicates")
+    return ratios
 
 
 def main():
@@ -104,6 +164,9 @@ def main():
                         help='Checkpoint directory (default: ./checkpoints/<timestamp>)')
     parser.add_argument('--ema-decay', type=float, default=0.0,
                         help='EMA decay for validation/checkpoint averaging (0 disables EMA)')
+    parser.add_argument('--ema-foreach', action='store_true',
+                        help='Update EMA tensors with grouped foreach kernels. '
+                             'Experimental and off by default.')
     parser.add_argument('--gradient-accumulation', type=int, default=1)
     parser.add_argument('--log-interval', type=int, default=100)
     parser.add_argument('--save-interval', type=int, default=5000)
@@ -131,6 +194,10 @@ def main():
                         help='Max n_features per synthetic table (default: 250)')
     parser.add_argument('--fixed-size', type=str, default=None,
                         help='Fixed NxF size (e.g. "1024x64"). Overrides random sampling.')
+    parser.add_argument('--context-ratio-min', type=float, default=0.3,
+                        help='Minimum labeled-context fraction (default: 0.3).')
+    parser.add_argument('--context-ratio-max', type=float, default=0.8,
+                        help='Maximum labeled-context fraction (default: 0.8).')
     parser.add_argument('--no-synth-v2', action='store_true',
                         help='Disable synth_v2 data augmentations (revert to Run 8 behavior)')
     parser.add_argument('--no-synth-v3', action='store_true',
@@ -362,6 +429,61 @@ def main():
                              'cudnn.deterministic).')
     parser.add_argument('--debug-dump-steps', type=int, default=5,
                         help='Number of optimizer steps to dump (default: 5)')
+    parser.add_argument(
+        '--shape-palette',
+        type=parse_shape_palette,
+        default=(),
+        metavar='ROWSxFEATURES:WEIGHT,...',
+        help='Explicit weighted physical-shape palette. Experimental and off '
+             'by default; mutually exclusive with --fixed-size.',
+    )
+    parser.add_argument(
+        '--context-ratio-palette',
+        type=parse_context_ratio_palette,
+        default=(),
+        metavar='RATIO,...',
+        help='Optional discrete context/query ratios. This bounds eval_pos '
+             'compiler signatures but changes the training curriculum.',
+    )
+    parser.add_argument(
+        '--compile-encoder-layers',
+        choices=['none', 'static', 'dynamic'],
+        default='none',
+        help='Regionally compile one shared encoder-layer forward. "static" '
+             'compiles exact signatures and requires a bounded shape/ratio '
+             'contract. "dynamic" compiles shape-generic kernels and needs no '
+             'palette, so it leaves the data curriculum untouched. '
+             'Experimental and off by default.',
+    )
+    parser.add_argument(
+        '--compile-mode',
+        choices=['default', 'reduce-overhead', 'max-autotune-no-cudagraphs'],
+        default='default',
+        help='torch.compile mode used by --compile-encoder-layers.',
+    )
+    parser.add_argument(
+        '--compile-cache-limit',
+        type=int,
+        default=1024,
+        help='Maximum live Dynamo variants for static encoder compilation.',
+    )
+    parser.add_argument(
+        '--compile-disable-ddp-optimizer',
+        action='store_true',
+        help='Disable Dynamo DDPOptimizer graph splitting. This is faster and '
+             'disk-cacheable for regional layer compilation on the tested model.',
+    )
+    parser.add_argument('--freeze-unused-heads', action='store_true', default=True,
+                        help='Freeze the feature decoder when feature loss remains zero.')
+    parser.add_argument('--no-freeze-unused-heads', dest='freeze_unused_heads',
+                        action='store_false',
+                        help='Keep the feature decoder trainable.')
+    parser.add_argument('--skip-zero-feature-decoder', action='store_true',
+                        help='Skip feature-decoder execution when feature loss stays '
+                             'zero. Requires unused-head freezing; off by default.')
+    parser.add_argument('--native-rms-norm', action='store_true',
+                        help='Use PyTorch native RMSNorm kernels during this run. '
+                             'Experimental and off by default.')
     args = parser.parse_args()
 
     # Seed Python/NumPy/torch from --seed so same-seed runs are reproducible.
@@ -398,6 +520,44 @@ def main():
         parser.error("--target-aware-warmup-steps must be >= 0")
     if not 0.0 <= args.target_aware_init_scale <= 1.0:
         parser.error("--target-aware-init-scale must be in [0, 1]")
+    if not 0 < args.context_ratio_min <= args.context_ratio_max < 1:
+        parser.error(
+            "--context-ratio-min/--context-ratio-max must satisfy "
+            "0 < min <= max < 1"
+        )
+    if args.shape_palette and args.fixed_size:
+        parser.error("--shape-palette and --fixed-size are mutually exclusive")
+    if args.compile_cache_limit <= 0:
+        parser.error("--compile-cache-limit must be positive")
+    if args.compile_encoder_layers == 'static':
+        if not args.shape_palette and not args.fixed_size:
+            parser.error(
+                "--compile-encoder-layers static requires --shape-palette "
+                "or --fixed-size"
+            )
+        if not args.context_ratio_palette:
+            parser.error(
+                "--compile-encoder-layers static requires "
+                "--context-ratio-palette"
+            )
+    if (args.compile_disable_ddp_optimizer
+            and args.compile_encoder_layers == 'none'):
+        parser.error(
+            "--compile-disable-ddp-optimizer requires --compile-encoder-layers"
+        )
+    feature_loss_stays_zero = (
+        args.feature_loss_weight == 0.0
+        and (args.feature_loss_weight_end is None
+             or args.feature_loss_weight_end == 0.0)
+    )
+    if args.skip_zero_feature_decoder and not feature_loss_stays_zero:
+        parser.error(
+            "--skip-zero-feature-decoder requires feature loss to remain zero"
+        )
+    if args.skip_zero_feature_decoder and not args.freeze_unused_heads:
+        parser.error(
+            "--skip-zero-feature-decoder requires --freeze-unused-heads"
+        )
     # Load model architecture config
     config_source = args.checkpoint or "bundled model_base.json"
     print(f"Loading model config from {config_source}")
@@ -526,6 +686,25 @@ def main():
         print("Building model from scratch (random initialization)")
     model = build_model(model_config)
 
+    if args.native_rms_norm:
+        native_norm_count = 0
+        for module in model.modules():
+            if isinstance(module, RMSNorm):
+                module.use_native = True
+                native_norm_count += 1
+        if local_rank == 0:
+            print(f"Native RMSNorm enabled ({native_norm_count} modules)")
+
+    if (args.freeze_unused_heads and feature_loss_stays_zero
+            and getattr(model, 'feature_decoder', None) is not None):
+        for parameter in model.feature_decoder.parameters():
+            parameter.requires_grad_(False)
+        if args.skip_zero_feature_decoder:
+            model._skip_feature_decoder = True
+        if local_rank == 0:
+            action = "skipped" if args.skip_zero_feature_decoder else "grad disabled"
+            print(f"  [freeze] feature_decoder {action} (feature loss is 0)")
+
     # Freeze column_y_aware_alpha if requested (V10c control experiment).
     if args.freeze_column_y_alpha and getattr(model, 'column_y_aware_alpha', None) is not None:
         model.column_y_aware_alpha.requires_grad_(False)
@@ -539,6 +718,34 @@ def main():
         print(f"Model parameters: {n_params:,} total, {n_trainable:,} trainable")
 
     model.to(device)
+
+    if args.compile_encoder_layers != 'none':
+        cache_limit = max(8, int(args.compile_cache_limit))
+        torch._dynamo.config.cache_size_limit = cache_limit
+        torch._dynamo.config.recompile_limit = cache_limit
+        torch._dynamo.config.accumulated_cache_size_limit = cache_limit
+        torch._dynamo.config.accumulated_recompile_limit = cache_limit
+        if args.compile_disable_ddp_optimizer:
+            torch._dynamo.config.optimize_ddp = False
+        compile_mode = None if args.compile_mode == 'default' else args.compile_mode
+        layers = model.transformer_encoder.layers
+        use_dynamic = args.compile_encoder_layers == 'dynamic'
+        compiled_forward = torch.compile(
+            type(layers[0]).forward,
+            dynamic=use_dynamic,
+            fullgraph=False,
+            mode=compile_mode,
+        )
+        for layer in layers:
+            layer.forward = types.MethodType(compiled_forward, layer)
+        if local_rank == 0:
+            print(
+                f'{args.compile_encoder_layers.capitalize()} regional '
+                'compilation enabled: '
+                f'{len(layers)} encoder layers, mode={args.compile_mode}, '
+                f'cache_limit={cache_limit}, '
+                f'ddp_optimizer={not args.compile_disable_ddp_optimizer}'
+            )
 
     if args.gradient_checkpointing:
         model.transformer_encoder.gradient_checkpointing = True
@@ -615,6 +822,33 @@ def main():
         if local_rank == 0:
             print(f"Fixed size: {fixed_n_samples} samples x {fixed_n_features} features")
 
+    feature_multiple = int(model_config.get('features_per_group', 2))
+    for rows, features, _weight in args.shape_palette:
+        if features % feature_multiple:
+            parser.error(
+                f"Explicit palette feature count {features} is not divisible by "
+                f"model features_per_group={feature_multiple}"
+            )
+        if rows * features > max_budget:
+            parser.error(
+                f"Explicit palette shape {rows}x{features} exceeds "
+                f"--max-budget={max_budget}"
+            )
+    if local_rank == 0 and (args.shape_palette or args.context_ratio_palette):
+        physical_shapes = len(args.shape_palette) if args.shape_palette else 'sampled'
+        context_shapes = (
+            len(args.context_ratio_palette)
+            if args.context_ratio_palette
+            else sum(
+                args.context_ratio_min <= ratio <= args.context_ratio_max
+                for ratio in NoriTrainer.CONTEXT_RATIO_BUCKETS
+            )
+        )
+        print(
+            f"Static sampling contract: {physical_shapes} physical shapes x "
+            f"{context_shapes} context ratios"
+        )
+
     # Training config
     train_config = TrainingConfig(
         device=device,
@@ -636,6 +870,7 @@ def main():
         wandb_tags=args.wandb_tags,
         checkpoint_dir=args.checkpoint_dir,
         ema_decay=args.ema_decay,
+        ema_foreach=args.ema_foreach,
         gradient_accumulation=args.gradient_accumulation,
         log_interval=args.log_interval,
         save_interval=args.save_interval,
@@ -659,6 +894,17 @@ def main():
         **({"max_features": args.max_features} if args.max_features is not None else {}),
         fixed_n_samples=fixed_n_samples,
         fixed_n_features=fixed_n_features,
+        context_ratio_min=args.context_ratio_min,
+        context_ratio_max=args.context_ratio_max,
+        shape_palette=args.shape_palette,
+        context_ratio_palette=args.context_ratio_palette,
+        freeze_unused_heads=args.freeze_unused_heads,
+        skip_zero_feature_decoder=args.skip_zero_feature_decoder,
+        native_rms_norm=args.native_rms_norm,
+        compile_encoder_layers=args.compile_encoder_layers,
+        compile_mode=args.compile_mode,
+        compile_cache_limit=args.compile_cache_limit,
+        compile_disable_ddp_optimizer=args.compile_disable_ddp_optimizer,
         synth_v2=not args.no_synth_v2,
         synth_v3=not args.no_synth_v3,
         rich_reg_targets=not args.no_rich_reg_targets,

--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -91,6 +91,8 @@ class TrainingConfig:
     wandb_job_type: str | None = None
     wandb_tags: tuple[str, ...] = field(default_factory=tuple)
     ema_decay: float = 0.0
+    # Group EMA updates into device/dtype-specific foreach kernels.
+    ema_foreach: bool = False
 
     # Compilation
     compile: bool = False
@@ -364,6 +366,22 @@ class TrainingConfig:
     # Context/query split
     context_ratio_min: float = 0.3
     context_ratio_max: float = 0.8
+    # Explicit weighted physical-shape palette. Each entry is
+    # (n_samples, n_features, weight).
+    shape_palette: tuple[tuple[int, int, float], ...] = field(default_factory=tuple)
+    # Optional discrete context/query ratios.
+    context_ratio_palette: tuple[float, ...] = field(default_factory=tuple)
+
+    # Execution-only head and kernel controls.
+    freeze_unused_heads: bool = True
+    skip_zero_feature_decoder: bool = False
+    native_rms_norm: bool = False
+
+    # Regional compiler execution.
+    compile_encoder_layers: str = "none"
+    compile_mode: str = "default"
+    compile_cache_limit: int = 1024
+    compile_disable_ddp_optimizer: bool = False
 
     # Async data prefetching
     prefetch_workers: int = 4  # number of background data generation processes (0 = disabled)

--- a/src/synthefy_nori/training/loss.py
+++ b/src/synthefy_nori/training/loss.py
@@ -193,8 +193,6 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
 
     batch_size = y_true.shape[0]
     n_query = y_true.shape[1]
-    feature_pred = model_output['feature_pred']  # [B, seq_len, n_groups, fpg]
-
     # ------------------------------------------------------------------
     # 1. Y prediction loss (target column, always masked for query rows)
     # ------------------------------------------------------------------
@@ -356,6 +354,12 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
             'n_feat_cells': 0,
         }
         return y_loss_avg, loss_dict
+
+    feature_pred = model_output.get('feature_pred')
+    if feature_pred is None:
+        raise ValueError(
+            "feature_pred is required when feature_loss_weight is positive"
+        )
 
     # ------------------------------------------------------------------
     # 2. Feature reconstruction loss (masked cells only)

--- a/src/synthefy_nori/training/trainer.py
+++ b/src/synthefy_nori/training/trainer.py
@@ -7,6 +7,7 @@ import os
 import time
 import math
 import warnings
+from collections import defaultdict
 from contextlib import nullcontext
 
 import numpy as np
@@ -19,6 +20,36 @@ from synthefy_nori.training.masking import create_masks, random_mask_type, rando
 from synthefy_nori.training.loss import compute_ccmm_loss
 from synthefy_nori.training.optim import build_optimizer
 from synthefy_nori.training.prefetch import DataPrefetcher
+
+
+def _foreach_ema_update(
+        ema_state: dict[str, torch.Tensor],
+        current_state: dict[str, torch.Tensor],
+        decay: float,
+) -> None:
+    # Update EMA tensors in device/dtype groups instead of scalar kernels.
+    floating_groups: dict[
+        tuple[torch.device, torch.dtype],
+        tuple[list[torch.Tensor], list[torch.Tensor]],
+    ] = defaultdict(lambda: ([], []))
+    nonfloating_pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+
+    for name, tensor in current_state.items():
+        ema_tensor = ema_state[name]
+        if torch.is_floating_point(tensor):
+            ema_tensors, current_tensors = floating_groups[
+                (tensor.device, tensor.dtype)
+            ]
+            ema_tensors.append(ema_tensor)
+            current_tensors.append(tensor.detach())
+        else:
+            nonfloating_pairs.append((ema_tensor, tensor))
+
+    for ema_tensors, current_tensors in floating_groups.values():
+        torch._foreach_mul_(ema_tensors, decay)
+        torch._foreach_add_(ema_tensors, current_tensors, alpha=1.0 - decay)
+    for ema_tensor, tensor in nonfloating_pairs:
+        ema_tensor.copy_(tensor)
 
 
 def get_wcd_schedule(optimizer, warmup_steps, decay_start_step, total_steps, lr_min):
@@ -186,7 +217,15 @@ class NoriTrainer:
         cfg = self.config
         rng = self.shared_rng  # Same across all ranks
 
-        if cfg.fixed_n_samples is not None and cfg.fixed_n_features is not None:
+        explicit_shape = bool(cfg.shape_palette)
+        if explicit_shape:
+            weights = np.asarray(
+                [entry[2] for entry in cfg.shape_palette], dtype=np.float64
+            )
+            weights /= weights.sum()
+            shape_index = int(rng.choice(len(cfg.shape_palette), p=weights))
+            n_samples, n_features, _weight = cfg.shape_palette[shape_index]
+        elif cfg.fixed_n_samples is not None and cfg.fixed_n_features is not None:
             # Fixed size mode: skip random sampling but still consume rng
             # to keep shared_rng in sync with code that expects these draws.
             rng.uniform(0, 1)  # consume log_n_samples draw
@@ -204,16 +243,16 @@ class NoriTrainer:
             log_min_f, log_max_f = np.log(cfg.min_features), np.log(cfg.max_features)
             u_f = rng.uniform(0, 1) ** (1.0 / cfg.dim_bias_features)
             n_features = int(np.exp(log_min_f + u_f * (log_max_f - log_min_f)))
-            # Must be even (features_per_group=2)
             if n_features % cfg.features_per_group != 0:
                 n_features += cfg.features_per_group - (n_features % cfg.features_per_group)
             n_features = max(cfg.features_per_group, n_features)
 
-        # OOM protection: cap dimensions to stay within budget.
-        # Always respect min_samples — shrink features first.
         budget = cfg.max_sample_feature_budget
-        if n_samples * n_features > budget:
-            # Shrink features to fit n_samples within budget
+        if explicit_shape and n_samples * n_features > budget:
+            raise ValueError(
+                f"Explicit shape {n_samples}x{n_features} exceeds budget {budget}"
+            )
+        if not explicit_shape and n_samples * n_features > budget:
             max_feat = budget // n_samples
             max_feat -= max_feat % cfg.features_per_group
             max_feat = max(cfg.features_per_group, max_feat)
@@ -221,44 +260,36 @@ class NoriTrainer:
             if max_feat >= cfg.features_per_group:
                 n_features = min(n_features, max_feat)
             else:
-                # Even min features won't fit — shrink samples too
                 n_features = cfg.features_per_group
                 n_samples = max(cfg.min_samples, budget // n_features)
 
-        # Shape bucketing AFTER budget cap: round down to largest bucket
-        # that fits within the budget-capped dimensions. Always bucket —
-        # the model was trained on bucketed shapes and the offline pool
-        # stores data in these exact buckets.
-        valid_s = [b for b in self.SAMPLE_BUCKETS
-                   if b <= n_samples and b >= cfg.min_samples]
-        valid_f = [b for b in self.FEATURE_BUCKETS if b <= n_features]
-        n_samples = max(valid_s) if valid_s else max(
-            cfg.min_samples, self.SAMPLE_BUCKETS[0])
-        n_features = max(valid_f) if valid_f else self.FEATURE_BUCKETS[0]
+        if not explicit_shape:
+            valid_s = [b for b in self.SAMPLE_BUCKETS
+                       if b <= n_samples and b >= cfg.min_samples]
+            valid_f = [b for b in self.FEATURE_BUCKETS if b <= n_features]
+            n_samples = max(valid_s) if valid_s else max(
+                cfg.min_samples, self.SAMPLE_BUCKETS[0])
+            n_features = max(valid_f) if valid_f else self.FEATURE_BUCKETS[0]
 
-        # Task type selection
         if cfg.task_type == 'both':
             task_type = 'reg' if rng.random() < cfg.regression_ratio else 'cls'
         else:
-            # Still consume the rng value to keep shared_rng in sync for DDP
             rng.random()
             task_type = cfg.task_type
 
-        # Number of classes
         n_classes = None
         if task_type == 'cls':
             n_classes = int(rng.integers(cfg.min_classes, cfg.max_classes + 1))
 
-        # Context/query split ratio — sampled here (shared_rng) so eval_pos
-        # is identical across all ranks and shared_rng stays in sync.
-        context_ratio = rng.uniform(cfg.context_ratio_min, cfg.context_ratio_max)
-
-        # Quantize context_ratio to nearest bucket — keeps eval_pos bounded
-        # and matches the distribution the model was trained on.
-        valid_cr = [cr for cr in self.CONTEXT_RATIO_BUCKETS
-                    if cr >= cfg.context_ratio_min and cr <= cfg.context_ratio_max]
-        if valid_cr:
-            context_ratio = min(valid_cr, key=lambda cr: abs(cr - context_ratio))
+        if cfg.context_ratio_palette:
+            ratio_index = int(rng.integers(len(cfg.context_ratio_palette)))
+            context_ratio = cfg.context_ratio_palette[ratio_index]
+        else:
+            context_ratio = rng.uniform(cfg.context_ratio_min, cfg.context_ratio_max)
+            valid_cr = [cr for cr in self.CONTEXT_RATIO_BUCKETS
+                        if cr >= cfg.context_ratio_min and cr <= cfg.context_ratio_max]
+            if valid_cr:
+                context_ratio = min(valid_cr, key=lambda cr: abs(cr - context_ratio))
 
         return n_samples, n_features, task_type, n_classes, context_ratio
 
@@ -915,8 +946,10 @@ class NoriTrainer:
             ro = output['reg_output'].detach().float()
             print(f"  [DIAG] reg: mean={ro.mean():.4f} std={ro.std():.4f}")
 
-        fp = output['feature_pred'].detach().float()
-        print(f"  [DIAG] feat_pred: mean={fp.mean():.4f} std={fp.std():.4f}")
+        feature_pred = output.get('feature_pred')
+        if torch.is_tensor(feature_pred) and feature_pred.numel() > 0:
+            fp = feature_pred.detach().float()
+            print(f"  [DIAG] feat_pred: mean={fp.mean():.4f} std={fp.std():.4f}")
 
         # --- Process config sanity ---
         pc = output['process_config']
@@ -1311,6 +1344,13 @@ class NoriTrainer:
 
         with torch.no_grad():
             current_state = self._get_bare_model().state_dict()
+            if self.config.ema_foreach:
+                _foreach_ema_update(
+                    self.ema_state_dict,
+                    current_state,
+                    self.ema_decay,
+                )
+                return
             for name, tensor in current_state.items():
                 ema_tensor = self.ema_state_dict[name]
                 if torch.is_floating_point(tensor):

--- a/src/synthefy_nori/utils/loading.py
+++ b/src/synthefy_nori/utils/loading.py
@@ -69,7 +69,20 @@ def build_model(config:dict):
     )
     return model
 
-def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None):
+def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None,
+               native_rms_norm:bool=True):
+    """Load a Nori checkpoint for inference.
+
+    ``native_rms_norm`` selects PyTorch's fused ``F.rms_norm`` over the
+    decomposed pow/mean/rsqrt/mul chain. It defaults to True because every
+    inference and evaluation path reaches the model through this function, so
+    this is the one place that turns the kernel on everywhere. Measured on
+    1k/4k/8k-row tables: R2 shift <= 2e-5, largest per-row difference one bf16
+    ulp under autocast. Pass False to reproduce the historical path bit-for-bit.
+
+    Training does NOT come through here (the trainer builds via build_model),
+    so this default cannot silently change a training run.
+    """
     state_dict = _safe_torch_load(model_path)
 
     # Support both pretrained (.ckpt) and training checkpoint (.pt) formats
@@ -102,6 +115,12 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
 
     model = build_model(config)
     model.load_state_dict(weights)
+
+    if native_rms_norm:
+        from synthefy_nori.model.layer import RMSNorm
+        for module in model.modules():
+            if isinstance(module, RMSNorm):
+                module.use_native = True
 
     model.eval()
     return model

--- a/tests/test_dynamic_compile_and_loader_rms.py
+++ b/tests/test_dynamic_compile_and_loader_rms.py
@@ -1,0 +1,98 @@
+"""Dynamic regional compilation, and native RMSNorm at the loader choke point.
+
+`dynamic` exists because `static` can only be enabled together with a shape
+palette, and the palette changes the training curriculum. Dynamic compiles
+shape-generic kernels, so it needs no palette and leaves the curriculum alone.
+
+`load_model` is where native RMSNorm is turned on for inference: every
+inference and evaluation path reaches the model through it, while training
+builds via `build_model` and is therefore unaffected.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+import torch
+import torch.nn as nn
+
+from synthefy_nori.model.layer import RMSNorm
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "synthefy_nori.training.cli", *args],
+        capture_output=True, text=True, timeout=180,
+    )
+
+
+@pytest.mark.slow
+def test_dynamic_is_an_accepted_choice():
+    """Rejecting a bogus value makes argparse print the full choice list."""
+    result = _run_cli("--compile-encoder-layers", "definitely-not-a-mode")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "dynamic" in combined, combined[-2000:]
+    assert "static" in combined
+
+
+@pytest.mark.slow
+def test_static_still_requires_a_bounded_shape_contract():
+    """Unbounded shapes with dynamic=False would blow the Dynamo cache limit
+    and silently degrade to eager, so the CLI must keep rejecting it."""
+    result = _run_cli("--compile-encoder-layers", "static")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "requires --shape-palette" in combined, combined[-2000:]
+
+
+class _TinyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = RMSNorm((4,))
+        self.b = nn.Sequential(RMSNorm((4,)), nn.Linear(4, 4))
+
+
+def _patch_loader(monkeypatch, model):
+    import synthefy_nori.utils.loading as loading
+
+    monkeypatch.setattr(loading, "_safe_torch_load",
+                        lambda *a, **k: {"config": {}, "state_dict": {}})
+    monkeypatch.setattr(loading, "build_model", lambda cfg: model)
+    monkeypatch.setattr(model, "load_state_dict", lambda *a, **k: None)
+    return loading
+
+
+def test_load_model_enables_native_rms_by_default(monkeypatch):
+    model = _TinyNet()
+    loading = _patch_loader(monkeypatch, model)
+
+    loading.load_model("ignored.ckpt")
+
+    assert model.a.use_native is True
+    assert model.b[0].use_native is True
+
+
+def test_load_model_can_opt_out(monkeypatch):
+    model = _TinyNet()
+    loading = _patch_loader(monkeypatch, model)
+
+    loading.load_model("ignored.ckpt", native_rms_norm=False)
+
+    assert model.a.use_native is False
+    assert model.b[0].use_native is False
+
+
+def test_native_and_decomposed_rms_agree_closely():
+    """Same algorithm, different kernel: agreement to well inside bf16 ulp."""
+    torch.manual_seed(0)
+    x = torch.randn(8, 32, 64)
+
+    norm = RMSNorm((64,))
+    decomposed = norm(x)
+    norm.use_native = True
+    native = norm(x)
+
+    assert torch.allclose(decomposed, native, rtol=1e-5, atol=1e-6)

--- a/tests/test_inference_execution_overrides.py
+++ b/tests/test_inference_execution_overrides.py
@@ -1,0 +1,194 @@
+"""Execution-only inference speedups on NoriPredictor.
+
+Two settings, neither of which may change what the model predicts:
+
+* ``skip_unused_feature_decoder`` - skip the feature decoder when its output
+  cannot be read (mask_prediction off). Default ON, so the parity test below
+  is the one that has to hold.
+* ``native_rms_norm`` - fused RMSNorm kernel. Default OFF because it is not
+  bit-identical.
+
+Both are applied per call and undone afterwards: ``NoriPredictor(model=...)``
+may be handed a module the caller also trains with, and a leaked
+``_skip_feature_decoder`` would silently zero its feature-reconstruction loss.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from synthefy_nori.inference.predictor import NoriPredictor
+from synthefy_nori.model.layer import RMSNorm
+
+
+def _stub_predictor(model, *, mask_prediction=False,
+                    skip_unused_feature_decoder=True, native_rms_norm=None):
+    """A NoriPredictor with only the attributes _execution_overrides reads.
+
+    Bypasses __init__ so the test stays on CPU and off the config/pipeline
+    machinery, which is irrelevant to the override contract.
+    """
+    predictor = NoriPredictor.__new__(NoriPredictor)
+    predictor.model = model
+    predictor.mask_prediction = mask_prediction
+    predictor.skip_unused_feature_decoder = skip_unused_feature_decoder
+    predictor.native_rms_norm = native_rms_norm
+    return predictor
+
+
+class _TinyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.norm_a = RMSNorm((4,))
+        self.inner = nn.Sequential(RMSNorm((4,)), nn.Linear(4, 4))
+
+
+def test_constructor_defaults():
+    import inspect
+
+    params = inspect.signature(NoriPredictor.__init__).parameters
+    assert params["skip_unused_feature_decoder"].default is True
+    # None = inherit the model's setting; see test_inherits_* below.
+    assert params["native_rms_norm"].default is None
+
+
+def test_skip_applied_then_restored():
+    model = _TinyModule()
+    predictor = _stub_predictor(model)
+
+    assert getattr(model, "_skip_feature_decoder", False) is False
+    with predictor._execution_overrides():
+        assert model._skip_feature_decoder is True
+    assert model._skip_feature_decoder is False
+
+
+def test_skip_not_applied_when_mask_prediction_is_on():
+    """The imputation path reads feature_pred, so it must never be skipped."""
+    model = _TinyModule()
+    predictor = _stub_predictor(model, mask_prediction=True)
+
+    with predictor._execution_overrides():
+        assert getattr(model, "_skip_feature_decoder", False) is False
+
+
+def test_skip_respects_opt_out():
+    model = _TinyModule()
+    predictor = _stub_predictor(model, skip_unused_feature_decoder=False)
+
+    with predictor._execution_overrides():
+        assert getattr(model, "_skip_feature_decoder", False) is False
+
+
+def test_state_restored_on_exception():
+    model = _TinyModule()
+    predictor = _stub_predictor(model, native_rms_norm=True)
+
+    with pytest.raises(RuntimeError):
+        with predictor._execution_overrides():
+            assert model._skip_feature_decoder is True
+            assert model.norm_a.use_native is True
+            raise RuntimeError("boom")
+
+    assert model._skip_feature_decoder is False
+    assert model.norm_a.use_native is False
+    assert model.inner[0].use_native is False
+
+
+def test_native_rms_norm_reaches_every_rms_module():
+    model = _TinyModule()
+    predictor = _stub_predictor(model, native_rms_norm=True)
+
+    with predictor._execution_overrides():
+        assert model.norm_a.use_native is True
+        assert model.inner[0].use_native is True
+    assert model.norm_a.use_native is False
+    assert model.inner[0].use_native is False
+
+
+def test_native_rms_norm_can_be_forced_off():
+    """False must force the decomposed path even on a model already using the
+    fused kernel -- otherwise opting out is impossible on the model= path."""
+    model = _TinyModule()
+    model.norm_a.use_native = True
+    model.inner[0].use_native = True
+    predictor = _stub_predictor(model, native_rms_norm=False)
+
+    with predictor._execution_overrides():
+        assert model.norm_a.use_native is False
+        assert model.inner[0].use_native is False
+    # and restored afterwards
+    assert model.norm_a.use_native is True
+    assert model.inner[0].use_native is True
+
+
+def test_inherits_model_setting_by_default():
+    """Default None must not override an explicit load_model(native=False)."""
+    off = _TinyModule()
+    with _stub_predictor(off)._execution_overrides():
+        assert off.norm_a.use_native is False
+
+    on = _TinyModule()
+    on.norm_a.use_native = True
+    on.inner[0].use_native = True
+    with _stub_predictor(on)._execution_overrides():
+        assert on.norm_a.use_native is True
+
+
+def test_preexisting_native_flag_is_not_clobbered():
+    """A model already configured for native RMSNorm keeps it after the call."""
+    model = _TinyModule()
+    model.norm_a.use_native = True
+    predictor = _stub_predictor(model, native_rms_norm=True)
+
+    with predictor._execution_overrides():
+        assert model.norm_a.use_native is True
+    assert model.norm_a.use_native is True
+    assert model.inner[0].use_native is False
+
+
+@pytest.mark.slow
+def test_forward_parity_reg_output_is_bit_identical():
+    """Skipping the decoder must not perturb the regression output at all.
+
+    This is what makes the default safe: the decoder's result is dropped when
+    mask_prediction is off, so removing the work is not a speed/accuracy
+    trade-off.
+    """
+    from synthefy_nori.training.cli import load_model_config
+    from synthefy_nori.utils.loading import build_model
+
+    mc = load_model_config(None)
+    mc['mask_prediction'] = True
+    mc['embed_dim'] = 32
+    mc['hid_dim'] = 64
+    mc['nlayers'] = 2
+    mc['nhead'] = 2
+    for sub_key in ('encoder_config_x', 'encoder_config_y'):
+        sub = mc.get(sub_key, {})
+        for field in ('embedding_size', 'mask_embedding_size'):
+            if field in sub:
+                sub[field] = 32
+
+    model = build_model(mc).to('cpu').eval()
+
+    torch.manual_seed(0)
+    x = torch.randn(1, 16, 4)
+    y = torch.randn(1, 16)
+    eval_pos = 8
+
+    def run():
+        torch.manual_seed(1234)  # feature positional embeddings are re-drawn
+        with torch.inference_mode():
+            return model(x=x, y=y, eval_pos=eval_pos, task_type='reg')
+
+    baseline = run()
+    assert baseline['feature_pred'] is not None
+
+    predictor = _stub_predictor(model)
+    with predictor._execution_overrides():
+        skipped = run()
+
+    assert skipped['feature_pred'] is None
+    assert torch.equal(baseline['reg_output'], skipped['reg_output'])
+    assert torch.equal(baseline['cls_output'], skipped['cls_output'])

--- a/tests/test_rms_norm.py
+++ b/tests/test_rms_norm.py
@@ -1,0 +1,41 @@
+import torch
+
+from synthefy_nori.model.layer import RMSNorm
+
+
+def _manual_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor | None,
+    eps: float,
+) -> torch.Tensor:
+    output = x * x.pow(2).mean(-1, keepdim=True).add(eps).rsqrt()
+    return output if weight is None else output * weight
+
+
+def test_rms_norm_defaults_to_historical_implementation():
+    generator = torch.Generator().manual_seed(91)
+    x = torch.randn(4, 7, 128, generator=generator)
+    norm = RMSNorm(128, eps=1e-5)
+
+    assert norm.use_native is False
+    assert torch.equal(norm(x), _manual_rms_norm(x, norm.weight, norm.eps))
+
+
+def test_native_rms_norm_matches_manual_float32():
+    generator = torch.Generator().manual_seed(92)
+    x = torch.randn(4, 7, 128, generator=generator)
+    norm = RMSNorm(128, eps=1e-5)
+    norm.use_native = True
+
+    expected = _manual_rms_norm(x, norm.weight, norm.eps)
+    actual = norm(x)
+
+    assert torch.equal(actual, expected)
+
+
+def test_native_rms_norm_preserves_parameter_schema():
+    affine = RMSNorm(32, eps=1e-5, elementwise_affine=True)
+    non_affine = RMSNorm(32, eps=1e-5, elementwise_affine=False)
+
+    assert tuple(affine.state_dict()) == ("weight",)
+    assert non_affine.state_dict() == {}

--- a/tests/test_training_ema.py
+++ b/tests/test_training_ema.py
@@ -1,0 +1,30 @@
+import torch
+
+from synthefy_nori.training.trainer import _foreach_ema_update
+
+
+def test_foreach_ema_matches_scalar_update_exactly():
+    generator = torch.Generator().manual_seed(17)
+    current = {
+        "weight": torch.randn(7, 5, generator=generator),
+        "bias": torch.randn(5, generator=generator),
+        "wide": torch.randn(3, generator=generator, dtype=torch.float64),
+        "counter": torch.tensor(9, dtype=torch.int64),
+    }
+    initial = {
+        name: torch.randn_like(value) if torch.is_floating_point(value) else value - 1
+        for name, value in current.items()
+    }
+    expected = {name: value.clone() for name, value in initial.items()}
+    actual = {name: value.clone() for name, value in initial.items()}
+    decay = 0.999
+
+    for name, value in current.items():
+        if torch.is_floating_point(value):
+            expected[name].mul_(decay).add_(value, alpha=1.0 - decay)
+        else:
+            expected[name].copy_(value)
+    _foreach_ema_update(actual, current, decay)
+
+    for name in expected:
+        assert torch.equal(actual[name], expected[name]), name

--- a/tests/test_zero_feature_loss.py
+++ b/tests/test_zero_feature_loss.py
@@ -1,0 +1,43 @@
+import pytest
+import torch
+
+from synthefy_nori.training.loss import compute_ccmm_loss
+
+
+def _model_output(feature_pred):
+    return {
+        "cls_output": torch.empty(2, 3, 0),
+        "reg_output": torch.zeros(2, 3, 1),
+        "feature_pred": feature_pred,
+        "process_config": {
+            "n_x_padding": 0,
+            "num_used_features": None,
+            "mean_for_normalization": None,
+            "std_for_normalization": None,
+            "features_per_group": 1,
+        },
+    }
+
+
+def _loss(feature_pred, feature_loss_weight):
+    return compute_ccmm_loss(
+        _model_output(feature_pred),
+        y_true=torch.ones(2, 3),
+        x_original=torch.zeros(2, 5, 4),
+        feature_mask=torch.zeros(2, 5, 4, dtype=torch.bool),
+        task_type="reg",
+        feature_loss_weight=feature_loss_weight,
+        regression_loss="mse",
+    )
+
+
+def test_zero_feature_loss_does_not_require_decoder_output():
+    loss, metrics = _loss(feature_pred=None, feature_loss_weight=0.0)
+
+    assert loss.item() == pytest.approx(10.0)
+    assert metrics["feat_loss"] == 0.0
+
+
+def test_positive_feature_loss_requires_decoder_output():
+    with pytest.raises(ValueError, match="feature_pred is required"):
+        _loss(feature_pred=None, feature_loss_weight=0.1)

--- a/uv.lock
+++ b/uv.lock
@@ -3781,7 +3781,7 @@ wheels = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.13.1"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },


### PR DESCRIPTION
## Summary

- accelerate training with native RMSNorm, grouped foreach EMA updates, and regional dynamic `torch.compile`
- keep the natural training shape curriculum unchanged in the bundled launchers; exact static compilation remains opt-in behind explicit shape palettes
- accelerate inference with native RMSNorm and output-safe feature-decoder skipping
- publish the static compile cache prebuilder and reproducible training compile benchmark under their public-facing locations
- document execution defaults, opt-outs, cache compatibility, measurements, and curriculum caveats
- bump `synthefy-nori` from `0.13.1` to `0.14.0`

## Compatibility and scope

- no checkpoint or parameter-schema change
- no hosted API, client wire, billing, pricing, key-management, or model-slug change
- callers requiring the historical RMSNorm execution path can still set `native_rms_norm=False` through the lower-level loader or predictor

## Validation

- `uv run pytest`: 261 passed, 2 skipped, 34 deselected
- `uv run ruff check src scripts benchmarks tests`
- shell syntax checks for public training and precompile launchers
- import and `0.14.0` version smoke check
- benchmark CLI help smoke check
- `uv lock --check`
- `uv build`
- `uvx twine check --strict dist/*`
- built wheel metadata reports `synthefy-nori` version `0.14.0`