### PR TITLE
feat(client): support all built-in large-context policies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.0.3';
+          assert synthefy.__version__ == '7.0.4';
           assert synthefy_nori.__version__ == '0.19.0'"
       - run: uv run pytest
       - run: >-
@@ -38,13 +38,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.3-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.4-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.0.3.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.0.4.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.0.3-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.0.4-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -68,7 +68,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.3"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.0.4"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.3] - Unreleased
+## [7.0.4] - Unreleased
+
+### Added
+
+- Added large-context selection to `SynthefyNoriClient.predict` in local,
+  Baseten remote, and SageMaker modes. Hosted modes accept a string naming every
+  installed built-in policy, including `boost`, `safeboost`, and parameter
+  strings; custom policies remain local-only. `last_large_context_report`
+  echoes the resolved policy and proves how many internal Nori calls ran.
+  Hosted policy execution stops before a 65th internal call; direct local use
+  remains unlimited by default. Hosted calls retain no customer context between
+  requests; Snowflake SPCS rejects the unsupported fifth-options shape explicitly.
+
+### Removed (breaking)
+
+- Removed the exported `HOSTED_LARGE_CONTEXT_POLICIES` snapshot. It was not
+  used for validation and could not stay synchronized with the installed
+  server registry. Code importing that constant must upgrade alongside this
+  client change and pass policy specs directly to `predict` instead.
+
+## [7.0.3] - 2026-08-20
 
 ### Added
 

--- a/libs/synthefy/README.md
+++ b/libs/synthefy/README.md
@@ -448,18 +448,21 @@ preds = client.predict(
 print(client.last_large_context_report)
 ```
 
-The client/hosted contract is deliberately narrower than direct
-`NoriRegressor` use:
+Here are some commonly used built-in policies:
 
-| policy | maximum internal Nori calls | hosted status |
-| --- | ---: | --- |
-| `"random"` | 1 | supported |
-| `"cluster_route"` | 8 | supported; recommended default when enabled |
-| `"cluster_route_g4"` | 4 | supported |
+| policy | hosted status |
+| --- | --- |
+| `"random"` | supported |
+| `"cluster_route"` | supported; recommended default when enabled |
+| `"cluster_route_g4"` | supported |
+| `"safeboost"` | supported |
+| `"boost"` | supported; prefer `safeboost` |
 
-Custom callables, module/file paths, parameter strings, holdout gates,
-`boost`, and `safeboost` remain local research APIs available through
-`NoriRegressor` directly. They are not serialized to a shared endpoint.
+Hosted and SageMaker support built-ins from the installed Nori version. See
+[`policies.py`](../../src/synthefy_nori/inference/policies.py) for the complete
+current list and configuration options. Hosted modes forward policy-name strings
+unchanged, including parameter strings such as `"safeboost[nu=0.25]"`. Custom
+callables and module/file policies remain local-only.
 `large_context_cache_entries` is also intentionally absent from the client:
 each client call is one-shot, fits the supplied `X_train` again, and hosted
 serving retains no customer context across requests.

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.0.3"
+version = "7.0.4"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -1,7 +1,6 @@
 from synthefy.nori_data_models import (
     DEFAULT_LARGE_CONTEXT_SEED,
     DEFAULT_LARGE_CONTEXT_THRESHOLD,
-    HOSTED_LARGE_CONTEXT_POLICIES,
     LargeContextPolicy,
     LargeContextReport,
     MEMORY_PRESETS,
@@ -15,12 +14,11 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.0.3"
+__version__ = "7.0.4"
 
 __all__ = [
     "DEFAULT_LARGE_CONTEXT_SEED",
     "DEFAULT_LARGE_CONTEXT_THRESHOLD",
-    "HOSTED_LARGE_CONTEXT_POLICIES",
     "LargeContextPolicy",
     "LargeContextReport",
     "MEMORY_PRESETS",

--- a/libs/synthefy/src/synthefy/data_models.py
+++ b/libs/synthefy/src/synthefy/data_models.py
@@ -45,18 +45,10 @@ class NoriPredictRequest(BaseModel):
     quantiles : List[float] or None, optional
         Tau levels in ``(0, 1)`` for ``output_type="quantiles"``, in the caller's
         order. Omitted from the body when ``None``.
-    large_context_policy : {"random", "cluster_route", "cluster_route_g4"} or None
-        Hosted-safe context-selection policy. Omitted when unset.
-
-        * ``"random"`` -- 1 internal Nori call. One shared context window, chosen at
-          random. The cheapest fallback; no routing, no accuracy upside.
-        * ``"cluster_route"`` -- up to 8 internal Nori calls. Clusters query rows into
-          groups, each scored against its own local context pool. The recommended
-          choice: the only one with full coverage on the validated benchmark sweep and
-          it never regressed below ``"random"``.
-        * ``"cluster_route_g4"`` -- the same mechanism, up to 4 calls (cheaper). Best
-          mean score on the tables it was measured against, but that measurement covers
-          a smaller subset -- not a safe blanket default.
+    large_context_policy : optional
+        A policy-name string in hosted modes; local mode also accepts a callable.
+        The client forwards it unchanged, and the installed policy registry is the
+        source of truth for supported built-ins and parameters.
     large_context_threshold : int or None, optional
         Context row count strictly above which the policy engages. Valid only
         with ``large_context_policy``.

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -44,7 +44,6 @@ from synthefy.data_models import NoriPredictRequest, NoriPredictResponse
 from synthefy.nori_data_models import (
     DEFAULT_LARGE_CONTEXT_SEED,
     DEFAULT_LARGE_CONTEXT_THRESHOLD,
-    HOSTED_LARGE_CONTEXT_POLICIES,
     LargeContextPolicy,
     LargeContextReport,
     MAX_LARGE_CONTEXT_SEED,
@@ -593,6 +592,7 @@ def _validate_large_context_controls(
     seed: Optional[int],
     output_type: str,
     model: Optional[str],
+    mode: str,
 ) -> None:
     """Fail before preprocessing, checkpoint load, or a paid hosted request.
 
@@ -615,13 +615,10 @@ def _validate_large_context_controls(
                 "both large_context_threshold and large_context_seed."
             )
         return
-    if not isinstance(policy, str) or policy not in HOSTED_LARGE_CONTEXT_POLICIES:
+    if not isinstance(policy, str) and (mode != "local" or not callable(policy)):
         raise ValueError(
-            f"large_context_policy must be one of "
-            f"{HOSTED_LARGE_CONTEXT_POLICIES}; got {policy!r}. Custom "
-            "callables/paths, gates, boosting policies, and parameter strings "
-            "remain available through NoriRegressor directly, not the shared "
-            "client/hosted contract."
+            "large_context_policy must be a policy name string; custom callables "
+            "are supported only in local mode."
         )
     if threshold is not None and (
         isinstance(threshold, bool)
@@ -677,7 +674,9 @@ def _normalized_large_context_report(
     if report is None:
         return LargeContextReport(
             applied=False,
-            policy=policy,
+            policy=(
+                policy if isinstance(policy, str) else getattr(policy, "__name__", repr(policy))
+            ),
             threshold=threshold,
             seed=seed,
             reason="below_threshold",
@@ -1426,26 +1425,14 @@ class SynthefyNoriClient:
             settings needs far more query rows than the hosted request-body limit allows
             (~64 MiB) -- so lowering ``elements_budget`` is what lets a hosted caller reach
             the cached path at all.
-        large_context_policy : {"random", "cluster_route", "cluster_route_g4"} or None
+        large_context_policy : str, callable, or None
             Select context rows explicitly when `len(X_train)` exceeds
-            `large_context_threshold`. Off by default. The same bounded menu
-            works in local, remote, and SageMaker modes:
-
-            - `random`: 1 internal Nori call. One shared context window, chosen
-              at random. The cheapest fallback; no routing, no accuracy upside.
-            - `cluster_route`: at most 8 internal Nori calls. Clusters query
-              rows into groups, each scored against its own local context
-              pool. **Recommended** -- the only policy with full coverage on
-              the validated benchmark sweep, and it never regressed below
-              `random`.
-            - `cluster_route_g4`: the same mechanism at a smaller group count
-              (at most 4 calls, cheaper). Best mean score on the tables it was
-              measured against, but that measurement covers a smaller subset
-              -- not a safe blanket default.
-
-            Direct `NoriRegressor` use retains the broader local research API
-            (callables, paths, parameter strings, gates and boosting
-            policies); those values are not a shared network contract.
+            `large_context_threshold`. Off by default. Remote and SageMaker
+            modes forward a policy-name string unchanged; the server accepts
+            every built-in in its installed Nori registry, including `random`,
+            `cluster_route`, `cluster_route_g4`, `safeboost`, and `boost`.
+            Parameter strings such as `safeboost[nu=0.25]` are supported.
+            Local mode additionally accepts a custom callable.
 
             Point output only: `mean` and `median` are supported;
             `quantiles`/`full` and Nori Thinking variants fail before
@@ -1576,6 +1563,7 @@ class SynthefyNoriClient:
             seed=large_context_seed,
             output_type=output_type,
             model=self.model,
+            mode=self.mode,
         )
         request_categorical_columns = categorical_columns
         if _has_declared_text_columns(text_columns):
@@ -1994,11 +1982,12 @@ class SynthefyNoriClient:
                 else DEFAULT_LARGE_CONTEXT_SEED
             )
             mismatches = []
-            if report.policy != request.large_context_policy:
+            expected_policy = request.large_context_policy.strip()
+            if report.policy != expected_policy:
                 mismatches.append(
-                    f"policy={report.policy!r}, expected "
-                    f"{request.large_context_policy!r}"
+                    f"policy={report.policy!r}, expected {expected_policy!r}"
                 )
+
             if report.threshold != expected_threshold:
                 mismatches.append(
                     f"threshold={report.threshold}, expected {expected_threshold}"

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -1,8 +1,9 @@
 """Lightweight Nori client/serving data models.
 
 ``MemoryPolicy`` mirrors the authoritative model in ``synthefy-nori``. The
-large-context types below instead define the deliberately bounded client/wire
-subset of the library's broader local research API.
+large-context types below keep the client transport-neutral: local mode may forward
+a Python callable, while hosted modes send a policy-name string for the server's
+authoritative resolver to validate.
 
 **This is a copy, and the original is authoritative.** The policy is defined by
 ``synthefy_nori.inference.memory_policy.MemoryPolicy``, in the repo that also runs the
@@ -35,7 +36,7 @@ local mode gates separately on what is installed — see ``_local_memory_policy_
 
 from __future__ import annotations
 
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from typing_extensions import Annotated
@@ -46,25 +47,20 @@ MEMORY_PRESETS = ('exact', 'max_context', 'off')
 #: The fallback rungs the server may report, in decreasing memory cost.
 MEMORY_RUNGS = ('no_cache', 'resident_bf16', 'resident_int8', 'offload_bf16', 'offload_int8', 'context_row_chunk', 'plain_loop')
 
-#: Large-context policies safe to execute on a shared hosted endpoint. The local
-#: NoriRegressor deliberately accepts a much broader research extension surface
-#: (callables, module/file paths, parameter strings, gates and boosting policies).
-#: None of those are a network contract: callables/paths are code execution, while the
-#: unbounded policies can multiply model calls without a serving or billing cap.
-HOSTED_LARGE_CONTEXT_POLICIES = ('random', 'cluster_route', 'cluster_route_g4')
-
 #: The direct library's defaults, copied here because synthefy must remain usable
 #: without importing the heavyweight synthefy-nori package.
 DEFAULT_LARGE_CONTEXT_THRESHOLD = 50_000
 DEFAULT_LARGE_CONTEXT_SEED = 0
 
-#: Wire-level bounds. The policy menu caps model calls (1, 8 and 4 respectively);
-#: these cap the two remaining integer controls before a request is sent.
+#: Hosted serving owns its work bounds; these cap the two integer controls before
+#: a request is sent.
 MAX_LARGE_CONTEXT_THRESHOLD = 10_000_000
 MAX_LARGE_CONTEXT_SEED = 2**32 - 1
 
 MemoryPreset = Literal['exact', 'max_context', 'off']
-LargeContextPolicy = Literal['random', 'cluster_route', 'cluster_route_g4']
+#: Local mode also accepts callables; hosted modes require a policy-name string and
+#: let the server's installed synthefy-nori resolver decide whether it is valid.
+LargeContextPolicy = Union[str, Callable[..., Any]]
 
 
 class MemoryPolicy(BaseModel):
@@ -323,8 +319,10 @@ class LargeContextReport(BaseModel):
             "inference ran instead; see reason."
         )
     )
-    policy: LargeContextPolicy = Field(
-        description="Resolved built-in policy name honored by the server."
+    policy: str = Field(
+        description=(
+            "Resolved policy name when available; otherwise a display label for the skipped request."
+        )
     )
     threshold: int = Field(
         ge=1,
@@ -372,12 +370,7 @@ class LargeContextReport(BaseModel):
     gate_winner: Optional[str] = Field(
         None,
         description=(
-            "Winning policy for a local holdout gate. Hosted serving does not accept "
-            "gates, but the response model carries the field for local parity. Always "
-            "null today: none of HOSTED_LARGE_CONTEXT_POLICIES runs the gate path, so no "
-            "code path in this engine can set it to a real value. A future change that "
-            "exposes a hosted gate must add its own coverage for a non-null response -- "
-            "this field having a place in the schema already is not evidence that it works."
+            "Winning policy when a holdout gate was requested; otherwise null."
         ),
     )
 

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -2614,9 +2614,9 @@ def test_missing_large_context_report_fails_the_capability_handshake():
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        ("policy", "random"),
         ("threshold", 2),
         ("seed", 8),
+        ("policy", "random"),
     ],
 )
 def test_mismatched_large_context_report_fails_closed(field, value):
@@ -2640,11 +2640,49 @@ def test_mismatched_large_context_report_fails_closed(field, value):
         "boost",
         "safeboost",
         "cluster_route[groups=16]",
-        ["random", "cluster_route"],
-        True,
     ],
 )
-def test_client_rejects_non_hosted_large_context_policies_before_network(policy):
+def test_client_forwards_large_context_policy_strings_unchanged(policy):
+    capture: Dict = {}
+    report = {
+        **_LARGE_CONTEXT_REPORT,
+        "policy": policy,
+        "threshold": 50_000,
+        "seed": 0,
+    }
+    client = _client_with(_large_context_handler(capture, report))
+    client.predict(
+        _X_TRAIN,
+        _Y_TRAIN,
+        _X_TEST,
+        large_context_policy=policy,
+    )
+    assert capture["body"]["large_context_policy"] == policy
+    assert client.last_large_context_report["policy"] == policy
+
+
+def test_remote_client_rejects_callable_large_context_policy_before_network():
+    calls = {"count": 0}
+
+    def custom_policy(_problem, _rng):
+        pass
+
+    def handler(_request):
+        calls["count"] += 1
+        return httpx.Response(500)
+
+    client = _client_with(handler)
+    with pytest.raises(ValueError, match="policy name string"):
+        client.predict(
+            _X_TRAIN,
+            _Y_TRAIN,
+            _X_TEST,
+            large_context_policy=custom_policy,
+        )
+    assert calls["count"] == 0
+
+
+def test_remote_client_rejects_non_string_policy_before_network():
     calls = {"count": 0}
 
     def handler(_request):
@@ -2652,12 +2690,12 @@ def test_client_rejects_non_hosted_large_context_policies_before_network(policy)
         return httpx.Response(500)
 
     client = _client_with(handler)
-    with pytest.raises(ValueError, match="large_context_policy"):
+    with pytest.raises(ValueError, match="policy name string"):
         client.predict(
             _X_TRAIN,
             _Y_TRAIN,
             _X_TEST,
-            large_context_policy=policy,
+            large_context_policy=["random", "cluster_route"],
         )
     assert calls["count"] == 0
 
@@ -2710,7 +2748,7 @@ def test_large_context_report_is_cleared_even_when_the_next_call_is_rejected():
             _X_TRAIN,
             _Y_TRAIN,
             _X_TEST,
-            large_context_policy="boost",
+            large_context_policy=lambda *_: None,
         )
     assert client.last_large_context_report is None
 
@@ -2731,14 +2769,34 @@ def test_large_context_request_model_is_bounded_and_omits_unset_fields():
     assert "large_context_policy" not in NoriPredictRequest(**base).to_wire()
     with pytest.raises(ValueError):
         NoriPredictRequest(**base, large_context_threshold=123)
-    with pytest.raises(ValueError):
-        NoriPredictRequest(**base, large_context_policy="boost")
+    for policy in ("boost", "safeboost", "cluster_route[groups=16]"):
+        assert (
+            NoriPredictRequest(**base, large_context_policy=policy).to_wire()["large_context_policy"] == policy
+        )
     with pytest.raises(ValueError):
         NoriPredictRequest(
             **base,
             large_context_policy="random",
             large_context_seed=2**32,
         )
+
+
+def test_local_skipped_report_uses_the_callable_name():
+    from synthefy import nori_client as module
+
+    def custom_policy(_problem, _rng):
+        pass
+
+    request = NoriPredictRequest(
+        X_train=_X_TRAIN,
+        y_train=_Y_TRAIN,
+        X_test=_X_TEST,
+        large_context_policy=custom_policy,
+    )
+    report = module._normalized_large_context_report(request, None)
+
+    assert report["applied"] is False
+    assert report["policy"] == "custom_policy"
 
 
 def test_local_large_context_uses_the_estimator_and_copies_its_report(monkeypatch):
@@ -2751,6 +2809,9 @@ def test_local_large_context_uses_the_estimator_and_copies_its_report(monkeypatc
     from synthefy import nori_client as module
 
     seen: Dict = {}
+
+    def custom_policy(_problem, _rng):
+        pass
 
     class FakeRegressor:
         def __init__(
@@ -2796,7 +2857,7 @@ def test_local_large_context_uses_the_estimator_and_copies_its_report(monkeypatc
                 "categorical_levels": categorical_levels,
             }
             self.large_context_report_ = {
-                "policy": self.large_context_policy,
+                "policy": getattr(self.large_context_policy, "__name__", self.large_context_policy),
                 "window": 2,
                 "n_train": 3,
                 "n_test": 2,
@@ -2814,19 +2875,22 @@ def test_local_large_context_uses_the_estimator_and_copies_its_report(monkeypatc
         _X_TRAIN,
         _Y_TRAIN,
         _X_TEST,
-        large_context_policy="cluster_route",
+        large_context_policy=custom_policy,
         large_context_threshold=1,
         large_context_seed=7,
     )
     assert predictions == [0.4, 0.5]
     assert seen["init"] == {
         "model": "nori-30m",
-        "large_context_policy": "cluster_route",
+        "large_context_policy": custom_policy,
         "large_context_threshold": 1,
         "large_context_seed": 7,
         "large_context_cache_entries": 1,
     }
-    assert client.last_large_context_report == _LARGE_CONTEXT_REPORT
+    assert client.last_large_context_report == {
+        **_LARGE_CONTEXT_REPORT,
+        "policy": "custom_policy",
+    }
 
 
 def test_local_large_context_has_a_clear_old_package_guard(monkeypatch):

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -190,6 +190,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         embedder="minilm",
         text_max_cardinality: int | None = None,
         text_normalize: bool | None = None,
+        large_context_max_calls: int | None = None,
     ) -> None:
         """Configure the estimator (arguments are stored verbatim; see class docs).
 
@@ -271,8 +272,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 See :mod:`synthefy_nori.inference.large_context` — and note that ``"boost"``
                 measured −0.229 worst-case, so prefer ``"safeboost"`` or a list.
 
-                The three bounded policies also available over the hosted API, and which
-                to reach for:
+                Three common built-in policies, and which to reach for:
 
                 * ``"random"`` — **1** Nori call. One shared context window, chosen at
                   random. The cheapest fallback; no routing, no accuracy upside.
@@ -295,6 +295,9 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 gets no cache hits at 1, since each pool evicts the previous one; raise
                 it to the pool count to keep the rotation. **Costs one full K/V cache
                 per entry**, which is why it is not raised automatically.
+            large_context_max_calls: optional ceiling on internal Nori calls made by one
+                policy prediction. None (default) leaves local use unlimited; hosted
+                serving supplies a bounded value.
 
         The discretize/categorical_levels pair are estimator-level defaults; the
         same-named ``predict`` kwargs override them per call. The text_* params take
@@ -347,6 +350,13 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         self.large_context_threshold = int(large_context_threshold)
         self.large_context_seed = int(large_context_seed)
         self.large_context_cache_entries = int(large_context_cache_entries)
+        if large_context_max_calls is not None and (
+            isinstance(large_context_max_calls, bool)
+            or not isinstance(large_context_max_calls, int)
+            or large_context_max_calls < 1
+        ):
+            raise ValueError("large_context_max_calls must be a positive integer or None")
+        self.large_context_max_calls = large_context_max_calls
         self._predictor = None
         self._feature_preprocessor = None
         # Legacy fitted-text slot retained for old pickles; new fits use the
@@ -721,6 +731,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             self._large_context_budget_features = predictor.budget_n_features(self.X_train_)
         window = predictor.max_context_rows(
             self.X_train_, budget_n_features=self._large_context_budget_features)
+        max_nori_calls = getattr(self, "large_context_max_calls", None)
         if self._large_context_problem is None or self._large_context_problem.window != window:
             previous = self._large_context_problem
             self._large_context_problem = build_problem(
@@ -729,6 +740,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 y_norm,
                 window=window,
                 seed=self.large_context_seed,
+                max_nori_calls=max_nori_calls,
             )
             if previous is not None:
                 # The window changed, so the cached DECISIONS are stale (a chain's
@@ -736,6 +748,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 # re-deriving it per memory_policy change is the cost this path exists
                 # to avoid.
                 self._large_context_problem.adopt_train_state(previous)
+        self._large_context_problem.max_nori_calls = max_nori_calls
         # A train-cache decision depends on every outside input that can change
         # `predict_fn`, not just the decoder. MemoryPolicy's JSON is stable, hashable,
         # includes defaults, and follows in-place dict changes between calls.

--- a/src/synthefy_nori/inference/large_context.py
+++ b/src/synthefy_nori/inference/large_context.py
@@ -110,6 +110,7 @@ def build_problem(
     window: int,
     seed: int = 0,
     embedder: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    max_nori_calls: Optional[int] = None,
 ) -> Problem:
     """The fitted half of a large-context prediction, with no query rows attached yet.
 
@@ -131,6 +132,8 @@ def build_problem(
         embedder: optional callable for embedding-space routing. Omitted on the
             production path -- the embed-recycle postmortem predicts no separability
             gain, and it would double the forward passes.
+        max_nori_calls: optional ceiling enforced before an internal model call starts.
+            None leaves local use unlimited; shared serving supplies its own bound.
     """
     if window < 1:
         raise ValueError(f"window must be >= 1, got {window}")
@@ -147,6 +150,7 @@ def build_problem(
         # NoriPredictor owns missing-value handling on this path; imputing first would
         # change what the model sees relative to an ordinary predict() on the same rows.
         impute=False,
+        max_nori_calls=max_nori_calls,
     )
 
 

--- a/src/synthefy_nori/inference/policies.py
+++ b/src/synthefy_nori/inference/policies.py
@@ -110,6 +110,10 @@ class LargeContextPolicyFallbackWarning(DegradedPipelineWarning, LargeContextPol
     """
 
 
+class LargeContextCallLimitError(RuntimeError):
+    """A policy attempted more internal Nori calls than its caller permits."""
+
+
 QUERY_CHUNK = 25_000
 """Max query rows per Nori call. The transductive RBF+poly preprocessing is
 O(n_query * F * poly) and upstream of the transformer (the #235 preprocessing wall),
@@ -274,6 +278,7 @@ class Problem:
         embedder: Optional[Callable[[np.ndarray], np.ndarray]] = None,
         query_chunk: int = QUERY_CHUNK,
         impute: bool = True,
+        max_nori_calls: Optional[int] = None,
     ):
         self.predict_fn = predict_fn
         self.X_train, self.y_train = X_train, np.asarray(y_train, dtype=np.float64)
@@ -287,6 +292,13 @@ class Problem:
         self.window, self.seed = window, seed
         self.embedder, self.query_chunk = embedder, query_chunk
         self.impute = impute
+        if max_nori_calls is not None and (
+            isinstance(max_nori_calls, bool)
+            or not isinstance(max_nori_calls, int)
+            or max_nori_calls < 1
+        ):
+            raise ValueError("max_nori_calls must be a positive integer or None")
+        self.max_nori_calls = max_nori_calls
         # The seed the CURRENT run's rng was drawn from. Part of every chain-cache key:
         # a chain's shards come from that rng, so a different seed is a different chain
         # and must not be served from the cache. `run_policy` sets it per call.
@@ -366,10 +378,21 @@ class Problem:
         """One shared context = one cache build, however many query chunks it serves.
         A subproblem also bills its parent, so a gate's cost includes its holdout sweep.
         """
+        lineage = []
         problem = self
         while problem is not None:
-            problem.nori_calls += 1
+            if (
+                problem.max_nori_calls is not None
+                and problem.nori_calls >= problem.max_nori_calls
+            ):
+                raise LargeContextCallLimitError(
+                    f"large-context policy exceeded the "
+                    f"{problem.max_nori_calls}-call limit"
+                )
+            lineage.append(problem)
             problem = problem._parent
+        for problem in lineage:
+            problem.nori_calls += 1
 
     def predict_arrays(self, X_context, y_context, X_query) -> np.ndarray:
         """One shared-context Nori call over raw arrays; chunks the query block.
@@ -534,6 +557,7 @@ class Problem:
             np.asarray(X_test), None,
             window=self.window, seed=self.seed, embedder=self.embedder,
             query_chunk=self.query_chunk, impute=self.impute,
+            max_nori_calls=self.max_nori_calls,
         )
         # BY REFERENCE, both of them: the view is throwaway, so anything it derives
         # lazily has to land in state the fitted Problem keeps. Assigning copies here is
@@ -581,6 +605,7 @@ class Problem:
             self.embedder,
             self.query_chunk,
             self.impute,
+            self.max_nori_calls,
         )
         sub._parent = self
         return sub
@@ -945,6 +970,8 @@ def holdout_gate(candidates: Sequence[str | Policy], holdout: int = 2000) -> Pol
         for name, fn in resolved:
             try:
                 score = r2(sub.y_test, fn(sub, np.random.default_rng(problem.seed + 11)))
+            except LargeContextCallLimitError:
+                raise
             except Exception as exc:  # noqa: BLE001 - a broken candidate must not sink the gate
                 print(f"    gate candidate {name} FAILED: {exc}", flush=True)
                 continue

--- a/tests/test_large_context_policy.py
+++ b/tests/test_large_context_policy.py
@@ -424,6 +424,31 @@ def test_build_problem_opts_out_of_imputation():
         ridge_predict, np.zeros((10, 2)), np.zeros(10), window=5).impute is False
 
 
+def test_call_limit_stops_a_gate_before_the_next_predictor_call():
+    calls = {"count": 0}
+
+    def counted_predict(_X_context, _y_context, X_query):
+        calls["count"] += 1
+        return np.zeros(len(X_query))
+
+    X_train = np.arange(6, dtype=np.float32).reshape(-1, 1)
+    base = large_context.build_problem(
+        counted_predict,
+        X_train,
+        np.arange(6, dtype=np.float64),
+        window=2,
+        max_nori_calls=1,
+    )
+    with pytest.warns(pol.LargeContextPolicyWarning):
+        with pytest.raises(pol.LargeContextCallLimitError, match="1-call limit"):
+            large_context.run_policy(
+                base,
+                np.array([[0.5], [4.5]], dtype=np.float32),
+                policy_spec=["random", "cluster_route"],
+            )
+    assert calls["count"] == 1
+
+
 # ------------------------------------------------------------------ tier 1 capacity
 def test_cache_capacity_is_not_a_memory_policy_field():
     """It is a library-only implementation detail, and MemoryPolicy is mirrored in the

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -87,6 +87,36 @@ def test_rebalance_with_categorical_features_pickles():
     np.testing.assert_allclose(restored.worker.transform(x), expected, rtol=1e-6, atol=1e-6)
 
 
+def test_legacy_large_context_pickle_defaults_missing_call_limit_to_none():
+    from synthefy_nori import NoriRegressor
+
+    class StubPredictor:
+        def budget_n_features(self, _X):
+            return 2
+
+        def max_context_rows(self, _X, *, budget_n_features):
+            assert budget_n_features == 2
+            return 2
+
+        def predict(self, _X_context, _y_context, X_query):
+            return np.zeros(len(X_query))
+
+    model = NoriRegressor(large_context_policy="random", large_context_threshold=1)
+    model.X_train_ = np.arange(8, dtype=np.float32).reshape(4, 2)
+    model.__dict__.pop("large_context_max_calls")
+    restored = pickle.loads(pickle.dumps(model))
+
+    predictions = restored._large_context_predict(
+        StubPredictor(),
+        np.ones((1, 2), dtype=np.float32),
+        np.arange(4, dtype=np.float64),
+        decoder=("mean", "mean"),
+    )
+
+    np.testing.assert_array_equal(predictions, np.zeros(1))
+    assert restored._large_context_problem.max_nori_calls is None
+
+
 @pytest.mark.slow
 def test_fitted_regressor_pickles_and_predicts_identically():
     """End-to-end reproduction from issue #45: fit, stdlib-pickle, predict.

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -101,8 +101,8 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     assert root["project"]["version"] == "0.19.0"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.0.3"
-    assert _declared_version() == "7.0.3"
+    assert client["project"]["version"] == "7.0.4"
+    assert _declared_version() == "7.0.4"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -374,7 +374,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.0.3"
+    assert client_entries[0]["version"] == "7.0.4"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6391,7 +6391,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.0.3"
+version = "7.0.4"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Publishes the exact green staging promotion from Synthefy/synthefy-nori-staging#33 (staging squash 5c9291b; internal source Synthefy/synthefy-nori-internal#512).

Scope:
- remove the hosted client policy-name allowlist
- accept any built-in policy name/parameter string supported by the installed server registry
- retain custom Python callables as local-only
- add boost/safeboost and parameterized-policy coverage
- prepare synthefy 7.0.4 and synthefy-nori 0.19.0

Validation:
- public tree exactly matches green staging tree 0a57860
- 986 passed, 8 skipped, 59 deselected
- ruff passed
- synthefy 7.0.4 wheel/sdist built
- synthefy-nori 0.19.0 wheel/sdist built
- git diff --check passed