### PR TITLE
release: synthefy-nori 0.19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.0.1';
-          assert synthefy_nori.__version__ == '0.18.0'"
+          assert synthefy_nori.__version__ == '0.19.0'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.19.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -20,7 +20,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,7 +98,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.18.0"
+    assert root["project"]["version"] == "0.19.0"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.0.1"

--- a/uv.lock
+++ b/uv.lock
@@ -6474,7 +6474,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## What

Version bump for the next `synthefy-nori` release. `0.18.0` → **0.19.0**. Release preparation only — no tag, no publish.

The client stays at **7.0.1**.

## What 0.19.0 actually contains

Rebased onto `main` after two more PRs landed, so this is no longer a single-change release:

| Commit | Change |
| --- | --- |
| `f3ba344` (#123) | **breaking** — `model=` required; `NoriRegressor()`, `NoriEmbedding()`, `infer(...)`, `predict(...)` raise instead of silently loading the ~6M base; bare `"nori"` alias removed |
| `d57faa6` (#122) | auto-detect Apple MPS for inference |
| `00def60` (#121) | unify categorical DataFrame preprocessing across Nori APIs |

The minor bump on 0.x is driven by #123 being breaking.

This also closes a live gap: `docs.synthefy.com` already states both entry points raise, and published 0.18.0 does not. The release is what makes the docs true.

## The six places

Per `RELEASING.md` the version lives in more places than its own project file. All five in-repo locations are set; the sixth is the tag, created at publish time from public `main`:

| Location | Enforced by |
| --- | --- |
| `pyproject.toml` | publish workflow |
| `src/synthefy_nori/__init__.py` | publish workflow |
| `uv.lock` (synthefy-nori workspace entry) | `uv sync --locked` in `ci.yml` |
| `.github/workflows/ci.yml` (inline `__version__` assertion) | itself |
| `tests/test_synthefy_workspace.py` (asserts `project.version`) | `pytest` |

`uv.lock` I edited by matching the `name = "synthefy-nori"` block specifically rather than the bare version string, so no unrelated dependency pin moved.

#121 and #122 both touched `ci.yml`, `pyproject.toml`, `uv.lock` and `test_synthefy_workspace.py` — the same files this bump touches — so the branch was rebased rather than left stale. All five locations re-verified at `0.19.0` after the rebase.

## Checks (re-run after the rebase)

```
uv sync --locked                clean — lock is not stale
uv run pytest                   412 passed, 6 skipped, 55 deselected
uv build                        synthefy_nori-0.19.0  sdist + wheel
ruff check src scripts tests    All checks passed!
RELEASING.md miss-grep          no stray 0.18.0 outside historical references
```

Earlier on the pre-rebase commit I also ran the skill's §C gate — **executing** all 14 documented constructions from `README.md`, `libs/synthefy/README.md` and `examples/` rather than reading them, since #123 changes a public signature. 13 construct clean; `mode="sagemaker"` raises `ImportError: needs the AWS extra` because `boto3` isn't installed, which is exactly what `README.md:89` documents.

## ⚠️ One decision this PR does *not* make

0.19.0 is a loaded version number. `src/synthefy_nori/configs/__init__.py` schedules a deprecation to expire at exactly this version:

```python
# Renamed in 0.18.0. […] Delete this map in 0.19.0.
_RENAMED_IN_0_18 = {"reg_allordinal_poly10_adaptive_svd256.json": DEFAULT_INFERENCE_CONFIG}
```

and the warning it emits tells users the old name *"is removed in 0.19.0"*. `tests/test_config_routing.py:62` repeats it.

Shipping as-is means 0.19.0 emits a warning saying "removed in 0.19.0" **while running 0.19.0 and still resolving the name** — the same code-vs-message contradiction this release exists to fix. Two resolutions:

1. **Honour the schedule** — delete `_RENAMED_IN_0_18`, its branch in `config_path`, and flip `test_legacy_name_still_resolves_with_a_deprecation_warning`. It was pre-announced with a `DeprecationWarning` through a full minor, and this release is already breaking.
2. **Extend the window** — keep the alias, move every "0.19.0" in those messages to "0.20.0".

Not decided here: either way removes or extends public behavior.

## Not in this PR

No tag, no GitHub Release, no publisher dispatch. `RELEASING.md` gates publication on public CI green plus rebase-sync/drop-check confirming the promoted change is still present — and internal has still not absorbed the promotion (`merge-base --is-ancestor` says no), so the chain is not nested yet.