### PR TITLE
Promote staging to public + release synthefy 7.0.2 / synthefy-nori 0.18.1 (nori-100m)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.0.1';
-          assert synthefy_nori.__version__ == '0.18.0'"
+          assert synthefy.__version__ == '7.0.2';
+          assert synthefy_nori.__version__ == '0.18.1'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests
@@ -38,13 +38,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.1-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.2-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.0.1.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.0.2.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.1-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.2-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.1"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.2"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.1] - Unreleased
+## [7.0.2] - Unreleased
+
+### Added
+
+- Added the `nori-100m` size to `NORI_VARIANTS`, so `model="nori-100m"` (and the
+  raw gateway slug `"synthefy/nori-100m"`) select the ~98.3M checkpoint in both
+  hosted and local modes. The weights are public at
+  [`Synthefy/Nori-100M`](https://huggingface.co/Synthefy/Nori-100M).
+
+## [7.0.1] - 2026-08-15
 
 ### Added
 

--- a/libs/synthefy/README.md
+++ b/libs/synthefy/README.md
@@ -133,7 +133,8 @@ Synthefy API if you'd rather not run it locally.
    ```python
    from synthefy import SynthefyNoriClient
 
-   # model is required -- name a size: "nori-30m" (~29.2M) or "nori-6m" (~6M base).
+   # model is required -- name a size: "nori-100m" (~98.3M), "nori-30m" (~29.2M),
+   # or "nori-6m" (~6M base).
    client = SynthefyNoriClient(mode="local", model="nori-30m")   # runs on this machine, no API key
 
    y_pred = client.predict(
@@ -253,7 +254,8 @@ preds = client.predict(X_train, y_train, X_test, as_pandas=True)
 
 The client targets the Baseten inference **gateway**
 (`https://inference.baseten.co/predict`); `model=` is required and names a size —
-`"nori-30m"` (→ `synthefy/nori-30m`) or `"nori-6m"` (→ `synthefy/nori-6m`). The
+`"nori-100m"` (→ `synthefy/nori-100m`), `"nori-30m"` (→ `synthefy/nori-30m`), or
+`"nori-6m"` (→ `synthefy/nori-6m`). The
 gateway resolves that slug to a deployment, so you never name a deployment yourself.
 
 `timeout` and `max_retries` are also configurable on the constructor.
@@ -540,7 +542,7 @@ continuous mean is already optimal for those metrics.
 
 ### SynthefyNoriClient (Tabular Regression)
 
-- `SynthefyNoriClient(api_key=None, *, mode="remote", timeout=300.0, max_retries=2, base_url=..., endpoint=..., model, user_agent=None, endpoint_name=None, region_name=None)` — `model` is **required everywhere** and accepts the three released Nori variants (`nori-6m`, `nori-30m`, and `nori-30m-thinking-medium`) or an explicit custom HTTP slug; there is no `None`/default model path. SageMaker uses response streaming for all three so large 30M requests can run beyond the regular-response limit while `predict()` still returns one normal result.
+- `SynthefyNoriClient(api_key=None, *, mode="remote", timeout=300.0, max_retries=2, base_url=..., endpoint=..., model, user_agent=None, endpoint_name=None, region_name=None)` — `model` is **required everywhere** and accepts the released Nori variants (`nori-6m`, `nori-30m`, `nori-100m`, and `nori-30m-thinking-medium`) or an explicit custom HTTP slug; there is no `None`/default model path. SageMaker uses response streaming for every variant so large 30M/100M requests can run beyond the regular-response limit while `predict()` still returns one normal result.
   - `mode`: `"remote"` (hosted, default), `"local"` (in-process via
     `synthefy-nori`), or `"sagemaker"` (a named SageMaker endpoint using the AWS
     credential chain).

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.0.1"
+version = "7.0.2"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -10,7 +10,7 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.0.1"
+__version__ = "7.0.2"
 
 __all__ = [
     "MEMORY_PRESETS",

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -64,8 +64,8 @@ _MODEL_REQUIRED: Any = object()
 #   local_variant       = the name forwarded to synthefy-nori's ``model=`` selector (local mode)
 # Every selector names its size -- there is no bare "nori"/"synthefy/nori", so a slug never silently
 # changes which model it serves (``model=`` is required; see the constructor). "nori-6m" is the ~6M
-# base; "nori-30m" is the ~29.2M variant. The raw gateway slugs are listed too so they load the
-# right checkpoint locally instead of being treated as a raw HF repo.
+# base; "nori-30m" is the ~29.2M variant; "nori-100m" is the ~98.3M variant. The raw gateway slugs
+# are listed too so they load the right checkpoint locally instead of being treated as a raw HF repo.
 # The "nori-30m-thinking-medium" entries are the test-time-compute variant: hosted-API only,
 # so they map a remote gateway slug but have NO local variant -- the thinking guard in __init__
 # refuses it in mode="local" (its ``local_variant`` below is therefore never consulted).
@@ -74,8 +74,10 @@ _MODEL_REQUIRED: Any = object()
 NORI_VARIANTS = {
     "nori-6m": ("synthefy/nori-6m", "nori-6m"),
     "nori-30m": ("synthefy/nori-30m", "nori-30m"),
+    "nori-100m": ("synthefy/nori-100m", "nori-100m"),
     "synthefy/nori-6m": ("synthefy/nori-6m", "nori-6m"),
     "synthefy/nori-30m": ("synthefy/nori-30m", "nori-30m"),
+    "synthefy/nori-100m": ("synthefy/nori-100m", "nori-100m"),
     # Thinking (test-time compute) -- hosted deployments only; local is refused by the
     # thinking guard. Medium is the only released Thinking budget.
     "nori-30m-thinking-medium": ("synthefy/nori-30m-thinking-medium", None),
@@ -128,7 +130,8 @@ def _resolve_local_variant(model: Optional[str]) -> Optional[str]:
     """Resolve the synthefy-nori ``model=`` value for local inference, or raise if impossible.
 
     ``"nori-6m"``/``"synthefy/nori-6m"`` run the ~6M base checkpoint; ``"nori-30m"``/
-    ``"synthefy/nori-30m"`` run the 29.2M checkpoint. ``None`` forwards no ``model=`` (so
+    ``"synthefy/nori-30m"`` run the 29.2M checkpoint; ``"nori-100m"``/``"synthefy/nori-100m"``
+    run the 98.3M checkpoint. ``None`` forwards no ``model=`` (so
     synthefy-nori, which itself requires an explicit model, would raise). Any other selector has
     no local checkpoint, so this
     raises :class:`ValueError` instead of silently falling back to the base model -- a Nori
@@ -139,14 +142,14 @@ def _resolve_local_variant(model: Optional[str]) -> Optional[str]:
         raise ValueError(
             f"model={model!r} is a Nori Thinking (test-time-compute) variant, which runs only "
             "on the hosted Synthefy API and has no local checkpoint. Use mode='remote' with a "
-            "Baseten API key to run Thinking, or select 'nori-6m'/'nori-30m' for local "
-            "inference."
+            "Baseten API key to run Thinking, or select 'nori-6m'/'nori-30m'/'nori-100m' for "
+            "local inference."
         )
     if model is None or model in NORI_VARIANTS:
         return _resolve_variant(model)[1]
     raise ValueError(
         f"model={model!r} has no local checkpoint and cannot run in mode='local'. Local "
-        "inference supports the base model ('nori-6m') and 'nori-30m'. For hosted-only "
+        "inference supports 'nori-6m', 'nori-30m' and 'nori-100m'. For hosted-only "
         "variants (e.g. Nori Thinking) or a custom deployment slug, use mode='remote' with a "
         "Baseten API key."
     )

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -32,8 +32,11 @@ from synthefy.nori_client import (
     GATEWAY_ENDPOINT,
     NORI_VARIANTS,
     SAGEMAKER_MAX_BODY_BYTES,
+    SAGEMAKER_VARIANTS,
+    _MODEL_NAMES,
     _is_thinking_model,
     _nullable_matrix,
+    _resolve_local_variant,
     _resolve_remote_levels,
     _resolve_text_device,
     _snap_to_levels,
@@ -1490,7 +1493,63 @@ def test_no_bare_nori_slug():
     # The ambiguous bare selectors are gone -- only size-explicit names/slugs resolve.
     assert "nori" not in NORI_VARIANTS
     assert "synthefy/nori" not in NORI_VARIANTS
-    assert set(NORI_VARIANTS) >= {"nori-6m", "nori-30m", "synthefy/nori-6m", "synthefy/nori-30m"}
+    assert set(NORI_VARIANTS) >= {
+        "nori-6m",
+        "nori-30m",
+        "nori-100m",
+        "synthefy/nori-6m",
+        "synthefy/nori-30m",
+        "synthefy/nori-100m",
+    }
+
+
+def test_nori_100m_resolves_like_the_other_sizes():
+    # The ~98.3M variant is a plain size selector: friendly name and raw slug both map to the
+    # nori-100m gateway slug and the nori-100m local checkpoint (no Thinking, no special case).
+    c100 = SynthefyNoriClient(api_key="k", model="nori-100m")
+    assert c100.model == "synthefy/nori-100m"
+    assert c100._local_variant == "nori-100m"
+
+    craw = SynthefyNoriClient(api_key="k", model="synthefy/nori-100m")
+    assert craw.model == "synthefy/nori-100m"
+    assert craw._local_variant == "nori-100m"
+
+    assert not _is_thinking_model("nori-100m")
+
+
+def test_nori_100m_is_offered_everywhere_the_size_list_is_derived():
+    # _MODEL_NAMES and SAGEMAKER_VARIANTS are both derived from NORI_VARIANTS, so a new size
+    # must appear in each without a second edit.
+    assert "nori-100m" in _MODEL_NAMES
+    assert "nori-100m" in SAGEMAKER_VARIANTS
+    assert "nori-30m-thinking-medium" in _MODEL_NAMES
+    assert all("/" not in name for name in _MODEL_NAMES)
+    # Thinking has no local checkpoint; nori-100m does. Assert the behaviour directly rather
+    # than through a derived name list.
+    assert _resolve_local_variant("nori-100m") == "nori-100m"
+    with pytest.raises(ValueError, match="no local checkpoint"):
+        _resolve_local_variant("nori-30m-thinking-medium")
+
+
+def test_local_mode_passes_nori_100m_to_predict(monkeypatch):
+    seen: Dict = {}
+
+    def fake_predict(X_train, y_train, X_test, *, task=None, model="__unset__"):
+        seen["model"] = model
+        return [0.0]
+
+    monkeypatch.setattr("synthefy.nori_client._load_local_predict", lambda: fake_predict)
+    client = SynthefyNoriClient(mode="local", model="nori-100m")
+    client.predict(X_train=_XTR, y_train=_YTR, X_test=_XTE)
+    assert seen["model"] == "nori-100m"
+
+
+def test_remote_body_uses_nori_100m_gateway_slug():
+    capture: Dict = {}
+    client = SynthefyNoriClient(api_key="k", model="nori-100m")
+    _attach_mock(client, _ok_handler([1.0], capture))
+    client.predict(X_train=_XTR, y_train=_YTR, X_test=_XTE)
+    assert capture["body"]["model"] == "synthefy/nori-100m"
 
 
 def test_remote_body_uses_variant_gateway_slug():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.18.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -20,7 +20,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/src/synthefy_nori/hf.py
+++ b/src/synthefy_nori/hf.py
@@ -17,14 +17,15 @@ DEFAULT_CHECKPOINT_FILENAME = os.environ.get(
 )
 
 # Model-variant registry: friendly name -> Hugging Face repo id. A size is REQUIRED -- there is no
-# default "nori"; every caller must pick ``model="nori-6m"`` or ``model="nori-30m"`` on NoriRegressor
-# / infer / predict (or ``download_checkpoint(model=...)``). Naming the size keeps the identifier
-# stable: it never silently changes which weights it loads. ``"nori-6m"`` is the ~6M base and honors
-# the SYNTHEFY_NORI_HF_REPO override. Add one line per new variant. An unknown name is treated as a
-# raw repo id, so an explicit ``"org/repo"`` still works.
+# default "nori"; every caller must pick ``model="nori-6m"``, ``model="nori-30m"``, or
+# ``model="nori-100m"`` on NoriRegressor / infer / predict (or ``download_checkpoint(model=...)``).
+# Naming the size keeps the identifier stable: it never silently changes which weights it loads.
+# ``"nori-6m"`` is the ~6M base and honors the SYNTHEFY_NORI_HF_REPO override. Add one line per new
+# variant. An unknown name is treated as a raw repo id, so an explicit ``"org/repo"`` still works.
 NORI_MODELS = {
     "nori-6m": DEFAULT_MODEL_REPO_ID,  # ~6M base (honors SYNTHEFY_NORI_HF_REPO)
     "nori-30m": "Synthefy/Nori-30M",   # ~29.2M scaling-law variant
+    "nori-100m": "Synthefy/Nori-100M", # ~98.3M scaling-law variant
 }
 
 
@@ -41,7 +42,7 @@ def _is_thinking_model(model: str) -> bool:
 
 def resolve_model_repo(model: str | None) -> str:
     """Map a variant name to its HF repo id. A size is required: ``None`` or a bare ``"nori"``
-    raises (there is no default) -- pick ``"nori-6m"`` or ``"nori-30m"``. A known name -> its repo;
+    raises (there is no default) -- pick one of :data:`NORI_MODELS`. A known name -> its repo;
     anything else is returned unchanged (so a raw ``"org/repo"`` id also works).
 
     A Nori Thinking selector raises :class:`ValueError`: it has no downloadable checkpoint here,
@@ -57,8 +58,8 @@ def resolve_model_repo(model: str | None) -> str:
             f"model={model!r} selects a Nori Thinking (test-time-compute) variant, which runs "
             "only on the hosted Synthefy API. The synthefy-nori package does single-pass local "
             "inference and has no Thinking checkpoint. Use the hosted API (e.g. the `synthefy` "
-            "client with mode='remote') for Thinking, or select 'nori-6m' / 'nori-30m' "
-            "for local inference."
+            "client with mode='remote') for Thinking, or select one of "
+            f"{', '.join(repr(name) for name in NORI_MODELS)} for local inference."
         )
     return NORI_MODELS.get(model, model)
 
@@ -96,14 +97,15 @@ def download_checkpoint(
     """Download a checkpoint from the Hugging Face Hub and return its local path.
 
     ``model`` selects a registry variant (e.g. ``"nori-6m"``) and overrides ``repo_id``. A size is
-    required: with neither ``model`` nor ``repo_id`` given, this raises -- pass
-    ``model="nori-6m"``/``"nori-30m"`` or an explicit ``repo_id``.
+    required: with neither ``model`` nor ``repo_id`` given, this raises -- pass a
+    :data:`NORI_MODELS` name as ``model=`` or an explicit ``repo_id``.
     """
     if model is not None:
         repo_id = resolve_model_repo(model)
     elif repo_id is None:
         raise ValueError(
-            "download_checkpoint requires model= ('nori-6m'/'nori-30m') or an explicit repo_id="
+            "download_checkpoint requires model= "
+            f"({'/'.join(repr(name) for name in NORI_MODELS)}) or an explicit repo_id="
         )
     try:
         from huggingface_hub import hf_hub_download

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -11,13 +11,14 @@ def test_hf_defaults_are_public_strings():
 def test_model_variant_registry_resolution():
     # friendly variant names -> HF repo ids
     assert hf.resolve_model_repo("nori-30m") == "Synthefy/Nori-30M"
+    assert hf.resolve_model_repo("nori-100m") == "Synthefy/Nori-100M"
     assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID    # ~6M base
     # A size is required -- None and a bare "nori" both raise (there is no default).
     for missing in (None, "nori"):
         with pytest.raises(ValueError, match=r"model is required"):
             hf.resolve_model_repo(missing)
     assert hf.resolve_model_repo("Synthefy/Custom-Repo") == "Synthefy/Custom-Repo"  # raw id passes through
-    assert set(hf.NORI_MODELS) == {"nori-6m", "nori-30m"}
+    assert set(hf.NORI_MODELS) == {"nori-6m", "nori-30m", "nori-100m"}
     assert "nori" not in hf.NORI_MODELS
 
 

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,11 +98,11 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.18.0"
+    assert root["project"]["version"] == "0.18.1"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.0.1"
-    assert _declared_version() == "7.0.1"
+    assert client["project"]["version"] == "7.0.2"
+    assert _declared_version() == "7.0.2"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -374,7 +374,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.0.1"
+    assert client_entries[0]["version"] == "7.0.2"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6391,7 +6391,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.0.1"
+version = "7.0.2"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },
@@ -6474,7 +6474,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary
Final cascade step for the **Nori-100M** variant: internal [#477](https://github.com/Synthefy/synthefy-nori-internal/pull/477)/[#481](https://github.com/Synthefy/synthefy-nori-internal/pull/481) → staging [#28](https://github.com/Synthefy/synthefy-nori-staging/pull/28) → here. Both published distributions gain the size:

| distribution | change |
|---|---|
| `synthefy-nori` | `NORI_MODELS["nori-100m"] -> Synthefy/Nori-100M`; the two size-list error strings now derive from the registry instead of hardcoding `'nori-6m'/'nori-30m'` |
| `synthefy` | `NORI_VARIANTS` gains `"nori-100m"` and `"synthefy/nori-100m"` |

## The model is already live
- **HuggingFace** [`Synthefy/Nori-100M`](https://huggingface.co/Synthefy/Nori-100M) — public; anonymous download + `NoriRegressor` load/fit/predict verified.
- **Baseten production** — a real customer call to `https://inference.baseten.co/predict` with `model: synthefy/nori-100m` returns HTTP 200, correct predictions, `usage` block intact. All 13 prod key groups are granted the slug.

So this PR is what lets a `pip install` user reach it; the serving side is already done.

## Versions

| | from | to |
|---|---|---|
| `synthefy` | 7.0.1 | **7.0.2** |
| `synthefy-nori` | 0.18.0 | **0.18.1** |

Bumped in **every enforced location**, not just the project files: `pyproject.toml` ×2, `__init__.py` ×2, `uv.lock` (regenerated), `.github/workflows/ci.yml` — both the inline assertions **and its hardcoded artifact filenames** (`synthefy-7.0.2-py3-none-any.whl`, `.tar.gz`) — and `tests/test_synthefy_workspace.py`.

`0.19.0` is deliberately **not** used for `synthefy-nori`: it is already reserved in-tree for removing the `_RENAMED_IN_0_18` config-name shim (`src/synthefy_nori/configs/__init__.py`), an unrelated breaking change.

Also corrected the changelog's `## [7.0.1] - Unreleased` heading — 7.0.1 has been on PyPI since 2026-08-15. Pre-existing drift, fixed in passing.

## Deliberately NOT promoted
- `libs/synthefy/SOURCE_SNAPSHOT.json` and `tests/test_synthefy_source_import.py` — the issue-#216 provenance ledger. Verified with `git ls-tree` that **neither file exists in staging or public**; it is an internal-only audit artifact.
- Internal #478/#482/#483 (serving registry, Truss config, SageMaker, the truss-client bump, serving docs) — neither staging nor public has a `serving/` tree.

## Test plan
- [x] `uv run pytest` — **412 passed, 6 skipped**
- [x] `uv run ruff check src scripts tests ci/*.py` — clean
- [x] `uv.lock` regenerated; both workspace members show the new versions
- [x] `RELEASING.md`'s stale-version grep — only legitimate hits remain (workflow input *examples*, and "Renamed in 0.18.0" statements that stay true)

## Release order after merge
`RELEASING.md` requires the lightweight SDK first, since `synthefy-nori` declares `synthefy>=7,<8`:

1. tag `synthefy-v7.0.2` → release → approve the `synthefy-pypi` environment → verify
2. then tag `synthefy-nori-v0.18.1` → release → approve `synthefy-nori-pypi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
