### PR TITLE
Add Nori-100M model variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.0.1';
-          assert synthefy_nori.__version__ == '0.18.0'"
+          assert synthefy_nori.__version__ == '0.18.1'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.18.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -20,7 +20,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/src/synthefy_nori/hf.py
+++ b/src/synthefy_nori/hf.py
@@ -17,14 +17,15 @@ DEFAULT_CHECKPOINT_FILENAME = os.environ.get(
 )
 
 # Model-variant registry: friendly name -> Hugging Face repo id. A size is REQUIRED -- there is no
-# default "nori"; every caller must pick ``model="nori-6m"`` or ``model="nori-30m"`` on NoriRegressor
-# / infer / predict (or ``download_checkpoint(model=...)``). Naming the size keeps the identifier
-# stable: it never silently changes which weights it loads. ``"nori-6m"`` is the ~6M base and honors
-# the SYNTHEFY_NORI_HF_REPO override. Add one line per new variant. An unknown name is treated as a
-# raw repo id, so an explicit ``"org/repo"`` still works.
+# default "nori"; every caller must pick ``model="nori-6m"``, ``model="nori-30m"``, or
+# ``model="nori-100m"`` on NoriRegressor / infer / predict (or ``download_checkpoint(model=...)``).
+# Naming the size keeps the identifier stable: it never silently changes which weights it loads.
+# ``"nori-6m"`` is the ~6M base and honors the SYNTHEFY_NORI_HF_REPO override. Add one line per new
+# variant. An unknown name is treated as a raw repo id, so an explicit ``"org/repo"`` still works.
 NORI_MODELS = {
     "nori-6m": DEFAULT_MODEL_REPO_ID,  # ~6M base (honors SYNTHEFY_NORI_HF_REPO)
     "nori-30m": "Synthefy/Nori-30M",   # ~29.2M scaling-law variant
+    "nori-100m": "Synthefy/Nori-100M", # ~98.3M scaling-law variant
 }
 
 

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -11,13 +11,14 @@ def test_hf_defaults_are_public_strings():
 def test_model_variant_registry_resolution():
     # friendly variant names -> HF repo ids
     assert hf.resolve_model_repo("nori-30m") == "Synthefy/Nori-30M"
+    assert hf.resolve_model_repo("nori-100m") == "Synthefy/Nori-100M"
     assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID    # ~6M base
     # A size is required -- None and a bare "nori" both raise (there is no default).
     for missing in (None, "nori"):
         with pytest.raises(ValueError, match=r"model is required"):
             hf.resolve_model_repo(missing)
     assert hf.resolve_model_repo("Synthefy/Custom-Repo") == "Synthefy/Custom-Repo"  # raw id passes through
-    assert set(hf.NORI_MODELS) == {"nori-6m", "nori-30m"}
+    assert set(hf.NORI_MODELS) == {"nori-6m", "nori-30m", "nori-100m"}
     assert "nori" not in hf.NORI_MODELS
 
 

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,7 +98,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.18.0"
+    assert root["project"]["version"] == "0.18.1"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.0.1"

--- a/uv.lock
+++ b/uv.lock
@@ -6474,7 +6474,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary
- Registers `nori-100m` (~98.3M params, checkpoint `v2-100m-deep-001/tier4-v6-0p7458`) in the `NORI_MODELS` variant registry, pointing at the new public [Synthefy/Nori-100M](https://huggingface.co/Synthefy/Nori-100M) HuggingFace repo (weights already uploaded and verified: anonymous download + `NoriRegressor` load/fit/predict all work).
- On our internal TabArena Elo leaderboard this checkpoint ranks **3rd of 21** tracked models, ahead of Nori-30M, TabPFN-3, and EXAONE-Tabular. Only the TabArena suite has been run for this checkpoint so far (not TALENT-100/CTR23), so the HF model card reports TabArena-only results rather than an "Overall" figure.
- Mirrors the `nori-30m` precedent (same registry pattern, same HF repo layout: `nori.pt` + `config.json` + `README.md` + banner).

## Version note
Bumped to **0.18.1** (patch — purely additive, no breaking changes) rather than 0.19.0. `0.19.0` is already reserved in-tree (`src/synthefy_nori/configs/__init__.py`, `_RENAMED_IN_0_18`) for the planned removal of a deprecated config-name shim — an unrelated breaking change that shouldn't be bundled with this one.

## Test plan
- [x] `uv run pytest` — 412 passed, 6 skipped
- [x] `uv run ruff check src scripts tests ci/*.py` — clean
- [x] `uv.lock` regenerated and committed
- [x] Verified anonymous HF download + `NoriRegressor(model_path=...)` load/fit/predict against the live `Synthefy/Nori-100M` repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)