### PR TITLE
ci: remove Nori TestPyPI publisher

### DIFF
--- a/.github/workflows/publish-synthefy-nori.yml
+++ b/.github/workflows/publish-synthefy-nori.yml
@@ -17,9 +17,9 @@ on:
       target:
         description: "Package index"
         required: true
-        default: testpypi
+        default: pypi
         type: choice
-        options: [testpypi, pypi]
+        options: [pypi]
       tag:
         description: "Exact existing tag, for example synthefy-nori-v0.17.3"
         required: true
@@ -149,28 +149,6 @@ jobs:
           name: ${{ steps.coordinates.outputs.artifact }}
           path: dist/synthefy-nori/
           if-no-files-found: error
-
-  publish-testpypi:
-    name: Publish synthefy-nori to TestPyPI
-    needs: build
-    if: >-
-      needs.build.outputs.target == 'testpypi' &&
-      github.repository == 'Synthefy/synthefy-nori'
-    runs-on: ubuntu-latest
-    environment:
-      name: synthefy-nori-testpypi
-      url: https://test.pypi.org/project/synthefy-nori/${{ needs.build.outputs.version }}/
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: ${{ needs.build.outputs.artifact }}
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
     name: Publish synthefy-nori to PyPI

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,10 +69,11 @@ The workflows verify tag, project metadata, module `__version__`, and built whee
 metadata agree. They also require the peeled tag commit to be an ancestor of
 public `main`, so a tag from an unpromoted branch cannot publish.
 
-## Rehearse on TestPyPI
+## Rehearse the lightweight SDK on TestPyPI
 
-Manual dispatch is deliberately tag-bound. Supply distribution, version, target,
-and tag explicitly, and select that same existing tag as the workflow ref:
+The lightweight `synthefy` SDK retains a TestPyPI rehearsal path. Manual
+dispatch is deliberately tag-bound: supply distribution, version, target, and
+tag explicitly, and select that same existing tag as the workflow ref:
 
 ```bash
 gh workflow run publish-synthefy.yml \\
@@ -82,19 +83,13 @@ gh workflow run publish-synthefy.yml \\
   -f version=7.0.0 \\
   -f target=testpypi \\
   -f tag=synthefy-v7.0.0
-
-gh workflow run publish-synthefy-nori.yml \\
-  --repo Synthefy/synthefy-nori \\
-  --ref synthefy-nori-v0.17.3 \\
-  -f distribution=synthefy-nori \\
-  -f version=0.17.3 \\
-  -f target=testpypi \\
-  -f tag=synthefy-nori-v0.17.3
 ```
 
 A branch ref, mismatched tag/version, wrong distribution, or tag not contained in
-public `main` fails before building. TestPyPI uploads use distinct environments
-and trusted-publisher identities from production.
+public `main` fails before building. The SDK TestPyPI upload uses a distinct
+environment and trusted-publisher identity from production. `synthefy-nori`
+publishes only to production PyPI; its workflow still performs the same strict
+artifact metadata and clean-install validation before the protected upload.
 
 Before production, rehearse three clean environments:
 
@@ -104,9 +99,9 @@ Before production, rehearse three clean environments:
 
 The mixed released-heavy/candidate-light environment must either pass its
 supported smoke test or fail immediately with explicit version guidance. These
-candidate-wheel rehearsals do not depend on either package index. Because the
-heavy wheel resolves `synthefy>=7,<8`, dispatch its TestPyPI publisher only after
-the selected lightweight SDK version has been verified on PyPI.
+candidate-wheel rehearsals do not depend on either package index. The heavy
+wheel resolves `synthefy>=7,<8`, so publish it only after the selected
+lightweight SDK version has been verified on PyPI.
 
 ## Publish to PyPI
 
@@ -147,8 +142,8 @@ Approve `synthefy-nori-pypi`, then verify `synthefy-nori==0.17.3` resolves
 `synthefy-nori[forecasting]` work in clean environments.
 
 Each workflow builds only its own project root, runs strict metadata checks,
-clean-installs the wheel, and runs `uv pip check` before upload. Every TestPyPI
-and PyPI upload job is additionally gated by:
+clean-installs the wheel, and runs `uv pip check` before upload. Every package
+index upload job is additionally gated by:
 
 ```text
 github.repository == 'Synthefy/synthefy-nori'
@@ -158,14 +153,13 @@ That makes the same workflow files safe to validate in internal and staging.
 
 ## Trusted-publisher setup
 
-Create four exact workflow/environment pairs in both GitHub and the matching
+Create three exact workflow/environment pairs in both GitHub and the matching
 package index:
 
 | Package | Index | Workflow | GitHub environment |
 |---|---|---|---|
 | `synthefy` | TestPyPI | `publish-synthefy.yml` | `synthefy-testpypi` |
 | `synthefy` | PyPI | `publish-synthefy.yml` | `synthefy-pypi` |
-| `synthefy-nori` | TestPyPI | `publish-synthefy-nori.yml` | `synthefy-nori-testpypi` |
 | `synthefy-nori` | PyPI | `publish-synthefy-nori.yml` | `synthefy-nori-pypi` |
 
 Require reviewers on both production environments. At cutover, revoke the

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -16,6 +16,8 @@ _SPECS = {
         "tag_prefix": "synthefy-v",
         "project_root": "libs/synthefy",
         "build": "uv build --package synthefy --no-sources",
+        "targets": ["testpypi", "pypi"],
+        "publish_jobs": {"publish-testpypi", "publish-pypi"},
         "environments": {"synthefy-testpypi", "synthefy-pypi"},
     },
     "synthefy-nori": {
@@ -23,10 +25,9 @@ _SPECS = {
         "tag_prefix": "synthefy-nori-v",
         "project_root": ".",
         "build": "uv build --package synthefy-nori --no-sources",
-        "environments": {
-            "synthefy-nori-testpypi",
-            "synthefy-nori-pypi",
-        },
+        "targets": ["pypi"],
+        "publish_jobs": {"publish-pypi"},
+        "environments": {"synthefy-nori-pypi"},
     },
 }
 
@@ -63,7 +64,7 @@ def test_generic_publisher_is_removed_and_namespaced_publishers_are_complete():
         assert inputs["distribution"]["options"] == [distribution]
         assert inputs["version"]["required"] == "true"
         assert inputs["tag"]["required"] == "true"
-        assert inputs["target"]["options"] == ["testpypi", "pypi"]
+        assert inputs["target"]["options"] == spec["targets"]
 
         build = workflow["jobs"]["build"]
         assert spec["tag_prefix"] in build["if"]
@@ -83,6 +84,8 @@ def test_generic_publisher_is_removed_and_namespaced_publishers_are_complete():
         assert "releases/latest" not in body
         assert "latest release" not in body
         assert "secrets." not in body
+        if "testpypi" not in spec["targets"]:
+            assert "testpypi" not in body
 
 
 def test_only_public_namespaced_jobs_can_publish_with_oidc():
@@ -102,7 +105,7 @@ def test_only_public_namespaced_jobs_can_publish_with_oidc():
             for name, job in workflow["jobs"].items()
             if name.startswith("publish-")
         }
-        assert set(publish_jobs) == {"publish-testpypi", "publish-pypi"}
+        assert set(publish_jobs) == spec["publish_jobs"]
         assert build.get("permissions") is None
 
         for job in publish_jobs.values():
@@ -125,7 +128,9 @@ def test_only_public_namespaced_jobs_can_publish_with_oidc():
             if name not in publish_jobs:
                 assert job.get("permissions", {}).get("id-token") != "write"
 
-    assert len(environments) == 4
+    assert environments == set().union(
+        *(spec["environments"] for spec in _SPECS.values())
+    )
     assert len(artifact_names) == 2
 
 


### PR DESCRIPTION
## Summary

- delete the `synthefy-nori` TestPyPI publishing job
- restrict manual Nori publisher dispatches to production PyPI
- update release-workflow guards and release documentation accordingly
- leave the separate lightweight `synthefy` SDK TestPyPI rehearsal unchanged

The production `synthefy-nori-pypi` OIDC publisher, protected environment, tag validation, artifact checks, and clean-install gate are unchanged.

## Validation

- `uv run pytest` — 377 passed, 6 skipped, 53 deselected
- `uv run ruff check src scripts tests` — passed
- `uv build --package synthefy-nori --no-sources` — passed