### PR TITLE
fix: restore Python 3.9 package imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.0.0';
-          assert synthefy_nori.__version__ == '0.17.0'"
+          assert synthefy_nori.__version__ == '0.17.1'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/.github/workflows/publish-synthefy-nori.yml
+++ b/.github/workflows/publish-synthefy-nori.yml
@@ -11,7 +11,7 @@ on:
         type: choice
         options: [synthefy-nori]
       version:
-        description: "Exact package version, for example 0.17.0"
+        description: "Exact package version, for example 0.17.1"
         required: true
         type: string
       target:
@@ -21,7 +21,7 @@ on:
         type: choice
         options: [testpypi, pypi]
       tag:
-        description: "Exact existing tag, for example synthefy-nori-v0.17.0"
+        description: "Exact existing tag, for example synthefy-nori-v0.17.1"
         required: true
         type: string
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@ Publish the lightweight SDK first. The heavy package declares
 create an unresolvable release.
 
 1. Publish and verify `synthefy 7.0.0` (or the selected fix-forward version).
-2. Publish and verify `synthefy-nori 0.17.0`.
+2. Publish and verify `synthefy-nori 0.17.1`.
 3. Merge customer documentation only after both documented install commands
    resolve from PyPI.
 
@@ -85,11 +85,11 @@ gh workflow run publish-synthefy.yml \\
 
 gh workflow run publish-synthefy-nori.yml \\
   --repo Synthefy/synthefy-nori \\
-  --ref synthefy-nori-v0.17.0 \\
+  --ref synthefy-nori-v0.17.1 \\
   -f distribution=synthefy-nori \\
-  -f version=0.17.0 \\
+  -f version=0.17.1 \\
   -f target=testpypi \\
-  -f tag=synthefy-nori-v0.17.0
+  -f tag=synthefy-nori-v0.17.1
 ```
 
 A branch ref, mismatched tag/version, wrong distribution, or tag not contained in
@@ -135,14 +135,14 @@ uv pip check --python /tmp/synthefy-release-check/bin/python
 Only after that succeeds, create the heavy release:
 
 ```bash
-gh release create synthefy-nori-v0.17.0 \\
+gh release create synthefy-nori-v0.17.1 \\
   --repo Synthefy/synthefy-nori \\
   --target main \\
-  --title "synthefy-nori 0.17.0" \\
+  --title "synthefy-nori 0.17.1" \\
   --generate-notes
 ```
 
-Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.0` resolves
+Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.1` resolves
 `synthefy>=7,<8` and that local regression plus
 `synthefy-nori[forecasting]` work in clean environments.
 
@@ -197,7 +197,7 @@ credentials and delete them after testing.
 ## Failure and rollback
 
 PyPI artifacts are immutable. If `synthefy 7.0.0` fails verification, do not
-publish `synthefy-nori 0.17.0`; fix forward with `7.0.1`. If the heavy package
-fails after publication, fix forward with `0.17.1`. Never reuse a version or
+publish `synthefy-nori 0.17.1`; fix forward with `7.0.1`. If the heavy package
+fails after publication, fix forward with `0.17.2`. Never reuse a version or
 re-enable the old publisher. Existing `synthefy 6.3.0` and
 `synthefy-nori 0.16.0` remain installable during validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.17.0"
+version = "0.17.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -34,6 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
+    "eval-type-backport>=0.2; python_version < '3.10'",
     "einops>=0.7",
     "huggingface-hub>=1.0",
     "kditransform>=1.0",

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -19,7 +19,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,7 +98,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.17.0"
+    assert root["project"]["version"] == "0.17.1"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.0.0"
@@ -409,6 +409,10 @@ def test_python_floors_preserve_public_python39_compatibility():
     root = _toml(_ROOT / "pyproject.toml")["project"]
     client = _toml(_CLIENT / "pyproject.toml")["project"]
 
+    assert (
+        "eval-type-backport>=0.2; python_version < '3.10'"
+        in root["dependencies"]
+    )
     assert root["requires-python"] == ">=3.9"
     assert client["requires-python"] == ">=3.9"
     assert "Programming Language :: Python :: 3.9" in root["classifiers"]

--- a/uv.lock
+++ b/uv.lock
@@ -5516,10 +5516,11 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },
+    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "huggingface-hub", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "huggingface-hub", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "kditransform" },
@@ -5581,6 +5582,7 @@ train = [
 requires-dist = [
     { name = "build", marker = "extra == 'dev'" },
     { name = "einops", specifier = ">=0.7" },
+    { name = "eval-type-backport", marker = "python_full_version < '3.10'", specifier = ">=0.2" },
     { name = "huggingface-hub", specifier = ">=1.0" },
     { name = "kditransform", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'eval'" },


### PR DESCRIPTION
Promotes the validated fix-forward from internal PR #443 and staging PR #21.

The 0.17.0 wheel declares Python 3.9 support, but importing it on Python 3.9 fails while Pydantic evaluates postponed PEP 604 annotations. This bumps the heavy package to 0.17.1 and declares eval-type-backport only for Python below 3.10.

Validation:
- internal CI passed, including packaged serving-container cases
- staging package, distribution, Torch 2.8-2.13, GPU, embeddings, build, and training gates passed
- clean Python 3.9 forecasting install/import passed with eval-type-backport 0.4.0
- clean Python 3.11 forecasting install/import passed without installing the backport
- both clean environments passed uv pip check

No serving behavior or model code changes.