### PR TITLE
Promote staging to public: pin the QASS mode into model_config

### DIFF
--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -142,6 +142,7 @@ class QASSMaxScaling(nn.Module):
         num_heads: int,
         head_dim: int,
         hidden_dim: int = 64,
+        qass_mode: Optional[str] = None,
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
     ):
@@ -165,6 +166,38 @@ class QASSMaxScaling(nn.Module):
         nn.init.zeros_(self.gate_mlp[-1].weight)
         nn.init.zeros_(self.gate_mlp[-1].bias)
 
+        # qass_mode selects which learned components are active:
+        #   - "log_only":  q * log(n)                  (base & gate frozen/ignored)
+        #   - "base_only": q * base_scale              (gate frozen/ignored)
+        #   - "full":      q * base_scale * gate_scale
+        # Honoring it is required for older "log_only" checkpoints that still
+        # carry trained base/gate weights: running them "full" silently applies
+        # the wrong attention temperature.
+        #
+        # Precedence: explicit argument > SYNTHEFY_QASS_MODE > "full".
+        # `build_model` resolves the mode from the architecture config once and
+        # passes it down explicitly, so a model's attention temperature is a
+        # function of its own config and nothing else. The env var stays as a
+        # deliberate experiment override for callers that construct this module
+        # directly; it must NOT be able to override a config-resolved mode,
+        # because that is process-global state deciding model behaviour.
+        if qass_mode is None:
+            qass_mode = os.environ.get("SYNTHEFY_QASS_MODE", "full")
+        self.qass_mode = str(qass_mode).strip().lower()
+        if self.qass_mode not in {"full", "base_only", "log_only"}:
+            raise ValueError(
+                "qass_mode (argument or SYNTHEFY_QASS_MODE) must be one of "
+                f"full, base_only, log_only; got {self.qass_mode!r}"
+            )
+        if self.qass_mode == "log_only":
+            for p in self.base_mlp.parameters():
+                p.requires_grad_(False)
+            for p in self.gate_mlp.parameters():
+                p.requires_grad_(False)
+        elif self.qass_mode == "base_only":
+            for p in self.gate_mlp.parameters():
+                p.requires_grad_(False)
+
     def forward(self, q: torch.Tensor, key_len: int) -> torch.Tensor:
         if key_len <= 1:
             return q
@@ -181,10 +214,14 @@ class QASSMaxScaling(nn.Module):
         log_n = torch.tensor(
             math.log(float(max(key_len, 2))), device=q.device, dtype=q.dtype
         )
+        if self.qass_mode == "log_only":
+            return q * log_n.view(1, 1, 1, 1)
         base_delta = self.base_mlp(log_n.view(1, 1)).view(
             1, 1, self.num_heads, self.head_dim
         )
         base_scale = log_n.view(1, 1, 1, 1) * (1.0 + torch.tanh(base_delta))
+        if self.qass_mode == "base_only":
+            return q * base_scale
         gate_scale = 1.0 + torch.tanh(self.gate_mlp(q))
         return q * base_scale * gate_scale
 
@@ -202,6 +239,9 @@ class MultiheadAttention(torch.nn.Module):
         use_logn_attention: bool = False,
         use_learnable_attn_temperature: bool = False,
         attn_n_ref: float = 1024.0,
+        # Appended, not inserted: this signature is not keyword-only, so adding a
+        # parameter mid-list would silently shift any positional caller.
+        qass_mode: Optional[str] = None,
     ):
         super().__init__()
         assert embed_dim % num_heads == 0, "embed_dim must be divisible by num_heads"
@@ -247,6 +287,7 @@ class MultiheadAttention(torch.nn.Module):
                 num_heads=self.num_heads,
                 head_dim=self.head_dim,
                 hidden_dim=64,
+                qass_mode=qass_mode,
                 device=device,
                 dtype=dtype,
             )
@@ -501,6 +542,8 @@ class EncoderBaseLayer(nn.Module):
                  use_logn_attention: bool = False,
                  use_learnable_attn_temperature: bool = False,
                  attn_n_ref: float = 1024.0,
+                 # Appended, not inserted — this signature is not keyword-only.
+                 qass_mode: str|None = None,
                  ):
         super().__init__()
         self.use_logn_attention = use_logn_attention
@@ -574,6 +617,7 @@ class EncoderBaseLayer(nn.Module):
                                                             dropout=self.dropout,
                                                             recompute=self.recompute_attn,
                                                             use_qassmax=use_qassmax,
+                                                            qass_mode=qass_mode,
                                                             use_logn_attention=use_logn_attention,
                                                             use_learnable_attn_temperature=use_learnable_attn_temperature,
                                                             attn_n_ref=attn_n_ref,

--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 import torch
 
-from synthefy_nori.utils.loading import build_model
+from synthefy_nori.utils.loading import build_model, finalize_arch_config
 from synthefy_nori.model.layer import RMSNorm
 from synthefy_nori.training.config import TrainingConfig, package_config_path
 from synthefy_nori.training.trainer import NoriTrainer
@@ -680,6 +680,13 @@ def main():
             f"Architecture extras: QASSMax={'on' if model_config['use_qassmax'] else 'off'}, "
             f"TAE={'on' if model_config['use_target_aware_embedding'] else 'off'}"
         )
+
+    # Pin every architecture flag into model_config now that all overrides have
+    # been applied. model_config is the only architecture record the checkpoint
+    # carries, so a flag left unwritten here is a flag a later load has to guess.
+    finalize_arch_config(model_config)
+    if local_rank == 0 and 'qass_mode' in model_config:
+        print(f"QASS mode: {model_config['qass_mode']} (pinned into model_config)")
 
     # Build model from scratch (random init)
     if local_rank == 0:

--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -284,16 +284,13 @@ class TrainingConfig:
     # in query get count=0.
     freq_count_encode_prob: float = 0.0
 
-    # logN attention scaling: pre-multiply Q by log(n_keys)/log(n_ref) so
-    # softmax stays sharp as context length grows. attn_n_ref is the
-    # reference length where the factor equals 1 (no change).
-    use_logn_attention: bool = False
-    attn_n_ref: float = 1024.0
-
-    # Learnable per-layer attention temperature: each MultiheadAttention has
-    # an nn.Parameter scalar (init 1.0, .abs() applied) multiplied into the
-    # attention scale. Lets the model learn per-layer attention sharpness.
-    use_learnable_attn_temperature: bool = False
+    # NOTE: use_logn_attention / attn_n_ref / use_learnable_attn_temperature used
+    # to be declared here. They were never read: no CLI flag set them and the
+    # trainer builds the model from `model_config`, not from this dataclass. They
+    # are architecture, so they live in `model_config` -- see
+    # loading.finalize_arch_config, which pins them into every checkpoint. Do not
+    # re-add architecture fields here: a value that looks like a record of the run
+    # but is really an unread default is worse than no field at all.
 
     # Context missingness augmentation: probability of injecting random NaN cells
     # across the full feature matrix (including context rows). Teaches the model

--- a/src/synthefy_nori/utils/loading.py
+++ b/src/synthefy_nori/utils/loading.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pickle
 
 import torch
@@ -32,7 +33,84 @@ def _safe_torch_load(path):
         with torch.serialization.safe_globals([TrainingConfig]):
             return torch.load(path, map_location="cpu", weights_only=True)
 
+# The attention-scale flags and their defaults. ``finalize_arch_config`` stamps
+# this table into every new checkpoint's ``model_config``; ``build_model`` falls
+# back to it for checkpoints saved before it did. One table, so the value a run
+# trains with and the value a later load assumes cannot drift apart.
+_ATTENTION_SCALE_DEFAULTS = {
+    "use_logn_attention": False,
+    "use_learnable_attn_temperature": False,
+    "attn_n_ref": 1024.0,
+}
+
+
+def resolve_qass_mode(config: dict) -> str:
+    """Return the QASS attention mode an *architecture* config describes.
+
+    ``config`` must be the architecture dict -- the same one ``build_model``
+    consumes. Never a ``TrainingConfig``: that object carries no architecture,
+    and reading it here would make the resolved mode depend on the checkpoint's
+    container format rather than on the model.
+
+    An explicit ``qass_mode`` is honored verbatim. Anything else resolves to
+    "full", because "full" is the only mode this tree has ever trained:
+    ``QASSMaxScaling`` had no mode switch until now, so every checkpoint written
+    without a ``qass_mode`` ran the full ``base * gate`` path and carries trained
+    base/gate weights. Resolving such a checkpoint to anything else would discard
+    those weights and silently apply the wrong attention temperature.
+
+    So this is a widening, not a change: nothing that loads today resolves
+    differently, and a checkpoint that *does* record a mode -- the released
+    ``Nori-30M`` already carries ``qass_mode: "full"`` -- is now honored instead
+    of ignored. Going forward ``finalize_arch_config`` pins the mode before
+    training, so new checkpoints never reach the fallback at all.
+    """
+    explicit_mode = config.get("qass_mode")
+    if explicit_mode is not None:
+        return str(explicit_mode)
+    return "full"
+
+
+def finalize_arch_config(model_config: dict) -> dict:
+    """Complete ``model_config`` in place so it fully describes the architecture.
+
+    ``model_config`` is the single source of truth for architecture: it is what
+    ``build_model`` consumes at training time and what the trainer embeds in
+    every checkpoint. So anything ``build_model`` reads has to be written here
+    explicitly -- otherwise a later load re-derives it, and a re-derivation is
+    only ever as good as the guess behind it.
+
+    Call this once, after every architecture override has been applied and
+    before ``build_model``.
+
+    ``qass_mode`` is pinned before the attention-scale keys are defaulted. The
+    order does not change the outcome here, but it keeps this function honest:
+    the mode is derived from the config the caller actually assembled, never
+    from a value this function just invented.
+
+    ``SYNTHEFY_QASS_MODE`` is honoured here and *only* here: this is the single
+    point where the environment can influence the architecture, and it does so
+    by being written into ``model_config``. Everything downstream --
+    ``build_model`` and the ``QASSMaxScaling`` modules it constructs -- reads the
+    config, never the environment. So an override still works end to end, the
+    checkpoint records the mode the run actually trained with, and there is no
+    second channel that can disagree with the first.
+    """
+    if bool(model_config.get("use_qassmax", False)):
+        env_mode = os.environ.get("SYNTHEFY_QASS_MODE")
+        model_config["qass_mode"] = (
+            env_mode.strip().lower() if env_mode else resolve_qass_mode(model_config)
+        )
+    for key, default in _ATTENTION_SCALE_DEFAULTS.items():
+        model_config.setdefault(key, default)
+    return model_config
+
+
 def build_model(config:dict):
+    # Pre-``finalize_arch_config`` checkpoints omit these; fall back to the same
+    # table finalize stamps in, so old and new checkpoints agree.
+    attn_scale = {k: config.get(k, v) for k, v in _ATTENTION_SCALE_DEFAULTS.items()}
+    use_qassmax = bool(config.get('use_qassmax', False))
     model = FeaturesTransformer(
         preprocess_config_x=config['preprocess_config_x'],
         encoder_config_x=config['encoder_config_x'],
@@ -60,12 +138,15 @@ def build_model(config:dict):
         cross_share_all_kv_heads=config.get('cross_share_all_kv_heads', True),
         seq_attn_isolated=config.get('seq_attn_isolated', False),
         seq_attn_serial=config.get('seq_attn_serial', False),
-        use_qassmax=config.get('use_qassmax', False),
+        use_qassmax=use_qassmax,
+        # Resolved here, once, from this config — not read back out of the
+        # environment inside QASSMaxScaling.
+        qass_mode=resolve_qass_mode(config) if use_qassmax else None,
         use_target_aware_embedding=config.get('use_target_aware_embedding', False),
         use_column_specific_y_aware=config.get('use_column_specific_y_aware', False),
-        use_logn_attention=config.get('use_logn_attention', False),
-        use_learnable_attn_temperature=config.get('use_learnable_attn_temperature', False),
-        attn_n_ref=float(config.get('attn_n_ref', 1024.0)),
+        use_logn_attention=bool(attn_scale['use_logn_attention']),
+        use_learnable_attn_temperature=bool(attn_scale['use_learnable_attn_temperature']),
+        attn_n_ref=float(attn_scale['attn_n_ref']),
     )
     return model
 
@@ -87,7 +168,11 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
 
     # Support both pretrained (.ckpt) and training checkpoint (.pt) formats
     if 'model_config' in state_dict:
-        # Training checkpoint format (new): has architecture config embedded
+        # Training checkpoint format (new): has architecture config embedded.
+        # `model_config` is the architecture record -- read it and nothing else.
+        # `state_dict['config']` is the TrainingConfig (hyperparameters, no
+        # architecture); merging it in here would make the resolved QASS mode a
+        # function of the container format instead of the model.
         config = state_dict['model_config']
         weights = state_dict.get('ema_state_dict') or state_dict['model_state_dict']
     elif 'model_state_dict' in state_dict:
@@ -107,6 +192,9 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
         config = state_dict['config']
         weights = state_dict['state_dict']
 
+    # Copy before mutating: `config` is a dict embedded in the loaded checkpoint,
+    # and callers (e.g. the eval harness) reuse that object.
+    config = dict(config)
     config['mask_prediction'] = mask_prediction
 
     # Strip torch.compile "_orig_mod." prefix if present

--- a/tests/test_qass_mode.py
+++ b/tests/test_qass_mode.py
@@ -1,0 +1,317 @@
+"""Regression tests for QASS attention-mode handling.
+
+``QASSMaxScaling`` now has a ``qass_mode`` switch (full / base_only / log_only)
+and reads it from the architecture config. Two things must stay true, and both
+are silent failures if they don't:
+
+  * a checkpoint that records no mode keeps running "full" — that is what every
+    checkpoint this repo has produced actually trained, and its base/gate
+    weights are live;
+  * a checkpoint that *does* record a mode gets that mode, from its own config
+    and not from process-global state.
+"""
+
+import math
+
+import torch
+
+from synthefy_nori.model.layer import QASSMaxScaling
+from synthefy_nori.utils.loading import resolve_qass_mode
+
+
+def _poison(module: QASSMaxScaling) -> None:
+    """Make every learned QASS component non-trivial, so a mode that is supposed
+    to ignore them will visibly diverge if it doesn't."""
+    with torch.no_grad():
+        for p in module.parameters():
+            p.add_(0.5)
+
+
+def test_log_only_ignores_base_and_gate(monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "log_only")
+    m = QASSMaxScaling(num_heads=2, head_dim=4)
+    _poison(m)  # trained weights present, but log_only must ignore them
+    q = torch.randn(1, 5, 2, 4)
+    out = m(q, key_len=100)
+    expected = q * math.log(100.0)
+    assert torch.allclose(out, expected, atol=1e-5)
+
+
+def test_full_uses_gate(monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "full")
+    m = QASSMaxScaling(num_heads=2, head_dim=4)
+    _poison(m)
+    q = torch.randn(1, 5, 2, 4)
+    out = m(q, key_len=100)
+    # full mode applies base+gate, so it must differ from pure log(n) scaling
+    assert not torch.allclose(out, q * math.log(100.0), atol=1e-4)
+
+
+def test_base_only_ignores_gate(monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "base_only")
+    m = QASSMaxScaling(num_heads=2, head_dim=4)
+    _poison(m)
+    q = torch.randn(1, 5, 2, 4)
+    out = m(q, key_len=64)
+    log_n = math.log(64.0)
+    base_delta = m.base_mlp(torch.tensor([[log_n]])).view(1, 1, 2, 4)
+    base_scale = log_n * (1.0 + torch.tanh(base_delta))
+    assert torch.allclose(out, q * base_scale, atol=1e-5)
+
+
+def test_invalid_mode_raises(monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "bogus")
+    try:
+        QASSMaxScaling(num_heads=2, head_dim=4)
+    except ValueError as e:
+        assert "SYNTHEFY_QASS_MODE" in str(e)
+    else:
+        raise AssertionError("invalid qass_mode should raise ValueError")
+
+
+def test_explicit_qass_mode_beats_env(monkeypatch):
+    """A config-resolved mode must not be overridable by process-global state.
+
+    `build_model` resolves the mode from the architecture config and passes it
+    down explicitly. If the env could still win, a stray SYNTHEFY_QASS_MODE in
+    someone's shell would change what a checkpoint computes.
+    """
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "full")
+    m = QASSMaxScaling(num_heads=2, head_dim=4, qass_mode="log_only")
+    assert m.qass_mode == "log_only"
+    _poison(m)
+    q = torch.randn(1, 5, 2, 4)
+    assert torch.allclose(m(q, key_len=100), q * math.log(100.0), atol=1e-5)
+
+
+def test_qass_mode_falls_back_to_env_then_full(monkeypatch):
+    """Back-compat: no explicit mode -> env -> "full"."""
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "base_only")
+    assert QASSMaxScaling(num_heads=2, head_dim=4).qass_mode == "base_only"
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    assert QASSMaxScaling(num_heads=2, head_dim=4).qass_mode == "full"
+
+
+def _tiny_arch_config(**overrides) -> dict:
+    """A buildable 2-layer architecture config, from the bundled base."""
+    import json
+
+    from synthefy_nori.training.config import package_config_path
+
+    with open(package_config_path("model_base.json"), "r", encoding="utf-8") as f:
+        config = json.load(f)
+    config.update(nlayers=2, **overrides)
+    return config
+
+
+def _qass_modes(model) -> set:
+    return {m.qass_mode for m in model.modules()
+            if type(m).__name__ == "QASSMaxScaling"}
+
+
+def _build(config):
+    from synthefy_nori.utils.loading import build_model
+
+    return build_model(config)
+
+
+def test_built_model_mode_follows_config_not_env(monkeypatch):
+    """End-to-end: the built model's attention temperature comes from its own
+    config, whatever the environment says."""
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "full")
+    model = _build(_tiny_arch_config(use_qassmax=True, qass_mode="log_only"))
+    assert _qass_modes(model) == {"log_only"}
+
+
+def test_resolve_qass_mode_honors_explicit_and_otherwise_says_full():
+    # An explicit qass_mode is honored verbatim -- this is what the released
+    # Nori-30M carries, and what QASSMaxScaling used to ignore.
+    assert resolve_qass_mode({"use_qassmax": True, "qass_mode": "full"}) == "full"
+    assert resolve_qass_mode({"use_qassmax": True, "qass_mode": "log_only"}) == "log_only"
+
+    # No recorded mode -> "full". Every checkpoint this tree has produced ran
+    # the full base*gate path (QASSMaxScaling had no mode switch), so its
+    # base/gate weights are trained and must stay live. Resolving these to
+    # anything else would silently discard them.
+    assert resolve_qass_mode({"use_qassmax": True}) == "full"
+    assert resolve_qass_mode({"use_qassmax": True, "use_logn_attention": False}) == "full"
+
+
+def test_training_cli_checkpoints_keep_running_full():
+    """The exact shape the training CLI has always written must stay "full".
+
+    `cli.py` sets `use_qassmax = not --no-qassmax` (on by default) and never
+    writes `use_logn_attention`, so this is what every checkpoint trained from
+    this repo records. It trained "full"; it must keep loading as "full".
+    """
+    assert resolve_qass_mode({"use_qassmax": True, "nlayers": 12}) == "full"
+
+
+def test_no_qassmax_means_no_mode_is_passed(monkeypatch):
+    """use_qassmax=False builds no QASSMaxScaling, so no mode is resolved."""
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "log_only")
+    config = _tiny_arch_config(use_qassmax=False)
+    model = _build(config)
+    assert not [m for m in model.modules() if type(m).__name__ == "QASSMaxScaling"]
+
+
+# ---------------------------------------------------------------------------
+# One config. Architecture lives in `model_config` and nowhere else.
+#
+# A training `.pt` also stores `config` (the TrainingConfig). That object holds
+# hyperparameters, not architecture -- the trainer builds from `model_config`
+# alone -- so `load_model` must never read it for arch flags. It once looked
+# like a second, fuller record of the architecture; reading it made the resolved
+# QASS mode a function of which container the checkpoint sat in.
+#
+# Going forward `finalize_arch_config` pins every arch flag before training, so
+# the "full" fallback in `resolve_qass_mode` only ever sees older files.
+# ---------------------------------------------------------------------------
+
+def _resolved_mode_for(state_dict, monkeypatch, mask_prediction=False):
+    """Run load_model's config selection and return the QASS mode it resolves."""
+    from synthefy_nori.utils import loading
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    monkeypatch.setattr(loading, "_safe_torch_load", lambda _p: state_dict)
+    captured = {}
+
+    def fake_build_model(config):
+        captured["config"] = config
+        captured["mode"] = loading.resolve_qass_mode(config)
+        raise _StopBuild
+
+    monkeypatch.setattr(loading, "build_model", fake_build_model)
+    try:
+        loading.load_model("ignored.pt", mask_prediction=mask_prediction)
+    except _StopBuild:
+        pass
+    return captured.get("mode"), captured["config"]
+
+
+class _StopBuild(Exception):
+    """Abort load_model once build_model has seen the config."""
+
+
+# The shape the training CLI writes: QASSMax on, no recorded mode -> "full".
+_MODEL_CONFIG = {"use_qassmax": True, "nlayers": 2, "embed_dim": 8}
+
+
+def test_same_arch_config_resolves_the_same_in_both_containers(monkeypatch):
+    """The mode follows the architecture dict, not the container it sits in."""
+    arch = {**_MODEL_CONFIG, "qass_mode": "base_only"}
+    pt = {"model_config": dict(arch), "config": {}, "model_state_dict": {}}
+    ckpt = {"config": dict(arch), "state_dict": {}}
+
+    pt_mode, _ = _resolved_mode_for(pt, monkeypatch)
+    ckpt_mode, _ = _resolved_mode_for(ckpt, monkeypatch)
+
+    assert pt_mode == ckpt_mode == "base_only", (
+        f"container format changed the attention temperature: "
+        f".pt -> {pt_mode!r}, .ckpt -> {ckpt_mode!r}"
+    )
+
+
+def test_training_config_never_supplies_architecture(monkeypatch):
+    """A `.pt`'s TrainingConfig must not reach the architecture.
+
+    `TrainingConfig` used to declare `use_logn_attention: bool = False` and
+    `attn_n_ref: float = 1024.0` -- unread defaults, not a record of the run.
+    Letting them through would build the model from values nothing ever trained
+    with, and `attn_n_ref` in particular changes the attention scale.
+    """
+    pt = {
+        "model_config": dict(_MODEL_CONFIG),
+        "config": {"use_logn_attention": True, "attn_n_ref": 4096.0, "lr": 1e-4},
+        "model_state_dict": {},
+    }
+    mode, config = _resolved_mode_for(pt, monkeypatch)
+    assert mode == "full"
+    assert config.get("attn_n_ref") != 4096.0
+    assert config.get("use_logn_attention") is not True
+
+
+def test_load_model_does_not_mutate_the_checkpoint(monkeypatch):
+    """`mask_prediction` must not be written into the loaded checkpoint's dict."""
+    model_config = dict(_MODEL_CONFIG)
+    pt = {"model_config": model_config, "config": {}, "model_state_dict": {}}
+    _resolved_mode_for(pt, monkeypatch, mask_prediction=True)
+    assert "mask_prediction" not in model_config
+
+
+# ---------------------------------------------------------------------------
+# finalize_arch_config: the write side. Every new checkpoint lands in era 1.
+# ---------------------------------------------------------------------------
+
+def test_finalize_pins_the_mode_and_stamps_the_attention_scale(monkeypatch):
+    """Finalize records the mode the run will actually train with, and fills in
+    the attention-scale keys from the one shared defaults table."""
+    from synthefy_nori.utils.loading import finalize_arch_config
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    config = finalize_arch_config(dict(_MODEL_CONFIG))
+    assert config["qass_mode"] == "full"
+    assert config["use_logn_attention"] is False
+    assert config["attn_n_ref"] == 1024.0
+
+
+def test_finalized_config_round_trips_to_the_same_mode(monkeypatch):
+    """Reloading a finalized config reproduces the mode training used."""
+    from synthefy_nori.utils.loading import finalize_arch_config
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    config = finalize_arch_config(dict(_MODEL_CONFIG))
+    pt = {"model_config": config, "config": {}, "model_state_dict": {}}
+    mode, _ = _resolved_mode_for(pt, monkeypatch)
+    assert mode == "full"
+
+
+def test_finalize_records_the_env_override(monkeypatch):
+    """finalize is the ONE place the env can influence the architecture.
+
+    It does so by writing the override into `model_config`, which `build_model`
+    then reads — so the override still works end to end, and the checkpoint
+    records the mode the run actually trained with. Nothing downstream reads
+    the environment, so there is no second channel to disagree with this one.
+    """
+    from synthefy_nori.utils.loading import finalize_arch_config
+
+    monkeypatch.setenv("SYNTHEFY_QASS_MODE", "Full")
+    config = finalize_arch_config(dict(_MODEL_CONFIG))
+    assert config["qass_mode"] == "full"
+
+
+def test_finalize_keeps_an_explicit_mode(monkeypatch):
+    from synthefy_nori.utils.loading import finalize_arch_config
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    config = finalize_arch_config({**_MODEL_CONFIG, "qass_mode": "base_only"})
+    assert config["qass_mode"] == "base_only"
+
+
+def test_finalize_skips_qass_mode_without_qassmax(monkeypatch):
+    """No QASSMax means no mode to record -- don't invent one."""
+    from synthefy_nori.utils.loading import finalize_arch_config
+
+    monkeypatch.delenv("SYNTHEFY_QASS_MODE", raising=False)
+    config = finalize_arch_config({"use_qassmax": False, "nlayers": 2})
+    assert "qass_mode" not in config
+
+
+def test_training_config_has_no_architecture_fields():
+    """Guard the invariant: architecture belongs to model_config only."""
+    from synthefy_nori.training.config import TrainingConfig
+
+    fields = set(TrainingConfig.__dataclass_fields__)
+    leaked = fields & {
+        "use_logn_attention",
+        "attn_n_ref",
+        "use_learnable_attn_temperature",
+        "qass_mode",
+        "use_qassmax",
+    }
+    assert not leaked, (
+        f"architecture fields leaked back into TrainingConfig: {sorted(leaked)}. "
+        "They belong in model_config (see loading.finalize_arch_config)."
+    )


### PR DESCRIPTION
Promotes staging [#24](https://github.com/Synthefy/synthefy-nori-staging/pull/24), which
carried internal [#346](https://github.com/Synthefy/synthefy-nori-internal/pull/346) together
with its successor [#379](https://github.com/Synthefy/synthefy-nori-internal/pull/379).
Applied to `main` unchanged — `public` and `staging` were both at `a5074ad`, so the patch
cherry-picks byte-for-byte.

No version bump: this lands at 0.17.2 and rides along with the next release.

## One config

`model_config` is the single source of truth for architecture — it is what `build_model`
consumes and what the trainer embeds in every checkpoint. It was saved **incomplete**:
`build_model` read four flags that nothing ever wrote into it (`qass_mode`,
`use_logn_attention`, `use_learnable_attn_temperature`, `attn_n_ref`), so a checkpoint
recorded less than the model it described and every load had to re-derive the difference.

**Write side** — `finalize_arch_config(model_config)`, called in `cli.py` after every
architecture override and before `build_model`. New checkpoints record the mode and the
attention-scale flags the run actually trained with.

**Read side** — `QASSMaxScaling` gains the `qass_mode` switch (`full` / `base_only` /
`log_only`) and takes it as an argument. `build_model` resolves it from the architecture
config once and passes it down, so a model's attention temperature is a function of its own
config. `SYNTHEFY_QASS_MODE` is honoured in `finalize_arch_config` and nowhere else —
process-global state should not decide what a checkpoint computes.

**No drift** — `_ATTENTION_SCALE_DEFAULTS` is one table that finalize stamps in and
`build_model` falls back to, so the value a run trains with and the value a later load
assumes cannot diverge.

**Cleanup** — three vestigial `TrainingConfig` fields are gone. They were never read: no CLI
flag set them, and the trainer builds from `model_config`, not the dataclass.

**Bug fixed along the way** — `load_model` did `config['mask_prediction'] = ...` on the dict
embedded in the loaded checkpoint. Copied first now.

## An unrecorded mode means `full` here

An explicit `qass_mode` is honoured verbatim; anything else resolves to `full`.

This matters for OSS users' own checkpoints. `cli.py` sets
`model_config['use_qassmax'] = not args.no_qassmax` — on by default — and nothing ever
writes `use_logn_attention` into `model_config`. So every checkpoint this repo's training CLI
has produced records neither key. Those runs trained the full `base * gate` path, because
`QASSMaxScaling` had no mode switch until now, and their `base_mlp`/`gate_mlp` weights are
live. Resolving them to anything but `full` would silently discard those weights and apply
the wrong attention temperature.

Internal resolves this same shape through a three-era table whose era 3 means `log_only`.
That table records *internal's* early-V13 training history and is deliberately **not**
promoted — it has no meaning in a tree that never ran those eras.

## Existing checkpoints: measured, not assumed

Same input, same seed, released weights, `main` vs this branch:

| checkpoint | `qass_mode` in config | resolves | `sha256(predictions)` |
|---|---|---|---|
| `Synthefy/Nori` (6M) — **`main` (a5074ad)** | absent | *(no mode switch)* | `877fec6d609a1bd0dfb1fae9e7f9661a5c23e6528d5ac373c042b86fc19a85eb` |
| `Synthefy/Nori` (6M) — **this branch** | absent | `full` | `877fec6d609a1bd0dfb1fae9e7f9661a5c23e6528d5ac373c042b86fc19a85eb` |

Bit-for-bit identical across all 32 `QASSMaxScaling` modules.

And the variant that already records a mode this tree was ignoring:

| checkpoint | `use_qassmax` | `qass_mode` | `use_logn_attention` | resolves |
|---|---|---|---|---|
| `Synthefy/Nori` (6M) | `True` | absent | `False` | `full` |
| `Synthefy/Nori-30M` | `True` | `'full'` | absent | `full` |

`Nori-30M` has carried `qass_mode: "full"` all along; this is the change that starts
honouring it rather than ignoring it.

## Tests

19 tests in `tests/test_qass_mode.py` covering both sides: mode semantics (`log_only`
ignores base+gate, `base_only` ignores gate, invalid mode raises), an explicit mode beating
the environment, the built model's mode following its config, `TrainingConfig` never
supplying architecture, `load_model` not mutating the checkpoint, finalize pinning and
round-tripping, and a guard that architecture fields cannot creep back into `TrainingConfig`.

The one that pins this PR's central claim:

```python
def test_training_cli_checkpoints_keep_running_full():
    """`cli.py` sets use_qassmax on by default and never writes
    use_logn_attention, so this is what every checkpoint trained from this
    repo records. It trained "full"; it must keep loading as "full"."""
    assert resolve_qass_mode({"use_qassmax": True, "nlayers": 12}) == "full"
```

```
377 passed, 6 skipped, 53 deselected
ruff check src scripts tests -> All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
