### PR TITLE
docs: explain reusable local context

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,11 @@ configuration `memory_policy={"reuse_context_cache": False}`. All shared serving
 engine) enforce that value automatically, because one replica may handle multiple people
 or workloads. This does **not** disable the K/V cache within a request; it only prevents
 retaining it for a later request.
+An explicit request for `reuse_context_cache=True` is rejected at the shared-serving
+boundary rather than being silently ignored.
+The one-shot `synthefy_nori.predict` and `infer` helpers create a fresh estimator
+per call, so cross-call reuse requires keeping a fitted `NoriRegressor` (or another
+wrapper that retains one) alive.
 
 **Known limit:** at large row counts × many columns, the first thing to run out of
 memory is the transductive preprocessing (RBF + polynomial expansion over the whole

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -99,6 +99,39 @@ accuracy loss rather than a rounding-level effect: it counts context rows discar
 to fit. Set `allow_subsample=False` to make that case an error instead of a silent
 shrink.
 
+### Reusing an unchanged context across predictions
+
+A persistent local estimator retains its encoded context by default, so repeated
+predictions with new query rows do not have to encode the same context again:
+
+```python
+reg = NoriRegressor(model="nori-6m").fit(X_train, y_train)
+morning = reg.predict(morning_queries)
+afternoon = reg.predict(afternoon_queries)  # reuses the encoded context
+```
+
+Reuse requires the same `NoriRegressor` instance and exactly unchanged context
+values and cache parameters. Changing `X_train`, `y_train`, cache precision,
+offload behavior, fit row chunk, or seed rebuilds the cache. A small query that
+reports `no_cache` did not build an eligible cache and therefore has nothing to
+retain.
+
+To discard context-derived state after each prediction:
+
+```python
+reg = NoriRegressor(
+    model="nori-6m",
+    memory_policy={"reuse_context_cache": False},
+).fit(X_train, y_train)
+```
+
+This still uses the normal K/V cache within each prediction. The one-shot
+`synthefy_nori.predict` and `infer` helpers construct a new estimator per call,
+so they cannot reuse context across calls. Shared serving processes always disable
+cross-request retention because a replica may serve different callers.
+An explicit `reuse_context_cache=True` request is rejected at the serving boundary
+rather than being silently ignored.
+
 Field-by-field reference, the budget knobs, and the measured saving per lever:
 [README, "Serving memory on large tables"](../README.md#serving-memory-on-large-tables).
 


### PR DESCRIPTION
## Summary
- document how persistent NoriRegressor instances reuse an exactly unchanged encoded context across predictions
- distinguish the normal within-prediction K/V cache from cross-call retention
- explain that one-shot helpers cannot reuse context and that shared serving disables retention and rejects explicit true requests

## Verification
- git diff --check
- uv run pytest tests/test_context_cache.py tests/test_memory_policy.py -q (127 passed, 15 deselected)

Related client support: https://github.com/Synthefy/synthefy/pull/54
Implementation release: https://github.com/Synthefy/synthefy-nori/pull/101