### PR TITLE
Release dataframe forecasting client in synthefy 7.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.0.0';
+          assert synthefy.__version__ == '7.0.1';
           assert synthefy_nori.__version__ == '0.17.3'"
       - run: uv run pytest
       - run: >-
@@ -38,13 +38,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.0-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.1-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.0.0.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.0.1.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.0-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.1-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.0"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.1"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \
@@ -106,7 +106,8 @@ jobs:
             -c "$GITHUB_WORKSPACE/libs/synthefy/pytest.ini" \
             "$GITHUB_WORKSPACE/libs/synthefy/tests/test_tsfeatures.py" \
             "$GITHUB_WORKSPACE/tests/test_nori_ts_parity.py" \
-            "$GITHUB_WORKSPACE/tests/test_nori_ts_backend.py"
+            "$GITHUB_WORKSPACE/tests/test_nori_ts_backend.py" \
+            "$GITHUB_WORKSPACE/libs/synthefy/tests/test_nori_ts_contract.py"
   distribution-boundaries:
     name: CI validate distribution boundaries
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-synthefy.yml
+++ b/.github/workflows/publish-synthefy.yml
@@ -11,7 +11,7 @@ on:
         type: choice
         options: [synthefy]
       version:
-        description: "Exact package version, for example 7.0.0"
+        description: "Exact package version, for example 7.0.1"
         required: true
         type: string
       target:
@@ -21,7 +21,7 @@ on:
         type: choice
         options: [testpypi, pypi]
       tag:
-        description: "Exact existing tag, for example synthefy-v7.0.0"
+        description: "Exact existing tag, for example synthefy-v7.0.1"
         required: true
         type: string
 

--- a/docs/architecture/0003-release-pr-404-dataframe-forecasting.md
+++ b/docs/architecture/0003-release-pr-404-dataframe-forecasting.md
@@ -1,0 +1,33 @@
+# Release PR 404 dataframe forecasting through the public client
+
+Status: accepted for PR 404 release preparation
+
+Implementation: https://github.com/Synthefy/synthefy-nori-internal/pull/404
+
+## Decision
+
+Release the DataFrame forecasting additions in the lightweight `synthefy`
+distribution as version 7.0.1. Version 7.0.0 is already immutable on PyPI.
+
+`NoriTSForecaster` owns time-series validation, feature generation, and forecast
+reconstruction. It accepts a configured `SynthefyNoriClient`, and every prepared
+series executes through that client's existing `predict` contract. Do not add a
+second `predict_df` implementation to `SynthefyNoriClient`; the client continues
+to own backend transport while the forecaster owns workflow orchestration.
+
+The public package README and changelog must show `future_df=`,
+`target_column=`, and injected-client usage. Contract coverage must instantiate
+the real public client and prove that the DataFrame workflow reaches its
+`predict` method. `target_column=` selects one target per call; reject sequences
+with an explicit unsupported-multiple-targets error until the workflow owns a
+deliberate multi-target orchestration contract.
+
+## Release scope
+
+This is an L1 lightweight-client release. The feature performs horizon and
+covariate preparation locally and reuses the existing regression request and
+response contract, so it requires no Baseten deployment, gateway binding,
+billing, key-management, model-weight, or heavy-package change.
+
+Promote the identical patch from internal to staging to public. Only the public
+repository may create `synthefy-v7.0.1` or publish the package.

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,7 +5,32 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.0] - Unreleased
+## [7.0.1] - Unreleased
+
+### Added
+
+- Added `future_df=` to `NoriTSForecaster.predict_df` for explicit forecast
+  horizons with numeric known-future covariates, such as planned promotions,
+  holidays, weather, or scheduled prices. The horizon must contain exactly the
+  same series and covariates as history, and future target values are rejected
+  to prevent leakage.
+- Added `target_column=` to the same DataFrame workflow so callers can preserve
+  domain names such as `sales` instead of renaming the target to `target`.
+  It accepts one target column per call and clearly rejects multiple targets.
+  Forecasts continue to execute through the configured
+  `SynthefyNoriClient`, including remote, SageMaker, and local modes.
+- Added `reuse_context_cache` to the public `MemoryPolicy` mirror, keeping the
+  lightweight client aligned with the `synthefy-nori 0.17.3` hosted and local
+  contract and allowing retained context reuse to be disabled explicitly.
+
+### Changed
+
+- `predict_df` now accepts exactly one of `prediction_length=` or `future_df=`.
+  The existing generated-horizon behavior remains available through
+  `prediction_length=`.
+
+
+## [7.0.0] - 2026-08-12
 
 ### Removed
 

--- a/libs/synthefy/README.md
+++ b/libs/synthefy/README.md
@@ -50,6 +50,57 @@ pip install "synthefy[text]"
 pip install "synthefy[aws]"
 ```
 
+## Nori — DataFrame Forecasting
+
+`NoriTSForecaster` turns time-series DataFrames into regression requests and
+runs every request through a configured `SynthefyNoriClient`. That keeps the
+forecasting workflow identical across hosted Baseten, SageMaker, and local
+execution.
+
+Use `future_df=` when the forecast horizon includes values known in advance.
+The target may use a domain-specific name such as `sales`:
+
+```python
+import os
+
+import pandas as pd
+
+from synthefy import SynthefyNoriClient
+from synthefy.nori_ts import NoriTSForecaster
+
+history = pd.DataFrame({
+    "timestamp": pd.date_range("2026-01-01", periods=48, freq="h"),
+    "sales": [100.0 + hour for hour in range(48)],
+    "promotion": [0.0] * 48,
+})
+future = pd.DataFrame({
+    "timestamp": pd.date_range("2026-01-03", periods=12, freq="h"),
+    "promotion": [0.0] * 6 + [1.0] * 6,
+})
+
+client = SynthefyNoriClient(
+    mode="remote",
+    model="nori-6m",
+    api_key=os.environ["SYNTHEFY_NORI_API_KEY"],
+)
+forecaster = NoriTSForecaster(
+    client=client,
+    quantiles=[0.1, 0.5, 0.9],
+)
+forecast = forecaster.predict_df(
+    history,
+    future_df=future,
+    target_column="sales",
+)
+```
+
+`future_df` must contain future timestamps and every numeric covariate used in
+history. Its target must be absent or entirely missing; observed future targets
+would leak the answer. When there are no future covariates, pass
+`prediction_length=` instead and the forecaster generates the horizon.
+`target_column` accepts one column name per call; multiple target columns are
+not supported yet.
+
 ## Nori — Tabular In-Context Regression
 
 `SynthefyNoriClient` is the lightweight client for **Synthefy Nori**, an

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.0.0"
+version = "7.0.1"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -10,7 +10,7 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 
 __all__ = [
     "MEMORY_PRESETS",

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -61,7 +61,7 @@ class MemoryPolicy(BaseModel):
     fields are rejected here rather than silently dropped, matching the server.
 
     Note that ``NoriPredictRequest.memory_policy`` is deliberately NOT typed as this class.
-    Pydantic would coerce a caller's partial dict into a full instance and send all twelve
+    Pydantic would coerce a caller's partial dict into a full instance and send all thirteen
     fields — semantically identical today, but it would make the CLIENT pin the server's
     defaults, so a later change to a default would be silently overridden by every older
     client. Only the fields you actually set go on the wire; the server applies its own
@@ -77,6 +77,17 @@ class MemoryPolicy(BaseModel):
             "whole context for every batch of query rows instead: correct, but several "
             "times slower on a large query set, and it may have to drop context rows to "
             "fit. "
+        ),
+    )
+
+    reuse_context_cache: bool = Field(
+        True,
+        description=(
+            "Retain and reuse the encoded context across separate predict() calls "
+            "on this estimator when the context and cache parameters are exactly "
+            "unchanged. False still uses the K/V cache within each prediction, but "
+            "does not retain context-derived state afterwards. Shared serving "
+            "processes force this off; local fit-once/predict-many use keeps it on."
         ),
     )
 

--- a/libs/synthefy/src/synthefy/nori_ts/core.py
+++ b/libs/synthefy/src/synthefy/nori_ts/core.py
@@ -250,28 +250,189 @@ class NoriTSForecaster:
     def predict_df(
         self,
         context_df: pd.DataFrame,
-        prediction_length: int,
+        prediction_length: Optional[int] = None,
+        future_df: Optional[pd.DataFrame] = None,
+        target_column: str = _TARGET,
         *,
         freq=None,
     ) -> pd.DataFrame:
-        """Forecast from a plain DataFrame.
+        """Forecast from plain DataFrames — the high-level, TabPFN-TS-style entry point.
 
-        `context_df` needs columns `timestamp`, `target`, and optionally
-        `item_id` (defaults to a single series with id 0). Returns a plain
-        DataFrame indexed by (item_id, timestamp) with `target` + quantile cols.
-        Pass ``freq=`` when the history is gappy and its cadence cannot be
-        inferred reliably (for example, ``freq="h"`` for hourly data).
+        Pass **exactly one** of:
+
+        * ``prediction_length`` — forecast this many steps past the end of history,
+          extrapolating the calendar (no future covariates), or
+        * ``future_df`` — an explicit horizon frame carrying the future timestamps
+          (and any known-future covariates). Its target must be absent or all-NaN.
+
+        Parameters
+        ----------
+        context_df : DataFrame
+            History. Needs a ``timestamp`` column and the target column; ``item_id``
+            is optional (defaults to a single series with id ``0``). Extra **numeric**
+            columns are treated as covariates.
+        prediction_length : int, optional
+            Horizon length. Mutually exclusive with ``future_df``.
+        future_df : DataFrame, optional
+            Explicit horizon: one row per future ``(item_id, timestamp)``, plus any
+            known-future covariates. Its ``item_id`` set must match history exactly,
+            and every numeric covariate used in history must be present here. Mutually
+            exclusive with ``prediction_length``. Rows are ordered by item and
+            timestamp before feature generation, and every horizon timestamp must
+            follow that item's history.
+        target_column : str, default "target"
+            Name of the single target column in ``context_df``. Multiple target
+            columns are not supported. The selected column is normalised to
+            ``"target"`` internally and restored under its original name in the
+            output.
+        freq : optional
+            Explicit frequency used with ``prediction_length`` when the history cadence
+            cannot be inferred (for example, ``freq="h"``).
+
+        Returns
+        -------
+        DataFrame indexed by ``(item_id, timestamp)`` with the point forecast under
+        ``target_column`` and one column per quantile level (``"0.1"`` … ``"0.9"``).
         """
-        df = context_df.copy()
-        if "item_id" not in df.columns:
-            df["item_id"] = 0
-        train_tsdf = TimeSeriesDataFrame.from_data_frame(df)
-        if self.context_length and self.context_length > 0:
-            train_tsdf = train_tsdf.slice_by_timestep(-self.context_length, None)
-        test_tsdf = generate_test_X(
-            train_tsdf,
-            prediction_length=prediction_length,
-            freq=freq,
+        train_tsdf, test_tsdf = self._build_forecast_frames(
+            context_df, prediction_length, future_df, target_column, freq=freq
         )
         pred = self.predict(train_tsdf, test_tsdf)
-        return pd.DataFrame(pred)
+        out = pd.DataFrame(pred)
+        if target_column != _TARGET:  # restore the caller's target name
+            out = out.rename(columns={_TARGET: target_column})
+        return out
+
+    def _build_forecast_frames(
+        self,
+        context_df: pd.DataFrame,
+        prediction_length: Optional[int],
+        future_df: Optional[pd.DataFrame],
+        target_column: str,
+        *,
+        freq=None,
+    ):
+        """Validate inputs and build (train_tsdf, test_tsdf) for :meth:`predict`.
+
+        Kept separate from ``predict_df`` so the whole DataFrame contract — the
+        one-of check, target normalisation, no-leakage guard and covariate
+        selection — is unit-testable without a checkpoint. Returns two
+        ``TimeSeriesDataFrame``s whose target is named ``"target"`` and which carry
+        an identical set of used covariates.
+        """
+        if not isinstance(target_column, str):
+            raise ValueError(
+                "`target_column` must be one column name; multiple target columns "
+                "are not supported yet"
+            )
+        if (prediction_length is None) == (future_df is None):
+            raise ValueError(
+                "provide exactly one of `prediction_length` or `future_df` "
+                "(got both or neither)"
+            )
+
+        history = context_df.copy()
+        if "timestamp" not in history.columns:
+            raise ValueError("`context_df` must have a `timestamp` column")
+        if target_column not in history.columns:
+            raise ValueError(
+                f"target column {target_column!r} not found in `context_df` "
+                f"(columns: {list(history.columns)})"
+            )
+        if "item_id" not in history.columns:
+            history["item_id"] = 0
+        history["timestamp"] = pd.to_datetime(history["timestamp"])
+        history = history.sort_values(["item_id", "timestamp"], kind="stable")
+
+        # Normalise the target name to the internal "target" the rest of the
+        # pipeline expects. Guard the corner case where a *different* column is
+        # already literally called "target" (it would be silently clobbered).
+        if target_column != _TARGET:
+            if _TARGET in history.columns:
+                raise ValueError(
+                    f"`context_df` already has a {_TARGET!r} column while "
+                    f"target_column={target_column!r}; rename it to avoid a collision"
+                )
+            history = history.rename(columns={target_column: _TARGET})
+        if history[_TARGET].isna().any():
+            raise ValueError("the history target has missing values; fill or drop them first")
+
+        reserved = {"item_id", "timestamp", _TARGET}
+        # Covariates are the numeric non-reserved history columns; non-numeric extras
+        # (labels, strings) are ignored rather than fed to the regressor.
+        hist_cov = [c for c in history.columns
+                    if c not in reserved and pd.api.types.is_numeric_dtype(history[c])]
+
+        if future_df is not None:
+            future = future_df.copy()
+            if "timestamp" not in future.columns:
+                raise ValueError("`future_df` must have a `timestamp` column")
+            if len(future) == 0:
+                raise ValueError("`future_df` is empty; nothing to forecast")
+            if "item_id" not in future.columns:
+                future["item_id"] = 0
+            future["timestamp"] = pd.to_datetime(future["timestamp"])
+            if future.duplicated(["item_id", "timestamp"]).any():
+                raise ValueError(
+                    "`future_df` must contain at most one row per "
+                    "(`item_id`, `timestamp`)"
+                )
+            # No leakage: a target in the horizon must be absent or entirely NaN.
+            for tcol in {target_column, _TARGET} & set(future.columns):
+                if not future[tcol].isna().all():
+                    raise ValueError(
+                        f"`future_df` column {tcol!r} carries target values; the "
+                        "horizon target must be absent or all-NaN (no leakage)"
+                    )
+            future = future.drop(columns=[c for c in {target_column, _TARGET} if c in future.columns])
+            # item_ids must line up exactly with history.
+            h_ids, f_ids = set(history["item_id"]), set(future["item_id"])
+            if h_ids != f_ids:
+                raise ValueError(
+                    f"`future_df` item_ids {sorted(f_ids)} do not match "
+                    f"history item_ids {sorted(h_ids)}"
+                )
+            history_end = history.groupby("item_id", sort=False)["timestamp"].max()
+            future_start = future.groupby("item_id", sort=False)["timestamp"].min()
+            overlapping = [
+                item_id
+                for item_id in history_end.index
+                if future_start.loc[item_id] <= history_end.loc[item_id]
+            ]
+            if overlapping:
+                raise ValueError(
+                    "every `future_df` timestamp must be later than its item's "
+                    f"history (violations for item_ids {overlapping[:5]})"
+                )
+            future = future.sort_values(["item_id", "timestamp"], kind="stable")
+            # Every numeric covariate used in history must be supplied (and numeric)
+            # for the whole horizon; use exactly that shared set.
+            used_cov = []
+            for c in hist_cov:
+                if c not in future.columns:
+                    raise ValueError(
+                        f"covariate {c!r} is in history but missing from `future_df`; "
+                        "known-future covariates must be supplied across the whole horizon"
+                    )
+                if not pd.api.types.is_numeric_dtype(future[c]):
+                    raise ValueError(f"covariate {c!r} in `future_df` is not numeric")
+                used_cov.append(c)
+            future[_TARGET] = np.nan
+            test_df = future[["item_id", "timestamp", _TARGET] + used_cov]
+            test_tsdf = TimeSeriesDataFrame.from_data_frame(test_df)
+        else:
+            if not isinstance(prediction_length, (int, np.integer)) or prediction_length <= 0:
+                raise ValueError(
+                    f"`prediction_length` must be a positive integer, got {prediction_length!r}"
+                )
+            used_cov = []  # no way to know future covariates without an explicit horizon
+            test_tsdf = None  # built from the (capped) history below
+
+        # History carries only the target + the covariates we'll actually use.
+        train_df = history[["item_id", "timestamp", _TARGET] + used_cov]
+        train_tsdf = TimeSeriesDataFrame.from_data_frame(train_df)
+        if self.context_length and self.context_length > 0:
+            train_tsdf = train_tsdf.slice_by_timestep(-self.context_length, None)
+        if test_tsdf is None:
+            test_tsdf = generate_test_X(train_tsdf, prediction_length=prediction_length, freq=freq)
+        return train_tsdf, test_tsdf

--- a/libs/synthefy/tests/test_nori_data_models.py
+++ b/libs/synthefy/tests/test_nori_data_models.py
@@ -83,7 +83,8 @@ def test_the_report_keeps_fields_this_version_does_not_know():
 
 def test_defaults_match_the_documented_behaviour():
     policy = MemoryPolicy()
-    assert policy.cache is True and policy.cache_dtype == "bf16"
+    assert policy.cache is True and policy.reuse_context_cache is True
+    assert policy.cache_dtype == "bf16"
     assert policy.allow_quantization is True and policy.offload_to_host is True
     assert policy.gpu_budget_frac == 0.4 and policy.host_budget_frac == 0.25
     assert policy.allow_subsample is True

--- a/libs/synthefy/tests/test_nori_ts_contract.py
+++ b/libs/synthefy/tests/test_nori_ts_contract.py
@@ -1,0 +1,281 @@
+"""Model-free contract tests for the canonical Nori forecasting facade."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+pytest.importorskip("datasets")
+pytest.importorskip("gluonts")
+pytest.importorskip("joblib")
+pytest.importorskip("scipy")
+pytest.importorskip("statsmodels")
+
+from synthefy import SynthefyNoriClient
+from synthefy.nori_ts import NoriTSForecaster
+from synthefy.nori_ts.core import _TARGET
+from synthefy.nori_ts.tsfeatures import RunningIndexFeature
+
+
+class _FakeClient:
+    mode = "remote"
+    model = "nori-6m"
+
+    def __init__(self):
+        self.calls = []
+
+    def predict(self, X_train, y_train, X_test, **kwargs):
+        self.calls.append(
+            {
+                "X_train": np.asarray(X_train).copy(),
+                "y_train": np.asarray(y_train).copy(),
+                "X_test": np.asarray(X_test).copy(),
+                **kwargs,
+            }
+        )
+        return np.zeros((len(kwargs["quantiles"]), len(X_test)), dtype=float)
+
+
+def _forecaster(**kwargs):
+    return NoriTSForecaster(client=_FakeClient(), **kwargs)
+
+
+def _history(
+    n=40,
+    freq="h",
+    target_column="target",
+    item_id=0,
+    start="2021-01-01",
+    **covariates,
+):
+    data = {
+        "timestamp": pd.date_range(start, periods=n, freq=freq),
+        target_column: np.arange(n, dtype=float),
+    }
+    if item_id is not None:
+        data["item_id"] = item_id
+    data.update({name: np.asarray(values, dtype=float) for name, values in covariates.items()})
+    return pd.DataFrame(data)
+
+
+def _future(n, freq="h", item_id=0, start=None, **covariates):
+    data = {"timestamp": pd.date_range(start, periods=n, freq=freq)}
+    if item_id is not None:
+        data["item_id"] = item_id
+    data.update({name: np.asarray(values, dtype=float) for name, values in covariates.items()})
+    return pd.DataFrame(data)
+
+
+def test_predict_df_requires_exactly_one_horizon_argument():
+    forecaster = _forecaster()
+    history = _history()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        forecaster.predict_df(history)
+    with pytest.raises(ValueError, match="exactly one"):
+        forecaster.predict_df(
+            history,
+            prediction_length=5,
+            future_df=_future(5, start="2021-01-02 16:00"),
+        )
+
+
+def test_predict_df_rejects_missing_timestamp_and_target():
+    forecaster = _forecaster()
+
+    with pytest.raises(ValueError, match="timestamp"):
+        forecaster.predict_df(pd.DataFrame({"target": [1.0, 2.0]}), prediction_length=3)
+    with pytest.raises(ValueError, match="target column 'sales' not found"):
+        forecaster.predict_df(
+            _history(), prediction_length=3, target_column="sales"
+        )
+
+
+def test_predict_df_rejects_multiple_target_columns_clearly():
+    forecaster = _forecaster()
+    history = _history(target_column="sales")
+    history["units"] = np.arange(len(history), dtype=float)
+
+    with pytest.raises(ValueError, match="multiple target columns are not supported yet"):
+        forecaster.predict_df(
+            history,
+            prediction_length=3,
+            target_column=["sales", "units"],
+        )
+
+
+def test_predict_df_rejects_non_positive_horizon():
+    forecaster = _forecaster()
+
+    for invalid in (0, -4):
+        with pytest.raises(ValueError, match="positive integer"):
+            forecaster.predict_df(_history(), prediction_length=invalid)
+
+
+def test_prediction_length_drops_history_covariates_without_future_values():
+    forecaster = _forecaster()
+    history = _history(n=30, temperature=np.linspace(0, 1, 30))
+
+    train, test = forecaster._build_forecast_frames(
+        history,
+        prediction_length=6,
+        future_df=None,
+        target_column="target",
+    )
+
+    assert list(train.columns) == [_TARGET]
+    assert list(test.columns) == [_TARGET]
+    assert test[_TARGET].isna().all()
+    assert len(test) == 6
+
+
+def test_custom_target_is_normalized_and_name_collisions_are_rejected():
+    forecaster = _forecaster()
+    history = _history(target_column="sales")
+
+    train, _ = forecaster._build_forecast_frames(
+        history,
+        prediction_length=4,
+        future_df=None,
+        target_column="sales",
+    )
+    assert _TARGET in train.columns
+    assert "sales" not in train.columns
+
+    history["target"] = 0.0
+    with pytest.raises(ValueError, match="collision"):
+        forecaster._build_forecast_frames(
+            history,
+            prediction_length=4,
+            future_df=None,
+            target_column="sales",
+        )
+
+
+def test_future_covariates_flow_through_fake_backend_in_timestamp_order():
+    n, horizon = 30, 6
+    temperature = np.linspace(10, 20, n)
+    future_temperature = np.linspace(20, 21, horizon)
+    history = _history(
+        n=n,
+        target_column="sales",
+        temperature=temperature,
+    ).iloc[::-1]
+    history["region"] = "north"
+    future = _future(
+        horizon,
+        start="2021-01-02 06:00",
+        temperature=future_temperature,
+    ).iloc[::-1]
+    forecaster = _forecaster(
+        features=[RunningIndexFeature()],
+        quantiles=[0.1, 0.5, 0.9],
+    )
+
+    output = forecaster.predict_df(
+        history,
+        future_df=future,
+        target_column="sales",
+    )
+
+    call = forecaster.client.calls[0]
+    np.testing.assert_allclose(call["y_train"], np.arange(n, dtype=float))
+    np.testing.assert_allclose(call["X_train"][:, 0], temperature)
+    np.testing.assert_allclose(call["X_test"][:, 0], future_temperature)
+    np.testing.assert_array_equal(call["X_test"][:, 1], np.arange(n, n + horizon))
+    assert list(output.index.get_level_values("timestamp")) == sorted(future["timestamp"])
+    assert "sales" in output.columns
+    assert _TARGET not in output.columns
+
+
+def test_predict_df_runs_through_public_synthefy_nori_client(monkeypatch):
+    n, horizon = 30, 6
+    history = _history(
+        n=n,
+        target_column="sales",
+        temperature=np.linspace(10, 20, n),
+    )
+    future = _future(
+        horizon,
+        start="2021-01-02 06:00",
+        temperature=np.linspace(20, 21, horizon),
+    )
+    calls = []
+    client = SynthefyNoriClient(
+        api_key="test-key",
+        mode="remote",
+        model="nori-6m",
+    )
+
+    def predict(X_train, y_train, X_test, **kwargs):
+        calls.append((X_train, y_train, X_test, kwargs))
+        return np.vstack(
+            [np.full(len(X_test), level, dtype=float) for level in kwargs["quantiles"]]
+        )
+
+    monkeypatch.setattr(client, "predict", predict)
+    try:
+        output = NoriTSForecaster(
+            client=client,
+            features=[RunningIndexFeature()],
+            quantiles=[0.1, 0.5, 0.9],
+        ).predict_df(
+            history,
+            future_df=future,
+            target_column="sales",
+        )
+    finally:
+        client.close()
+
+    assert len(calls) == 1
+    _, _, X_test, kwargs = calls[0]
+    assert len(X_test) == horizon
+    assert kwargs == {
+        "output_type": "quantiles",
+        "quantiles": [0.1, 0.5, 0.9],
+    }
+    assert list(output.columns) == ["sales", "0.1", "0.5", "0.9"]
+    np.testing.assert_allclose(output["sales"], 0.5)
+
+
+def test_future_target_values_are_rejected_as_leakage():
+    future = _future(5, start="2021-01-02 16:00")
+    future["target"] = 1.0
+
+    with pytest.raises(ValueError, match="no leakage"):
+        _forecaster().predict_df(_history(), future_df=future)
+
+
+def test_future_item_ids_must_match_history():
+    history = _history(n=20, item_id=0)
+    future = _future(5, start="2021-01-01 20:00", item_id=1)
+
+    with pytest.raises(ValueError, match="item_ids"):
+        _forecaster().predict_df(history, future_df=future)
+
+
+def test_history_covariate_must_be_numeric_and_present_in_future():
+    history = _history(n=20, temperature=np.linspace(0, 1, 20))
+    future = _future(5, start="2021-01-01 20:00")
+
+    with pytest.raises(ValueError, match="missing from `future_df`"):
+        _forecaster().predict_df(history, future_df=future)
+
+    future["temperature"] = "unknown"
+    with pytest.raises(ValueError, match="not numeric"):
+        _forecaster().predict_df(history, future_df=future)
+
+
+def test_future_rejects_duplicate_and_history_overlapping_timestamps():
+    history = _history(n=20)
+    duplicate = _future(3, start="2021-01-01 20:00")
+    duplicate = pd.concat([duplicate, duplicate.iloc[[0]]], ignore_index=True)
+
+    with pytest.raises(ValueError, match="at most one row"):
+        _forecaster().predict_df(history, future_df=duplicate)
+
+    overlapping = _future(3, start="2021-01-01 19:00")
+    with pytest.raises(ValueError, match="later than"):
+        _forecaster().predict_df(history, future_df=overlapping)

--- a/tests/test_ci_routing.py
+++ b/tests/test_ci_routing.py
@@ -54,6 +54,7 @@ def test_client_artifact_tests_keep_their_explicit_offline_route():
     workflow = _workflow()
     scripts = "\n".join(_run_steps(workflow["jobs"]["synthefy-artifact"]))
     assert '"$GITHUB_WORKSPACE/tests/test_nori_ts_parity.py"' in scripts
+    assert '"$GITHUB_WORKSPACE/libs/synthefy/tests/test_nori_ts_contract.py"' in scripts
 
     assert '"$GITHUB_WORKSPACE/libs/synthefy/tests"' in scripts
     assert any(

--- a/tests/test_nori_ts.py
+++ b/tests/test_nori_ts.py
@@ -177,3 +177,61 @@ def test_predict_df_end_to_end():
     # quantiles are monotone (no crossing) at every horizon step
     q = out[["0.1", "0.5", "0.9"]].to_numpy()
     assert (np.diff(q, axis=1) >= -1e-6).all()
+
+
+@pytest.mark.slow
+def test_predict_df_end_to_end_custom_target_multiseries():
+    rng = np.random.default_rng(1)
+    n = 200
+    frames = []
+    for item in (0, 1):
+        t = np.arange(n)
+        series = 5 + item + 3 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 0.2, n)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "item_id": item,
+                    "timestamp": pd.date_range("2021-01-01", periods=n, freq="h"),
+                    "sales": series,
+                }
+            )
+        )
+    history = pd.concat(frames, ignore_index=True)
+
+    output = NoriTSForecaster(
+        mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]
+    ).predict_df(history, prediction_length=12, target_column="sales")
+
+    assert set(output.index.get_level_values("item_id")) == {0, 1}
+    assert len(output) == 24
+    assert "sales" in output.columns
+    assert np.isfinite(output["sales"].to_numpy()).all()
+
+
+@pytest.mark.slow
+def test_predict_df_end_to_end_future_known_covariate():
+    rng = np.random.default_rng(2)
+    n, horizon = 240, 24
+    t = np.arange(n)
+    temperature = 15 + 10 * np.sin(2 * np.pi * t / 24)
+    history = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2021-01-01", periods=n, freq="h"),
+            "target": 2 * temperature + rng.normal(0, 0.5, n),
+            "temperature": temperature,
+        }
+    )
+    future_t = np.arange(n, n + horizon)
+    future = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2021-01-11", periods=horizon, freq="h"),
+            "temperature": 15 + 10 * np.sin(2 * np.pi * future_t / 24),
+        }
+    )
+
+    output = NoriTSForecaster(
+        mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]
+    ).predict_df(history, future_df=future)
+
+    assert len(output) == horizon
+    assert np.isfinite(output["0.5"].to_numpy()).all()

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -101,8 +101,8 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     assert root["project"]["version"] == "0.17.3"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.0.0"
-    assert _declared_version() == "7.0.0"
+    assert client["project"]["version"] == "7.0.1"
+    assert _declared_version() == "7.0.1"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -375,7 +375,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.0.0"
+    assert client_entries[0]["version"] == "7.0.1"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -5433,7 +5433,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.0.0"
+version = "7.0.1"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Public promotion

Promotes the fully validated staging release for `synthefy 7.0.1`.

- Internal source: https://github.com/Synthefy/synthefy-nori-internal/pull/404
- Staging promotion: https://github.com/Synthefy/synthefy-nori-staging/pull/25
- Customer docs, staged until PyPI verification:
  https://github.com/Synthefy/synthefy-docs/pull/66

## What ships

- `NoriTSForecaster.predict_df(future_df=...)` for explicit horizons with
  numeric known-future covariates.
- `target_column=` with preservation of domain target names in forecast output.
- An explicit one-target-column-per-call guard.
- Backend composition through `SynthefyNoriClient` for remote, SageMaker, and
  local execution.
- `synthefy 7.0.1` package metadata, changelog, README, and artifact tests.
- `MemoryPolicy.reuse_context_cache`, aligned with the current
  `synthefy-nori 0.17.3` hosted/local contract.

## Promotion evidence

- Public candidate tree is byte-identical to merged staging tree
  `4df917a1573b71a3ddebab7d42ebe57e657da724`.
- Staging PR 25 passed all 18 checks:
  - package cutover and distribution-boundary rehearsals;
  - wheel/sdist tests on Python 3.9 and 3.11;
  - unit, inference, training, embeddings, and aggregate gates;
  - Torch 2.8 through 2.13 compatibility;
  - both Modal GPU checks.
- Local staging validation: 377 heavy tests and 222 lightweight-client tests
  passed; Ruff and both package builds passed.
- `git diff --check` passed.

## Release action after merge

After public CI and rebase-sync/drop-check are green, create GitHub Release
`synthefy-v7.0.1`. The public-only publisher will build, validate, and upload
the lightweight distribution to PyPI through the protected
`synthefy-pypi` environment. Merge docs PR 66 only after a clean install and
forecasting smoke succeed from PyPI.

No Baseten redeploy is required because the serving wire contract is unchanged.
