### PR TITLE
release: synthefy 7.0.3 / synthefy-nori 0.18.2 (large_context_policy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.0.2';
-          assert synthefy_nori.__version__ == '0.18.1'"
+          assert synthefy.__version__ == '7.0.3';
+          assert synthefy_nori.__version__ == '0.18.2'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests
@@ -38,13 +38,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.2-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.3-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.0.2.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.0.3.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.2-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.3-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.2"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.3"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.2] - Unreleased
+## [7.0.3] - Unreleased
+
+### Added
+
+- Added bounded large-context selection to `SynthefyNoriClient.predict` in
+  local, Baseten remote, and SageMaker modes. The shared contract accepts
+  `random`, `cluster_route`, and `cluster_route_g4` plus a bounded threshold
+  and seed; `last_large_context_report` proves what ran and how many internal
+  Nori calls it made. Hosted calls are one-shot and retain no customer context
+  between requests; Snowflake SPCS rejects the unsupported fifth-options shape
+  explicitly.
+
+## [7.0.2] - 2026-08-17
 
 ### Added
 
@@ -50,16 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [7.0.0] - 2026-08-12
-
-### Added
-
-- Added bounded large-context selection to ``SynthefyNoriClient.predict`` in
-  local, Baseten remote, and SageMaker modes. The shared contract accepts
-  ``random``, ``cluster_route``, and ``cluster_route_g4`` plus a bounded
-  threshold and seed; ``last_large_context_report`` proves what ran and how
-  many internal Nori calls it made. Hosted calls are one-shot and retain no
-  customer context between requests; Snowflake SPCS rejects the unsupported
-  fifth-options shape explicitly.
 
 ### Removed
 

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.0.2"
+version = "7.0.3"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -15,7 +15,7 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.0.2"
+__version__ = "7.0.3"
 
 __all__ = [
     "DEFAULT_LARGE_CONTEXT_SEED",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.18.1"
+version = "0.18.2"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -20,7 +20,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.18.1"
+__version__ = "0.18.2"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -98,11 +98,11 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.18.1"
+    assert root["project"]["version"] == "0.18.2"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.0.2"
-    assert _declared_version() == "7.0.2"
+    assert client["project"]["version"] == "7.0.3"
+    assert _declared_version() == "7.0.3"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -374,7 +374,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.0.2"
+    assert client_entries[0]["version"] == "7.0.3"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6391,7 +6391,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.0.2"
+version = "7.0.3"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },
@@ -6474,7 +6474,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Bump both distributions to publish the bounded large_context_policy
client/serving support merged in #131. Also fixes the CHANGELOG: the
large_context_policy entry had been mistakenly added under the already-
released, immutable 7.0.0 section instead of a new version, and 7.0.2
was still labeled "Unreleased" despite the synthefy-v7.0.2 tag already
existing.
