### PR TITLE
Promote staging to public: bound the context cache by total device bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ an H200:
 | `gpu_budget_frac` | `0.4` | share of total VRAM the resident cache may use |
 | `host_budget_frac` | `0.25` | share of total RAM an offloaded cache may use |
 | `gpu_budget_absolute_gb` / `host_budget_absolute_gb` | — | hard caps, for a shared GPU |
-| `reuse_context_cache` | `True` | retain an unchanged encoded context across separate local `predict()` calls; set `False` to rebuild each call while keeping the normal within-request K/V cache |
+| `reuse_context_cache` | `True` | retain an unchanged encoded context across separate local `predict()` calls; set `False` to rebuild each call while keeping the normal within-request K/V cache. Retention is bounded: on a CUDA device the retained contexts may use up to a quarter of total VRAM, and a single context larger than that is rebuilt each call rather than kept |
 | `cache_dtype` | `"bf16"` | precision the cache **starts** at |
 | `allow_quantization` | `True` | may bf16 drop to int8 to stay resident? |
 | `offload_to_host` | `True` | may the cache move to host RAM? |
@@ -605,6 +605,15 @@ configuration `memory_policy={"reuse_context_cache": False}`. All shared serving
 engine) enforce that value automatically, because one replica may handle multiple people
 or workloads. This does **not** disable the K/V cache within a request; it only prevents
 retaining it for a later request.
+
+Reuse is also bounded by size, which matters on wide tables. A retained context is roughly
+`nlayers × n_feature_groups × n_context` — modest on a typical table, but tens of GiB once a
+table has hundreds of columns, and the default regression path retains one per member of its
+8-member preprocessing ensemble. Retained contexts are therefore capped at a quarter of total
+VRAM, oldest evicted first, and a single context that exceeds that cap on its own is rebuilt
+each call instead of kept. Reuse is an optimization; leaving most of the device free for the
+forward pass is what keeps a large context from turning a slow prediction into a failed one.
+Devices without VRAM to exhaust (CPU) are not capped.
 
 **Known limit:** at large row counts × many columns, the first thing to run out of
 memory is the transductive preprocessing (RBF + polynomial expansion over the whole

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -1464,13 +1464,120 @@ class NoriPredictor:
         # table, so retaining the view would pin the (unbounded) query rows alive
         # too. One N_train x F copy is negligible against the per-layer K/V cache it
         # guards, which is ~nlayers x n_groups times larger.
-        cache[id_pipe] = (
-            key,
-            x_train_t.detach().clone(memory_format=torch.contiguous_format),
-            y_train_t.detach().clone(memory_format=torch.contiguous_format),
-            bundle,
-        )
+        #
+        # BOUND THE CACHE BY TOTAL BYTES. It is keyed per PIPE, and the default
+        # regression path runs an 8-member preprocessing ensemble, so an unbounded dict
+        # retains eight context caches at once. Each is ~nlayers x n_groups x n_ctx:
+        # small on a normal table, very large on a WIDE one. Measured on TALENT's
+        # topo_2_1 (7108 x 266 -> ~134 feature groups at features_per_group=2) one bundle
+        # is 15.2 GiB, so eight is 121.6 GiB and a 143 GiB H200 is exhausted before any
+        # query runs. The memory ladder then OOMs on every rung and even the plain-loop
+        # fallback dies -- though it needs only 14.5 GiB by itself -- because
+        # `torch.cuda.empty_cache()` cannot release tensors this dict still references.
+        #
+        # Evicting to a BYTE budget rather than a fixed count keeps the fit-once /
+        # serve-many amortization intact in the common case (8 small bundles all fit) and
+        # sheds bundles only when they are individually huge, which is precisely when
+        # retaining them is what breaks the run.
+        if self._evict_context_cache_for(cache, bundle):
+            cache[id_pipe] = (
+                key,
+                x_train_t.detach().clone(memory_format=torch.contiguous_format),
+                y_train_t.detach().clone(memory_format=torch.contiguous_format),
+                bundle,
+            )
         return bundle
+
+    @staticmethod
+    def _bundle_device_bytes(bundle) -> int:
+        """Best-effort GPU byte count for a context bundle.
+
+        Walks the bundle's tensors rather than trusting a declared size: the cache may
+        hold int8-quantized or host-offloaded K/V (``ScalableSeqKV``) whose real
+        footprint differs from the bf16 estimate the policy reports. Host-resident
+        tensors are excluded -- they are not what exhausts VRAM. Anything unrecognised
+        counts as 0 rather than raising: mis-measuring a bundle must never break a
+        prediction.
+        """
+        total = 0
+        seen: set[int] = set()
+
+        def walk(obj, depth: int = 0) -> None:
+            nonlocal total
+            if depth > 6 or id(obj) in seen:
+                return
+            seen.add(id(obj))
+            if isinstance(obj, torch.Tensor):
+                if obj.is_cuda:
+                    total += obj.element_size() * obj.nelement()
+                return
+            if isinstance(obj, dict):
+                for v in obj.values():
+                    walk(v, depth + 1)
+            elif isinstance(obj, (list, tuple, set)):
+                for v in obj:
+                    walk(v, depth + 1)
+            elif hasattr(obj, "__dict__"):
+                for v in vars(obj).values():
+                    walk(v, depth + 1)
+
+        try:
+            walk(bundle)
+        except Exception:                       # never let accounting break a predict
+            return 0
+        return total
+
+    def _context_cache_budget_bytes(self) -> "int | None":
+        """Bytes of retained context cache to allow, or ``None`` when no limit applies.
+
+        ``None`` means this device has no VRAM to exhaust -- CPU, MPS, or a device we cannot
+        measure. The failure this bound exists to prevent is specifically a **CUDA** OOM, so
+        on those devices the cache keeps its original unbounded fit-once / serve-many
+        behaviour rather than being silently disabled.
+
+        A CUDA device gets a share of total VRAM rather than an absolute, matching how every
+        other budget in ``memory_policy`` is expressed, so one setting ports from a 24 GB
+        laptop card to a 143 GB H200. Deliberately a MINORITY of the device: the cache is an
+        optimization, and leaving the majority free for the forward pass is what stops a
+        retained cache from turning a slow path into a fatal one.
+        """
+        frac = float(getattr(self, "_context_cache_budget_frac", 0.25))
+        try:
+            dev = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
+            if dev.type != "cuda":
+                return None
+            return int(torch.cuda.get_device_properties(dev).total_memory * frac)
+        except Exception:
+            return None                         # cannot measure -> leave behaviour unchanged
+
+    def _evict_context_cache_for(self, cache: dict, incoming) -> bool:
+        """Drop cached bundles (oldest first) until ``incoming`` fits the byte budget.
+
+        Returns whether ``incoming`` should be retained. False means the bundle is still
+        built and returned to the caller -- it simply is not kept for a later call. That
+        is the wide-table case: reuse is worth nothing if holding one bundle leaves no
+        room to run the model.
+        """
+        budget = self._context_cache_budget_bytes()
+        if budget is None:
+            return True                         # no device limit -> exactly the old behaviour
+        incoming_bytes = self._bundle_device_bytes(incoming)
+        if incoming_bytes > budget:
+            # The branch that fixes topo_2_1: a 15.2 GiB bundle against a 0.25 x 143 GiB
+            # budget is kept out, so eight of them can never accumulate. Release whatever
+            # is held so the forward pass gets the whole card.
+            cache.clear()
+            return False
+        held = {k: self._bundle_device_bytes(v[3]) for k, v in cache.items()}
+        total = sum(held.values())
+        # dict preserves insertion order, so iterating keys is oldest-first (LRU enough:
+        # a hit returns early and never re-inserts, so order tracks first use).
+        for k in list(cache.keys()):
+            if total + incoming_bytes <= budget:
+                break
+            total -= held.get(k, 0)
+            cache.pop(k, None)
+        return True
 
     def _context_cache_key(self, cache_dtype, offload_kv_cache, fit_row_chunk) -> tuple:
         """The non-tensor half of the cache key: everything OUTSIDE the context table

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -973,3 +973,81 @@ def test_failed_build_is_not_cached():
     good = get(model, x.clone(), y.clone())
     assert _built_from(good, x, y)
     assert len(model.builds) == 1
+
+
+# ---------------------------------------------------------------------------------
+# The predictor's cross-call context cache is keyed per PREPROCESSING PIPE, and the
+# default regression path runs an 8-member ensemble. Unbounded, that retains eight
+# context caches at once -- fine when each is small, fatal when each is large.
+#
+# Measured: TALENT's topo_2_1 (7108 rows x 266 features, ~134 feature groups at
+# features_per_group=2) builds a 15.2 GiB bundle. Eight of those is 121.6 GiB, which
+# exhausted a 143 GiB H200 before any query ran; the memory ladder then OOM'd on every
+# rung, and the plain-loop fallback died too even though it needs only 14.5 GiB on its
+# own, because `torch.cuda.empty_cache()` cannot free tensors the cache dict still
+# references. It silently cost two TALENT datasets on every arm of an A/B whose model
+# did not happen to short-circuit the cached path.
+#
+# These tests pin the bound itself (pure accounting, no GPU): a bundle larger than the
+# budget is never retained, and smaller ones are evicted oldest-first to stay under it.
+# ---------------------------------------------------------------------------------
+
+class _FakePredictor:
+    """Just enough of NoriPredictor to exercise the eviction arithmetic on CPU."""
+
+    _bundle_device_bytes = staticmethod(
+        lambda bundle: int(bundle["bytes"]))          # stand in for the tensor walk
+
+    def __init__(self, budget_bytes):
+        self._budget = budget_bytes
+
+    def _context_cache_budget_bytes(self):
+        return self._budget
+
+    # the real implementations, bound to this stub
+    from synthefy_nori.inference.predictor import NoriPredictor as _NP
+    _evict_context_cache_for = _NP._evict_context_cache_for
+
+
+def _entry(nbytes):
+    return ("key", None, None, {"bytes": nbytes})
+
+
+def test_context_cache_refuses_a_bundle_larger_than_the_budget():
+    """The wide-table case: one 15.2 GiB bundle against a 0.25 x 143 GiB budget."""
+    p = _FakePredictor(budget_bytes=35 * 1024**3)
+    cache = {"pipe0": _entry(15 * 1024**3)}
+    keep = p._evict_context_cache_for(cache, {"bytes": 40 * 1024**3})
+    assert keep is False, "an over-budget bundle must not be retained"
+    assert cache == {}, "and whatever was held must be released for the forward pass"
+
+
+def test_context_cache_evicts_oldest_until_the_new_bundle_fits():
+    p = _FakePredictor(budget_bytes=10 * 1024**3)
+    cache = {f"pipe{i}": _entry(3 * 1024**3) for i in range(3)}   # 9 GiB held
+    keep = p._evict_context_cache_for(cache, {"bytes": 3 * 1024**3})
+    assert keep is True
+    # 9 + 3 > 10, so exactly one (the oldest) is dropped to make room.
+    assert "pipe0" not in cache and "pipe1" in cache and "pipe2" in cache
+
+
+def test_context_cache_keeps_a_full_small_ensemble():
+    """The common case must not regress: 8 small bundles all fit, so none is evicted."""
+    p = _FakePredictor(budget_bytes=10 * 1024**3)
+    cache = {f"pipe{i}": _entry(256 * 1024**2) for i in range(8)}  # 2 GiB total
+    keep = p._evict_context_cache_for(cache, {"bytes": 256 * 1024**2})
+    assert keep is True
+    assert len(cache) == 8, "small ensembles keep their cross-call amortization"
+
+
+def test_context_cache_is_unbounded_when_the_device_has_no_vram_to_exhaust():
+    """CPU/MPS keep the original unbounded behaviour -- the bound guards a CUDA OOM only.
+
+    Regression test for the first cut of this fix, which returned a 0 budget for a
+    non-CUDA device and read 0 as "retain nothing". That silently disabled the context
+    cache for every CPU user and turned one build into one build *per query*.
+    """
+    p = _FakePredictor(budget_bytes=None)               # None = "no device limit applies"
+    cache = {"pipe0": _entry(1)}
+    assert p._evict_context_cache_for(cache, {"bytes": 10**12}) is True
+    assert "pipe0" in cache, "nothing is evicted when there is no device limit"


### PR DESCRIPTION
Promote staging to public — context-cache memory bound.

## Promotion chain

`synthefy-nori-internal` **#444** (`1824607a`) → `synthefy-nori-staging` **#22** (`22c2f84`) → here.

`git patch-id --stable` of the fix commit is **`01882ff07368de7aaa596e53d27dd5a0db3f6dc4`** in all
three tiers — identical, so rebase-sync de-duplicates rather than conflicts. The only textual
difference from internal is a hunk header (`@@ -1492` → `@@ -1464`); internal's `predictor.py`
carries 28 lines this tier does not.

**Not promoted:** internal #444 also set `SYNTHEFY_DISABLE_CACHED_INFERENCE=1` in
`modal/modal_bench.py`, an internal-only eval runner. `modal/` exists in neither staging nor
public, so that half stays in internal by construction.

**No version bump here.** This changes no public API — it makes a previously-fatal case work — so
it can ride the next release rather than justify its own. Say if you'd rather cut one.

## The bug

The cross-call context cache (`_context_cache`) is keyed per preprocessing **pipe** and was
**unbounded**. The default regression path runs an **8-member preprocessing ensemble**, so a single
`fit → predict` retains eight per-layer K/V bundles simultaneously.

Modest on a typical table. Not on a wide one:

| | TALENT `topo_2_1` |
|---|---|
| shape | 7108 × 266 |
| feature groups (`features_per_group=2`) | ~134 |
| **one** bundle | **15.2 GiB** (the policy's own figure) |
| **eight** bundles | **121.6 GiB** |
| device | H200, 143 GiB |

121.6 GiB is committed before a single query row is scored.

### Why the traceback points at the wrong thing

The memory ladder OOMs on `resident_bf16`, walks down its rungs, and dies **even in the plain
chunked loop** — a path needing only **14.5 GiB** here, which would otherwise have succeeded. It
fails because `torch.cuda.empty_cache()` cannot release tensors the cache dict still references,
so every rung runs against an already-poisoned heap. Two consequences, both of which cost real
debugging time:

1. The OOM **surfaces in the fallback**, not at the allocation that caused it. The fallback looks
   like the culprit and isn't.
2. Raising `SYNTHEFY_MAX_ELEMENTS_BUDGET` — the knob that looks relevant — makes it **strictly
   worse**. `topo_2_1` is 1,890,728 cells and never binds the 2M cap, so the cap was never the lever.

## The fix

Evict to a **byte budget** (0.25 of device VRAM) before retaining a bundle, and refuse a bundle
that alone exceeds it. This keeps fit-once / serve-many amortization in the common case — eight
small bundles still all fit — and sheds bundles only when retaining them is what breaks the run.
Bytes come from **walking the bundle's CUDA tensors**, not the policy's bf16 estimate, so
quantized and host-offloaded K/V (`ScalableSeqKV`) are accounted correctly.

A **non-CUDA device returns no budget and keeps the original unbounded behaviour** — the failure
being guarded is a CUDA OOM specifically. The first cut returned a `0` budget for CPU and read 0
as *"retain nothing"*, which silently disabled the cache for every CPU user and turned one build
into **one build per query**. 7 existing tests caught it; a regression test now pins that boundary.

## README (second commit)

The memory-policy table and the fit-once/predict-many paragraph both described
`reuse_context_cache` as unconditional retention across `predict()` calls. A reader sizing a
wide-table workload off that text would expect retention that no longer happens, so both now state
the bound. Landing it here rather than in a lower tier is deliberate — public is the cascade root,
so it propagates down to staging and internal automatically.

## Verification

Measured on internal before promotion — idle H200 (GPU 0, 143771 MiB), cache left **ON**, published
2M element budget, checkpoint `ab2-15m ctrl2`:

| library | result | peak |
|---|---|---|
| base | **FAILED** — `CUDA out of memory`, 971 MiB free of 139.35 GiB | 138.06 GiB |
| with fix | **OK** — `r2 = 0.0371`, 44 s | 93.14 GiB |

The fixed run still walks down to `context_row_chunk`: one 15.2 GiB bundle genuinely does not fit
`resident_bf16` on this table, which is expected physics rather than the bug. It just never
accumulates eight of them.

### Re-validated on this tier

Re-run here rather than assumed, since this tier's floor differs from where the fix was developed
(Python **≥3.9** vs ≥3.10, **torch<2.9** vs torch==2.10.0):

- **`CONTRIBUTING.md` gate, verbatim** — `ruff check src scripts tests`: **All checks passed**
  (identical on the base commit).
- **`uv run pytest`: 335 passed, 6 skipped** on **torch 2.8.0+cu128** — a different torch than the
  fix was developed against, which is the part that could have broken.
- **Python 3.9 byte-compile** of both changed files under real CPython 3.9.25 — OK. (`predictor.py`
  has `from __future__ import annotations` at line 1, so the `int | None` and `set[int]`
  annotations are never evaluated — this tier's base commit is itself a 3.9-import fix.)
- `tests/test_context_cache.py`: **28 passed** (23 pre-existing + 5 new).

New test coverage:
- refuses a bundle larger than the whole budget (the `topo_2_1` case)
- evicts oldest-first until the incoming bundle fits
- keeps a full 8-member ensemble when the bundles are small (amortization preserved)
- stays unbounded when the device has no VRAM to exhaust (the CPU regression above)
