### PR TITLE
docs: add SageMaker Marketplace notebook

### DIFF
--- a/examples/notebooks/Nori_AWS_SageMaker.ipynb
+++ b/examples/notebooks/Nori_AWS_SageMaker.ipynb
@@ -1,0 +1,413 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy Synthefy-Nori from AWS Marketplace\n",
+    "\n",
+    "This notebook deploys the subscribed Synthefy-Nori model package in your AWS account and invokes it with the released `SynthefyNoriClient`. One SageMaker model and endpoint serve all three peer models:\n",
+    "\n",
+    "- `nori-6m`\n",
+    "- `nori-30m`\n",
+    "- `nori-30m-thinking-medium`\n",
+    "\n",
+    "Each request selects a model explicitly. There is no default or primary model. The notebook also runs a batch transform job, shows the equivalent raw streaming request, and removes the billable resources at the end.\n",
+    "\n",
+    "> SageMaker GPU resources incur AWS infrastructure charges while they exist. Run the cleanup section even if an earlier cell fails."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Prerequisites\n",
+    "\n",
+    "Before running the notebook:\n",
+    "\n",
+    "1. Subscribe to **Synthefy-Nori** in AWS Marketplace and choose **Launch your software**.\n",
+    "2. Copy the model package ARN for the AWS Region where you will deploy it.\n",
+    "3. Have a SageMaker execution-role ARN that SageMaker can assume.\n",
+    "4. Confirm that the Region has quota for one `ml.g5.xlarge` endpoint and batch transform instance.\n",
+    "5. Provide an existing S3 bucket in the same Region for the batch example.\n",
+    "\n",
+    "The identity running this notebook needs permission to create and delete SageMaker models, endpoint configurations, endpoints, and transform jobs; pass the execution role; and read and write the selected S3 prefix."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Install the client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"synthefy==6.3.0\" boto3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Configure the deployment\n",
+    "\n",
+    "Replace the three placeholder values below. Use the model package ARN shown by AWS Marketplace after subscribing, not the seller's internal validation ARN. Resource names include a random suffix so repeated runs do not collide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "import uuid\n",
+    "\n",
+    "import boto3\n",
+    "from botocore.exceptions import ClientError\n",
+    "from synthefy import SynthefyNoriClient\n",
+    "\n",
+    "REGION = boto3.Session().region_name or \"us-east-1\"\n",
+    "MODEL_PACKAGE_ARN = \"PASTE_SUBSCRIBED_MODEL_PACKAGE_ARN\"\n",
+    "EXECUTION_ROLE_ARN = \"PASTE_SAGEMAKER_EXECUTION_ROLE_ARN\"\n",
+    "S3_BUCKET = \"PASTE_EXISTING_BUCKET_NAME\"\n",
+    "INSTANCE_TYPE = \"ml.g5.xlarge\"\n",
+    "\n",
+    "assert MODEL_PACKAGE_ARN.startswith(\"arn:aws:sagemaker:\"), \"Set MODEL_PACKAGE_ARN\"\n",
+    "assert EXECUTION_ROLE_ARN.startswith(\"arn:aws:iam::\"), \"Set EXECUTION_ROLE_ARN\"\n",
+    "assert not S3_BUCKET.startswith(\"PASTE_\"), \"Set S3_BUCKET\"\n",
+    "\n",
+    "run_id = uuid.uuid4().hex[:8]\n",
+    "resource_prefix = f\"nori-marketplace-{run_id}\"\n",
+    "model_name = f\"{resource_prefix}-model\"\n",
+    "endpoint_config_name = f\"{resource_prefix}-config\"\n",
+    "endpoint_name = f\"{resource_prefix}-endpoint\"\n",
+    "transform_job_name = f\"{resource_prefix}-batch\"\n",
+    "s3_prefix = f\"nori-marketplace-notebook/{resource_prefix}\"\n",
+    "\n",
+    "sm = boto3.client(\"sagemaker\", region_name=REGION)\n",
+    "s3 = boto3.client(\"s3\", region_name=REGION)\n",
+    "runtime = boto3.client(\"sagemaker-runtime\", region_name=REGION)\n",
+    "\n",
+    "tags = [\n",
+    "    {\"Key\": \"Project\", \"Value\": \"synthefy-nori-marketplace-notebook\"},\n",
+    "    {\"Key\": \"RunId\", \"Value\": run_id},\n",
+    "]\n",
+    "\n",
+    "print(f\"Region: {REGION}\")\n",
+    "print(f\"Resource prefix: {resource_prefix}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Prepare a sample request\n",
+    "\n",
+    "Nori performs in-context regression. `X_train` and `y_train` are labeled context supplied with the request; `X_test` contains the rows to predict. The model returns one prediction per `X_test` row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train = [[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [0.2, 0.8]]\n",
+    "y_train = [0.1, 0.9, 0.5, 0.3]\n",
+    "X_test = [[0.3, 0.7], [0.8, 0.2]]\n",
+    "\n",
+    "sample_payload = {\n",
+    "    \"model\": \"nori-6m\",\n",
+    "    \"task\": \"regression\",\n",
+    "    \"X_train\": X_train,\n",
+    "    \"y_train\": y_train,\n",
+    "    \"X_test\": X_test,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Create one SageMaker model\n",
+    "\n",
+    "The Marketplace model package contains the serving image and model artifacts. Do not add an inference-specification selector or create one SageMaker model per Nori variant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.create_model(\n",
+    "    ModelName=model_name,\n",
+    "    ExecutionRoleArn=EXECUTION_ROLE_ARN,\n",
+    "    PrimaryContainer={\"ModelPackageName\": MODEL_PACKAGE_ARN},\n",
+    "    Tags=tags,\n",
+    ")\n",
+    "print(f\"Created SageMaker model: {model_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Run batch transform\n",
+    "\n",
+    "This runs before endpoint creation so the notebook needs quota for only one GPU instance at a time. The transform job stops its instance automatically when it completes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_input_key = f\"{s3_prefix}/batch-input/sample.json\"\n",
+    "batch_output_prefix = f\"{s3_prefix}/batch-output\"\n",
+    "batch_input_uri = f\"s3://{S3_BUCKET}/{batch_input_key}\"\n",
+    "batch_output_uri = f\"s3://{S3_BUCKET}/{batch_output_prefix}/\"\n",
+    "\n",
+    "s3.put_object(\n",
+    "    Bucket=S3_BUCKET,\n",
+    "    Key=batch_input_key,\n",
+    "    Body=json.dumps(sample_payload, separators=(\",\", \":\")).encode(),\n",
+    "    ContentType=\"application/json\",\n",
+    ")\n",
+    "\n",
+    "sm.create_transform_job(\n",
+    "    TransformJobName=transform_job_name,\n",
+    "    ModelName=model_name,\n",
+    "    TransformInput={\n",
+    "        \"DataSource\": {\n",
+    "            \"S3DataSource\": {\"S3DataType\": \"S3Prefix\", \"S3Uri\": batch_input_uri}\n",
+    "        },\n",
+    "        \"ContentType\": \"application/json\",\n",
+    "        \"SplitType\": \"None\",\n",
+    "    },\n",
+    "    TransformOutput={\"S3OutputPath\": batch_output_uri, \"Accept\": \"application/json\"},\n",
+    "    TransformResources={\"InstanceType\": INSTANCE_TYPE, \"InstanceCount\": 1},\n",
+    "    Tags=tags,\n",
+    ")\n",
+    "\n",
+    "while True:\n",
+    "    description = sm.describe_transform_job(TransformJobName=transform_job_name)\n",
+    "    status = description[\"TransformJobStatus\"]\n",
+    "    print(f\"TransformJobStatus={status}\")\n",
+    "    if status == \"Completed\":\n",
+    "        break\n",
+    "    if status in {\"Failed\", \"Stopped\"}:\n",
+    "        raise RuntimeError(description.get(\"FailureReason\", f\"Transform job {status}\"))\n",
+    "    time.sleep(30)\n",
+    "\n",
+    "batch_output_key = f\"{batch_output_prefix}/sample.json.out\"\n",
+    "batch_body = s3.get_object(Bucket=S3_BUCKET, Key=batch_output_key)[\"Body\"].read()\n",
+    "batch_result = json.loads(batch_body)\n",
+    "print(json.dumps(batch_result, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Create a real-time endpoint\n",
+    "\n",
+    "Endpoint creation commonly takes 15 to 30 minutes and can take longer when the selected instance type has limited regional capacity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm.create_endpoint_config(\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"VariantName\": \"AllTraffic\",\n",
+    "            \"ModelName\": model_name,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"InstanceType\": INSTANCE_TYPE,\n",
+    "            \"InitialVariantWeight\": 1.0,\n",
+    "            \"ContainerStartupHealthCheckTimeoutInSeconds\": 1800,\n",
+    "        }\n",
+    "    ],\n",
+    "    Tags=tags,\n",
+    ")\n",
+    "sm.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    "    Tags=tags,\n",
+    ")\n",
+    "\n",
+    "while True:\n",
+    "    description = sm.describe_endpoint(EndpointName=endpoint_name)\n",
+    "    status = description[\"EndpointStatus\"]\n",
+    "    print(f\"EndpointStatus={status}\")\n",
+    "    if status == \"InService\":\n",
+    "        break\n",
+    "    if status in {\"Failed\", \"OutOfService\"}:\n",
+    "        raise RuntimeError(description.get(\"FailureReason\", f\"Endpoint {status}\"))\n",
+    "    time.sleep(30)\n",
+    "\n",
+    "print(f\"Endpoint ready: {endpoint_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Invoke all three models with SynthefyNoriClient\n",
+    "\n",
+    "The client uses the standard AWS credential chain, signs the request, sets the streaming attribute, joins heartbeat chunks, and returns the prediction array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = [\"nori-6m\", \"nori-30m\", \"nori-30m-thinking-medium\"]\n",
+    "predictions_by_model = {}\n",
+    "\n",
+    "for model in models:\n",
+    "    with SynthefyNoriClient(\n",
+    "        mode=\"sagemaker\",\n",
+    "        model=model,\n",
+    "        endpoint_name=endpoint_name,\n",
+    "        region_name=REGION,\n",
+    "        timeout=480,\n",
+    "    ) as client:\n",
+    "        predictions = client.predict(X_train, y_train, X_test)\n",
+    "\n",
+    "    assert len(predictions) == len(X_test)\n",
+    "    predictions_by_model[model] = predictions\n",
+    "    print(f\"{model}: {predictions}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Optional: invoke the streaming API directly\n",
+    "\n",
+    "Use this form when integrating without the Synthefy client. Every real-time model uses `InvokeEndpointWithResponseStream`, including `nori-6m`. Heartbeat payload parts contain JSON whitespace; join all payload bytes before decoding the result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = runtime.invoke_endpoint_with_response_stream(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    ContentType=\"application/json\",\n",
+    "    Accept=\"application/json\",\n",
+    "    CustomAttributes=\"synthefy-response-stream=v1\",\n",
+    "    Body=json.dumps(sample_payload, separators=(\",\", \":\")).encode(),\n",
+    ")\n",
+    "\n",
+    "body = b\"\".join(\n",
+    "    event[\"PayloadPart\"][\"Bytes\"]\n",
+    "    for event in response[\"Body\"]\n",
+    "    if \"PayloadPart\" in event\n",
+    ")\n",
+    "raw_result = json.loads(body)\n",
+    "if \"error\" in raw_result:\n",
+    "    raise RuntimeError(raw_result[\"error\"])\n",
+    "print(json.dumps(raw_result, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Cleanup\n",
+    "\n",
+    "Run this cell even if deployment or invocation failed. It deletes the endpoint, stops an interrupted transform job if necessary, and then removes the endpoint configuration, model, and notebook-owned S3 objects. The completed transform-job record remains visible in SageMaker but has no running instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_missing(error):\n",
+    "    return error.response.get(\"Error\", {}).get(\"Code\") == \"ValidationException\"\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    sm.delete_endpoint(EndpointName=endpoint_name)\n",
+    "    print(f\"Deleting endpoint: {endpoint_name}\")\n",
+    "    sm.get_waiter(\"endpoint_deleted\").wait(\n",
+    "        EndpointName=endpoint_name,\n",
+    "        WaiterConfig={\"Delay\": 30, \"MaxAttempts\": 80},\n",
+    "    )\n",
+    "except ClientError as error:\n",
+    "    if not is_missing(error):\n",
+    "        raise\n",
+    "\n",
+    "try:\n",
+    "    description = sm.describe_transform_job(TransformJobName=transform_job_name)\n",
+    "    status = description[\"TransformJobStatus\"]\n",
+    "    if status == \"InProgress\":\n",
+    "        sm.stop_transform_job(TransformJobName=transform_job_name)\n",
+    "        print(f\"Stopping transform job: {transform_job_name}\")\n",
+    "    while status in {\"InProgress\", \"Stopping\"}:\n",
+    "        time.sleep(15)\n",
+    "        status = sm.describe_transform_job(\n",
+    "            TransformJobName=transform_job_name\n",
+    "        )[\"TransformJobStatus\"]\n",
+    "except ClientError as error:\n",
+    "    if not is_missing(error):\n",
+    "        raise\n",
+    "\n",
+    "try:\n",
+    "    sm.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n",
+    "    print(f\"Deleted endpoint config: {endpoint_config_name}\")\n",
+    "except ClientError as error:\n",
+    "    if not is_missing(error):\n",
+    "        raise\n",
+    "\n",
+    "try:\n",
+    "    sm.delete_model(ModelName=model_name)\n",
+    "    print(f\"Deleted model: {model_name}\")\n",
+    "except ClientError as error:\n",
+    "    if not is_missing(error):\n",
+    "        raise\n",
+    "\n",
+    "paginator = s3.get_paginator(\"list_objects_v2\")\n",
+    "for page in paginator.paginate(Bucket=S3_BUCKET, Prefix=s3_prefix):\n",
+    "    objects = [{\"Key\": item[\"Key\"]} for item in page.get(\"Contents\", [])]\n",
+    "    if objects:\n",
+    "        s3.delete_objects(Bucket=S3_BUCKET, Delete={\"Objects\": objects, \"Quiet\": True})\n",
+    "print(f\"Deleted notebook S3 objects under s3://{S3_BUCKET}/{s3_prefix}/\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- add an end-to-end AWS Marketplace SageMaker notebook
- exercise batch transform and all three models through SynthefyNoriClient
- use unique resources and document reverse-order cleanup

## Validation

- notebook JSON parses successfully
- all Python code cells compile
- live AWS execution requires a subscribed buyer account, execution role, S3 bucket, and GPU quota