### PR TITLE
Promote staging to public + release 0.17.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.0.0';
-          assert synthefy_nori.__version__ == '0.17.1'"
+          assert synthefy_nori.__version__ == '0.17.2'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/.github/workflows/publish-synthefy-nori.yml
+++ b/.github/workflows/publish-synthefy-nori.yml
@@ -11,7 +11,7 @@ on:
         type: choice
         options: [synthefy-nori]
       version:
-        description: "Exact package version, for example 0.17.1"
+        description: "Exact package version, for example 0.17.2"
         required: true
         type: string
       target:
@@ -21,7 +21,7 @@ on:
         type: choice
         options: [testpypi, pypi]
       tag:
-        description: "Exact existing tag, for example synthefy-nori-v0.17.1"
+        description: "Exact existing tag, for example synthefy-nori-v0.17.2"
         required: true
         type: string
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@ Publish the lightweight SDK first. The heavy package declares
 create an unresolvable release.
 
 1. Publish and verify `synthefy 7.0.0` (or the selected fix-forward version).
-2. Publish and verify `synthefy-nori 0.17.1`.
+2. Publish and verify `synthefy-nori 0.17.2`.
 3. Merge customer documentation only after both documented install commands
    resolve from PyPI.
 
@@ -85,11 +85,11 @@ gh workflow run publish-synthefy.yml \\
 
 gh workflow run publish-synthefy-nori.yml \\
   --repo Synthefy/synthefy-nori \\
-  --ref synthefy-nori-v0.17.1 \\
+  --ref synthefy-nori-v0.17.2 \\
   -f distribution=synthefy-nori \\
-  -f version=0.17.1 \\
+  -f version=0.17.2 \\
   -f target=testpypi \\
-  -f tag=synthefy-nori-v0.17.1
+  -f tag=synthefy-nori-v0.17.2
 ```
 
 A branch ref, mismatched tag/version, wrong distribution, or tag not contained in
@@ -135,14 +135,14 @@ uv pip check --python /tmp/synthefy-release-check/bin/python
 Only after that succeeds, create the heavy release:
 
 ```bash
-gh release create synthefy-nori-v0.17.1 \\
+gh release create synthefy-nori-v0.17.2 \\
   --repo Synthefy/synthefy-nori \\
   --target main \\
-  --title "synthefy-nori 0.17.1" \\
+  --title "synthefy-nori 0.17.2" \\
   --generate-notes
 ```
 
-Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.1` resolves
+Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.2` resolves
 `synthefy>=7,<8` and that local regression plus
 `synthefy-nori[forecasting]` work in clean environments.
 
@@ -197,7 +197,7 @@ credentials and delete them after testing.
 ## Failure and rollback
 
 PyPI artifacts are immutable. If `synthefy 7.0.0` fails verification, do not
-publish `synthefy-nori 0.17.1`; fix forward with `7.0.1`. If the heavy package
-fails after publication, fix forward with `0.17.2`. Never reuse a version or
+publish `synthefy-nori 0.17.2`; fix forward with `7.0.1`. If the heavy package
+fails after publication, fix forward with `0.17.3`. Never reuse a version or
 re-enable the old publisher. Existing `synthefy 6.3.0` and
 `synthefy-nori 0.16.0` remain installable during validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.17.1"
+version = "0.17.2"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -19,7 +19,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -619,6 +619,42 @@ class NoriPredictor:
                 return output["cls_output"]
         return output
 
+    def _reject_nonfinite_output(
+            self,
+            out: torch.Tensor,
+            *,
+            path: str,
+            n_train: int,
+            n_test: int,
+    ) -> torch.Tensor:
+        """Raise when the model emits NaN/inf, instead of zero-filling it.
+
+        Zero-filling was never a safe default here: the predictor works in
+        standardized target space, so a zeroed prediction denormalizes to
+        exactly ``y_mean``. A fully non-finite forward therefore became a
+        *constant* prediction that was finite, plausible-looking, and useless —
+        ROC AUC 0.5 with no error anywhere in the call. That silent conversion
+        is what made issue #439 invisible for as long as it was.
+
+        There is deliberately no opt-out. A caller who wants the old behavior
+        can only want a number that is indistinguishable from a working
+        prediction while carrying no signal, so the only honest thing this can
+        return is an exception.
+        """
+        if torch.isfinite(out).all():
+            return out
+
+        n_bad = int((~torch.isfinite(out)).sum())
+        raise RuntimeError(
+            f"Nori produced {n_bad}/{out.numel()} non-finite prediction values "
+            f"(nan={int(torch.isnan(out).sum())}, inf={int(torch.isinf(out).sum())}) "
+            f"on the {path} path: n_context={n_train}, n_query={n_test}, "
+            f"dtype={out.dtype}, mixed_precision={self.mix_precision}. "
+            "These cannot be returned: in standardized target space they would "
+            "denormalize to the context target mean, i.e. a constant prediction "
+            "that scores at chance while reporting success."
+        )
+
     def _maybe_snap_discrete_y(self, y_train: np.ndarray,
                                  preds: np.ndarray) -> np.ndarray:
         """Snap regression predictions to nearest training y value when
@@ -1907,8 +1943,9 @@ class NoriPredictor:
                                     adaptive_query_chunk=policy.adaptive_query_chunk,
                                 )
                             output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
-                            if not torch.isfinite(output).all():
-                                output = torch.nan_to_num(output, nan=0.0, posinf=0.0, neginf=0.0)
+                            output = self._reject_nonfinite_output(
+                                output, path=f"cached ({policy.rung})",
+                                n_train=n_samples_train, n_test=n_samples_test)
                             outputs.append(output)
                             cached_done = True
                             if attempt_fit_chunk is not None and pinned is None:
@@ -2005,13 +2042,9 @@ class NoriPredictor:
                         chunk_output = chunk_output['reg_output']
 
                     chunk_output = self._unwrap_model_output(chunk_output, task_type="reg").squeeze(0)
-                    if not torch.isfinite(chunk_output).all():
-                        chunk_output = torch.nan_to_num(
-                            chunk_output,
-                            nan=0.0,
-                            posinf=0.0,
-                            neginf=0.0,
-                        )
+                    chunk_output = self._reject_nonfinite_output(
+                        chunk_output, path="plain chunked loop",
+                        n_train=n_samples_train, n_test=end_idx - i)
                     all_outputs.append(chunk_output)
                     
                 # Concatenate all test chunks (cached path already appended above)

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -169,8 +169,17 @@ class QASSMaxScaling(nn.Module):
         if key_len <= 1:
             return q
 
-        log_n = torch.log(
-            torch.tensor(float(max(key_len, 2)), device=q.device, dtype=q.dtype)
+        # Take the log in Python doubles and cast only the RESULT to q.dtype.
+        # Materializing `key_len` itself in q.dtype first overflows fp16 — its
+        # largest finite value is 65504, so any context of 65520+ rows becomes
+        # `inf` before log() ever runs, and inf propagates through base_scale
+        # into q, making the whole prediction non-finite. log(n) is ~11 for a
+        # 65k-row context, which every supported dtype represents exactly
+        # enough. Inference autocasts to fp16 on CUDA (the trainer uses bf16,
+        # which has the range to hide this), so the overflow only ever showed
+        # up at long-context inference. See issue #439.
+        log_n = torch.tensor(
+            math.log(float(max(key_len, 2))), device=q.device, dtype=q.dtype
         )
         base_delta = self.base_mlp(log_n.view(1, 1)).view(
             1, 1, self.num_heads, self.head_dim

--- a/tests/test_long_context_nonfinite.py
+++ b/tests/test_long_context_nonfinite.py
@@ -1,0 +1,209 @@
+"""Regression tests for issue #439 — long-context predictions collapsing to the
+context target mean.
+
+Two independent defects produced one silent failure:
+
+1. ``QASSMaxScaling.forward`` built the ``log(n)`` attention scale by first
+   materializing the context row count ``n`` in ``q.dtype``. Inference autocasts
+   to fp16 on CUDA (the trainer uses bf16), and fp16's largest finite value is
+   65504 — so any context of 65520+ rows became ``inf`` *before* ``log()`` ran.
+   The inf flowed through ``base_scale`` into ``q`` and every prediction went
+   NaN. The boundary is 65520, not 65536: fp16 round-to-nearest sends 65520 and
+   up to inf, while 65505..65519 still round down to 65504.
+
+2. ``NoriPredictor`` then replaced the NaNs with 0.0 and reported success. The
+   predictor works in standardized target space, so a zeroed prediction
+   denormalizes to exactly ``y_mean`` — a finite, plausible-looking *constant*
+   that scores at chance (ROC AUC 0.5) with no error raised anywhere.
+
+The fp16 tests below run on CPU: the overflow is a dtype cast, not a kernel or
+device behavior, so they reproduce the original bug in milliseconds. The
+end-to-end boundary check needs a real 65k-row forward and is marked ``slow``.
+"""
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from synthefy_nori.inference.predictor import NoriPredictor
+from synthefy_nori.model.layer import QASSMaxScaling
+
+# fp16 max finite is 65504; round-to-nearest-even sends 65520+ to inf.
+FP16_MAX_FINITE = 65504
+FP16_OVERFLOW_START = 65520
+
+
+# ---------------------------------------------------------------------------
+# 1. Root cause: log(n) must be computed before the cast, not after.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("key_len", [
+    65519,                  # last row count fp16 still rounds to a finite value
+    FP16_OVERFLOW_START,    # first row count that overflowed fp16
+    65535, 65536, 65537,    # the boundary named in the issue
+    70000,                  # a reported failing context
+    100000,                 # a reported failing context
+])
+def test_qassmax_finite_above_fp16_row_count_limit(key_len):
+    """A context longer than fp16 can represent must not poison the q scale."""
+    m = QASSMaxScaling(num_heads=2, head_dim=4).half()
+    q = torch.randn(1, 8, 2, 4, dtype=torch.float16)
+
+    out = m(q, key_len=key_len)
+
+    assert torch.isfinite(out).all(), (
+        f"QASSMaxScaling produced non-finite q at key_len={key_len}: "
+        f"nan={int(torch.isnan(out).sum())} inf={int(torch.isinf(out).sum())}. "
+        "log(n) is being taken after casting n to fp16."
+    )
+
+
+@pytest.mark.parametrize("key_len", [FP16_OVERFLOW_START, 70000, 100000])
+def test_qassmax_scale_is_log_n_not_inf(key_len):
+    """The zero-initialized default is exactly q*log(n) — check the value, not just finiteness.
+
+    Finiteness alone would pass if log(n) were clamped to the fp16 max instead
+    of actually computed, which would silently over-sharpen attention.
+    """
+    m = QASSMaxScaling(num_heads=2, head_dim=4).half()
+    q = torch.ones(1, 4, 2, 4, dtype=torch.float16)
+
+    scale = m(q, key_len=key_len).float().unique()
+
+    assert scale.numel() == 1
+    assert scale.item() == pytest.approx(math.log(key_len), rel=1e-3)
+
+
+@pytest.mark.parametrize("key_len", [2, 100, 1024, 8000, 60000, FP16_MAX_FINITE])
+def test_qassmax_below_boundary_matches_exact_log(key_len):
+    """Below the boundary, behavior is unchanged within fp16 tolerance.
+
+    Computing log(n) in double and casting the ~11-magnitude result costs at
+    most one fp16 ulp versus the old fp16-log-of-fp16-n, so predictions on
+    every context length that used to work must not move meaningfully.
+    """
+    m = QASSMaxScaling(num_heads=2, head_dim=4).half()
+    q = torch.randn(1, 8, 2, 4, dtype=torch.float16)
+
+    got = m(q, key_len=key_len).float()
+
+    # Reference: same math in float32, exact log — no fp16 anywhere.
+    ref_m = QASSMaxScaling(num_heads=2, head_dim=4)
+    ref_m.load_state_dict({k: v.float() for k, v in m.state_dict().items()})
+    expected = ref_m(q.float(), key_len=key_len)
+
+    torch.testing.assert_close(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_qassmax_respects_fp32_and_bf16():
+    """The fix must not change the dtype of the scale it builds."""
+    for dtype in (torch.float32, torch.bfloat16, torch.float16):
+        m = QASSMaxScaling(num_heads=2, head_dim=4).to(dtype)
+        q = torch.randn(1, 4, 2, 4, dtype=dtype)
+        out = m(q, key_len=70000)
+        assert out.dtype == dtype
+        assert torch.isfinite(out).all()
+
+
+# ---------------------------------------------------------------------------
+# 2. A non-finite forward must never become a silent constant prediction.
+# ---------------------------------------------------------------------------
+
+class _Stub:
+    """Minimal carrier for the real unbound method under test."""
+
+    mix_precision = True
+    _reject_nonfinite_output = NoriPredictor._reject_nonfinite_output
+
+
+def test_finite_output_passes_through_untouched():
+    out = torch.tensor([1.0, -2.5, 0.0])
+    got = _Stub()._reject_nonfinite_output(
+        out, path="cached", n_train=10, n_test=3)
+    assert got is out
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_output_raises_instead_of_zero_filling(bad):
+    out = torch.tensor([1.0, bad, 3.0])
+
+    with pytest.raises(RuntimeError) as exc:
+        _Stub()._reject_nonfinite_output(
+            out, path="cached (resident_bf16)", n_train=93729, n_test=4096)
+
+    msg = str(exc.value)
+    # The message has to carry enough to act on: where, how big, and why a
+    # zero-fill would have looked like a working run.
+    assert "non-finite" in msg
+    assert "n_context=93729" in msg and "n_query=4096" in msg
+    assert "resident_bf16" in msg
+    assert "context target mean" in msg
+
+
+def test_partial_nonfinite_also_raises():
+    """One bad row is enough. Those rows would silently become the mean."""
+    out = torch.cat([torch.randn(4095), torch.tensor([float("nan")])])
+
+    with pytest.raises(RuntimeError, match="1/4096 non-finite"):
+        _Stub()._reject_nonfinite_output(
+            out, path="plain chunked loop", n_train=70000, n_test=4096)
+
+
+def test_there_is_no_env_opt_out(monkeypatch):
+    """No environment variable may turn the raise back into a zero-fill.
+
+    An opt-out here can only produce a number indistinguishable from a working
+    prediction while carrying no signal, which is exactly the #439 failure mode.
+    """
+    for name in ("SYNTHEFY_ALLOW_NONFINITE_PREDICTIONS",
+                 "SYNTHEFY_ALLOW_NONFINITE",
+                 "SYNTHEFY_DISABLE_NONFINITE_CHECK"):
+        monkeypatch.setenv(name, "1")
+
+    with pytest.raises(RuntimeError):
+        _Stub()._reject_nonfinite_output(
+            torch.tensor([float("nan")]), path="cached", n_train=70000, n_test=1)
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end at the boundary (needs a GPU + the real checkpoint).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("n_train", [65535, 65536, 65537, 70000])
+def test_long_context_predictions_are_finite_and_varying(n_train):
+    """The acceptance criterion: no NaN, and no collapse to a constant."""
+    from synthefy_nori.hf import download_checkpoint
+    from synthefy_nori.utils.loading import load_model
+
+    device = torch.device("cuda")
+    ckpt = download_checkpoint(model="nori-6m")
+    model = load_model(ckpt, mask_prediction=False).to(device).eval()
+
+    n_test, n_feat = 2048, 12
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((n_train + n_test, n_feat)).astype(np.float32)
+    y = X[:, 0] * 0.8 + X[:, 1] * 0.3 + rng.standard_normal(n_train + n_test) * 0.1
+    y = ((y - y[:n_train].mean()) / y[:n_train].std()).astype(np.float32)
+
+    # enabled=True with no dtype is exactly what NoriPredictor does -> fp16.
+    with torch.autocast(device_type="cuda", enabled=True), torch.inference_mode():
+        out = model.forward_cached_regression(
+            x=torch.from_numpy(X).to(device).unsqueeze(0),
+            y=torch.from_numpy(y[:n_train]).to(device).unsqueeze(0),
+            eval_pos=n_train,
+            row_chunk_size=2048,
+        )
+    pred = out["reg_output"] if isinstance(out, dict) else out
+    pred = pred.float().squeeze(0)
+    if pred.dim() > 1:
+        pred = pred.mean(dim=-1)
+
+    assert torch.isfinite(pred).all(), f"non-finite predictions at n_train={n_train}"
+    assert pred.std().item() > 1e-3, (
+        f"predictions collapsed to a constant at n_train={n_train} "
+        f"(std={pred.std().item():.3e}) — the #439 failure mode"
+    )

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,7 +98,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.17.1"
+    assert root["project"]["version"] == "0.17.2"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -5516,7 +5516,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.17.1"
+version = "0.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary
- promotes the public-compatible #440 long-context inference fix from staging
- fixes fp16 overflow in QASS scaling above the 65,520-row boundary
- rejects non-finite regression output instead of silently returning the context mean
- prepares synthefy-nori 0.17.2 while keeping synthefy at 7.0.0

## Promotion gates
Depends on:
1. Synthefy/synthefy-nori-internal#445 merging
2. Synthefy/synthefy-nori-staging#23 merging
3. rebase-sync and drop-check confirming the staging promotion remains present

Keep this PR draft until all three gates clear. Only after this public PR merges, public CI is green, and the cascade/drop-check clears may the public repo create synthefy-nori-v0.17.2 or dispatch TestPyPI/PyPI publishing.

## Validation
- public focused long-context + release tests: 33 passed, 4 deselected
- candidate #440 source/test files are byte-identical to staging
- staging full suite: 354 passed, 6 skipped, 53 deselected
- Ruff passed
- wheel/sdist build and Twine strict checks passed
- clean-wheel install with synthefy 7.0.0 passed