### PR TITLE
chore: release synthefy-nori 0.17.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.0.0';
-          assert synthefy_nori.__version__ == '0.17.2'"
+          assert synthefy_nori.__version__ == '0.17.3'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/.github/workflows/publish-synthefy-nori.yml
+++ b/.github/workflows/publish-synthefy-nori.yml
@@ -11,7 +11,7 @@ on:
         type: choice
         options: [synthefy-nori]
       version:
-        description: "Exact package version, for example 0.17.2"
+        description: "Exact package version, for example 0.17.3"
         required: true
         type: string
       target:
@@ -21,7 +21,7 @@ on:
         type: choice
         options: [testpypi, pypi]
       tag:
-        description: "Exact existing tag, for example synthefy-nori-v0.17.2"
+        description: "Exact existing tag, for example synthefy-nori-v0.17.3"
         required: true
         type: string
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,7 +28,7 @@ Publish the lightweight SDK first. The heavy package declares
 create an unresolvable release.
 
 1. Publish and verify `synthefy 7.0.0` (or the selected fix-forward version).
-2. Publish and verify `synthefy-nori 0.17.2`.
+2. Publish and verify `synthefy-nori 0.17.3`.
 3. Merge customer documentation only after both documented install commands
    resolve from PyPI.
 
@@ -85,11 +85,11 @@ gh workflow run publish-synthefy.yml \\
 
 gh workflow run publish-synthefy-nori.yml \\
   --repo Synthefy/synthefy-nori \\
-  --ref synthefy-nori-v0.17.2 \\
+  --ref synthefy-nori-v0.17.3 \\
   -f distribution=synthefy-nori \\
-  -f version=0.17.2 \\
+  -f version=0.17.3 \\
   -f target=testpypi \\
-  -f tag=synthefy-nori-v0.17.2
+  -f tag=synthefy-nori-v0.17.3
 ```
 
 A branch ref, mismatched tag/version, wrong distribution, or tag not contained in
@@ -135,14 +135,14 @@ uv pip check --python /tmp/synthefy-release-check/bin/python
 Only after that succeeds, create the heavy release:
 
 ```bash
-gh release create synthefy-nori-v0.17.2 \\
+gh release create synthefy-nori-v0.17.3 \\
   --repo Synthefy/synthefy-nori \\
   --target main \\
-  --title "synthefy-nori 0.17.2" \\
+  --title "synthefy-nori 0.17.3" \\
   --generate-notes
 ```
 
-Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.2` resolves
+Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.3` resolves
 `synthefy>=7,<8` and that local regression plus
 `synthefy-nori[forecasting]` work in clean environments.
 
@@ -197,7 +197,7 @@ credentials and delete them after testing.
 ## Failure and rollback
 
 PyPI artifacts are immutable. If `synthefy 7.0.0` fails verification, do not
-publish `synthefy-nori 0.17.2`; fix forward with `7.0.1`. If the heavy package
-fails after publication, fix forward with `0.17.3`. Never reuse a version or
+publish `synthefy-nori 0.17.3`; fix forward with `7.0.1`. If the heavy package
+fails after publication, fix forward with `0.17.4`. Never reuse a version or
 re-enable the old publisher. Existing `synthefy 6.3.0` and
 `synthefy-nori 0.16.0` remain installable during validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.17.2"
+version = "0.17.3"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -19,7 +19,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,7 +98,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.17.2"
+    assert root["project"]["version"] == "0.17.3"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -5516,7 +5516,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.17.2"
+version = "0.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary

- bump `synthefy-nori` from 0.17.2 to 0.17.3 so the QASS config fix from #115 reaches PyPI immediately
- keep project metadata, module version, lockfile, CI assertions, publisher examples, and release instructions aligned
- record 0.17.4 as the next immutable-PyPI fix-forward version

No checkpoint, `synthefy` SDK, gateway, pricing, or entitlement changes.

## Validation

- `uv run pytest` — 377 passed, 6 skipped, 53 deselected
- `uv run ruff check src scripts tests` — passed
- `uv build --package synthefy-nori --no-sources` — built 0.17.3 sdist and wheel
- `twine check --strict` — both artifacts passed
- clean CPU wheel install + `uv pip check` — resolved `synthefy==7.0.0` and imported `synthefy-nori==0.17.3`