### PR TITLE
feat(api)!: require an explicit model= size (promote from staging)

### DIFF
--- a/.claude/skills/nori-regression/SKILL.md
+++ b/.claude/skills/nori-regression/SKILL.md
@@ -61,7 +61,7 @@ The exact, verified API is in `references/api.md` — read it before writing cod
 ```python
 from synthefy_nori import NoriRegressor
 
-reg = NoriRegressor(device=None)          # None -> cuda:0 if available, else CPU
+reg = NoriRegressor(device=None, model="nori-30m")          # None -> cuda:0 if available, else CPU
 reg.fit(X_train, y_train)                 # stores context; no training happens
 point = reg.predict(X_test)               # (n,) distribution mean
 lo, mid, hi = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])

--- a/.claude/skills/nori-regression/references/api.md
+++ b/.claude/skills/nori-regression/references/api.md
@@ -21,7 +21,7 @@ selection.
 ```python
 from synthefy_nori import NoriRegressor
 
-reg = NoriRegressor(device=None)   # None -> cuda:0 if available, else cpu
+reg = NoriRegressor(device=None, model="nori-30m")   # None -> cuda:0 if available, else cpu
 reg.fit(X_train, y_train)          # stores context; X -> float32 (n, d), y -> float64 (n,)
 point = reg.predict(X_test)        # (n,) distribution mean
 ```
@@ -29,14 +29,14 @@ point = reg.predict(X_test)        # (n,) distribution mean
 **Constructor (exact signature):**
 
 ```python
-NoriRegressor(model_path=None, *, device=None, inference_config=None, token=None,
+NoriRegressor(model_path=None, *, model, device=None, inference_config=None, token=None,
               augmentations=("yj",), yj_skew_threshold=10.0,
               quantile_collapse="mean", bar_temperature=1.0,
               bar_point_estimator="mean")
 ```
 
-- `model_path` — local checkpoint path; `None` downloads the default from the
-  Hugging Face Hub on first `predict`.
+- `model_path` — local checkpoint path. When `None`, `model=` is REQUIRED (a size:
+  "nori-6m"/"nori-30m") and its checkpoint downloads from the Hugging Face Hub on first `predict`.
 - `device` — `None` → `cuda:0` if available else CPU; or any torch device string.
 - `inference_config` — path to a bundled/custom inference config JSON; default
   is `default_inference.json`. Use
@@ -98,7 +98,7 @@ y_pred = infer(X_train, y_train, X_test)   # mean point predictions only
 
 ## Checkpoint & environment
 
-- Default checkpoint: HF repo `Synthefy/Nori` (override env
+- `model=` is required (no default). Base ("nori-6m") checkpoint: HF repo `Synthefy/Nori` (override env
   `SYNTHEFY_NORI_HF_REPO`), file `nori.pt` (env `SYNTHEFY_NORI_HF_FILENAME`),
   cached under `~/.cache/huggingface/hub`. The public checkpoint is ungated.
 - **Offline:** set `HF_HUB_OFFLINE=1` (a huggingface-hub feature) to serve from

--- a/.claude/skills/nori-regression/references/interpretability.md
+++ b/.claude/skills/nori-regression/references/interpretability.md
@@ -16,7 +16,7 @@ is set by `budget`.
 from synthefy_nori import NoriRegressor
 from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
-reg = NoriRegressor().fit(X_train, y_train)
+reg = NoriRegressor(model="nori-30m").fit(X_train, y_train)
 
 # Plain first-order Shapley values:
 explainer = get_nori_imputation_explainer(reg, X_train, index="SV", max_order=1)

--- a/.claude/skills/nori-regression/references/one-step-forecasting.md
+++ b/.claude/skills/nori-regression/references/one-step-forecasting.md
@@ -32,7 +32,7 @@ don't zero-fill). The target still must be finite.
 one estimator object:
 
 ```python
-reg = NoriRegressor(device="cpu")            # construct ONCE, refit per origin
+reg = NoriRegressor(device="cpu", model="nori-30m")            # construct ONCE, refit per origin
 for t in test_origins:                       # expanding window
     reg.fit(X[:t], y[:t])                    # context = everything before t
     point = reg.predict(X[t:t+1], output_type="median")

--- a/.claude/skills/nori-regression/templates/compare_baselines.py
+++ b/.claude/skills/nori-regression/templates/compare_baselines.py
@@ -52,7 +52,7 @@ def main() -> None:
     scoring = {"r2": "r2", "mae": "neg_mean_absolute_error"}
 
     models = {
-        "nori": (NoriRegressor(device=args.device), X),
+        "nori": (NoriRegressor(device=args.device, model="nori-30m"), X),
         "ridge": (Ridge(alpha=1.0), X_sk),
         "random_forest": (RandomForestRegressor(n_estimators=300, random_state=args.seed), X_sk),
     }

--- a/.claude/skills/nori-regression/templates/explain.py
+++ b/.claude/skills/nori-regression/templates/explain.py
@@ -84,7 +84,7 @@ def main() -> None:
         X, y = X.loc[y.notna()], y.loc[y.notna()]
 
     X_train, X_test, y_train, _ = train_test_split(X, y, test_size=0.2, random_state=args.seed)
-    reg = NoriRegressor(device=args.device)
+    reg = NoriRegressor(device=args.device, model="nori-30m")
     reg.fit(X_train.values, y_train.values)
 
     imp = shap_importance(reg, X_train.values, X_test.values[: args.k],

--- a/.claude/skills/nori-regression/templates/forecast_multi_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_multi_step.py
@@ -60,7 +60,7 @@ def rolling_direct(y: np.ndarray, X: np.ndarray, origins: range, *, horizon: int
                    device: str | None) -> pd.DataFrame:
     """At each origin t: context = rows whose features AND target are fully in
     the past (target rows <= t-h), then predict row t."""
-    reg = NoriRegressor(device=device)
+    reg = NoriRegressor(device=device, model="nori-30m")
     rows = []
     for t in origins:
         cut = t - horizon + 1  # rows [0, cut) have targets <= t-h+... strictly before t's info

--- a/.claude/skills/nori-regression/templates/forecast_one_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_one_step.py
@@ -47,7 +47,7 @@ def build_features(y: pd.Series, *, season: int, lags: tuple[int, ...] = (1, 2, 
 def rolling_one_step(y: np.ndarray, X: np.ndarray, origins: range, *,
                      device: str | None) -> pd.DataFrame:
     """Expanding-context backtest: refit (free) at each origin, predict one row."""
-    reg = NoriRegressor(device=device)  # construct once, refit per origin
+    reg = NoriRegressor(device=device, model="nori-30m")  # construct once, refit per origin
     rows = []
     for t in origins:
         reg.fit(X[:t], y[:t])

--- a/.claude/skills/nori-regression/templates/regress.py
+++ b/.claude/skills/nori-regression/templates/regress.py
@@ -57,7 +57,7 @@ def main() -> None:
     )
     print(f"rows: {len(X_train)} context / {len(X_test)} query, {X.shape[1]} features")
 
-    reg = NoriRegressor(device=args.device)
+    reg = NoriRegressor(device=args.device, model="nori-30m")
     reg.fit(X_train, y_train)
 
     mean_pred = reg.predict(X_test)                          # (n,) distribution mean

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and it uses the GPU automatically when one's available (CPU otherwise).
    ```python
    from synthefy_nori import NoriRegressor
 
-   reg = NoriRegressor(model="nori")      # "nori-30m" for the larger, stronger variant
+   reg = NoriRegressor(model="nori-6m")   # "nori-30m" for the larger, stronger variant
    reg.fit(X_train, y_train)              # stores your rows as context — no training happens
    y_pred = reg.predict(X_test)           # point predictions (predictive-distribution mean)
 
@@ -186,7 +186,7 @@ from synthefy_nori import NoriRegressor
 X, y = load_diabetes(return_X_y=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=0)
 
-model = NoriRegressor()    # downloads weights from the HF Hub on first use
+model = NoriRegressor(model="nori-30m")    # downloads weights from the HF Hub on first use
 model.fit(X_train, y_train)           # "fit" just stores the labeled rows as context
 pred = model.predict(X_test)          # predictions in a single forward pass, no training
 ```
@@ -196,7 +196,7 @@ skips the object entirely:
 
 ```python
 from synthefy_nori import predict
-pred = predict(X_train, y_train, X_test, task="regression")
+pred = predict(X_train, y_train, X_test, task="regression", model="nori-30m")
 ```
 
 To run from your own checkpoint instead of the Hub default, pass a path:
@@ -218,7 +218,7 @@ whole quantile bank (handy for CRPS / interval scoring, calibration, and
 prediction intervals):
 
 ```python
-model = NoriRegressor().fit(X_train, y_train)
+model = NoriRegressor(model="nori-30m").fit(X_train, y_train)
 
 # Quantiles at chosen levels -> shape (n_levels, n_samples)
 q10, q50, q90 = model.predict(X_test, output_type="quantiles",
@@ -275,7 +275,7 @@ hf auth login
 ```python
 # Option C: pass explicitly in code
 from synthefy_nori import NoriRegressor
-model = NoriRegressor(token="hf_xxxxxxxx")
+model = NoriRegressor(token="hf_xxxxxxxx", model="nori-30m")
 ```
 
 Get a token at <https://huggingface.co/settings/tokens> (read scope is
@@ -335,7 +335,7 @@ pip install "synthefy-nori[interpretability]"
 from synthefy_nori import NoriRegressor
 from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
-model = NoriRegressor().fit(X_train, y_train)
+model = NoriRegressor(model="nori-30m").fit(X_train, y_train)
 explainer = get_nori_imputation_explainer(model, X_train)   # imputation-based, model-agnostic
 sv = explainer.explain(X_test[:1], budget=128)              # SHAP/Shapley values for one prediction
 sv.plot_waterfall()                                         # additive contribution waterfall
@@ -382,7 +382,7 @@ Reproduce (prints the results table and writes `benchmarks/plots/shap_speed.png`
 ## Benchmarks
 
 Mean and median R² across 96 regression tasks from three public benchmark suites, for both
-Nori sizes — select with `model="nori"` (~6M, default) or `model="nori-30m"` (~29M):
+Nori sizes — `model=` is required; select `model="nori-6m"` (~6M) or `model="nori-30m"` (~29M):
 
 | Suite | Datasets | Nori · mean / median | Nori-30M · mean / median |
 |-------|---------:|:--------------------:|:------------------------:|

--- a/benchmarks/bench_kv_cache.py
+++ b/benchmarks/bench_kv_cache.py
@@ -113,7 +113,7 @@ def main() -> None:
         f"budget={MAX_ELEMENTS_BUDGET}"
     )
 
-    model = NoriRegressor(device=DEVICE).fit(x_train, y_train)
+    model = NoriRegressor(device=DEVICE, model="nori-6m").fit(x_train, y_train)
 
     # Warm up (downloads/compiles, allocates caches) with one throwaway predict.
     _ = model.predict(x_test_full[:128])

--- a/benchmarks/bench_shap_speed.py
+++ b/benchmarks/bench_shap_speed.py
@@ -130,7 +130,7 @@ def main():
     )
 
     print(f"Fitting NoriRegressor on {DEVICE} (first fit downloads checkpoint)...")
-    model = NoriRegressor(device=DEVICE).fit(X_train, y_train)
+    model = NoriRegressor(device=DEVICE, model="nori-6m").fit(X_train, y_train)
 
     def predict_fn(x):
         return np.asarray(model.predict(np.asarray(x)), dtype=np.float64).reshape(-1)

--- a/benchmarks/bench_shapiq_speed.py
+++ b/benchmarks/bench_shapiq_speed.py
@@ -94,7 +94,7 @@ def main() -> None:
 
     # Fit Nori on the reduced context and warm up the model with one predict.
     print(f"Fitting NoriRegressor on device={DEVICE} ...")
-    model = NoriRegressor(device=DEVICE).fit(X_ctx_sel, y_ctx)
+    model = NoriRegressor(device=DEVICE, model="nori-6m").fit(X_ctx_sel, y_ctx)
     t0 = time.perf_counter()
     _ = model.predict(explain_rows[:1])
     print(f"Warmup predict done in {time.perf_counter() - t0:.2f}s")

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -109,7 +109,7 @@ quality scores), declare it and predictions are mapped onto the level lattice
 observed in `fit`'s `y`:
 
 ```python
-reg = NoriRegressor().fit(X_train, y_train)          # y ∈ {3, 4, 5, 6, 7, 8}
+reg = NoriRegressor(model="nori-30m").fit(X_train, y_train)          # y ∈ {3, 4, 5, 6, 7, 8}
 labels = reg.predict(X_test, discretize="map-cell")                 # accuracy-optimal
 labels = reg.predict(X_test, discretize="median-cell")              # MAE-optimal
 labels = reg.predict(X_test, categorical_levels=[3, 4, 5, 6, 7, 8]) # known lattice, map-cell
@@ -167,7 +167,7 @@ Notes:
   reach them — `predict` kwargs override per call:
 
   ```python
-  gs = GridSearchCV(NoriRegressor(),
+  gs = GridSearchCV(NoriRegressor(model="nori-30m"),
                     {"discretize": ["map-cell", "median-cell", "snap-mean"]},
                     scoring="accuracy", cv=5)
   ```

--- a/docs/interpretability.md
+++ b/docs/interpretability.md
@@ -23,7 +23,7 @@ by `budget`).
 from synthefy_nori import NoriRegressor
 from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
-model = NoriRegressor().fit(X_train, y_train)
+model = NoriRegressor(model="nori-30m").fit(X_train, y_train)
 
 # index="k-SII", max_order=2 captures pairwise interactions;
 # use index="SV", max_order=1 for plain Shapley values.

--- a/examples/embedding_synthetic.py
+++ b/examples/embedding_synthetic.py
@@ -44,7 +44,7 @@ def extract_embeddings(X_train, y_train, X_test):
     ``get_embeddings`` call on its final full-data model.
     """
     embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
-                             model=NoriRegressor())
+                             model=NoriRegressor(model="nori-6m"))
     Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
     Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
 

--- a/examples/embedding_tabarena.py
+++ b/examples/embedding_tabarena.py
@@ -59,7 +59,7 @@ def extract_embeddings(X_train, y_train, X_test):
     ``get_embeddings`` call on its final full-data model.
     """
     embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
-                             model=NoriRegressor())
+                             model=NoriRegressor(model="nori-6m"))
     Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
     Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
 

--- a/examples/inference_regression.py
+++ b/examples/inference_regression.py
@@ -6,7 +6,7 @@ def main():
     y_train = [0.0, 1.0, 2.0]
     X_test = [[1.5, 0.5]]
 
-    model = NoriRegressor()
+    model = NoriRegressor(model="nori-6m")
     print(model.fit(X_train, y_train).predict(X_test))
 
 

--- a/examples/interpretability_regression.py
+++ b/examples/interpretability_regression.py
@@ -18,7 +18,7 @@ from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 X, y = load_diabetes(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=0)
 
-model = NoriRegressor()           # downloads weights from the HF Hub on first use
+model = NoriRegressor(model="nori-6m")           # downloads weights from the HF Hub on first use
 model.fit(X_train.values, y_train.values)
 
 # 1) Explain a single prediction with shapiq (Shapley values + pairwise interactions).

--- a/examples/notebooks/Nori_Demo_Local.ipynb
+++ b/examples/notebooks/Nori_Demo_Local.ipynb
@@ -202,7 +202,7 @@
    "outputs": [],
    "source": [
     "models = {\n",
-    "    \"Nori\": NoriRegressor(),  # downloads weights from the HF Hub on first use\n",
+    "    \"Nori\": NoriRegressor(model=\"nori-6m\"),  # downloads weights from the HF Hub on first use\n",
     "    \"RandomForest\": RandomForestRegressor(n_estimators=300, random_state=RANDOM_STATE),\n",
     "}\n",
     "if HAS_XGB:\n",
@@ -295,7 +295,7 @@
    },
    "outputs": [],
    "source": [
-    "nori = NoriRegressor().fit(X_ctx.values, y_ctx.values)\n",
+    "nori = NoriRegressor(model=\"nori-6m\").fit(X_ctx.values, y_ctx.values)\n",
     "\n",
     "# 80% central prediction interval for the first 40 test rows.\n",
     "q10, q50, q90 = nori.predict(\n",

--- a/examples/text_features_synthetic.py
+++ b/examples/text_features_synthetic.py
@@ -69,11 +69,11 @@ def run(n_train: int = 800, n_test: int = 200, svd_dim: int = 64,
     # Tabular-only baseline: review dropped, text_columns=[] -> numeric passthrough
     # + categorical label-encoding, no embedder. Same estimator as the +text run
     # below, just without the text column. Text config lives in the constructor.
-    tab = NoriRegressor(device=device, text_columns=[]).fit(df_train[tab_cols], y_train)
+    tab = NoriRegressor(device=device, model="nori-6m", text_columns=[]).fit(df_train[tab_cols], y_train)
     r_tab = float(r2_score(y_test, tab.predict(df_test[tab_cols])))
 
     # + text: same columns plus the review, embedded -> SVD -> appended columns.
-    reg = NoriRegressor(device=device, text_columns=["review"], svd_dim=svd_dim)
+    reg = NoriRegressor(device=device, model="nori-6m", text_columns=["review"], svd_dim=svd_dim)
     reg.fit(df_train[cols], y_train)
     r_text = float(r2_score(y_test, reg.predict(df_test[cols])))
     return r_tab, r_text

--- a/src/synthefy_nori/embedding/embedding.py
+++ b/src/synthefy_nori/embedding/embedding.py
@@ -37,9 +37,10 @@ class NoriEmbedding(TransformerMixin, BaseEstimator):
         Number of folds for cross-validation. ``0`` disables CV — the model is
         fit once on the entire training set and used for both train and unseen
         data. Must be ``0`` or ``>= 2``.
-    model : NoriRegressor, optional
-        Pre-configured estimator. When ``None``, a default ``NoriRegressor`` is
-        constructed at ``fit`` time.
+    model : NoriRegressor
+        Pre-configured estimator to embed with. **Required** — pass a ``NoriRegressor``
+        with an explicit size (e.g. ``NoriRegressor(model="nori-30m")``); there is no
+        default, and ``None`` raises at ``fit``.
     shuffle : bool, default=False
         Whether to shuffle the K-fold split. Independent of ``random_state``.
     random_state : int, optional
@@ -58,8 +59,9 @@ class NoriEmbedding(TransformerMixin, BaseEstimator):
 
     Examples
     --------
+    >>> from synthefy_nori import NoriRegressor
     >>> from synthefy_nori.embedding import NoriEmbedding
-    >>> embedding = NoriEmbedding(n_fold=5)
+    >>> embedding = NoriEmbedding(n_fold=5, model=NoriRegressor(model="nori-30m"))
     >>> train_embeds = embedding.fit_transform(X_train, y_train)  # OOF
     >>> test_embeds = embedding.transform(X_test)                 # final model
     """
@@ -78,10 +80,14 @@ class NoriEmbedding(TransformerMixin, BaseEstimator):
         self.random_state = random_state
 
     def _resolve_template(self) -> NoriRegressor:
-        """Return a fresh model to use (a clone of ``model`` or a default)."""
-        if self.model is not None:
-            return clone(self.model)
-        return NoriRegressor()
+        """Return a fresh model to use: a clone of ``model``. ``model`` is required -- there is
+        no default; pass a NoriRegressor with an explicit size."""
+        if self.model is None:
+            raise ValueError(
+                "NoriEmbedding requires model=<a NoriRegressor with an explicit size>, e.g. "
+                "NoriEmbedding(model=NoriRegressor(model='nori-30m')). There is no default."
+            )
+        return clone(self.model)
 
     def _compute_oof(self, X: np.ndarray, y: np.ndarray) -> np.ndarray:
         """Run K-fold and return OOF embeddings aligned to original order."""

--- a/src/synthefy_nori/hf.py
+++ b/src/synthefy_nori/hf.py
@@ -16,15 +16,14 @@ DEFAULT_CHECKPOINT_FILENAME = os.environ.get(
     "nori.pt",
 )
 
-# Model-variant registry: friendly name -> Hugging Face repo id. Selecting a Nori size is just
-# ``model="nori-30m"`` on NoriRegressor / infer / predict (or ``download_checkpoint(model=...)``).
-# ``"nori"`` is the default (the ~6M base) and honors the SYNTHEFY_NORI_HF_REPO override; add one
-# line per new variant. An unknown name is treated as a raw repo id, so an explicit ``"org/repo"``
-# still works.
-DEFAULT_MODEL = "nori"
+# Model-variant registry: friendly name -> Hugging Face repo id. A size is REQUIRED -- there is no
+# default "nori"; every caller must pick ``model="nori-6m"`` or ``model="nori-30m"`` on NoriRegressor
+# / infer / predict (or ``download_checkpoint(model=...)``). Naming the size keeps the identifier
+# stable: it never silently changes which weights it loads. ``"nori-6m"`` is the ~6M base and honors
+# the SYNTHEFY_NORI_HF_REPO override. Add one line per new variant. An unknown name is treated as a
+# raw repo id, so an explicit ``"org/repo"`` still works.
 NORI_MODELS = {
-    "nori": DEFAULT_MODEL_REPO_ID,     # base ~6M (default)
-    "nori-6m": DEFAULT_MODEL_REPO_ID,  # explicit alias for the base
+    "nori-6m": DEFAULT_MODEL_REPO_ID,  # ~6M base (honors SYNTHEFY_NORI_HF_REPO)
     "nori-30m": "Synthefy/Nori-30M",   # ~29.2M scaling-law variant
 }
 
@@ -41,20 +40,24 @@ def _is_thinking_model(model: str) -> bool:
 
 
 def resolve_model_repo(model: str | None) -> str:
-    """Map a variant name to its HF repo id: ``None`` -> the default (~6M) base, a known name
-    -> its repo, anything else returned unchanged (so a raw ``"org/repo"`` id also works).
+    """Map a variant name to its HF repo id. A size is required: ``None`` or a bare ``"nori"``
+    raises (there is no default) -- pick ``"nori-6m"`` or ``"nori-30m"``. A known name -> its repo;
+    anything else is returned unchanged (so a raw ``"org/repo"`` id also works).
 
     A Nori Thinking selector raises :class:`ValueError`: it has no downloadable checkpoint here,
     so without this guard it would fall through to a raw-repo lookup and fail with an opaque
     "repo not found" error instead of telling the caller it is a hosted-API-only variant."""
-    if model is None:
-        model = DEFAULT_MODEL
+    if model is None or model == "nori":
+        raise ValueError(
+            "model is required and must name a size -- choose one of: "
+            f"{', '.join(NORI_MODELS)}. There is no bare 'nori' default."
+        )
     if _is_thinking_model(model):
         raise ValueError(
             f"model={model!r} selects a Nori Thinking (test-time-compute) variant, which runs "
             "only on the hosted Synthefy API. The synthefy-nori package does single-pass local "
             "inference and has no Thinking checkpoint. Use the hosted API (e.g. the `synthefy` "
-            "client with mode='remote') for Thinking, or select 'nori' / 'nori-6m' / 'nori-30m' "
+            "client with mode='remote') for Thinking, or select 'nori-6m' / 'nori-30m' "
             "for local inference."
         )
     return NORI_MODELS.get(model, model)
@@ -81,7 +84,7 @@ def _access_error_message(repo_id: str) -> str:
 
 
 def download_checkpoint(
-    repo_id: str = DEFAULT_MODEL_REPO_ID,
+    repo_id: str | None = None,
     filename: str = DEFAULT_CHECKPOINT_FILENAME,
     *,
     model: str | None = None,
@@ -92,11 +95,16 @@ def download_checkpoint(
 ) -> str:
     """Download a checkpoint from the Hugging Face Hub and return its local path.
 
-    ``model`` selects a registry variant (e.g. ``"nori-30m"``) and, when given, overrides
-    ``repo_id``; leave it ``None`` to use ``repo_id`` (the ~6M base by default).
+    ``model`` selects a registry variant (e.g. ``"nori-6m"``) and overrides ``repo_id``. A size is
+    required: with neither ``model`` nor ``repo_id`` given, this raises -- pass
+    ``model="nori-6m"``/``"nori-30m"`` or an explicit ``repo_id``.
     """
     if model is not None:
         repo_id = resolve_model_repo(model)
+    elif repo_id is None:
+        raise ValueError(
+            "download_checkpoint requires model= ('nori-6m'/'nori-30m') or an explicit repo_id="
+        )
     try:
         from huggingface_hub import hf_hub_download
         from huggingface_hub.errors import (

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -30,8 +30,14 @@ def test_embedding_is_sklearn_estimator_and_clones():
     c = clone(e)
     assert c.get_params()["n_fold"] == 5
 
-    # default template construction is a NoriRegressor (no weights touched)
-    assert isinstance(NoriEmbedding()._resolve_template(), NoriRegressor)
+    # model is required -- there is no default template
+    with pytest.raises(ValueError, match="requires model"):
+        NoriEmbedding()._resolve_template()
+    # with an explicit model, the template is a clone of it (no weights touched)
+    assert isinstance(
+        NoriEmbedding(model=NoriRegressor(model="nori-6m"))._resolve_template(),
+        NoriRegressor,
+    )
 
 
 def test_n_fold_one_is_rejected():
@@ -76,7 +82,7 @@ def test_end_to_end_embeddings_real_checkpoint():
     y_train = (X_train[:, 0] * 2 - X_train[:, 1]).astype(np.float64)
     X_test = rng.normal(size=(8, 5)).astype(np.float32)
 
-    model = NoriRegressor().fit(X_train, y_train)
+    model = NoriRegressor(model="nori-6m").fit(X_train, y_train)
 
     test_emb = model.get_embeddings(X_test, data_source="test")
     assert test_emb.ndim == 3
@@ -88,5 +94,5 @@ def test_end_to_end_embeddings_real_checkpoint():
     assert train_emb.shape == (n_estimators, 60, embed_dim)
 
     # Same end-to-end through the sklearn transformer.
-    emb = NoriEmbedding(n_fold=0).fit_transform(X_train, y_train)
+    emb = NoriEmbedding(n_fold=0, model=NoriRegressor(model="nori-6m")).fit_transform(X_train, y_train)
     assert emb.shape[1] == 60 and emb.shape[2] == embed_dim

--- a/tests/embedding/test_embedding_clustering.py
+++ b/tests/embedding/test_embedding_clustering.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.slow
 
 def _embed_test_rows(X_train, y_train, X_test):
     """Fit on the context, return mean-over-ensemble test embeddings [n, dim]."""
-    model = NoriRegressor().fit(X_train, y_train)
+    model = NoriRegressor(model="nori-6m").fit(X_train, y_train)
     emb = model.get_embeddings(X_test, data_source="test")   # (n_est, n, dim)
     return emb.mean(axis=0)
 

--- a/tests/embedding/test_examples_smoke.py
+++ b/tests/embedding/test_examples_smoke.py
@@ -35,8 +35,8 @@ def test_public_construction_api_the_examples_use():
     default (non-slow) suite and blocks the merge before an example can ship
     with an internal-only constructor argument again.
     """
-    NoriRegressor()
-    NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=NoriRegressor())
+    NoriRegressor(model="nori-30m")
+    NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=NoriRegressor(model="nori-30m"))
 
 
 @pytest.mark.slow

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -22,7 +22,16 @@ def test_regressor_stores_model_variant_verbatim():
     model = NoriRegressor(model="nori-30m")
     assert model.model == "nori-30m"
     assert model.get_params()["model"] == "nori-30m"
-    assert NoriRegressor().model is None  # default: base 6M
+    # Stored verbatim (sklearn contract; no __init__ validation). There is no default:
+    # fitting/predicting without a model= (or model_path) raises at checkpoint load.
+    assert NoriRegressor().model is None
+
+
+def test_predict_without_model_or_path_raises_require_model():
+    # Neither model= nor model_path -> the require-model guard raises at checkpoint load,
+    # before any network call. Covers the public NoriRegressor.fit/predict entry point.
+    with pytest.raises(ValueError, match=r"requires model="):
+        NoriRegressor().fit([[0.0, 1.0], [1.0, 0.0]], [0.0, 1.0]).predict([[0.5, 0.5]])
 
 
 def test_resolve_model_path_threads_variant_to_download(monkeypatch):

--- a/tests/test_benchmark_performance.py
+++ b/tests/test_benchmark_performance.py
@@ -5,7 +5,7 @@ This mirrors the regression eval loop in the outer SynthefyPFN repo
 (``evaluation/datasets.py`` + ``evaluation/runner.py``), but driven through the
 public ``synthefy_nori`` package API (the same one used by ``test.py``):
 
-    model = NoriRegressor()
+    model = NoriRegressor(model="nori-30m")
     model.fit(X_train, y_train)
     pred = model.predict(X_test)
 

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -11,11 +11,14 @@ def test_hf_defaults_are_public_strings():
 def test_model_variant_registry_resolution():
     # friendly variant names -> HF repo ids
     assert hf.resolve_model_repo("nori-30m") == "Synthefy/Nori-30M"
-    assert hf.resolve_model_repo("nori") == hf.DEFAULT_MODEL_REPO_ID       # default 6M base
-    assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID    # explicit base alias
-    assert hf.resolve_model_repo(None) == hf.DEFAULT_MODEL_REPO_ID         # None -> default base
+    assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID    # ~6M base
+    # A size is required -- None and a bare "nori" both raise (there is no default).
+    for missing in (None, "nori"):
+        with pytest.raises(ValueError, match=r"model is required"):
+            hf.resolve_model_repo(missing)
     assert hf.resolve_model_repo("Synthefy/Custom-Repo") == "Synthefy/Custom-Repo"  # raw id passes through
-    assert {"nori", "nori-6m", "nori-30m"} <= set(hf.NORI_MODELS)
+    assert set(hf.NORI_MODELS) == {"nori-6m", "nori-30m"}
+    assert "nori" not in hf.NORI_MODELS
 
 
 def test_thinking_variant_is_rejected_not_downloaded():
@@ -38,6 +41,12 @@ def test_download_checkpoint_rejects_thinking_variant():
     # The guard fires through the download entry point too (before any network call).
     with pytest.raises(ValueError, match=r"Thinking.*hosted Synthefy API"):
         hf.download_checkpoint(model="nori-30m-thinking-medium", token=False)
+
+
+def test_download_checkpoint_requires_a_size():
+    # No model= and no repo_id -> raise (there is no default), before any network call.
+    with pytest.raises(ValueError, match=r"requires model="):
+        hf.download_checkpoint(token=False)
 
 
 def test_download_checkpoint_model_overrides_repo(monkeypatch):

--- a/tests/test_inference_e2e.py
+++ b/tests/test_inference_e2e.py
@@ -32,9 +32,10 @@ def _checkpoint_kwargs():
     local = os.environ.get("SYNTHEFY_NORI_TEST_CHECKPOINT")
     if local:
         return {"model_path": local}
-    # The default repo is public, so anonymous download works. Any HF token in
-    # the environment is picked up automatically (it only affects rate limits).
-    return {}
+    # model= is now required (the bare default was retired). "nori-6m" resolves to
+    # the public HF repo, so anonymous download works. Any HF token in the
+    # environment is picked up automatically (it only affects rate limits).
+    return {"model": "nori-6m"}
 
 
 def test_regressor_recovers_linear_signal():


### PR DESCRIPTION
## What

Final hop of `internal → staging → public`. Byte-identical to the merged staging commit `ab9188f` (Synthefy/synthefy-nori-staging#27) — no new authoring here.

## Why this is now urgent

`SynthefyNoriClient` already raised when `model=` was omitted; `NoriRegressor` silently loaded the ~6M base. The docstring for the required behavior had **already shipped** in `api.py`, so the published docs described a guard that did not exist.

The docs side has since merged (Synthefy/synthefy-docs#68), so `docs.synthefy.com` now tells readers:

> Both the `synthefy` client and `NoriRegressor` **require** it and raise a `ValueError` if you omit it — there is no default.

That is true on internal and staging, and **not** true of published `synthefy-nori` 0.18.0:

```python
>>> hf.resolve_model_repo(None)
'Synthefy/Nori'          # the ~6M base — no raise
```

Until this lands and a release carries it, the live docs are ahead of the package.

## Changes

| Area | Change |
| --- | --- |
| `hf.py` | Drop `DEFAULT_MODEL` and the bare `"nori"` registry key. `resolve_model_repo(None)` / `("nori")` now raise. `download_checkpoint(repo_id=None)` raises unless `model=` or an explicit `repo_id=` is given — the guard fires **before** any network call. |
| `NoriEmbedding` | `model=` required; no default `NoriRegressor` constructed at fit time. |
| Callers | `examples/`, the Colab notebook, `README.md`, `docs/inference.md`, `docs/interpretability.md`, `benchmarks/`, and the vendored `nori-regression` skill now name a size. |
| Tests | Registry is exactly `{nori-6m, nori-30m}`; `download_checkpoint` requires a size; `NoriRegressor().fit(...).predict(...)` raises at checkpoint load. |

Examples and benchmarks select **`nori-6m`**: they previously ran on the bare default, which *was* the ~6M base, so that is the size they were actually exercised and timed on. The Colab notebook's committed output came from 6M too. Matching change is open on internal as Synthefy/synthefy-nori-internal#472 so the rebase cascade doesn't reintroduce 30M.

The constructor still stores `model` verbatim with no `__init__` validation, so the sklearn `clone` / `get_params` contract is unchanged — the raise happens at checkpoint load. `tests/test_api_smoke.py` pins both halves.

## ⚠️ Breaking

`NoriRegressor()`, `NoriEmbedding()`, `infer(...)` and `predict(...)` without `model=` (or `model_path=`) now raise `ValueError` instead of defaulting to the ~6M base. Pass `model="nori-6m"` to keep the previous weights. The `"nori"` alias is removed — use `"nori-6m"`.

This needs a version bump before publishing; `RELEASING.md` notes the version lives in six places.

## Verification

`main` here was at `d961796` — exactly where staging sat before its merge — so the squash commit applied with `git apply --check` clean, and I confirmed all **30 files are byte-identical to staging's `ab9188f`**.

Staging ran this same tree **18/18 green**, including the full `CI test inference` job (12 min) and the torch-compat matrix 2.8.0 → 2.13.0.

I did **not** run the suite locally on this checkout — the environment is installed at public's own pinned `torch 2.8.0+cu128`, but I'm leaning on the byte-identical + staging-green evidence and letting this repo's CI be the gate. Flagging that explicitly rather than implying local test evidence I don't have.

---
_Generated by [Claude Code](https://claude.ai/code/session_016jVyqHDPUWkVWf2X8AffKs)_