### PR TITLE
style: ruff format the tree, then gate it in CI (#161)

### DIFF
--- a/.claude/skills/nori-regression/templates/compare_baselines.py
+++ b/.claude/skills/nori-regression/templates/compare_baselines.py
@@ -8,6 +8,7 @@ metric up front) is what makes the comparison honest. Nori is a scikit-learn
 estimator, so it drops straight into cross_validate. Results within one
 fold-std of the best are reported as ties.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -60,20 +61,25 @@ def main() -> None:
     rows = []
     for name, (model, X_m) in models.items():
         res = cross_validate(model, X_m, y, cv=cv, scoring=scoring)
-        rows.append({
-            "model": name,
-            "r2_mean": res["test_r2"].mean(), "r2_std": res["test_r2"].std(),
-            "mae_mean": -res["test_mae"].mean(), "mae_std": res["test_mae"].std(),
-        })
-        print(f"{name:14s} R² {rows[-1]['r2_mean']:.3f} ± {rows[-1]['r2_std']:.3f}   "
-              f"MAE {rows[-1]['mae_mean']:.3f} ± {rows[-1]['mae_std']:.3f}")
+        rows.append(
+            {
+                "model": name,
+                "r2_mean": res["test_r2"].mean(),
+                "r2_std": res["test_r2"].std(),
+                "mae_mean": -res["test_mae"].mean(),
+                "mae_std": res["test_mae"].std(),
+            }
+        )
+        print(
+            f"{name:14s} R² {rows[-1]['r2_mean']:.3f} ± {rows[-1]['r2_std']:.3f}   "
+            f"MAE {rows[-1]['mae_mean']:.3f} ± {rows[-1]['mae_std']:.3f}"
+        )
 
     table = pd.DataFrame(rows).sort_values("r2_mean", ascending=False).reset_index(drop=True)
     best = table.iloc[0]
     tied = table[table.r2_mean >= best.r2_mean - best.r2_std]
     if len(tied) > 1:
-        print(f"\nwithin one fold-std of the best ({best.model}): "
-              f"{', '.join(tied.model)} — treat these as tied.")
+        print(f"\nwithin one fold-std of the best ({best.model}): {', '.join(tied.model)} — treat these as tied.")
     else:
         print(f"\nbest: {best.model} (clear of the fold-noise band)")
 

--- a/.claude/skills/nori-regression/templates/explain.py
+++ b/.claude/skills/nori-regression/templates/explain.py
@@ -8,6 +8,7 @@ over a sample of query rows, plus optional PDP and feature selection.
 
 Needs the interpretability extra:  pip install "synthefy-nori[interpretability]"
 """
+
 from __future__ import annotations
 
 import argparse
@@ -22,9 +23,7 @@ from synthefy_nori import NoriRegressor
 try:
     from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 except ImportError as e:  # pragma: no cover - env-dependent
-    raise SystemExit(
-        'interpretability extra missing — pip install "synthefy-nori[interpretability]"'
-    ) from e
+    raise SystemExit('interpretability extra missing — pip install "synthefy-nori[interpretability]"') from e
 
 
 def first_order_vector(iv, n_features: int) -> np.ndarray:
@@ -47,8 +46,9 @@ def first_order_vector(iv, n_features: int) -> np.ndarray:
     return vec
 
 
-def shap_importance(reg, X_context: np.ndarray, X_query: np.ndarray,
-                    feature_names: list[str], *, budget: int = 128) -> pd.DataFrame:
+def shap_importance(
+    reg, X_context: np.ndarray, X_query: np.ndarray, feature_names: list[str], *, budget: int = 128
+) -> pd.DataFrame:
     """Per-feature mean(|Shapley|) over the query rows, sorted descending."""
     explainer = get_nori_imputation_explainer(reg, X_context, index="SV", max_order=1)
     acc = np.zeros(len(feature_names), dtype=float)
@@ -67,10 +67,21 @@ def main() -> None:
     ap.add_argument("--k", type=int, default=8, help="query rows to explain (Shapley is per-row)")
     ap.add_argument("--budget", type=int, default=128, help="coalitions per row; see interpretability.md")
     ap.add_argument("--seed", type=int, default=0)
-    ap.add_argument("--pdp", nargs="+", type=int, default=None, metavar="FEAT",
-                    help="feature indices to draw partial-dependence plots for")
-    ap.add_argument("--feature-selection", type=int, default=None, metavar="N",
-                    help="run sequential selection down to N features (slow)")
+    ap.add_argument(
+        "--pdp",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="FEAT",
+        help="feature indices to draw partial-dependence plots for",
+    )
+    ap.add_argument(
+        "--feature-selection",
+        type=int,
+        default=None,
+        metavar="N",
+        help="run sequential selection down to N features (slow)",
+    )
     args = ap.parse_args()
 
     if args.data is None:
@@ -87,23 +98,28 @@ def main() -> None:
     reg = NoriRegressor(device=args.device, model="nori-30m")
     reg.fit(X_train.values, y_train.values)
 
-    imp = shap_importance(reg, X_train.values, X_test.values[: args.k],
-                          list(X.columns), budget=args.budget)
+    imp = shap_importance(reg, X_train.values, X_test.values[: args.k], list(X.columns), budget=args.budget)
     print(f"mean(|SHAP|) over {min(args.k, len(X_test))} query rows (budget={args.budget}):")
     print(imp.to_string(index=False))
 
     if args.pdp:
         from synthefy_nori.interpretability.pdp import partial_dependence_plots
+
         partial_dependence_plots(reg, X_test.values, features=args.pdp, kind="average")
 
     if args.feature_selection:
         from synthefy_nori.interpretability.feature_selection import feature_selection
-        res = feature_selection(reg, X_train.values, y_train.values,
-                                n_features_to_select=args.feature_selection, cv=3,
-                                feature_names=list(X.columns))
+
+        res = feature_selection(
+            reg,
+            X_train.values,
+            y_train.values,
+            n_features_to_select=args.feature_selection,
+            cv=3,
+            feature_names=list(X.columns),
+        )
         print("selected:", res.selected_names)
-        print(f"CV R²: all-features {res.baseline_score_mean:.3f} -> "
-              f"selected {res.selected_score_mean:.3f}")
+        print(f"CV R²: all-features {res.baseline_score_mean:.3f} -> selected {res.selected_score_mean:.3f}")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/nori-regression/templates/forecast_multi_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_multi_step.py
@@ -13,6 +13,7 @@ because at forecast time the h-1 most recent periods are not observed yet.
 That is the whole trick: lag_h is the newest usable lag; lag_1..lag_{h-1}
 would be leaks.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -25,8 +26,9 @@ import pandas as pd
 from synthefy_nori import NoriRegressor
 
 
-def synthetic_series(n: int = 120, season: int = 12, seed: int = 7,
-                     ar: float = 0.7, sigma: float = 3.0) -> pd.DataFrame:
+def synthetic_series(
+    n: int = 120, season: int = 12, seed: int = 7, ar: float = 0.7, sigma: float = 3.0
+) -> pd.DataFrame:
     """Trend + seasonality + AR(1) noise. The autocorrelation matters: it makes
     horizon-2 genuinely harder than horizon-1, like real demand/telemetry."""
     rng = np.random.default_rng(seed)
@@ -39,25 +41,23 @@ def synthetic_series(n: int = 120, season: int = 12, seed: int = 7,
     return pd.DataFrame({"date": dates, "y": y})
 
 
-def build_features(y: pd.Series, *, horizon: int, season: int,
-                   n_lags: int = 3) -> pd.DataFrame:
+def build_features(y: pd.Series, *, horizon: int, season: int, n_lags: int = 3) -> pd.DataFrame:
     """Leak-safe for horizon h: every column uses only values <= t-h."""
     df = pd.DataFrame(index=y.index)
-    for k in range(horizon, horizon + n_lags):          # lag_h is the newest legal lag
+    for k in range(horizon, horizon + n_lags):  # lag_h is the newest legal lag
         df[f"lag{k}"] = y.shift(k)
     df[f"lag{max(season, horizon)}"] = y.shift(max(season, horizon))
     trailing = y.shift(horizon).rolling(season)
     df["roll_mean"] = trailing.mean()
     df["roll_std"] = trailing.std()
     t = np.arange(len(y))
-    df["trend"] = t                                      # calendar of the TARGET period is known
+    df["trend"] = t  # calendar of the TARGET period is known
     df["phase_sin"] = np.sin(2 * np.pi * (t % season) / season)
     df["phase_cos"] = np.cos(2 * np.pi * (t % season) / season)
     return df
 
 
-def rolling_direct(y: np.ndarray, X: np.ndarray, origins: range, *, horizon: int,
-                   device: str | None) -> pd.DataFrame:
+def rolling_direct(y: np.ndarray, X: np.ndarray, origins: range, *, horizon: int, device: str | None) -> pd.DataFrame:
     """At each origin t: context = rows whose features AND target are fully in
     the past (target rows <= t-h), then predict row t."""
     reg = NoriRegressor(device=device, model="nori-30m")
@@ -65,11 +65,9 @@ def rolling_direct(y: np.ndarray, X: np.ndarray, origins: range, *, horizon: int
     for t in origins:
         cut = t - horizon + 1  # rows [0, cut) have targets <= t-h+... strictly before t's info
         reg.fit(X[:cut], y[:cut])
-        point = float(np.atleast_1d(reg.predict(X[t:t + 1], output_type="median"))[0])
-        q = np.asarray(reg.predict(X[t:t + 1], output_type="quantiles",
-                                   quantiles=[0.1, 0.9])).reshape(2, -1)
-        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point,
-                     "q10": float(q[0, 0]), "q90": float(q[1, 0])})
+        point = float(np.atleast_1d(reg.predict(X[t : t + 1], output_type="median"))[0])
+        q = np.asarray(reg.predict(X[t : t + 1], output_type="quantiles", quantiles=[0.1, 0.9])).reshape(2, -1)
+        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point, "q10": float(q[0, 0]), "q90": float(q[1, 0])})
     return pd.DataFrame(rows)
 
 
@@ -100,8 +98,10 @@ def main() -> None:
     X = build_features(y, horizon=args.horizon, season=args.season).to_numpy(np.float32)
     yv = y.to_numpy(np.float64)
     origins = range(len(yv) - args.n_test, len(yv))
-    print(f"{len(yv)} periods, horizon={args.horizon}, last {args.n_test} origins "
-          f"({X.shape[1]} features; newest legal lag = lag{args.horizon})")
+    print(
+        f"{len(yv)} periods, horizon={args.horizon}, last {args.n_test} origins "
+        f"({X.shape[1]} features; newest legal lag = lag{args.horizon})"
+    )
 
     fc = rolling_direct(yv, X, origins, horizon=args.horizon, device=args.device)
     fc["date"] = df[date_col].iloc[fc.t].dt.date.values
@@ -117,8 +117,10 @@ def main() -> None:
         "coverage_10_90": float(((truth >= fc.q10) & (truth <= fc.q90)).mean()),
         "interval_width_mean": float((fc.q90 - fc.q10).mean()),
     }
-    print(f"MAE  nori={results['mae']:.3f}  last-known={results['mae_naive_lastknown']:.3f}  "
-          f"seasonal-naive={results['mae_naive_seasonal']:.3f}")
+    print(
+        f"MAE  nori={results['mae']:.3f}  last-known={results['mae_naive_lastknown']:.3f}  "
+        f"seasonal-naive={results['mae_naive_seasonal']:.3f}"
+    )
     print(f"coverage [q10,q90] {results['coverage_10_90']:.2f} (nominal 0.80)")
 
     fc[["date", "y_true", "y_pred", "q10", "q90"]].to_csv("forecasts.csv", index=False)

--- a/.claude/skills/nori-regression/templates/forecast_one_step.py
+++ b/.claude/skills/nori-regression/templates/forecast_one_step.py
@@ -8,6 +8,7 @@ baselines (last-value, seasonal-naive) for an honest comparison.
 
 Writes forecasts.csv (one row per origin) and results.json.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -44,19 +45,16 @@ def build_features(y: pd.Series, *, season: int, lags: tuple[int, ...] = (1, 2, 
     return df  # early rows hold NaN lags — fine as Nori context; don't zero-fill
 
 
-def rolling_one_step(y: np.ndarray, X: np.ndarray, origins: range, *,
-                     device: str | None) -> pd.DataFrame:
+def rolling_one_step(y: np.ndarray, X: np.ndarray, origins: range, *, device: str | None) -> pd.DataFrame:
     """Expanding-context backtest: refit (free) at each origin, predict one row."""
     reg = NoriRegressor(device=device, model="nori-30m")  # construct once, refit per origin
     rows = []
     for t in origins:
         reg.fit(X[:t], y[:t])
         # single-row predict can come back 0-d — normalize the shapes
-        point = float(np.atleast_1d(reg.predict(X[t:t + 1], output_type="median"))[0])
-        q = np.asarray(reg.predict(X[t:t + 1], output_type="quantiles",
-                                   quantiles=[0.1, 0.9])).reshape(2, -1)
-        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point,
-                     "q10": float(q[0, 0]), "q90": float(q[1, 0])})
+        point = float(np.atleast_1d(reg.predict(X[t : t + 1], output_type="median"))[0])
+        q = np.asarray(reg.predict(X[t : t + 1], output_type="quantiles", quantiles=[0.1, 0.9])).reshape(2, -1)
+        rows.append({"t": t, "y_true": float(y[t]), "y_pred": point, "q10": float(q[0, 0]), "q90": float(q[1, 0])})
     return pd.DataFrame(rows)
 
 
@@ -92,8 +90,7 @@ def main() -> None:
     X = build_features(y, season=args.season, lags=lags).to_numpy(np.float32)
     yv = y.to_numpy(np.float64)
     origins = range(len(yv) - args.n_test, len(yv))
-    print(f"{len(yv)} periods, forecasting the last {args.n_test} one step ahead "
-          f"(features: {X.shape[1]})")
+    print(f"{len(yv)} periods, forecasting the last {args.n_test} one step ahead (features: {X.shape[1]})")
 
     fc = rolling_one_step(yv, X, origins, device=args.device)
     fc["date"] = df[date_col].iloc[fc.t].dt.date.values
@@ -111,10 +108,11 @@ def main() -> None:
         "interval_width_mean": float((fc.q90 - fc.q10).mean()),
     }
 
-    print(f"MAE  nori={results['mae']:.3f}  last-value={results['mae_naive_last']:.3f}  "
-          f"seasonal-naive={results['mae_naive_seasonal']:.3f}")
-    print(f"WAPE nori={results['wape']:.3%}   [q10,q90] coverage "
-          f"{results['coverage_10_90']:.2f} (nominal 0.80)")
+    print(
+        f"MAE  nori={results['mae']:.3f}  last-value={results['mae_naive_last']:.3f}  "
+        f"seasonal-naive={results['mae_naive_seasonal']:.3f}"
+    )
+    print(f"WAPE nori={results['wape']:.3%}   [q10,q90] coverage {results['coverage_10_90']:.2f} (nominal 0.80)")
 
     fc[["date", "y_true", "y_pred", "q10", "q90"]].to_csv("forecasts.csv", index=False)
     Path(args.out).write_text(json.dumps(results, indent=2) + "\n")

--- a/.claude/skills/nori-regression/templates/regress.py
+++ b/.claude/skills/nori-regression/templates/regress.py
@@ -10,6 +10,7 @@ context; all compute happens in predict), reports R²/MAE for both the mean and
 median point estimates, and checks that the nominal 80% interval [q10, q90]
 actually covers ~80% of the held-out targets.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -52,15 +53,13 @@ def main() -> None:
     args = ap.parse_args()
 
     X, y = load_data(args.data, args.target)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=args.test_size, random_state=args.seed
-    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=args.test_size, random_state=args.seed)
     print(f"rows: {len(X_train)} context / {len(X_test)} query, {X.shape[1]} features")
 
     reg = NoriRegressor(device=args.device, model="nori-30m")
     reg.fit(X_train, y_train)
 
-    mean_pred = reg.predict(X_test)                          # (n,) distribution mean
+    mean_pred = reg.predict(X_test)  # (n,) distribution mean
     median_pred = reg.predict(X_test, output_type="median")  # robust for skewed targets
     q10, q50, q90 = reg.predict(X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
 
@@ -79,8 +78,9 @@ def main() -> None:
 
     print(f"R²   mean={results['r2_mean']:.3f}  median={results['r2_median']:.3f}")
     print(f"MAE  mean={results['mae_mean']:.3f}  median={results['mae_median']:.3f}")
-    print(f"[q10, q90] empirical coverage: {coverage:.2f} (nominal 0.80), "
-          f"mean width {results['interval_width_mean']:.3f}")
+    print(
+        f"[q10, q90] empirical coverage: {coverage:.2f} (nominal 0.80), mean width {results['interval_width_mean']:.3f}"
+    )
 
     out = Path(args.out)
     out.write_text(json.dumps(results, indent=2) + "\n")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           ci/validate_distribution_boundaries.py
           ci/probe_installed_distributions.py
           ci/probe_cutover_matrix.py
+      # Formatting is a gate, not a suggestion: the tree was formatted once with the
+      # locked ruff, so a diff that reflows untouched lines means a stale formatter,
+      # not style drift. Same version as uv.lock and the pre-commit hook.
+      - run: uv run ruff format --check .
       - run: uv build
 
   synthefy-artifact:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.15.12   # keep equal to the ruff version in uv.lock
     hooks:
       - id: ruff
+      - id: ruff-format

--- a/benchmarks/bench_kv_cache.py
+++ b/benchmarks/bench_kv_cache.py
@@ -53,9 +53,7 @@ import torch
 from synthefy_nori import NoriRegressor
 
 # --- Configuration -----------------------------------------------------------
-DATA_DIR = Path(
-    os.environ.get("NORI_BENCH_DATA_DIR", "cache/eval_datasets/QSAR-TID-11")
-)
+DATA_DIR = Path(os.environ.get("NORI_BENCH_DATA_DIR", "cache/eval_datasets/QSAR-TID-11"))
 TRAIN_CSV = DATA_DIR / "QSAR-TID-11_train.csv"
 TEST_CSV = DATA_DIR / "QSAR-TID-11_test.csv"
 PLOT_PATH = Path("benchmarks/plots/kv_cache_speed.png")
@@ -108,10 +106,7 @@ def main() -> None:
 
     x_train, y_train = load_csv(TRAIN_CSV)
     x_test_full, _ = load_csv(TEST_CSV)
-    print(
-        f"Loaded QSAR-TID-11: train {x_train.shape}, test {x_test_full.shape}, "
-        f"budget={MAX_ELEMENTS_BUDGET}"
-    )
+    print(f"Loaded QSAR-TID-11: train {x_train.shape}, test {x_test_full.shape}, budget={MAX_ELEMENTS_BUDGET}")
 
     model = NoriRegressor(device=DEVICE, model="nori-6m").fit(x_train, y_train)
 
@@ -127,8 +122,7 @@ def main() -> None:
         max_diff = float(np.max(np.abs(on_preds - off_preds)))
         rows.append((n, on_s, off_s, speedup, max_diff))
         print(
-            f"n_test={n:5d}  on={on_s:7.3f}s  off={off_s:7.3f}s  "
-            f"speedup={speedup:5.2f}x  max_pred_diff={max_diff:.2e}"
+            f"n_test={n:5d}  on={on_s:7.3f}s  off={off_s:7.3f}s  speedup={speedup:5.2f}x  max_pred_diff={max_diff:.2e}"
         )
 
     # --- Results table -------------------------------------------------------

--- a/benchmarks/bench_shap_speed.py
+++ b/benchmarks/bench_shap_speed.py
@@ -56,20 +56,16 @@ from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
 # --- Benchmark configuration ------------------------------------------------
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DATA_DIR = Path(
-    os.environ.get(
-        "NORI_BENCH_DATA_DIR", REPO_ROOT / "cache" / "eval_datasets" / "superconductivity"
-    )
-)
+DATA_DIR = Path(os.environ.get("NORI_BENCH_DATA_DIR", REPO_ROOT / "cache" / "eval_datasets" / "superconductivity"))
 TRAIN_CSV = DATA_DIR / "superconductivity_train.csv"
 TEST_CSV = DATA_DIR / "superconductivity_test.csv"
 PLOT_PATH = REPO_ROOT / "benchmarks" / "plots" / "shap_speed.png"
 
 DEVICE = "cuda:0"
-N_CONTEXT = 1500       # subsampled training context rows
-N_BACKGROUND = 64      # background/reference rows handed to the explainers
-N_FEATURES = 12        # small feature subset to keep Shapley tractable
-N_EXPLAIN = 5          # test rows explained per setting
+N_CONTEXT = 1500  # subsampled training context rows
+N_BACKGROUND = 64  # background/reference rows handed to the explainers
+N_FEATURES = 12  # small feature subset to keep Shapley tractable
+N_EXPLAIN = 5  # test rows explained per setting
 BUDGETS = [32, 64, 128, 256, 512]
 SEED = 0
 
@@ -90,7 +86,7 @@ def load_subset():
     test_idx = rng.choice(test.shape[0], size=N_EXPLAIN + N_BACKGROUND, replace=False)
     X_test_all = test[test_idx][:, feat_idx]
     X_background = X_test_all[:N_BACKGROUND]
-    X_explain = X_test_all[N_BACKGROUND:N_BACKGROUND + N_EXPLAIN]
+    X_explain = X_test_all[N_BACKGROUND : N_BACKGROUND + N_EXPLAIN]
     return X_train, y_train, X_background, X_explain
 
 
@@ -112,9 +108,7 @@ def time_shap_permutation(predict_fn, X_background, X_explain, max_evals):
 
 def time_shapiq(model, X_background, X_explain, budget):
     """Mean seconds per row for shapiq's imputation explainer (index='SV')."""
-    explainer = get_nori_imputation_explainer(
-        model, X_background, index="SV", max_order=1, imputer="baseline"
-    )
+    explainer = get_nori_imputation_explainer(model, X_background, index="SV", max_order=1, imputer="baseline")
     t0 = time.perf_counter()
     for row in X_explain:
         explainer.explain(row.reshape(1, -1), budget=budget)
@@ -124,10 +118,7 @@ def time_shapiq(model, X_background, X_explain, budget):
 def main():
     print(f"Loading superconductivity subset ({N_FEATURES} features)...")
     X_train, y_train, X_background, X_explain = load_subset()
-    print(
-        f"  context={X_train.shape}  background={X_background.shape}  "
-        f"explain={X_explain.shape}"
-    )
+    print(f"  context={X_train.shape}  background={X_background.shape}  explain={X_explain.shape}")
 
     print(f"Fitting NoriRegressor on {DEVICE} (first fit downloads checkpoint)...")
     model = NoriRegressor(device=DEVICE, model="nori-6m").fit(X_train, y_train)
@@ -158,10 +149,7 @@ def main():
     print("\n=== Mean seconds per explanation (per test row) ===")
     print(f"{'budget':>8} {'shap.Kernel':>14} {'shap.Permutation':>18} {'shapiq(SV)':>14}")
     for i, budget in enumerate(BUDGETS):
-        print(
-            f"{budget:>8} {kernel_times[i]:>14.3f} {perm_times[i]:>18.3f} "
-            f"{shapiq_times[i]:>14.3f}"
-        )
+        print(f"{budget:>8} {kernel_times[i]:>14.3f} {perm_times[i]:>18.3f} {shapiq_times[i]:>14.3f}")
 
     # --- Plot ---------------------------------------------------------------
     PLOT_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmarks/bench_shapiq_speed.py
+++ b/benchmarks/bench_shapiq_speed.py
@@ -45,16 +45,14 @@ from synthefy_nori import NoriRegressor
 from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 
 # --- Configuration -----------------------------------------------------------
-DATA_DIR = Path(
-    os.environ.get("NORI_BENCH_DATA_DIR", "cache/eval_datasets/superconductivity")
-)
+DATA_DIR = Path(os.environ.get("NORI_BENCH_DATA_DIR", "cache/eval_datasets/superconductivity"))
 TRAIN_CSV = DATA_DIR / "superconductivity_train.csv"
 TEST_CSV = DATA_DIR / "superconductivity_test.csv"
 PLOT_PATH = Path("benchmarks/plots/shapiq_speed.png")
 
-N_CONTEXT = 1500          # training context (also imputer background) rows
-N_FEATURES = 12           # top-variance feature subset for tractable coalitions
-N_EXPLAIN = 5             # test rows explained (mean per-explanation time reported)
+N_CONTEXT = 1500  # training context (also imputer background) rows
+N_FEATURES = 12  # top-variance feature subset for tractable coalitions
+N_EXPLAIN = 5  # test rows explained (mean per-explanation time reported)
 BUDGETS = [32, 64, 128, 256, 512]
 DEVICE = "cuda:0"
 SEED = 0
@@ -71,14 +69,10 @@ def main() -> None:
 
     X_train_full, y_train_full = load_csv(TRAIN_CSV)
     X_test_full, _ = load_csv(TEST_CSV)
-    print(
-        f"Loaded train {X_train_full.shape}, test {X_test_full.shape} "
-        f"({X_train_full.shape[1]} features)"
-    )
+    print(f"Loaded train {X_train_full.shape}, test {X_test_full.shape} ({X_train_full.shape[1]} features)")
 
     # Subsample the training context (and imputer background).
-    ctx_idx = rng.choice(X_train_full.shape[0], size=min(N_CONTEXT, X_train_full.shape[0]),
-                         replace=False)
+    ctx_idx = rng.choice(X_train_full.shape[0], size=min(N_CONTEXT, X_train_full.shape[0]), replace=False)
     X_ctx = X_train_full[ctx_idx]
     y_ctx = y_train_full[ctx_idx]
 
@@ -115,9 +109,7 @@ def main() -> None:
 
     results: dict[str, list[float]] = {}
     for label, cfg in settings:
-        explainer = get_nori_imputation_explainer(
-            model, X_ctx_sel, imputer="baseline", random_state=SEED, **cfg
-        )
+        explainer = get_nori_imputation_explainer(model, X_ctx_sel, imputer="baseline", random_state=SEED, **cfg)
         per_budget: list[float] = []
         for budget in BUDGETS:
             t0 = time.perf_counter()
@@ -134,9 +126,7 @@ def main() -> None:
     print(header)
     print("-" * len(header))
     for j, budget in enumerate(BUDGETS):
-        row = f"{budget:>8} | " + " | ".join(
-            f"{results[lbl][j]:>16.3f}" for lbl, _ in settings
-        )
+        row = f"{budget:>8} | " + " | ".join(f"{results[lbl][j]:>16.3f}" for lbl, _ in settings)
         print(row)
 
     # --- Plot ----------------------------------------------------------------

--- a/benchmarks/bench_training_compile.py
+++ b/benchmarks/bench_training_compile.py
@@ -29,9 +29,7 @@ def parse_shapes(raw: str) -> list[tuple[int, int, float]]:
             features = int(features_raw)
             ratio = float(ratio_raw)
         except ValueError as exc:
-            raise argparse.ArgumentTypeError(
-                "Shapes must use ROWSxFEATURES@CONTEXT_RATIO"
-            ) from exc
+            raise argparse.ArgumentTypeError("Shapes must use ROWSxFEATURES@CONTEXT_RATIO") from exc
         signature = (rows, features, ratio)
         if rows <= 1 or features <= 0 or not 0 < ratio < 1:
             raise argparse.ArgumentTypeError(f"Invalid shape signature: {item!r}")
@@ -106,15 +104,10 @@ def make_batch(
     generator = torch.Generator(device="cpu").manual_seed(seed)
     x = torch.randn(batch, rows, features, generator=generator)
     y = torch.randn(batch, rows, generator=generator)
-    query_mask = (
-        torch.rand(batch, rows - eval_pos, features, generator=generator) < 0.15
-    )
+    query_mask = torch.rand(batch, rows - eval_pos, features, generator=generator) < 0.15
     x[:, eval_pos:][query_mask] = float("nan")
     context = y[:, :eval_pos]
-    y = (
-        (y - context.mean(-1, keepdim=True))
-        / context.std(-1, keepdim=True).clamp_min(1e-8)
-    )
+    y = (y - context.mean(-1, keepdim=True)) / context.std(-1, keepdim=True).clamp_min(1e-8)
     return x.to(device), y.to(device)
 
 
@@ -127,11 +120,7 @@ def counters_snapshot():
     from torch._dynamo.utils import counters
 
     return {
-        str(category): {
-            str(key): int(value)
-            for key, value in values.items()
-            if isinstance(value, int) and value
-        }
+        str(category): {str(key): int(value) for key, value in values.items() if isinstance(value, int) and value}
         for category, values in counters.items()
         if values
     }
@@ -173,9 +162,7 @@ def main():
         default="interleaved",
     )
     parser.add_argument("--checkpoint-threshold", type=int, default=24576)
-    parser.add_argument(
-        "--checkpointing", choices=("auto", "on", "off"), default="auto"
-    )
+    parser.add_argument("--checkpointing", choices=("auto", "on", "off"), default="auto")
     parser.add_argument("--output")
     args = parser.parse_args()
 
@@ -213,11 +200,7 @@ def main():
 
     records = []
     started_all = time.perf_counter()
-    schedule = [
-        (cycle, shape_index)
-        for cycle in range(args.cycles)
-        for shape_index in range(len(args.shapes))
-    ]
+    schedule = [(cycle, shape_index) for cycle in range(args.cycles) for shape_index in range(len(args.shapes))]
     if args.shape_order == "grouped":
         schedule.sort(key=lambda item: (item[1], item[0]))
 

--- a/ci/modal_gpu_smoke.py
+++ b/ci/modal_gpu_smoke.py
@@ -25,6 +25,7 @@ Note: pin the ``modal`` version and verify the image/GPU API against your
 installed client -- this targets modal 1.x (``App`` / ``add_local_dir`` /
 ``gpu=`` / ``max_containers``).
 """
+
 from __future__ import annotations
 
 import tempfile
@@ -59,8 +60,16 @@ image = (
         "/src",
         # Keep the upload lean and never ship local build/venv/data artifacts.
         ignore=[
-            ".git", ".venv", "dist", "build", "*.png",
-            "data", "checkpoints", "results", "wandb", "cache",
+            ".git",
+            ".venv",
+            "dist",
+            "build",
+            "*.png",
+            "data",
+            "checkpoints",
+            "results",
+            "wandb",
+            "cache",
         ],
     )
 )
@@ -111,8 +120,14 @@ def gpu_smoke(torch_version: str = "locked") -> None:
         )
         subprocess.run(
             [
-                "uv", "pip", "install", "--no-config", "--python", python,
-                f"torch=={torch_version}", "--torch-backend=cu130",
+                "uv",
+                "pip",
+                "install",
+                "--no-config",
+                "--python",
+                python,
+                f"torch=={torch_version}",
+                "--torch-backend=cu130",
             ],
             cwd=repo,
             env=env,
@@ -120,8 +135,14 @@ def gpu_smoke(torch_version: str = "locked") -> None:
         )
         subprocess.run(
             [
-                "uv", "pip", "install", "--no-config", "--python", python,
-                "-e", ".[dev]",
+                "uv",
+                "pip",
+                "install",
+                "--no-config",
+                "--python",
+                python,
+                "-e",
+                ".[dev]",
             ],
             cwd=repo,
             env=env,
@@ -130,12 +151,17 @@ def gpu_smoke(torch_version: str = "locked") -> None:
 
     # Fail fast with a clear message if the GPU / driver isn't usable.
     subprocess.run(
-        [python, "-c",
-         "import torch; assert torch.cuda.is_available(), 'no CUDA device on the Modal runner';"
-         " print('GPU:', torch.cuda.get_device_name(0));"
-         " print('torch:', torch.__version__, 'CUDA:', torch.version.cuda,"
-         " 'cuDNN:', torch.backends.cudnn.version())"],
-        cwd=repo, env=env, check=True,
+        [
+            python,
+            "-c",
+            "import torch; assert torch.cuda.is_available(), 'no CUDA device on the Modal runner';"
+            " print('GPU:', torch.cuda.get_device_name(0));"
+            " print('torch:', torch.__version__, 'CUDA:', torch.version.cuda,"
+            " 'cuDNN:', torch.backends.cudnn.version())",
+        ],
+        cwd=repo,
+        env=env,
+        check=True,
     )
     # OPTIONAL flash-attn coverage (A100 is sm80, so FA2 is supported). Left off
     # because the codebase currently has no flash path; enable only once flash
@@ -144,10 +170,16 @@ def gpu_smoke(torch_version: str = "locked") -> None:
     #                cwd=repo, env=env, check=True)
     subprocess.run(
         [
-            pytest, "-m", "slow",
-            "tests/test_inference_e2e.py", "tests/test_training_smoke.py", "-q",
+            pytest,
+            "-m",
+            "slow",
+            "tests/test_inference_e2e.py",
+            "tests/test_training_smoke.py",
+            "-q",
         ],
-        cwd=repo, env=env, check=True,
+        cwd=repo,
+        env=env,
+        check=True,
     )
 
 

--- a/ci/probe_cutover_matrix.py
+++ b/ci/probe_cutover_matrix.py
@@ -16,20 +16,14 @@ def _installed_module(name: str, distribution: str, expected: str):
     module = importlib.import_module(name)
     actual = importlib.metadata.version(distribution)
     if actual != expected:
-        raise AssertionError(
-            f"{distribution} version {actual!r} does not match {expected!r}"
-        )
+        raise AssertionError(f"{distribution} version {actual!r} does not match {expected!r}")
     module_version = getattr(module, "__version__", actual)
     if module_version != actual:
-        raise AssertionError(
-            f"{name}.__version__={module_version!r} does not match {actual!r}"
-        )
+        raise AssertionError(f"{name}.__version__={module_version!r} does not match {actual!r}")
     module_path = Path(module.__file__).resolve()
     site_packages = Path(sysconfig.get_path("purelib")).resolve()
     if not module_path.is_relative_to(site_packages):
-        raise AssertionError(
-            f"{name} imported from {module_path}, outside {site_packages}"
-        )
+        raise AssertionError(f"{name} imported from {module_path}, outside {site_packages}")
     return module
 
 
@@ -43,13 +37,9 @@ def probe(
         synthefy = _installed_module("synthefy", "synthefy", expected_client)
         if "synthefy_nori" in sys.modules:
             raise AssertionError("import synthefy eagerly imported synthefy_nori")
-        synthefy_nori = _installed_module(
-            "synthefy_nori", "synthefy-nori", expected_nori
-        )
+        synthefy_nori = _installed_module("synthefy_nori", "synthefy-nori", expected_nori)
     else:
-        synthefy_nori = _installed_module(
-            "synthefy_nori", "synthefy-nori", expected_nori
-        )
+        synthefy_nori = _installed_module("synthefy_nori", "synthefy-nori", expected_nori)
         synthefy = _installed_module("synthefy", "synthefy", expected_client)
 
     capture: dict[str, Any] = {}
@@ -95,10 +85,7 @@ def probe(
         "kwargs": {},
     }:
         raise AssertionError(f"unexpected local call: {capture!r}")
-    print(
-        f"synthefy {expected_client} -> synthefy-nori {expected_nori} "
-        f"works in {order} order"
-    )
+    print(f"synthefy {expected_client} -> synthefy-nori {expected_nori} works in {order} order")
 
 
 def main() -> None:

--- a/ci/probe_installed_distributions.py
+++ b/ci/probe_installed_distributions.py
@@ -56,9 +56,7 @@ def _site_packages() -> Path:
 
 def _assert_absent(module_name: str) -> None:
     if importlib.util.find_spec(module_name) is not None:
-        raise AssertionError(
-            f"{module_name} is still importable after its distribution was removed"
-        )
+        raise AssertionError(f"{module_name} is still importable after its distribution was removed")
     distribution = _DISTRIBUTIONS[module_name]
     try:
         importlib.metadata.version(distribution)
@@ -73,9 +71,7 @@ def _import_installed(module_name: str):
     module_file = Path(module.__file__).resolve()
     site_packages = _site_packages()
     if not module_file.is_relative_to(site_packages):
-        raise AssertionError(
-            f"{module_name} imported from {module_file}, outside clean environment {site_packages}"
-        )
+        raise AssertionError(f"{module_name} imported from {module_file}, outside clean environment {site_packages}")
     actual_version = importlib.metadata.version(distribution)
     if getattr(module, "__version__", actual_version) != actual_version:
         raise AssertionError(f"{module_name}.__version__ does not match {actual_version}")
@@ -84,9 +80,7 @@ def _import_installed(module_name: str):
 
 def _assert_not_loaded(*module_names: str) -> None:
     loaded = sorted(
-        name
-        for name in sys.modules
-        if any(name == root or name.startswith(f"{root}.") for root in module_names)
+        name for name in sys.modules if any(name == root or name.startswith(f"{root}.") for root in module_names)
     )
     if loaded:
         raise AssertionError(f"optional modules loaded eagerly: {loaded}")
@@ -94,9 +88,7 @@ def _assert_not_loaded(*module_names: str) -> None:
 
 def _assert_not_importable(*module_names: str) -> None:
     importable = sorted(
-        module_name
-        for module_name in module_names
-        if importlib.util.find_spec(module_name) is not None
+        module_name for module_name in module_names if importlib.util.find_spec(module_name) is not None
     )
     if importable:
         raise AssertionError(f"unrelated optional modules are installed: {importable}")
@@ -110,10 +102,7 @@ def _import_required(*module_names: str) -> None:
 def _canonical_featurizer():
     from synthefy.featurize import align_and_featurize
 
-    if (
-        not callable(align_and_featurize)
-        or align_and_featurize.__module__ != "synthefy.featurize"
-    ):
+    if not callable(align_and_featurize) or align_and_featurize.__module__ != "synthefy.featurize":
         raise AssertionError("synthefy does not own the canonical tabular featurizer")
     return align_and_featurize
 
@@ -152,12 +141,8 @@ def _assert_legacy_tsfeatures_are_canonical():
         "feature_transformer",
         "ts_dataframe",
     ):
-        canonical_module = importlib.import_module(
-            f"synthefy.nori_ts.tsfeatures.{module_name}"
-        )
-        historical_module = importlib.import_module(
-            f"synthefy_nori.nori_ts.tsfeatures.{module_name}"
-        )
+        canonical_module = importlib.import_module(f"synthefy.nori_ts.tsfeatures.{module_name}")
+        historical_module = importlib.import_module(f"synthefy_nori.nori_ts.tsfeatures.{module_name}")
         if historical_module is not canonical_module:
             raise AssertionError(f"historical deep module {module_name} is not canonical")
     return canonical
@@ -246,9 +231,7 @@ def probe_extra(case: str) -> None:
         _probe_nori_extra(extra)
 
 
-def _assert_import_cause(
-    loader_name: str, expected_name: str, *, expect_wrapped: bool
-) -> None:
+def _assert_import_cause(loader_name: str, expected_name: str, *, expect_wrapped: bool) -> None:
     from synthefy import nori_client
 
     loader = getattr(nori_client, loader_name)
@@ -263,19 +246,15 @@ def _assert_import_cause(
         missing = exc.__cause__
         wrapped = True
     else:
-        raise AssertionError(
-            f"{loader_name} unexpectedly succeeded without a working synthefy_nori"
-        )
+        raise AssertionError(f"{loader_name} unexpectedly succeeded without a working synthefy_nori")
     if not isinstance(missing, ModuleNotFoundError) or missing.name != expected_name:
         raise AssertionError(
-            f"{loader_name} reported {missing!r}; expected "
-            f"ModuleNotFoundError({expected_name!r})"
+            f"{loader_name} reported {missing!r}; expected ModuleNotFoundError({expected_name!r})"
         ) from error
     if wrapped is not expect_wrapped:
         disposition = "wrapped" if wrapped else "unwrapped"
         raise AssertionError(
-            f"{loader_name} left {expected_name!r} {disposition}; "
-            f"expect_wrapped={expect_wrapped}"
+            f"{loader_name} left {expected_name!r} {disposition}; expect_wrapped={expect_wrapped}"
         ) from error
 
 
@@ -307,9 +286,7 @@ def _probe_missing_import_causes() -> None:
         importlib.invalidate_caches()
         sys.modules.pop("synthefy_nori", None)
         try:
-            _assert_all_loader_causes(
-                "sentinel_transitive_dep", expect_wrapped=False
-            )
+            _assert_all_loader_causes("sentinel_transitive_dep", expect_wrapped=False)
         finally:
             sys.modules.pop("synthefy_nori", None)
             sys.path.remove(temp_dir)
@@ -351,9 +328,7 @@ def probe_nori_only() -> None:
         importlib.import_module("synthefy_nori")
     except ModuleNotFoundError as exc:
         if exc.name != "synthefy":
-            raise AssertionError(
-                f"synthefy_nori failed for {exc.name!r}, expected its required synthefy edge"
-            ) from exc
+            raise AssertionError(f"synthefy_nori failed for {exc.name!r}, expected its required synthefy edge") from exc
     else:
         raise AssertionError("synthefy_nori imported without its required synthefy dependency")
     print("synthefy_nori remains installed and reports its missing synthefy dependency")

--- a/ci/validate_distribution_boundaries.py
+++ b/ci/validate_distribution_boundaries.py
@@ -94,20 +94,15 @@ def _validate_record(archive: ZipFile, members: frozenset[str], record_path: str
         payload = archive.read(path)
         expected_digest = _record_digest(payload)
         if digest != expected_digest:
-            raise BoundaryError(
-                f"{record_path}: hash mismatch for {path!r}: {digest!r} != {expected_digest!r}"
-            )
+            raise BoundaryError(f"{record_path}: hash mismatch for {path!r}: {digest!r} != {expected_digest!r}")
         if size != str(len(payload)):
-            raise BoundaryError(
-                f"{record_path}: size mismatch for {path!r}: {size!r} != {len(payload)!r}"
-            )
+            raise BoundaryError(f"{record_path}: size mismatch for {path!r}: {size!r} != {len(payload)!r}")
 
     missing = members.difference(recorded)
     extra = set(recorded).difference(members)
     if missing or extra:
         raise BoundaryError(
-            f"{record_path}: RECORD membership differs from the wheel; "
-            f"missing={sorted(missing)}, extra={sorted(extra)}"
+            f"{record_path}: RECORD membership differs from the wheel; missing={sorted(missing)}, extra={sorted(extra)}"
         )
 
 
@@ -124,14 +119,10 @@ def inspect_wheel(path: Path, *, distribution: str, namespace: str) -> WheelInfo
             raise BoundaryError(f"{path.name}: duplicate archive paths are not allowed")
 
         dist_info_dirs = {
-            name.split("/", 1)[0]
-            for name in members
-            if "/" in name and name.split("/", 1)[0].endswith(".dist-info")
+            name.split("/", 1)[0] for name in members if "/" in name and name.split("/", 1)[0].endswith(".dist-info")
         }
         if len(dist_info_dirs) != 1:
-            raise BoundaryError(
-                f"{path.name}: expected one .dist-info directory, found {sorted(dist_info_dirs)}"
-            )
+            raise BoundaryError(f"{path.name}: expected one .dist-info directory, found {sorted(dist_info_dirs)}")
         dist_info = next(iter(dist_info_dirs))
         record_path = f"{dist_info}/RECORD"
         metadata_path = f"{dist_info}/METADATA"
@@ -144,28 +135,22 @@ def inspect_wheel(path: Path, *, distribution: str, namespace: str) -> WheelInfo
         expected_distribution = _canonicalize_name(distribution)
         if actual_distribution != expected_distribution:
             raise BoundaryError(
-                f"{path.name}: METADATA Name is {actual_distribution!r}, "
-                f"expected {expected_distribution!r}"
+                f"{path.name}: METADATA Name is {actual_distribution!r}, expected {expected_distribution!r}"
             )
         version = str(metadata["Version"] or "")
         if not version:
             raise BoundaryError(f"{path.name}: METADATA Version is required")
 
-        runtime_files = frozenset(
-            name for name in members if not name.startswith(f"{dist_info}/")
-        )
+        runtime_files = frozenset(name for name in members if not name.startswith(f"{dist_info}/"))
         member_fingerprints = tuple(
             (name, hashlib.sha256(payload).hexdigest(), len(payload))
             for name in sorted(members)
             if name != record_path and (payload := archive.read(name))
         )
-        wrong_owner = sorted(
-            name for name in runtime_files if not name.startswith(f"{namespace}/")
-        )
+        wrong_owner = sorted(name for name in runtime_files if not name.startswith(f"{namespace}/"))
         if wrong_owner:
             raise BoundaryError(
-                f"{path.name}: {distribution} may own only {namespace}/ outside .dist-info; "
-                f"found {wrong_owner}"
+                f"{path.name}: {distribution} may own only {namespace}/ outside .dist-info; found {wrong_owner}"
             )
         if f"{namespace}/__init__.py" not in runtime_files:
             raise BoundaryError(f"{path.name}: missing {namespace}/__init__.py")
@@ -189,9 +174,7 @@ def _validate_extra_requirements(
     available_extras = {_canonicalize_name(extra) for extra in wheel.extras}
     missing_extras = sorted(set(expected).difference(available_extras))
     if missing_extras:
-        raise BoundaryError(
-            f"{wheel.distribution} does not provide expected extras: {missing_extras}"
-        )
+        raise BoundaryError(f"{wheel.distribution} does not provide expected extras: {missing_extras}")
 
     for extra, expected_requirements in expected.items():
         actual_requirements = []
@@ -205,17 +188,13 @@ def _validate_extra_requirements(
             )
             if standalone is None:
                 raise BoundaryError(
-                    f"{wheel.distribution}[{extra}] dependency must use a standalone "
-                    f"extra marker, found {value!r}"
+                    f"{wheel.distribution}[{extra}] dependency must use a standalone extra marker, found {value!r}"
                 )
             actual_requirements.append(_canonical_requirement(value))
         actual = tuple(sorted(actual_requirements))
         wanted = tuple(sorted(expected_requirements))
         if actual != wanted:
-            raise BoundaryError(
-                f"{wheel.distribution}[{extra}] requirements changed: "
-                f"{list(actual)} != {list(wanted)}"
-            )
+            raise BoundaryError(f"{wheel.distribution}[{extra}] requirements changed: {list(actual)} != {list(wanted)}")
 
 
 def _validate_dependency_direction(client: WheelInfo, nori: WheelInfo) -> None:
@@ -223,9 +202,7 @@ def _validate_dependency_direction(client: WheelInfo, nori: WheelInfo) -> None:
     if "synthefy-nori" in client_requirement_names:
         raise BoundaryError("synthefy must not depend on synthefy-nori in any dependency group")
     if client.extras != {"aws", "forecasting", "text"}:
-        raise BoundaryError(
-            f"synthefy extras changed: {sorted(client.extras)} != ['aws', 'forecasting', 'text']"
-        )
+        raise BoundaryError(f"synthefy extras changed: {sorted(client.extras)} != ['aws', 'forecasting', 'text']")
     _validate_extra_requirements(
         client,
         {
@@ -249,20 +226,13 @@ def _validate_dependency_direction(client: WheelInfo, nori: WheelInfo) -> None:
         },
     )
 
-    nori_edges = [
-        value for value in nori.requirements if _requirement_name(value) == "synthefy"
-    ]
+    nori_edges = [value for value in nori.requirements if _requirement_name(value) == "synthefy"]
     base_edges = [value for value in nori_edges if ";" not in value]
     if len(base_edges) != 1:
-        raise BoundaryError(
-            f"synthefy-nori must have exactly one unconditional synthefy edge, found {base_edges}"
-        )
+        raise BoundaryError(f"synthefy-nori must have exactly one unconditional synthefy edge, found {base_edges}")
     normalized_edge = re.sub(r"\s+", "", base_edges[0]).lower().replace("_", "-")
     if normalized_edge not in {"synthefy<8,>=7", "synthefy>=7,<8"}:
-        raise BoundaryError(
-            "synthefy-nori's base dependency must be synthefy>=7,<8; "
-            f"found {base_edges[0]!r}"
-        )
+        raise BoundaryError(f"synthefy-nori's base dependency must be synthefy>=7,<8; found {base_edges[0]!r}")
 
 
 def _validate_rebuild(direct: WheelInfo, rebuilt: WheelInfo) -> None:
@@ -277,9 +247,7 @@ def _validate_rebuild(direct: WheelInfo, rebuilt: WheelInfo) -> None:
     )
     changed = [name for name in comparable if getattr(direct, name) != getattr(rebuilt, name)]
     if changed:
-        raise BoundaryError(
-            f"{direct.distribution}: direct wheel and sdist-rebuilt wheel differ in {changed}"
-        )
+        raise BoundaryError(f"{direct.distribution}: direct wheel and sdist-rebuilt wheel differ in {changed}")
 
 
 def validate_artifacts(
@@ -291,15 +259,9 @@ def validate_artifacts(
 ) -> tuple[WheelInfo, WheelInfo]:
     """Validate the direct and sdist-rebuilt artifact pair for both distributions."""
     client = inspect_wheel(client_direct, distribution="synthefy", namespace="synthefy")
-    client_from_sdist = inspect_wheel(
-        client_rebuilt, distribution="synthefy", namespace="synthefy"
-    )
-    nori = inspect_wheel(
-        nori_direct, distribution="synthefy-nori", namespace="synthefy_nori"
-    )
-    nori_from_sdist = inspect_wheel(
-        nori_rebuilt, distribution="synthefy-nori", namespace="synthefy_nori"
-    )
+    client_from_sdist = inspect_wheel(client_rebuilt, distribution="synthefy", namespace="synthefy")
+    nori = inspect_wheel(nori_direct, distribution="synthefy-nori", namespace="synthefy_nori")
+    nori_from_sdist = inspect_wheel(nori_rebuilt, distribution="synthefy-nori", namespace="synthefy_nori")
 
     _validate_rebuild(client, client_from_sdist)
     _validate_rebuild(nori, nori_from_sdist)

--- a/examples/embedding_synthetic.py
+++ b/examples/embedding_synthetic.py
@@ -43,16 +43,14 @@ def extract_embeddings(X_train, y_train, X_test):
     leakage-free out-of-fold train embeddings) and the low-level
     ``get_embeddings`` call on its final full-data model.
     """
-    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
-                             model=NoriRegressor(model="nori-6m"))
+    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=NoriRegressor(model="nori-6m"))
     Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
-    Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
+    Z_test = embedder.transform(X_test).mean(axis=0)  # full-data model
 
     # Low-level call on the same fitted model (no extra load); shows the raw 3D
     # shape before we average over the ensemble axis.
     raw = embedder.model_.get_embeddings(X_test, data_source="test")
-    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}"
-          f"; averaged to 2D {Z_test.shape}")
+    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}; averaged to 2D {Z_test.shape}")
 
     native = np.asarray(embedder.model_.predict(X_test))  # Nori's native head
     return Z_train, Z_test, native
@@ -70,6 +68,7 @@ def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")  # headless: straight to file
         import matplotlib.pyplot as plt
         from sklearn.manifold import TSNE
@@ -80,18 +79,16 @@ def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
     def _tsne(M):
         M = StandardScaler().fit_transform(M)
         perp = float(min(30, max(5, (len(M) - 1) // 3)))  # valid for small n
-        return TSNE(n_components=2, perplexity=perp, init="pca",
-                    random_state=0).fit_transform(M)
+        return TSNE(n_components=2, perplexity=perp, init="pca", random_state=0).fit_transform(M)
 
     os.makedirs(OUT_DIR, exist_ok=True)
     fig, axes = plt.subplots(1, 2, figsize=(12, 5.2))
     sc = None
-    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"),
-                         (axes[1], _tsne(Z_embed), "Nori embeddings")):
-        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18,
-                        alpha=0.85, edgecolors="none")
+    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"), (axes[1], _tsne(Z_embed), "Nori embeddings")):
+        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18, alpha=0.85, edgecolors="none")
         ax.set_title(sub, fontsize=12)
-        ax.set_xticks([]); ax.set_yticks([])
+        ax.set_xticks([])
+        ax.set_yticks([])
     fig.suptitle(title, fontsize=14, fontweight="bold")
     fig.colorbar(sc, ax=axes, fraction=0.046, pad=0.04).set_label(cbar_label)
     path = os.path.join(OUT_DIR, fname)
@@ -111,8 +108,7 @@ def make_dataset(n=400, seed=0):
 
 def main():
     X_train, X_test, y_train, y_test = make_dataset()
-    print(f"synthetic regression: train={len(X_train)} test={len(X_test)} "
-          f"features={X_train.shape[1]}")
+    print(f"synthetic regression: train={len(X_train)} test={len(X_test)} features={X_train.shape[1]}")
 
     Z_train, Z_test, native = extract_embeddings(X_train, y_train, X_test)
 
@@ -123,9 +119,14 @@ def main():
     print(f"  kNN probe on embeddings  : {probe_r2:.4f}")
     print(f"  Nori native head (ref.)  : {native_r2:.4f}")
 
-    tsne_plot(X_test, Z_test, y_test,
-              "t-SNE — synthetic regression (color = target y)",
-              "embedding_synthetic_tsne.png", cbar_label="target y")
+    tsne_plot(
+        X_test,
+        Z_test,
+        y_test,
+        "t-SNE — synthetic regression (color = target y)",
+        "embedding_synthetic_tsne.png",
+        cbar_label="target y",
+    )
 
 
 if __name__ == "__main__":

--- a/examples/embedding_tabarena.py
+++ b/examples/embedding_tabarena.py
@@ -38,14 +38,14 @@ from synthefy_nori.evaluation.datasets import DatasetRegistry
 OUT_DIR = "results"
 CACHE_DIR = "cache/tabarena_reg"
 DEFAULT_DATASET = "wine_quality"
-MAX_TRAIN, MAX_TEST = 3000, 1500   # keep the demo fast (embeddings scale w/ context)
+MAX_TRAIN, MAX_TEST = 3000, 1500  # keep the demo fast (embeddings scale w/ context)
 
 
 def load_registry():
     """Download (once) and load the TabArena regression suite."""
     reg = DatasetRegistry(cache_dir="cache/eval_datasets", max_train_samples=MAX_TRAIN)
     if not os.path.isdir(CACHE_DIR) or not os.listdir(CACHE_DIR):
-        reg.download_tabarena(reg_dir=CACHE_DIR)   # needs `openml`
+        reg.download_tabarena(reg_dir=CACHE_DIR)  # needs `openml`
     reg.load_tabarena(reg_dir=CACHE_DIR)
     return reg
 
@@ -58,14 +58,12 @@ def extract_embeddings(X_train, y_train, X_test):
     leakage-free out-of-fold train embeddings) and the low-level
     ``get_embeddings`` call on its final full-data model.
     """
-    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0,
-                             model=NoriRegressor(model="nori-6m"))
+    embedder = NoriEmbedding(n_fold=5, shuffle=True, random_state=0, model=NoriRegressor(model="nori-6m"))
     Z_train = embedder.fit_transform(X_train, y_train).mean(axis=0)  # OOF, no leak
-    Z_test = embedder.transform(X_test).mean(axis=0)                 # full-data model
+    Z_test = embedder.transform(X_test).mean(axis=0)  # full-data model
 
     raw = embedder.model_.get_embeddings(X_test, data_source="test")
-    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}"
-          f"; averaged to 2D {Z_test.shape}")
+    print(f"  get_embeddings -> (n_estimators, n_samples, embed_dim) = {raw.shape}; averaged to 2D {Z_test.shape}")
 
     native = np.asarray(embedder.model_.predict(X_test))  # Nori's native head
     return Z_train, Z_test, native
@@ -74,8 +72,7 @@ def extract_embeddings(X_train, y_train, X_test):
 def ridge_probe(Z_train, y_train, Z_test, y_test):
     """A standardized Ridge regressor on the embeddings — a solid linear probe
     for the higher-dimensional embeddings of real data."""
-    probe = make_pipeline(StandardScaler(),
-                          RidgeCV(alphas=(0.1, 1.0, 10.0, 100.0, 1000.0)))
+    probe = make_pipeline(StandardScaler(), RidgeCV(alphas=(0.1, 1.0, 10.0, 100.0, 1000.0)))
     probe.fit(Z_train, y_train)
     return float(r2_score(y_test, probe.predict(Z_test)))
 
@@ -86,6 +83,7 @@ def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")  # headless: straight to file
         import matplotlib.pyplot as plt
         from sklearn.manifold import TSNE
@@ -96,18 +94,16 @@ def tsne_plot(X_raw, Z_embed, color, title, fname, *, cbar_label):
     def _tsne(M):
         M = StandardScaler().fit_transform(M)
         perp = float(min(30, max(5, (len(M) - 1) // 3)))  # valid for small n
-        return TSNE(n_components=2, perplexity=perp, init="pca",
-                    random_state=0).fit_transform(M)
+        return TSNE(n_components=2, perplexity=perp, init="pca", random_state=0).fit_transform(M)
 
     os.makedirs(OUT_DIR, exist_ok=True)
     fig, axes = plt.subplots(1, 2, figsize=(12, 5.2))
     sc = None
-    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"),
-                         (axes[1], _tsne(Z_embed), "Nori embeddings")):
-        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18,
-                        alpha=0.85, edgecolors="none")
+    for ax, pts, sub in ((axes[0], _tsne(X_raw), "raw features"), (axes[1], _tsne(Z_embed), "Nori embeddings")):
+        sc = ax.scatter(pts[:, 0], pts[:, 1], c=color, cmap="viridis", s=18, alpha=0.85, edgecolors="none")
         ax.set_title(sub, fontsize=12)
-        ax.set_xticks([]); ax.set_yticks([])
+        ax.set_xticks([])
+        ax.set_yticks([])
     fig.suptitle(title, fontsize=14, fontweight="bold")
     fig.colorbar(sc, ax=axes, fraction=0.046, pad=0.04).set_label(cbar_label)
     path = os.path.join(OUT_DIR, fname)
@@ -126,12 +122,9 @@ def subsample(X, y, n, seed=0):
 
 
 def main():
-    p = argparse.ArgumentParser(description=__doc__,
-                                formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--dataset", default=DEFAULT_DATASET,
-                   help="TabArena regression dataset name (see --list)")
-    p.add_argument("--list", action="store_true",
-                   help="print available dataset names and exit")
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dataset", default=DEFAULT_DATASET, help="TabArena regression dataset name (see --list)")
+    p.add_argument("--list", action="store_true", help="print available dataset names and exit")
     args = p.parse_args()
 
     reg = load_registry()
@@ -146,13 +139,11 @@ def main():
 
     entry = reg.get(f"tabarena/{args.dataset}")
     if entry is None:
-        raise SystemExit(f"Dataset '{args.dataset}' not found. Try --list "
-                         f"(e.g. {names[0]}).")
+        raise SystemExit(f"Dataset '{args.dataset}' not found. Try --list (e.g. {names[0]}).")
 
     X_train, y_train = entry.X_train, entry.y_train
     X_test, y_test = subsample(entry.X_test, entry.y_test, MAX_TEST)
-    print(f"{entry.name}: train={len(X_train)} test={len(X_test)} "
-          f"features={X_train.shape[1]}")
+    print(f"{entry.name}: train={len(X_train)} test={len(X_test)} features={X_train.shape[1]}")
 
     Z_train, Z_test, native = extract_embeddings(X_train, y_train, X_test)
 
@@ -163,9 +154,14 @@ def main():
     print(f"  Ridge probe on embeddings  : {probe_r2:.4f}")
     print(f"  Nori native head (ref.)    : {native_r2:.4f}")
 
-    tsne_plot(X_test, Z_test, y_test,
-              f"t-SNE — {entry.name} (color = target y)",
-              f"embedding_tabarena_{entry.name}_tsne.png", cbar_label="target y")
+    tsne_plot(
+        X_test,
+        Z_test,
+        y_test,
+        f"t-SNE — {entry.name} (color = target y)",
+        f"embedding_tabarena_{entry.name}_tsne.png",
+        cbar_label="target y",
+    )
 
 
 if __name__ == "__main__":

--- a/examples/interpretability_regression.py
+++ b/examples/interpretability_regression.py
@@ -18,22 +18,21 @@ from synthefy_nori.interpretability.shapiq import get_nori_imputation_explainer
 X, y = load_diabetes(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=0)
 
-model = NoriRegressor(model="nori-6m")           # downloads weights from the HF Hub on first use
+model = NoriRegressor(model="nori-6m")  # downloads weights from the HF Hub on first use
 model.fit(X_train.values, y_train.values)
 
 # 1) Explain a single prediction with shapiq (Shapley values + pairwise interactions).
 explainer = get_nori_imputation_explainer(model, X_train.values, index="k-SII", max_order=2)
 sv = explainer.explain(X_test.values[0:1], budget=128)
-print(sv)                          # top contributions / interactions
-sv.plot_waterfall()                # additive contribution waterfall
+print(sv)  # top contributions / interactions
+sv.plot_waterfall()  # additive contribution waterfall
 
 # 2) Global feature effect: partial dependence for two features.
 partial_dependence_plots(model, X_test.values, features=[0, 2], kind="average")
 
 # 3) Which features can we drop? (small/slow — ICL runs per CV fit)
-result = feature_selection(model, X_train.values, y_train.values,
-                           n_features_to_select=5, cv=3,
-                           feature_names=list(X.columns))
+result = feature_selection(
+    model, X_train.values, y_train.values, n_features_to_select=5, cv=3, feature_names=list(X.columns)
+)
 print("selected:", result.selected_names)
-print(f"CV R2: all-features {result.baseline_score_mean:.3f} -> "
-      f"selected {result.selected_score_mean:.3f}")
+print(f"CV R2: all-features {result.baseline_score_mean:.3f} -> selected {result.selected_score_mean:.3f}")

--- a/examples/text_features_synthetic.py
+++ b/examples/text_features_synthetic.py
@@ -27,10 +27,8 @@ from sklearn.metrics import r2_score
 from synthefy_nori import NoriRegressor
 
 # sentiment word -> its (hidden) contribution to the target
-_SENTIMENTS = [("terrible", -2.0), ("poor", -1.0), ("okay", 0.0),
-               ("good", 1.0), ("excellent", 2.0)]
-_FILLERS = ["fast shipping", "arrived late", "nice packaging",
-            "exactly as described", "would buy again"]
+_SENTIMENTS = [("terrible", -2.0), ("poor", -1.0), ("okay", 0.0), ("good", 1.0), ("excellent", 2.0)]
+_FILLERS = ["fast shipping", "arrived late", "nice packaging", "exactly as described", "would buy again"]
 _BRANDS = {"acme": 0.5, "globex": -0.5, "initech": 0.0}
 
 
@@ -58,8 +56,7 @@ def make_dataset(n: int, seed: int):
     return df, y.astype(np.float64)
 
 
-def run(n_train: int = 800, n_test: int = 200, svd_dim: int = 64,
-        device=None, seed: int = 0):
+def run(n_train: int = 800, n_test: int = 200, svd_dim: int = 64, device=None, seed: int = 0):
     """Fit Nori with and without the text column; return ``(r2_tabular, r2_text)``."""
     df_train, y_train = make_dataset(n_train, seed)
     df_test, y_test = make_dataset(n_test, seed + 1)
@@ -69,9 +66,7 @@ def run(n_train: int = 800, n_test: int = 200, svd_dim: int = 64,
     # Tabular-only baseline: the DataFrame automatically resolves brand as a
     # categorical and never loads the text embedder. Same estimator as the +text
     # run below, just without the review column.
-    tab = NoriRegressor(device=device, model="nori-6m").fit(
-        df_train[tab_cols], y_train
-    )
+    tab = NoriRegressor(device=device, model="nori-6m").fit(df_train[tab_cols], y_train)
     r_tab = float(r2_score(y_test, tab.predict(df_test[tab_cols])))
 
     # + text: same columns plus the review, embedded -> SVD -> appended columns.

--- a/libs/synthefy/src/synthefy/data_models.py
+++ b/libs/synthefy/src/synthefy/data_models.py
@@ -68,23 +68,15 @@ class NoriPredictRequest(BaseModel):
     output_type: Optional[str] = None
     quantiles: Optional[List[float]] = None
     large_context_policy: Optional[LargeContextPolicy] = None
-    large_context_threshold: Optional[int] = Field(
-        default=None, strict=True, ge=1, le=MAX_LARGE_CONTEXT_THRESHOLD
-    )
-    large_context_seed: Optional[int] = Field(
-        default=None, strict=True, ge=0, le=MAX_LARGE_CONTEXT_SEED
-    )
+    large_context_threshold: Optional[int] = Field(default=None, strict=True, ge=1, le=MAX_LARGE_CONTEXT_THRESHOLD)
+    large_context_seed: Optional[int] = Field(default=None, strict=True, ge=0, le=MAX_LARGE_CONTEXT_SEED)
 
     @model_validator(mode="after")
     def _large_context_parameters_need_a_policy(self):
         if self.large_context_policy is None and (
-            self.large_context_threshold is not None
-            or self.large_context_seed is not None
+            self.large_context_threshold is not None or self.large_context_seed is not None
         ):
-            raise ValueError(
-                "large_context_threshold/large_context_seed require "
-                "large_context_policy"
-            )
+            raise ValueError("large_context_threshold/large_context_seed require large_context_policy")
         return self
 
     def to_wire(self) -> Dict[str, Any]:

--- a/libs/synthefy/src/synthefy/errors.py
+++ b/libs/synthefy/src/synthefy/errors.py
@@ -67,9 +67,7 @@ def _extract_error_details(
 
     Returns a tuple of (message, request_id, error_code, parsed_body)
     """
-    request_id = response.headers.get("x-request-id") or response.headers.get(
-        "X-Request-Id"
-    )
+    request_id = response.headers.get("x-request-id") or response.headers.get("X-Request-Id")
     parsed: Any
     message: str = f"HTTP {response.status_code} Error"
     code: Optional[str] = None
@@ -80,21 +78,11 @@ def _extract_error_details(
         if isinstance(parsed, dict):
             error_obj: Any = parsed.get("error")
             if isinstance(error_obj, dict):
-                message = (
-                    error_obj.get("message")
-                    or error_obj.get("detail")
-                    or error_obj.get("error")
-                    or message
-                )
+                message = error_obj.get("message") or error_obj.get("detail") or error_obj.get("error") or message
                 code = error_obj.get("code") or error_obj.get("type")
                 request_id = request_id or error_obj.get("request_id")
             else:
-                message = (
-                    parsed.get("message")
-                    or parsed.get("detail")
-                    or parsed.get("error")
-                    or message
-                )
+                message = parsed.get("message") or parsed.get("detail") or parsed.get("error") or message
                 code = parsed.get("code") or parsed.get("type")
                 request_id = request_id or parsed.get("request_id")
         else:

--- a/libs/synthefy/src/synthefy/featurize.py
+++ b/libs/synthefy/src/synthefy/featurize.py
@@ -47,9 +47,7 @@ def _numeric_categories_to_values(frame: pd.DataFrame) -> pd.DataFrame:
     out = frame
     for column in frame.columns:
         series = frame[column]
-        if isinstance(series.dtype, pd.CategoricalDtype) and pd.api.types.is_numeric_dtype(
-            series.cat.categories
-        ):
+        if isinstance(series.dtype, pd.CategoricalDtype) and pd.api.types.is_numeric_dtype(series.cat.categories):
             if out is frame:
                 out = frame.copy()
             out[column] = series.astype("float64")
@@ -144,13 +142,11 @@ class DataFramePreprocessor:
     def _validate_parameters(self) -> None:
         if not isinstance(self.max_categorical_cardinality, int) or self.max_categorical_cardinality < 1:
             raise ValueError(
-                "max_categorical_cardinality must be a positive integer; got "
-                f"{self.max_categorical_cardinality!r}."
+                f"max_categorical_cardinality must be a positive integer; got {self.max_categorical_cardinality!r}."
             )
         if self.categorical_encoding not in CATEGORICAL_ENCODINGS:
             raise ValueError(
-                f"categorical_encoding must be one of {CATEGORICAL_ENCODINGS}; "
-                f"got {self.categorical_encoding!r}."
+                f"categorical_encoding must be one of {CATEGORICAL_ENCODINGS}; got {self.categorical_encoding!r}."
             )
 
     @staticmethod
@@ -181,10 +177,7 @@ class DataFramePreprocessor:
             raise ValueError(f"text_columns not found in the DataFrame: {missing_text}.")
         overlap = [column for column in declared_text if column in set(declared_categorical)]
         if overlap:
-            raise ValueError(
-                "categorical_columns and text_columns must not overlap; "
-                f"both contain {overlap}."
-            )
+            raise ValueError(f"categorical_columns and text_columns must not overlap; both contain {overlap}.")
 
         text_set = set(declared_text)
         categorical_set = set(declared_categorical)
@@ -252,9 +245,7 @@ class DataFramePreprocessor:
                     "encode it explicitly, or remove it."
                 )
             if len(counts) > self.max_categorical_cardinality:
-                selected = sorted(counts, key=lambda key: (-counts[key], key))[
-                    : self.max_categorical_cardinality
-                ]
+                selected = sorted(counts, key=lambda key: (-counts[key], key))[: self.max_categorical_cardinality]
             else:
                 selected = list(counts)
             selected = sorted(selected)
@@ -278,9 +269,7 @@ class DataFramePreprocessor:
                 f"missing columns={missing}, extra columns={extra}."
             )
         frame = frame.loc[:, self.columns_]
-        numeric_mismatches = [
-            column for column in self.numeric_columns_ if not _is_numeric_series(frame[column])
-        ]
+        numeric_mismatches = [column for column in self.numeric_columns_ if not _is_numeric_series(frame[column])]
         if numeric_mismatches:
             raise ValueError(
                 "X_train and X_test must have matching column types. Query type mismatch for "
@@ -288,9 +277,7 @@ class DataFramePreprocessor:
                 + _dtype_items(frame, numeric_mismatches)
                 + ". Convert them to numeric values before prediction."
             )
-        temporal_categorical = [
-            column for column in self.categorical_columns_ if _unsupported_temporal(frame[column])
-        ]
+        temporal_categorical = [column for column in self.categorical_columns_ if _unsupported_temporal(frame[column])]
         if temporal_categorical:
             raise ValueError(
                 "Query categorical column(s) have unsupported temporal dtype: "

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -204,10 +204,7 @@ def _load_aws_sdk() -> Tuple[Any, Any]:
         import boto3
         from botocore.config import Config
     except ImportError as exc:  # pragma: no cover - exercised without the extra
-        raise ImportError(
-            "A SageMaker deployment needs the AWS extra: install "
-            "`pip install \"synthefy[aws]\"`."
-        ) from exc
+        raise ImportError('A SageMaker deployment needs the AWS extra: install `pip install "synthefy[aws]"`.') from exc
     return boto3, Config
 
 
@@ -267,11 +264,7 @@ def _reject_non_numeric_columns(frame: pd.DataFrame, name: str) -> None:
     This helper runs after public DataFrame preprocessing, so any remaining
     categorical/text/temporal column means the schema was not resolved.
     """
-    non_numeric = [
-        str(col)
-        for col in frame.columns
-        if not pd.api.types.is_numeric_dtype(frame[col])
-    ]
+    non_numeric = [str(col) for col in frame.columns if not pd.api.types.is_numeric_dtype(frame[col])]
     if non_numeric:
         raise ValueError(
             f"{name} has unresolved non-numeric column(s) {non_numeric}. Pass raw "
@@ -303,8 +296,7 @@ def _coerce_matrix(arr: MatrixLike, name: str) -> np.ndarray:
             ) from exc
     if matrix.ndim != 2:
         raise ValueError(
-            f"{name} must be 2D with shape (n_rows, n_features); "
-            f"got {matrix.ndim}D with shape {matrix.shape}"
+            f"{name} must be 2D with shape (n_rows, n_features); got {matrix.ndim}D with shape {matrix.shape}"
         )
     return matrix
 
@@ -326,26 +318,16 @@ def _coerce_vector(arr: VectorLike, name: str) -> np.ndarray:
         vector = arr.to_numpy(dtype=float).reshape(-1)
     elif isinstance(arr, pd.Series):
         if not pd.api.types.is_numeric_dtype(arr):
-            raise ValueError(
-                f"{name} must be numeric; got a non-numeric Series "
-                f"(dtype {arr.dtype})."
-            )
+            raise ValueError(f"{name} must be numeric; got a non-numeric Series (dtype {arr.dtype}).")
         vector = arr.to_numpy(dtype=float)
     else:
         try:
             vector = np.asarray(arr, dtype=float)
         except (ValueError, TypeError) as exc:
-            raise ValueError(
-                f"{name} must be a numeric 1D array/list; got error: {exc}"
-            ) from exc
+            raise ValueError(f"{name} must be a numeric 1D array/list; got error: {exc}") from exc
     if vector.ndim != 1:
-        raise ValueError(
-            f"{name} must be 1D with shape (n_rows,); "
-            f"got {vector.ndim}D with shape {vector.shape}"
-        )
+        raise ValueError(f"{name} must be 1D with shape (n_rows,); got {vector.ndim}D with shape {vector.shape}")
     return vector
-
-
 
 
 def _build_nori_request(
@@ -400,17 +382,11 @@ def _build_nori_request(
     if n_features == 0:
         raise ValueError("X_train must contain at least one feature column")
     if y_train_arr.shape[0] != n_context:
-        raise ValueError(
-            f"X_train has {n_context} rows but y_train has "
-            f"{y_train_arr.shape[0]}; they must match"
-        )
+        raise ValueError(f"X_train has {n_context} rows but y_train has {y_train_arr.shape[0]}; they must match")
     if X_test_arr.shape[0] == 0:
         raise ValueError("X_test must contain at least one query row")
     if X_test_arr.shape[1] != n_features:
-        raise ValueError(
-            f"X_test has {X_test_arr.shape[1]} features but X_train has "
-            f"{n_features}; they must match"
-        )
+        raise ValueError(f"X_test has {X_test_arr.shape[1]} features but X_train has {n_features}; they must match")
     if not isinstance(task, str) or not task.strip():
         raise ValueError("task must be a non-empty string")
 
@@ -460,7 +436,7 @@ def _load_local_predict() -> Any:
             raise
         raise ImportError(
             "Local nori inference requires the optional 'synthefy-nori' "
-            'package. Install it with: pip install synthefy-nori.'
+            "package. Install it with: pip install synthefy-nori."
         ) from exc
     return local_predict
 
@@ -481,9 +457,7 @@ def _validate_output_type(
     levels were given.
     """
     if output_type not in _OUTPUT_TYPES:
-        raise ValueError(
-            f"output_type must be one of {_OUTPUT_TYPES}; got {output_type!r}."
-        )
+        raise ValueError(f"output_type must be one of {_OUTPUT_TYPES}; got {output_type!r}.")
     if discretizing and (output_type != DEFAULT_OUTPUT_TYPE or quantiles is not None):
         raise ValueError(
             "categorical output (discretize=/categorical_levels=) returns "
@@ -492,10 +466,7 @@ def _validate_output_type(
             "chooses the summary), not with output_type/quantiles."
         )
     if quantiles is not None and output_type != "quantiles":
-        raise ValueError(
-            "quantiles= is only valid with output_type='quantiles'; got "
-            f"output_type={output_type!r}."
-        )
+        raise ValueError(f"quantiles= is only valid with output_type='quantiles'; got output_type={output_type!r}.")
     if output_type != "quantiles":
         return None
     if quantiles is None:
@@ -511,9 +482,7 @@ def _validate_output_type(
             "tau level in (0, 1); got an empty sequence."
         )
     if not np.all(np.isfinite(levels)) or np.any((levels <= 0.0) | (levels >= 1.0)):
-        raise ValueError(
-            f"quantiles must lie strictly in (0, 1); got {quantiles!r}."
-        )
+        raise ValueError(f"quantiles must lie strictly in (0, 1); got {quantiles!r}.")
     return [float(level) for level in levels]
 
 
@@ -532,7 +501,7 @@ def _load_local_regressor() -> Any:
             raise
         raise ImportError(
             "Local nori inference requires the optional 'synthefy-nori' "
-            'package. Install it with: pip install synthefy-nori.'
+            "package. Install it with: pip install synthefy-nori."
         ) from exc
     return NoriRegressor
 
@@ -617,8 +586,7 @@ def _validate_large_context_controls(
         return
     if not isinstance(policy, str) and (mode != "local" or not callable(policy)):
         raise ValueError(
-            "large_context_policy must be a policy name string; custom callables "
-            "are supported only in local mode."
+            "large_context_policy must be a policy name string; custom callables are supported only in local mode."
         )
     if threshold is not None and (
         isinstance(threshold, bool)
@@ -630,13 +598,10 @@ def _validate_large_context_controls(
             f"{MAX_LARGE_CONTEXT_THRESHOLD:,}; got {threshold!r}."
         )
     if seed is not None and (
-        isinstance(seed, bool)
-        or not isinstance(seed, Integral)
-        or not 0 <= int(seed) <= MAX_LARGE_CONTEXT_SEED
+        isinstance(seed, bool) or not isinstance(seed, Integral) or not 0 <= int(seed) <= MAX_LARGE_CONTEXT_SEED
     ):
         raise ValueError(
-            "large_context_seed must be an integer between 0 and "
-            f"{MAX_LARGE_CONTEXT_SEED:,}; got {seed!r}."
+            f"large_context_seed must be an integer between 0 and {MAX_LARGE_CONTEXT_SEED:,}; got {seed!r}."
         )
     if output_type in _DISTRIBUTION_OUTPUT_TYPES:
         raise ValueError(
@@ -654,9 +619,7 @@ def _validate_large_context_controls(
         )
 
 
-def _normalized_large_context_report(
-    request: NoriPredictRequest, report: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
+def _normalized_large_context_report(request: NoriPredictRequest, report: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Give local mode the same typed per-call report as hosted modes."""
     policy = request.large_context_policy
     if policy is None:
@@ -666,17 +629,11 @@ def _normalized_large_context_report(
         if request.large_context_threshold is not None
         else DEFAULT_LARGE_CONTEXT_THRESHOLD
     )
-    seed = (
-        request.large_context_seed
-        if request.large_context_seed is not None
-        else DEFAULT_LARGE_CONTEXT_SEED
-    )
+    seed = request.large_context_seed if request.large_context_seed is not None else DEFAULT_LARGE_CONTEXT_SEED
     if report is None:
         return LargeContextReport(
             applied=False,
-            policy=(
-                policy if isinstance(policy, str) else getattr(policy, "__name__", repr(policy))
-            ),
+            policy=(policy if isinstance(policy, str) else getattr(policy, "__name__", repr(policy))),
             threshold=threshold,
             seed=seed,
             reason="below_threshold",
@@ -724,7 +681,7 @@ def _resolve_remote_levels(
             "distribution — the hosted endpoint returns only point "
             'predictions. Pass discretize="snap-mean" explicitly (nearest '
             "level to the point prediction), or use local mode "
-            '(pip install synthefy-nori) for the full strategy set.'
+            "(pip install synthefy-nori) for the full strategy set."
         )
     if discretize != _REMOTE_DISCRETIZE_METHOD:
         raise ValueError(
@@ -732,22 +689,20 @@ def _resolve_remote_levels(
             "distribution, which the hosted endpoint does not return; "
             'remote mode supports discretize="snap-mean" (nearest level to '
             "the returned point prediction). For the full strategy set, use "
-            'local mode (pip install synthefy-nori).'
+            "local mode (pip install synthefy-nori)."
         )
     if categorical_levels is None:
         levels = np.unique(np.asarray(y_train, dtype=float))
         levels = levels[np.isfinite(levels)]
         if levels.size == 0:
             raise ValueError(
-                "y_train has no finite values to derive categorical levels "
-                "from; pass categorical_levels explicitly."
+                "y_train has no finite values to derive categorical levels from; pass categorical_levels explicitly."
             )
     else:
         levels = np.unique(np.asarray(categorical_levels, dtype=float).reshape(-1))
         if levels.size == 0 or not np.all(np.isfinite(levels)):
             raise ValueError(
-                "categorical_levels must be a non-empty sequence of finite "
-                f"numbers; got {categorical_levels!r}"
+                f"categorical_levels must be a non-empty sequence of finite numbers; got {categorical_levels!r}"
             )
     return levels
 
@@ -766,6 +721,7 @@ def _snap_to_levels(predictions: List[float], levels: "np.ndarray") -> List[floa
 # --------------------------------------------------------------------------- #
 # Distribution output shaping (output_type="quantiles" / "full")
 # --------------------------------------------------------------------------- #
+
 
 def _quantile_frame(
     values: "np.ndarray",
@@ -804,10 +760,7 @@ def _nullable_rows_to_array(rows: Sequence[Sequence[Optional[float]]]) -> "np.nd
     except (ValueError, TypeError) as exc:
         # Ragged rows: numpy >= 2 rejects an inhomogeneous shape. Report it as a
         # malformed response rather than letting the raw numpy message surface.
-        raise ValueError(
-            "The server returned a malformed quantile block (rows of unequal "
-            f"length): {exc}"
-        ) from exc
+        raise ValueError(f"The server returned a malformed quantile block (rows of unequal length): {exc}") from exc
     if arr.ndim != 2:
         raise ValueError(
             "The server returned a malformed quantile block: expected a 2D "
@@ -855,9 +808,7 @@ def _shape_full(
     """
     if as_pandas:
         return {
-            "quantiles": _quantile_frame(
-                q_by_row, taus.tolist(), X_test=X_test, y_train=y_train
-            ),
+            "quantiles": _quantile_frame(q_by_row, taus.tolist(), X_test=X_test, y_train=y_train),
             "taus": taus.tolist(),
             "mean": pd.Series(
                 mean,
@@ -928,9 +879,7 @@ def _widen_text_columns(
     ``X_train``. Both inputs must be DataFrames; their indexes are preserved for
     ``as_pandas`` output.
     """
-    resolved_text_device = (
-        _resolve_text_device(text_device) if isinstance(embedder, str) else None
-    )
+    resolved_text_device = _resolve_text_device(text_device) if isinstance(embedder, str) else None
     return _align_and_featurize(
         X_train,
         X_test,
@@ -1088,24 +1037,13 @@ class SynthefyNoriClient:
     ) -> None:
         if mode == "auto":
             raise ValueError(
-                "mode='auto' has been removed; choose one explicit execution "
-                "mode: 'remote', 'sagemaker', or 'local'"
+                "mode='auto' has been removed; choose one explicit execution mode: 'remote', 'sagemaker', or 'local'"
             )
         if mode not in _VALID_MODES:
-            raise ValueError(
-                f"mode must be one of {_VALID_MODES}; got {mode!r}"
-            )
+            raise ValueError(f"mode must be one of {_VALID_MODES}; got {mode!r}")
         if auth_scheme not in _VALID_AUTH_SCHEMES:
-            raise ValueError(
-                f"auth_scheme must be one of {_VALID_AUTH_SCHEMES}; "
-                f"got {auth_scheme!r}"
-            )
-        if (
-            isinstance(timeout, bool)
-            or not isinstance(timeout, Real)
-            or not np.isfinite(timeout)
-            or timeout <= 0
-        ):
+            raise ValueError(f"auth_scheme must be one of {_VALID_AUTH_SCHEMES}; got {auth_scheme!r}")
+        if isinstance(timeout, bool) or not isinstance(timeout, Real) or not np.isfinite(timeout) or timeout <= 0:
             raise ValueError("timeout must be a finite number greater than zero")
         if isinstance(max_retries, bool) or not isinstance(max_retries, Integral) or max_retries < 0:
             raise ValueError("max_retries must be a non-negative integer")
@@ -1116,14 +1054,9 @@ class SynthefyNoriClient:
                     "SigV4-signs with the standard AWS credential chain"
                 )
             if not endpoint_name or not endpoint_name.strip():
-                raise ValueError(
-                    "endpoint_name is required with mode='sagemaker'"
-                )
+                raise ValueError("endpoint_name is required with mode='sagemaker'")
         elif endpoint_name is not None or region_name is not None:
-            raise ValueError(
-                "endpoint_name and region_name are only valid with "
-                "mode='sagemaker'"
-            )
+            raise ValueError("endpoint_name and region_name are only valid with mode='sagemaker'")
         if model is _MODEL_REQUIRED or model is None:
             raise ValueError(
                 "model is required -- there is no default; every request names a size. "
@@ -1189,9 +1122,7 @@ class SynthefyNoriClient:
                     "environment variable when mode='remote'"
                 )
             self.api_key: Optional[str] = api_key
-            self.client: Optional[httpx.Client] = httpx.Client(
-                base_url=self.base_url
-            )
+            self.client: Optional[httpx.Client] = httpx.Client(base_url=self.base_url)
         else:  # local
             self.api_key = api_key  # unused in local mode; may be None
             self.client = None
@@ -1542,8 +1473,7 @@ class SynthefyNoriClient:
         # text_columns, a checkpoint, or a paid network round-trip).
         if self.mode == "sagemaker" and extra_headers is not None:
             raise ValueError(
-                "extra_headers is only valid for HTTP remote mode; SageMaker "
-                "requests are SigV4-signed by boto3"
+                "extra_headers is only valid for HTTP remote mode; SageMaker requests are SigV4-signed by boto3"
             )
         if self.mode == "sagemaker" and timeout is not None:
             warnings.warn(
@@ -1571,8 +1501,14 @@ class SynthefyNoriClient:
             # send the widened numeric matrix through the normal request path
             # (works identically for local / remote / AWS backends).
             X_train, X_test = _widen_text_columns(
-                X_train, X_test, text_columns, svd_dim, embedder,
-                max_categorical_cardinality, categorical_encoding, text_device,
+                X_train,
+                X_test,
+                text_columns,
+                svd_dim,
+                embedder,
+                max_categorical_cardinality,
+                categorical_encoding,
+                text_device,
                 categorical_columns,
             )
             # The widened frames are already numeric; do not resolve the original
@@ -1589,20 +1525,19 @@ class SynthefyNoriClient:
         # values that actually ran, never leaving the caller to infer them.
         if large_context_policy is not None:
             resolved_large_context_threshold = (
-                DEFAULT_LARGE_CONTEXT_THRESHOLD
-                if large_context_threshold is None
-                else int(large_context_threshold)
+                DEFAULT_LARGE_CONTEXT_THRESHOLD if large_context_threshold is None else int(large_context_threshold)
             )
             resolved_large_context_seed = (
-                DEFAULT_LARGE_CONTEXT_SEED
-                if large_context_seed is None
-                else int(large_context_seed)
+                DEFAULT_LARGE_CONTEXT_SEED if large_context_seed is None else int(large_context_seed)
             )
         else:
             resolved_large_context_threshold = None
             resolved_large_context_seed = None
         request = _build_nori_request(
-            X_train, y_train, X_test, task,
+            X_train,
+            y_train,
+            X_test,
+            task,
             categorical_columns=request_categorical_columns,
             max_categorical_cardinality=max_categorical_cardinality,
             categorical_encoding=categorical_encoding,
@@ -1641,8 +1576,12 @@ class SynthefyNoriClient:
                     y_train=y_train,
                 )
             return _shape_full(
-                q_by_row, taus, mean,
-                as_pandas=as_pandas, X_test=X_test, y_train=y_train,
+                q_by_row,
+                taus,
+                mean,
+                as_pandas=as_pandas,
+                X_test=X_test,
+                y_train=y_train,
             )
 
         if self.mode == "local":
@@ -1655,9 +1594,7 @@ class SynthefyNoriClient:
         else:
             remote_levels = None
             if discretize is not None or categorical_levels is not None:
-                remote_levels = _resolve_remote_levels(
-                    request.y_train, discretize, categorical_levels
-                )
+                remote_levels = _resolve_remote_levels(request.y_train, discretize, categorical_levels)
             if self.mode == "sagemaker":
                 predictions = self._predict_aws(
                     request,
@@ -1710,7 +1647,7 @@ class SynthefyNoriClient:
             raise ImportError(
                 f"output_type={output_type!r} requires a newer synthefy-nori (with "
                 "output_type= on NoriRegressor.predict, added in 0.6.0). Upgrade "
-                'with: pip install -U synthefy-nori.'
+                "with: pip install -U synthefy-nori."
             )
         init_kwargs: Dict[str, Any] = {}
         if self._local_variant is not None:
@@ -1720,14 +1657,14 @@ class SynthefyNoriClient:
                 raise ImportError(
                     f"Local Nori variant {self._local_variant!r} requires a newer "
                     "synthefy-nori (with the model= selector). Upgrade with: "
-                    'pip install -U synthefy-nori.'
+                    "pip install -U synthefy-nori."
                 )
             init_kwargs["model"] = self._local_variant
         if request.memory_policy is not None:
             if not _local_memory_policy_available():
                 raise ImportError(
                     "memory_policy= requires synthefy-nori >= 0.13.0 (the serving-memory policy). "
-                    'Upgrade with: pip install -U synthefy-nori.'
+                    "Upgrade with: pip install -U synthefy-nori."
                 )
             # NoriRegressor belongs to another package and expects its own MemoryPolicy
             # class (or a plain input), not this client's equivalent pydantic class.
@@ -1827,9 +1764,7 @@ class SynthefyNoriClient:
         (``(n_levels, n_query)``) but ``"full"`` row-major; both are normalized to
         row-major here so one shaping path serves local and remote alike.
         """
-        result = self._local_regressor_predict(
-            request, output_type=output_type, quantile_levels=quantile_levels
-        )
+        result = self._local_regressor_predict(request, output_type=output_type, quantile_levels=quantile_levels)
         n_query = len(request.X_test)
         if output_type == "quantiles":
             levels = quantile_levels or []
@@ -1860,16 +1795,11 @@ class SynthefyNoriClient:
         discretize: Optional[str] = None,
         categorical_levels: Optional[VectorLike] = None,
     ) -> List[float]:
-        if (
-            output_type != DEFAULT_OUTPUT_TYPE
-            or request.large_context_policy is not None
-        ):
+        if output_type != DEFAULT_OUTPUT_TYPE or request.large_context_policy is not None:
             # "median" is a point output but still needs the estimator API
             # (see _local_regressor_predict). Discretization cannot reach here:
             # _validate_output_type rejects that combination up front.
-            if (
-                discretize is not None or categorical_levels is not None
-            ) and not _local_discretize_available():
+            if (discretize is not None or categorical_levels is not None) and not _local_discretize_available():
                 raise ImportError(
                     "Categorical-target discretization (discretize=/"
                     "categorical_levels=) requires a newer synthefy-nori. "
@@ -1891,7 +1821,7 @@ class SynthefyNoriClient:
                 raise ImportError(
                     "Categorical-target discretization (discretize=/"
                     "categorical_levels=) requires a newer synthefy-nori. "
-                    'Upgrade with: pip install -U synthefy-nori.'
+                    "Upgrade with: pip install -U synthefy-nori."
                 )
             if discretize is not None:
                 extra["discretize"] = discretize
@@ -1901,7 +1831,7 @@ class SynthefyNoriClient:
             if not _local_memory_policy_available():
                 raise ImportError(
                     "memory_policy= requires synthefy-nori >= 0.13.0 (the serving-memory policy). "
-                    'Upgrade with: pip install -U synthefy-nori.'
+                    "Upgrade with: pip install -U synthefy-nori."
                 )
             # A dict, not our MemoryPolicy instance: the library's coerce() accepts its OWN
             # class, a dict, a preset name or None -- a same-named class from this package is
@@ -1920,7 +1850,7 @@ class SynthefyNoriClient:
             if "model" not in inspect.signature(local_predict).parameters:
                 raise ImportError(
                     f"Local Nori variant {self._local_variant!r} requires a newer synthefy-nori "
-                    '(with the model= selector). Upgrade with: pip install -U synthefy-nori.'
+                    "(with the model= selector). Upgrade with: pip install -U synthefy-nori."
                 )
             extra["model"] = self._local_variant
         result = local_predict(
@@ -1977,21 +1907,15 @@ class SynthefyNoriClient:
                 else DEFAULT_LARGE_CONTEXT_THRESHOLD
             )
             expected_seed = (
-                request.large_context_seed
-                if request.large_context_seed is not None
-                else DEFAULT_LARGE_CONTEXT_SEED
+                request.large_context_seed if request.large_context_seed is not None else DEFAULT_LARGE_CONTEXT_SEED
             )
             mismatches = []
             expected_policy = request.large_context_policy.strip()
             if report.policy != expected_policy:
-                mismatches.append(
-                    f"policy={report.policy!r}, expected {expected_policy!r}"
-                )
+                mismatches.append(f"policy={report.policy!r}, expected {expected_policy!r}")
 
             if report.threshold != expected_threshold:
-                mismatches.append(
-                    f"threshold={report.threshold}, expected {expected_threshold}"
-                )
+                mismatches.append(f"threshold={report.threshold}, expected {expected_threshold}")
             if report.seed != expected_seed:
                 mismatches.append(f"seed={report.seed}, expected {expected_seed}")
             if mismatches:
@@ -2003,8 +1927,7 @@ class SynthefyNoriClient:
             self.last_large_context_report = report.model_dump()
         if output_type != DEFAULT_OUTPUT_TYPE and parsed.output_type != output_type:
             honored = (
-                "omitted the output_type field entirely, so it predates "
-                "distribution output"
+                "omitted the output_type field entirely, so it predates distribution output"
                 if parsed.output_type is None
                 else f"honored output_type={parsed.output_type!r} instead"
             )
@@ -2013,7 +1936,7 @@ class SynthefyNoriClient:
                 f"it {honored}. Such a deployment answers with the distribution "
                 f"mean, which is indistinguishable from a real {output_type!r} "
                 "result, so this is raised rather than returning means as if they "
-                'were what you asked for. Use local mode (pip install '
+                "were what you asked for. Use local mode (pip install "
                 'synthefy-nori, then mode="local"), or point at a deployment '
                 "that serves distribution output."
             )
@@ -2034,9 +1957,7 @@ class SynthefyNoriClient:
         if status < 400 or status > 599:
             status = 500
         message = (
-            aws_response.get("OriginalMessage")
-            or error.get("Message")
-            or "SageMaker endpoint returned a model error"
+            aws_response.get("OriginalMessage") or error.get("Message") or "SageMaker endpoint returned a model error"
         )
         details = {
             "error": {
@@ -2092,16 +2013,13 @@ class SynthefyNoriClient:
         """Invoke the configured SageMaker endpoint with a SigV4-signed request."""
         if self._aws_client is None or self.endpoint_name is None:
             raise RuntimeError(
-                "SageMaker transport is not initialized; construct the client with "
-                "mode='sagemaker' and endpoint_name"
+                "SageMaker transport is not initialized; construct the client with mode='sagemaker' and endpoint_name"
             )
         if self._sagemaker_model is None:
             raise RuntimeError("SageMaker transport has no resolved model identity")
         payload = request.to_wire()
         payload["model"] = self._sagemaker_model
-        body = json.dumps(payload, separators=(",", ":"), allow_nan=False).encode(
-            "utf-8"
-        )
+        body = json.dumps(payload, separators=(",", ":"), allow_nan=False).encode("utf-8")
         if len(body) > SAGEMAKER_MAX_BODY_BYTES:
             raise ValueError(
                 "The SageMaker request body is "
@@ -2128,9 +2046,7 @@ class SynthefyNoriClient:
         raw = self._read_sagemaker_stream(response_body)
         response_data = json.loads(raw)
         if not isinstance(response_data, dict):
-            raise ValueError(
-                "SageMaker endpoint returned JSON that was not an object"
-            )
+            raise ValueError("SageMaker endpoint returned JSON that was not an object")
         stream_error = response_data.get("error")
         if isinstance(stream_error, dict) and "status_code" in stream_error:
             status = int(stream_error.get("status_code", 500))
@@ -2139,13 +2055,7 @@ class SynthefyNoriClient:
             _raise_for_status(
                 httpx.Response(
                     status,
-                    json={
-                        "error": {
-                            "message": stream_error.get(
-                                "message", "SageMaker streaming inference failed"
-                            )
-                        }
-                    },
+                    json={"error": {"message": stream_error.get("message", "SageMaker streaming inference failed")}},
                 )
             )
         actual_model = response_data.get("model")
@@ -2243,9 +2153,7 @@ class SynthefyNoriClient:
             timeout=timeout,
             extra_headers=extra_headers,
         )
-        return self._parse_hosted_distribution(
-            request, parsed=parsed, output_type=output_type
-        )
+        return self._parse_hosted_distribution(request, parsed=parsed, output_type=output_type)
 
     def _predict_aws_distribution(
         self,
@@ -2254,9 +2162,7 @@ class SynthefyNoriClient:
         output_type: str,
     ) -> Tuple["np.ndarray", "np.ndarray", "np.ndarray"]:
         parsed = self._invoke_sagemaker_predict(request, output_type=output_type)
-        return self._parse_hosted_distribution(
-            request, parsed=parsed, output_type=output_type
-        )
+        return self._parse_hosted_distribution(request, parsed=parsed, output_type=output_type)
 
     def _parse_hosted_distribution(
         self,
@@ -2286,22 +2192,18 @@ class SynthefyNoriClient:
             requested = np.asarray(request.quantiles, dtype=float)
             if taus.shape[0] != requested.shape[0]:
                 raise ValueError(
-                    f"Requested {requested.shape[0]} quantile level(s) but the "
-                    f"server returned {taus.shape[0]}."
+                    f"Requested {requested.shape[0]} quantile level(s) but the server returned {taus.shape[0]}."
                 )
             # The returned levels must be the requested ones, in order: the
             # columns are labeled from the request, so levels that drifted would
             # mean data at one tau labeled with another.
             if not np.allclose(taus, requested, rtol=0.0, atol=1e-9):
                 raise ValueError(
-                    f"Requested quantile levels {requested.tolist()} but the "
-                    f"server returned {taus.tolist()}."
+                    f"Requested quantile levels {requested.tolist()} but the server returned {taus.tolist()}."
                 )
         return q_by_row, taus, np.asarray(parsed.predictions, dtype=float)
 
-    def _headers(
-        self, *, extra_headers: Optional[Dict[str, str]] = None
-    ) -> Dict[str, str]:
+    def _headers(self, *, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         headers: Dict[str, str] = {
             "User-Agent": self.user_agent,
             "Content-Type": "application/json",
@@ -2311,28 +2213,19 @@ class SynthefyNoriClient:
             headers.update(extra_headers)
         return headers
 
-    def _should_retry(
-        self, response: Optional[httpx.Response], exc: Optional[Exception]
-    ) -> bool:
+    def _should_retry(self, response: Optional[httpx.Response], exc: Optional[Exception]) -> bool:
         if exc is not None:
             # Connection errors/timeouts are retryable
             return True
         if response is None:
             return False
-        if (
-            response.status_code in (408, 409, 425, 429)
-            or 500 <= response.status_code <= 599
-        ):
+        if response.status_code in (408, 409, 425, 429) or 500 <= response.status_code <= 599:
             return True
         return False
 
-    def _compute_backoff(
-        self, attempt: int, response: Optional[httpx.Response]
-    ) -> float:
+    def _compute_backoff(self, attempt: int, response: Optional[httpx.Response]) -> float:
         if response is not None:
-            retry_after = response.headers.get(
-                "retry-after"
-            ) or response.headers.get("Retry-After")
+            retry_after = response.headers.get("retry-after") or response.headers.get("Retry-After")
             if retry_after is not None:
                 try:
                     parsed_retry_after = float(retry_after)
@@ -2392,9 +2285,7 @@ class SynthefyNoriClient:
                 last_exc = APIConnectionError(str(exc))
 
             # Decide to retry
-            if attempt < attempts - 1 and self._should_retry(
-                response, last_exc
-            ):
+            if attempt < attempts - 1 and self._should_retry(response, last_exc):
                 delay = self._compute_backoff(attempt, response)
                 time.sleep(delay)
                 continue

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -42,10 +42,18 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from typing_extensions import Annotated
 
 #: Named starting points accepted wherever a policy is expected, instead of a field dict.
-MEMORY_PRESETS = ('exact', 'max_context', 'off')
+MEMORY_PRESETS = ("exact", "max_context", "off")
 
 #: The fallback rungs the server may report, in decreasing memory cost.
-MEMORY_RUNGS = ('no_cache', 'resident_bf16', 'resident_int8', 'offload_bf16', 'offload_int8', 'context_row_chunk', 'plain_loop')
+MEMORY_RUNGS = (
+    "no_cache",
+    "resident_bf16",
+    "resident_int8",
+    "offload_bf16",
+    "offload_int8",
+    "context_row_chunk",
+    "plain_loop",
+)
 
 #: The direct library's defaults, copied here because synthefy must remain usable
 #: without importing the heavyweight synthefy-nori package.
@@ -57,7 +65,7 @@ DEFAULT_LARGE_CONTEXT_SEED = 0
 MAX_LARGE_CONTEXT_THRESHOLD = 10_000_000
 MAX_LARGE_CONTEXT_SEED = 2**32 - 1
 
-MemoryPreset = Literal['exact', 'max_context', 'off']
+MemoryPreset = Literal["exact", "max_context", "off"]
 #: Local mode also accepts callables; hosted modes require a policy-name string and
 #: let the server's installed synthefy-nori resolver decide whether it is valid.
 LargeContextPolicy = Union[str, Callable[..., Any]]
@@ -110,7 +118,7 @@ class MemoryPolicy(BaseModel):
     )
 
     cache_dtype: Literal["bf16", "int8"] = Field(
-        'bf16',
+        "bf16",
         description=(
             "Precision the K/V cache STARTS at. bf16 is bit-exact and is the default; set "
             "'int8' to quantize from the outset (~1.9x smaller, |dR2| ~ 6e-6) when you "
@@ -130,7 +138,9 @@ class MemoryPolicy(BaseModel):
     )
 
     gpu_budget_frac: float = Field(
-        0.4, gt=0, le=1,
+        0.4,
+        gt=0,
+        le=1,
         description=(
             "Share of TOTAL VRAM the resident cache may occupy before we offload. A "
             "fraction so one setting is portable across GPUs. Total rather than free "
@@ -140,7 +150,8 @@ class MemoryPolicy(BaseModel):
     )
 
     gpu_budget_absolute_gb: Optional[float] = Field(
-        None, ge=0,
+        None,
+        ge=0,
         description=(
             "Hard VRAM ceiling in GiB, overriding gpu_budget_frac. For a co-tenanted GPU, "
             "where a fixed cap is the requirement and a share of the card is the wrong "
@@ -161,7 +172,9 @@ class MemoryPolicy(BaseModel):
     )
 
     host_budget_frac: float = Field(
-        0.25, gt=0, le=1,
+        0.25,
+        gt=0,
+        le=1,
         description=(
             "Share of total physical RAM the offloaded cache may occupy. A fraction "
             "because a flat GB default is a latent bug: 128 GB 'fits' on a 32 GB laptop "
@@ -171,7 +184,8 @@ class MemoryPolicy(BaseModel):
     )
 
     host_budget_absolute_gb: Optional[float] = Field(
-        None, ge=0,
+        None,
+        ge=0,
         description=(
             "Hard host-RAM ceiling in GiB, overriding host_budget_frac. None = use the "
             "fraction; 0 = never offload. 0 is deliberately legal: it is also what a "
@@ -181,7 +195,8 @@ class MemoryPolicy(BaseModel):
     )
 
     context_row_chunk: Optional[int] = Field(
-        None, gt=0,
+        None,
+        gt=0,
         description=(
             "Bound the fit-time build working set to this many context rows (bit-exact). "
             "None = off, with 2048 engaged automatically after an OOM. Pinning a value "
@@ -199,7 +214,8 @@ class MemoryPolicy(BaseModel):
     )
 
     elements_budget: Optional[int] = Field(
-        None, gt=0,
+        None,
+        gt=0,
         description=(
             "Per-forward element cap driving query chunk size and context subsampling. "
             "None = derive it from available VRAM. Upstream of everything else here: the "
@@ -247,10 +263,7 @@ class MemoryReport(BaseModel):
 
     est_cache_gb: Optional[float] = Field(
         None,
-        description=(
-            "Full-precision cache footprint for this request's context, in GiB. Reported, "
-            "not set. "
-        ),
+        description=("Full-precision cache footprint for this request's context, in GiB. Reported, not set. "),
     )
 
     resident_gb: Optional[float] = Field(
@@ -271,7 +284,8 @@ class MemoryReport(BaseModel):
     )
 
     dropped_context_rows: int = Field(
-        0, ge=0,
+        0,
+        ge=0,
         description=(
             "Context rows the caller had to subsample away to fit. Non-zero only on the "
             "plain_loop rung; recorded so a shrunk context is visible in memory_report_ "
@@ -320,9 +334,7 @@ class LargeContextReport(BaseModel):
         )
     )
     policy: str = Field(
-        description=(
-            "Resolved policy name when available; otherwise a display label for the skipped request."
-        )
+        description=("Resolved policy name when available; otherwise a display label for the skipped request.")
     )
     threshold: int = Field(
         ge=1,
@@ -357,21 +369,17 @@ class LargeContextReport(BaseModel):
     full_context: Optional[bool] = Field(
         None,
         description=(
-            "Whether the applied policy used the complete context in one call. "
-            "Null when the policy did not engage."
+            "Whether the applied policy used the complete context in one call. Null when the policy did not engage."
         ),
     )
     reused_train_state: bool = Field(
         description=(
-            "Whether train-derived policy state was reused. Shared hosted requests "
-            "are one-shot and report false."
+            "Whether train-derived policy state was reused. Shared hosted requests are one-shot and report false."
         )
     )
     gate_winner: Optional[str] = Field(
         None,
-        description=(
-            "Winning policy when a holdout gate was requested; otherwise null."
-        ),
+        description=("Winning policy when a holdout gate was requested; otherwise null."),
     )
 
 
@@ -402,6 +410,4 @@ def _accept_another_packages_policy(value: Any) -> Any:
 
 #: What ``memory_policy=`` accepts: a preset name, a policy, a plain dict (validated into one),
 #: or another package's equivalent. Anything else is a pydantic error before a request is sent.
-MemoryPolicyInput = Annotated[
-    Union[MemoryPreset, MemoryPolicy], BeforeValidator(_accept_another_packages_policy)
-]
+MemoryPolicyInput = Annotated[Union[MemoryPreset, MemoryPolicy], BeforeValidator(_accept_another_packages_policy)]

--- a/libs/synthefy/src/synthefy/nori_ts/core.py
+++ b/libs/synthefy/src/synthefy/nori_ts/core.py
@@ -321,23 +321,16 @@ class NoriTSForecaster:
         an identical set of used covariates.
         """
         if not isinstance(target_column, str):
-            raise ValueError(
-                "`target_column` must be one column name; multiple target columns "
-                "are not supported yet"
-            )
+            raise ValueError("`target_column` must be one column name; multiple target columns are not supported yet")
         if (prediction_length is None) == (future_df is None):
-            raise ValueError(
-                "provide exactly one of `prediction_length` or `future_df` "
-                "(got both or neither)"
-            )
+            raise ValueError("provide exactly one of `prediction_length` or `future_df` (got both or neither)")
 
         history = context_df.copy()
         if "timestamp" not in history.columns:
             raise ValueError("`context_df` must have a `timestamp` column")
         if target_column not in history.columns:
             raise ValueError(
-                f"target column {target_column!r} not found in `context_df` "
-                f"(columns: {list(history.columns)})"
+                f"target column {target_column!r} not found in `context_df` (columns: {list(history.columns)})"
             )
         if "item_id" not in history.columns:
             history["item_id"] = 0
@@ -360,8 +353,7 @@ class NoriTSForecaster:
         reserved = {"item_id", "timestamp", _TARGET}
         # Covariates are the numeric non-reserved history columns; non-numeric extras
         # (labels, strings) are ignored rather than fed to the regressor.
-        hist_cov = [c for c in history.columns
-                    if c not in reserved and pd.api.types.is_numeric_dtype(history[c])]
+        hist_cov = [c for c in history.columns if c not in reserved and pd.api.types.is_numeric_dtype(history[c])]
 
         if future_df is not None:
             future = future_df.copy()
@@ -373,10 +365,7 @@ class NoriTSForecaster:
                 future["item_id"] = 0
             future["timestamp"] = pd.to_datetime(future["timestamp"])
             if future.duplicated(["item_id", "timestamp"]).any():
-                raise ValueError(
-                    "`future_df` must contain at most one row per "
-                    "(`item_id`, `timestamp`)"
-                )
+                raise ValueError("`future_df` must contain at most one row per (`item_id`, `timestamp`)")
             # No leakage: a target in the horizon must be absent or entirely NaN.
             for tcol in {target_column, _TARGET} & set(future.columns):
                 if not future[tcol].isna().all():
@@ -388,16 +377,11 @@ class NoriTSForecaster:
             # item_ids must line up exactly with history.
             h_ids, f_ids = set(history["item_id"]), set(future["item_id"])
             if h_ids != f_ids:
-                raise ValueError(
-                    f"`future_df` item_ids {sorted(f_ids)} do not match "
-                    f"history item_ids {sorted(h_ids)}"
-                )
+                raise ValueError(f"`future_df` item_ids {sorted(f_ids)} do not match history item_ids {sorted(h_ids)}")
             history_end = history.groupby("item_id", sort=False)["timestamp"].max()
             future_start = future.groupby("item_id", sort=False)["timestamp"].min()
             overlapping = [
-                item_id
-                for item_id in history_end.index
-                if future_start.loc[item_id] <= history_end.loc[item_id]
+                item_id for item_id in history_end.index if future_start.loc[item_id] <= history_end.loc[item_id]
             ]
             if overlapping:
                 raise ValueError(
@@ -422,9 +406,7 @@ class NoriTSForecaster:
             test_tsdf = TimeSeriesDataFrame.from_data_frame(test_df)
         else:
             if not isinstance(prediction_length, (int, np.integer)) or prediction_length <= 0:
-                raise ValueError(
-                    f"`prediction_length` must be a positive integer, got {prediction_length!r}"
-                )
+                raise ValueError(f"`prediction_length` must be a positive integer, got {prediction_length!r}")
             used_cov = []  # no way to know future covariates without an explicit horizon
             test_tsdf = None  # built from the (capped) history below
 

--- a/libs/synthefy/src/synthefy/nori_ts/tsfeatures/auto_features.py
+++ b/libs/synthefy/src/synthefy/nori_ts/tsfeatures/auto_features.py
@@ -45,9 +45,7 @@ class AutoSeasonalFeature(FeatureGenerator):
 
     def __init__(self, config: Optional[dict] = None):
         # Create default config from Config class
-        default_config = {
-            k: v for k, v in vars(self.Config).items() if not k.startswith("__")
-        }
+        default_config = {k: v for k, v in vars(self.Config).items() if not k.startswith("__")}
 
         # Initialize config with defaults
         self.config = default_config.copy()
@@ -77,9 +75,7 @@ class AutoSeasonalFeature(FeatureGenerator):
             "linear",
             "constant",
         ]:
-            logger.warning(
-                f"Invalid detrend_type: {self.config['detrend_type']}, using 'linear'"
-            )
+            logger.warning(f"Invalid detrend_type: {self.config['detrend_type']}, using 'linear'")
             self.config["detrend_type"] = "linear"
 
     def generate(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -93,9 +89,7 @@ class AutoSeasonalFeature(FeatureGenerator):
         codes, _ = pd.factorize(df.index.get_level_values("item_id"), sort=False)
         n_series = int(codes.max()) + 1 if n else 0
         periods_by_series = np.full((n_series, max_top_k), np.nan)
-        for code, (_item_id, target) in enumerate(
-            df["target"].groupby(level="item_id", sort=False)
-        ):
+        for code, (_item_id, target) in enumerate(df["target"].groupby(level="item_id", sort=False)):
             periods = [p for p, _ in self.find_seasonal_periods(target, **self.config)]
             for i, period in enumerate(periods[:max_top_k]):
                 periods_by_series[code, i] = period
@@ -121,18 +115,14 @@ class AutoSeasonalFeature(FeatureGenerator):
         target_values: pd.Series,
         max_top_k: int = 10,
         do_detrend: bool = True,
-        detrend_type: Literal[
-            "first_diff", "loess", "linear", "constant"
-        ] = "first_diff",
+        detrend_type: Literal["first_diff", "loess", "linear", "constant"] = "first_diff",
         use_peaks_only: bool = True,
         apply_hann_window: bool = True,
         zero_padding_factor: int = 2,
         round_to_closest_integer: bool = True,
         validate_with_acf: bool = False,
         sampling_interval: float = 1.0,
-        magnitude_threshold: Optional[
-            float
-        ] = 0.05,  # Default relative threshold (5% of max)
+        magnitude_threshold: Optional[float] = 0.05,  # Default relative threshold (5% of max)
         relative_threshold: bool = True,  # Interpret threshold as a fraction of max FFT magnitude
         exclude_zero: bool = False,
     ) -> List[Tuple[float, float]]:
@@ -224,16 +214,12 @@ class AutoSeasonalFeature(FeatureGenerator):
                 # Fallback to considering all frequency bins if no peaks are found
                 peak_indices = np.arange(len(fft_magnitudes))
             # Sort the peak indices by magnitude in descending order
-            sorted_peak_indices = peak_indices[
-                np.argsort(fft_magnitudes[peak_indices])[::-1]
-            ]
+            sorted_peak_indices = peak_indices[np.argsort(fft_magnitudes[peak_indices])[::-1]]
             top_indices = sorted_peak_indices[:max_top_k]
         else:
             sorted_indices = np.argsort(fft_magnitudes)[::-1]
             if threshold_value is not None:
-                sorted_indices = [
-                    i for i in sorted_indices if fft_magnitudes[i] >= threshold_value
-                ]
+                sorted_indices = [i for i in sorted_indices if fft_magnitudes[i] >= threshold_value]
             top_indices = sorted_indices[:max_top_k]
 
         # Convert frequencies to periods (avoiding division by zero)
@@ -261,10 +247,7 @@ class AutoSeasonalFeature(FeatureGenerator):
             top_indices = top_indices[unique_period_indices]
 
         # Pair each period with its corresponding magnitude
-        results = [
-            (top_periods[i], fft_magnitudes[top_indices[i]])
-            for i in range(len(top_indices))
-        ]
+        results = [(top_periods[i], fft_magnitudes[top_indices[i]]) for i in range(len(top_indices))]
 
         # Validate with ACF if requested and filter the results accordingly
         if validate_with_acf:
@@ -274,15 +257,11 @@ class AutoSeasonalFeature(FeatureGenerator):
                 nlags=N_original,
                 fft=True,
             )
-            acf_peak_indices, _ = find_peaks(
-                acf_values, height=1.96 / np.sqrt(N_original)
-            )
+            acf_peak_indices, _ = find_peaks(acf_values, height=1.96 / np.sqrt(N_original))
             validated_results = []
             for period, mag in results:
                 period_int = int(round(period))
-                if period_int < len(acf_values) and any(
-                    abs(period_int - peak) <= 1 for peak in acf_peak_indices
-                ):
+                if period_int < len(acf_values) and any(abs(period_int - peak) <= 1 for peak in acf_peak_indices):
                     validated_results.append((period, mag))
             if validated_results:
                 results = validated_results
@@ -293,9 +272,7 @@ class AutoSeasonalFeature(FeatureGenerator):
         return results
 
 
-def detrend(
-    x: np.ndarray, detrend_type: Literal["first_diff", "loess", "linear", "constant"]
-) -> np.ndarray:
+def detrend(x: np.ndarray, detrend_type: Literal["first_diff", "loess", "linear", "constant"]) -> np.ndarray:
     if detrend_type == "first_diff":
         return np.diff(x, prepend=x[0])
 

--- a/libs/synthefy/src/synthefy/nori_ts/tsfeatures/data_preparation.py
+++ b/libs/synthefy/src/synthefy/nori_ts/tsfeatures/data_preparation.py
@@ -58,9 +58,7 @@ def generate_test_X(
     for i, last_ts in enumerate(last_timestamps):
         start_ts = last_ts + freq_offset
         timestamps = pd.date_range(start=start_ts, periods=prediction_length, freq=freq)
-        all_timestamps[i * prediction_length : (i + 1) * prediction_length] = (
-            timestamps.values
-        )
+        all_timestamps[i * prediction_length : (i + 1) * prediction_length] = timestamps.values
 
     # Build single DataFrame with vectorized arrays
     test_df = pd.DataFrame(
@@ -239,11 +237,7 @@ offset_alias_to_period_alias = {
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 def to_gluonts_univariate(hf_dataset: datasets.Dataset):
-    series_fields = [
-        col
-        for col in hf_dataset.features
-        if isinstance(hf_dataset.features[col], datasets.Sequence)
-    ]
+    series_fields = [col for col in hf_dataset.features if isinstance(hf_dataset.features[col], datasets.Sequence)]
     series_fields.remove("timestamp")
     dataset_length = hf_dataset.info.splits["train"].num_examples * len(series_fields)
     dataset_freq = pd.infer_freq(hf_dataset[0]["timestamp"])

--- a/libs/synthefy/src/synthefy/nori_ts/tsfeatures/feature_transformer.py
+++ b/libs/synthefy/src/synthefy/nori_ts/tsfeatures/feature_transformer.py
@@ -36,9 +36,7 @@ class FeatureTransformer:
 
         self._validate_input(train_tsdf, test_tsdf, target_column)
 
-        static_features = self._merge_static_features(
-            train_tsdf.static_features, test_tsdf.static_features
-        )
+        static_features = self._merge_static_features(train_tsdf.static_features, test_tsdf.static_features)
 
         # Input columns (target + covariates) keep their dtype; only generated columns
         # are downcast to float32 below. The whole featurized frame lives in host RAM
@@ -64,11 +62,7 @@ class FeatureTransformer:
         # The generated features (calendar, seasonal, running index) are bounded and
         # exactly representable in float32, so the downcast is lossless.
         generated_float_cols = [
-            c
-            for c in tsdf.columns
-            if c not in input_columns
-            and c != "_is_train"
-            and tsdf[c].dtype == np.float64
+            c for c in tsdf.columns if c not in input_columns and c != "_is_train" and tsdf[c].dtype == np.float64
         ]
         if generated_float_cols:
             tsdf = tsdf.astype({c: np.float32 for c in generated_float_cols})
@@ -78,16 +72,10 @@ class FeatureTransformer:
         test_slice = tsdf[~tsdf["_is_train"]].drop(columns=["_is_train"])
         del tsdf
 
-        train_tsdf = TimeSeriesDataFrame(
-            pd.DataFrame(train_slice), static_features=static_features
-        )
-        test_tsdf = TimeSeriesDataFrame(
-            pd.DataFrame(test_slice), static_features=static_features
-        )
+        train_tsdf = TimeSeriesDataFrame(pd.DataFrame(train_slice), static_features=static_features)
+        test_tsdf = TimeSeriesDataFrame(pd.DataFrame(test_slice), static_features=static_features)
 
-        assert not train_tsdf[target_column].isna().any(), (
-            "All target values in train_tsdf should be non-NaN"
-        )
+        assert not train_tsdf[target_column].isna().any(), "All target values in train_tsdf should be non-NaN"
         assert test_tsdf[target_column].isna().all()
 
         return train_tsdf, test_tsdf
@@ -114,9 +102,7 @@ class FeatureTransformer:
         target_column: str,
     ):
         if target_column not in train_tsdf.columns:
-            raise ValueError(
-                f"Target column '{target_column}' not found in training data"
-            )
+            raise ValueError(f"Target column '{target_column}' not found in training data")
 
         if not test_tsdf[target_column].isna().all():
             raise ValueError("Test data should not contain target values")

--- a/libs/synthefy/src/synthefy/nori_ts/tsfeatures/ts_dataframe.py
+++ b/libs/synthefy/src/synthefy/nori_ts/tsfeatures/ts_dataframe.py
@@ -168,15 +168,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
         elif isinstance(data, Iterable):
             data = self._construct_tsdf_from_iterable_dataset(data, num_cpus=num_cpus)
         else:
-            raise ValueError(
-                f"data must be a pd.DataFrame, Iterable, string or Path (received {type(data)})."
-            )
+            raise ValueError(f"data must be a pd.DataFrame, Iterable, string or Path (received {type(data)}).")
         super().__init__(data=data, *args, **kwargs)  # type: ignore
         self._static_features: Optional[pd.DataFrame] = None
         if static_features is not None:
-            self.static_features = self._construct_static_features(
-                static_features, id_column=id_column
-            )
+            self.static_features = self._construct_static_features(static_features, id_column=id_column)
 
     @property
     def _constructor(self) -> Type[TimeSeriesDataFrame]:
@@ -200,20 +196,14 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if id_column is not None:
             assert id_column in df.columns, f"Column '{id_column}' not found!"
             if id_column != ITEMID and ITEMID in df.columns:
-                logger.warning(
-                    f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions.")
                 df.rename(columns={ITEMID: "__" + ITEMID}, inplace=True)
             df.rename(columns={id_column: ITEMID}, inplace=True)
 
         if timestamp_column is not None:
-            assert timestamp_column in df.columns, (
-                f"Column '{timestamp_column}' not found!"
-            )
+            assert timestamp_column in df.columns, f"Column '{timestamp_column}' not found!"
             if timestamp_column != TIMESTAMP and TIMESTAMP in df.columns:
-                logger.warning(
-                    f"Renaming existing column '{TIMESTAMP}' -> '__{TIMESTAMP}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{TIMESTAMP}' -> '__{TIMESTAMP}' to avoid name collisions.")
                 df.rename(columns={TIMESTAMP: "__" + TIMESTAMP}, inplace=True)
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
@@ -224,27 +214,20 @@ class TimeSeriesDataFrame(pd.DataFrame):
         return df.set_index([ITEMID, TIMESTAMP])
 
     @classmethod
-    def _construct_tsdf_from_iterable_dataset(
-        cls, iterable_dataset: Iterable, num_cpus: int = -1
-    ) -> pd.DataFrame:
+    def _construct_tsdf_from_iterable_dataset(cls, iterable_dataset: Iterable, num_cpus: int = -1) -> pd.DataFrame:
         def load_single_item(item_id: int, ts: dict) -> pd.DataFrame:
             start_timestamp = ts["start"]
             freq = start_timestamp.freq
             if isinstance(start_timestamp, pd.Period):
                 start_timestamp = start_timestamp.to_timestamp(how="S")
             target = ts["target"]
-            datetime_index = tuple(
-                pd.date_range(start_timestamp, periods=len(target), freq=freq)
-            )
-            idx = pd.MultiIndex.from_product(
-                [(item_id,), datetime_index], names=[ITEMID, TIMESTAMP]
-            )
+            datetime_index = tuple(pd.date_range(start_timestamp, periods=len(target), freq=freq))
+            idx = pd.MultiIndex.from_product([(item_id,), datetime_index], names=[ITEMID, TIMESTAMP])
             return pd.Series(target, name="target", index=idx).to_frame()
 
         cls._validate_iterable(iterable_dataset)
         all_ts = Parallel(n_jobs=num_cpus)(
-            delayed(load_single_item)(item_id, ts)
-            for item_id, ts in enumerate(iterable_dataset)
+            delayed(load_single_item)(item_id, ts) for item_id, ts in enumerate(iterable_dataset)
         )
         return pd.concat(all_ts)
 
@@ -257,21 +240,12 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if not isinstance(data.index, pd.MultiIndex):
             raise ValueError(f"data must have pd.MultiIndex, got {type(data.index)}")
         if not pd.api.types.is_datetime64_dtype(data.index.dtypes[TIMESTAMP]):
-            raise ValueError(
-                f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`."
-            )
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`.")
         if not data.index.names == (f"{ITEMID}", f"{TIMESTAMP}"):
-            raise ValueError(
-                f"data must have index names as ('{ITEMID}', '{TIMESTAMP}'), got {data.index.names}"
-            )
+            raise ValueError(f"data must have index names as ('{ITEMID}', '{TIMESTAMP}'), got {data.index.names}")
         item_id_index = data.index.levels[0]
-        if not (
-            pd.api.types.is_integer_dtype(item_id_index)
-            or pd.api.types.is_string_dtype(item_id_index)
-        ):
-            raise ValueError(
-                f"all entries in index `{ITEMID}` must be of integer or string dtype"
-            )
+        if not (pd.api.types.is_integer_dtype(item_id_index) or pd.api.types.is_string_dtype(item_id_index)):
+            raise ValueError(f"all entries in index `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _validate_data_frame(cls, df: pd.DataFrame):
@@ -287,17 +261,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if df[TIMESTAMP].isnull().any():
             raise ValueError(f"`{TIMESTAMP}` column can not have nan")
         if not pd.api.types.is_datetime64_dtype(df[TIMESTAMP]):
-            raise ValueError(
-                f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`."
-            )
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`.")
         item_id_column = df[ITEMID]
-        if not (
-            pd.api.types.is_integer_dtype(item_id_column)
-            or pd.api.types.is_string_dtype(item_id_column)
-        ):
-            raise ValueError(
-                f"all entries in column `{ITEMID}` must be of integer or string dtype"
-            )
+        if not (pd.api.types.is_integer_dtype(item_id_column) or pd.api.types.is_string_dtype(item_id_column)):
+            raise ValueError(f"all entries in column `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _validate_iterable(cls, data: Iterable):
@@ -310,17 +277,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         for i, ts in enumerate(itertools.chain([first], data)):
             if not isinstance(ts, dict):
-                raise ValueError(
-                    f"{i}'th time-series in data must be a dict, got{type(ts)}"
-                )
+                raise ValueError(f"{i}'th time-series in data must be a dict, got{type(ts)}")
             if not ("target" in ts and "start" in ts):
-                raise ValueError(
-                    f"{i}'th time-series in data must have 'target' and 'start', got{ts.keys()}"
-                )
+                raise ValueError(f"{i}'th time-series in data must have 'target' and 'start', got{ts.keys()}")
             if not isinstance(ts["start"], pd.Period):
-                raise ValueError(
-                    f"{i}'th time-series must have a pandas Period as 'start', got {ts['start']}"
-                )
+                raise ValueError(f"{i}'th time-series must have a pandas Period as 'start', got {ts['start']}")
 
     @classmethod
     def from_data_frame(
@@ -424,9 +385,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         )
 
     @classmethod
-    def from_iterable_dataset(
-        cls, iterable_dataset: Iterable, num_cpus: int = -1
-    ) -> TimeSeriesDataFrame:
+    def from_iterable_dataset(cls, iterable_dataset: Iterable, num_cpus: int = -1) -> TimeSeriesDataFrame:
         """Construct a ``TimeSeriesDataFrame`` from an Iterable of dictionaries each of which
         represent a single time series.
 
@@ -473,13 +432,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
             )
 
         if id_column is not None:
-            assert id_column in static_features.columns, (
-                f"Column '{id_column}' not found in static_features!"
-            )
+            assert id_column in static_features.columns, f"Column '{id_column}' not found in static_features!"
             if id_column != ITEMID and ITEMID in static_features.columns:
-                logger.warning(
-                    f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions.")
                 static_features.rename(columns={ITEMID: "__" + ITEMID}, inplace=True)
             static_features.rename(columns={id_column: ITEMID}, inplace=True)
         return static_features
@@ -500,9 +455,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             if isinstance(value, pd.Series):
                 value = value.to_frame()
             if not isinstance(value, pd.DataFrame):
-                raise ValueError(
-                    f"static_features must be a pandas DataFrame (received object of type {type(value)})"
-                )
+                raise ValueError(f"static_features must be a pandas DataFrame (received object of type {type(value)})")
             if isinstance(value.index, pd.MultiIndex):
                 raise ValueError("static_features cannot have a MultiIndex")
 
@@ -524,9 +477,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         self._static_features = value
 
-    def infer_frequency(
-        self, num_items: Optional[int] = None, raise_if_irregular: bool = False
-    ) -> str:
+    def infer_frequency(self, num_items: Optional[int] = None, raise_if_irregular: bool = False) -> str:
         """Infer the time series frequency based on the timestamps of the observations.
 
         Parameters
@@ -550,9 +501,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
         ts_df = self
         if num_items is not None and ts_df.num_items > num_items:
-            items_subset = ts_df.item_ids.to_series().sample(
-                n=num_items, random_state=123
-            )
+            items_subset = ts_df.item_ids.to_series().sample(n=num_items, random_state=123)
             ts_df = ts_df.loc[items_subset]
 
         if not ts_df.index.is_monotonic_increasing:
@@ -593,9 +542,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                         f"Cannot infer frequency. Items with irregular frequency: {reprlib.repr(irregular_items)}"
                     )
                 else:
-                    raise ValueError(
-                        f"Cannot infer frequency. Multiple frequencies detected: {unique_freqs}"
-                    )
+                    raise ValueError(f"Cannot infer frequency. Multiple frequencies detected: {unique_freqs}")
             else:
                 return IRREGULAR_TIME_INDEX_FREQSTR
         else:
@@ -655,9 +602,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             self.static_features = other._static_features
         return self
 
-    def split_by_time(
-        self, cutoff_time: pd.Timestamp
-    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+    def split_by_time(self, cutoff_time: pd.Timestamp) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
         """Split dataframe to two different ``TimeSeriesDataFrame`` s before and after a certain ``cutoff_time``.
 
         Parameters
@@ -772,13 +717,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         """
         if start_index is not None and not isinstance(start_index, int):
-            raise ValueError(
-                f"start_index must be of type int or None (got {type(start_index)})"
-            )
+            raise ValueError(f"start_index must be of type int or None (got {type(start_index)})")
         if end_index is not None and not isinstance(end_index, int):
-            raise ValueError(
-                f"end_index must be of type int or None (got {type(end_index)})"
-            )
+            raise ValueError(f"end_index must be of type int or None (got {type(end_index)})")
 
         if start_index is None and end_index is None:
             # Return a copy to avoid in-place modification.
@@ -803,9 +744,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             slice_end = (
                 lengths.copy()
                 if end_index is None
-                else np.clip(
-                    np.where(end_index >= 0, end_index, lengths + end_index), 0, lengths
-                )
+                else np.clip(np.where(end_index >= 0, end_index, lengths + end_index), 0, lengths)
             )
 
             # Filter out invalid slices where start >= end
@@ -830,15 +769,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
             return self.loc[mask]
         else:
             # Fall back to a slow groupby operation
-            result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(
-                slice(start_index, end_index)
-            )
+            result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(slice(start_index, end_index))
             result.static_features = self.static_features
             return result
 
-    def slice_by_time(
-        self, start_time: pd.Timestamp, end_time: pd.Timestamp
-    ) -> TimeSeriesDataFrame:
+    def slice_by_time(self, start_time: pd.Timestamp, end_time: pd.Timestamp) -> TimeSeriesDataFrame:
         """Select a subsequence from each time series between start (inclusive) and end (exclusive) timestamps.
 
         Parameters
@@ -855,9 +790,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
 
         if end_time < start_time:
-            raise ValueError(
-                f"end_time {end_time} is earlier than start_time {start_time}"
-            )
+            raise ValueError(f"end_time {end_time} is earlier than start_time {start_time}")
 
         nanosecond_before_end_time = end_time - pd.Timedelta(nanoseconds=1)
         return TimeSeriesDataFrame(
@@ -886,9 +819,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         except Exception as err:  # noqa
             raise IOError(f"Could not load pickled data set due to error: {str(err)}")
 
-    def fill_missing_values(
-        self, method: str = "auto", value: float = 0.0
-    ) -> TimeSeriesDataFrame:
+    def fill_missing_values(self, method: str = "auto", value: float = 0.0) -> TimeSeriesDataFrame:
         """Fill missing values represented by NaN.
 
         .. note::
@@ -960,9 +891,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             filled_df = grouped_df.ffill()
             # If necessary, fill missing values at the start of each time series with bfill
             if filled_df.isna().any(axis=None):
-                filled_df = filled_df.groupby(
-                    level=ITEMID, sort=False, group_keys=False
-                ).bfill()
+                filled_df = filled_df.groupby(level=ITEMID, sort=False, group_keys=False).bfill()
         elif method in ["ffill", "pad"]:
             filled_df = grouped_df.ffill()
         elif method in ["bfill", "backfill"]:
@@ -1066,9 +995,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
         df = self
         if not df.index.is_monotonic_increasing:
-            logger.warning(
-                "Sorting the dataframe index before generating the train/test split."
-            )
+            logger.warning("Sorting the dataframe index before generating the train/test split.")
             df = df.sort_index()
         test_data = df.slice_by_timestep(None, end_index)
         train_data = test_data.slice_by_timestep(None, -prediction_length)
@@ -1193,9 +1120,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         def resample_chunk(chunk: Iterable[Tuple[str, pd.DataFrame]]) -> pd.DataFrame:
             resampled_dfs = []
             for item_id, df in chunk:
-                resampled_df = df.resample(offset, level=TIMESTAMP, **kwargs).agg(
-                    aggregation
-                )
+                resampled_df = df.resample(offset, level=TIMESTAMP, **kwargs).agg(aggregation)
                 resampled_dfs.append(pd.concat({item_id: resampled_df}, names=[ITEMID]))
             return pd.concat(resampled_dfs)
 
@@ -1204,13 +1129,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
         df = pd.DataFrame(self)
         # Make sure that timestamp index has dtype 'datetime64[ns]', otherwise index may contain NaT values.
         # See https://github.com/autogluon/autogluon/issues/4917
-        df.index = df.index.set_levels(
-            df.index.levels[1].astype("datetime64[ns]"), level=TIMESTAMP
-        )
+        df.index = df.index.set_levels(df.index.levels[1].astype("datetime64[ns]"), level=TIMESTAMP)
         chunks = split_into_chunks(df.groupby(level=ITEMID, sort=False), chunk_size)
-        resampled_chunks = Parallel(n_jobs=num_cpus)(
-            delayed(resample_chunk)(chunk) for chunk in chunks
-        )
+        resampled_chunks = Parallel(n_jobs=num_cpus)(delayed(resample_chunk)(chunk) for chunk in chunks)
         resampled_df = TimeSeriesDataFrame(pd.concat(resampled_chunks))
         resampled_df.static_features = self.static_features
         return resampled_df
@@ -1224,9 +1145,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         This method assumes that the TimeSeriesDataFrame is sorted by [item_id, timestamp].
         """
-        return np.concatenate(
-            [[0], np.cumsum(self.num_timesteps_per_item().to_numpy())]
-        ).astype(np.int32)
+        return np.concatenate([[0], np.cumsum(self.num_timesteps_per_item().to_numpy())]).astype(np.int32)
 
     # inline typing stubs for various overridden methods
     if TYPE_CHECKING:
@@ -1238,9 +1157,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         def reindex(*args, **kwargs) -> Self: ...  # type: ignore
 
         @overload
-        def __new__(
-            cls, data: pd.DataFrame, static_features: Optional[pd.DataFrame] = None
-        ) -> Self: ...  # type: ignore
+        def __new__(cls, data: pd.DataFrame, static_features: Optional[pd.DataFrame] = None) -> Self: ...  # type: ignore
 
         @overload
         def __getitem__(self, items: List[str]) -> Self: ...  # type: ignore

--- a/libs/synthefy/src/synthefy/text_features.py
+++ b/libs/synthefy/src/synthefy/text_features.py
@@ -34,19 +34,18 @@ except ModuleNotFoundError as exc:
     if exc.name != "sklearn":
         raise
     raise ImportError(
-        'Text features need the optional scikit-learn package. Install it with '
-        '`pip install "synthefy[text]"`.'
+        'Text features need the optional scikit-learn package. Install it with `pip install "synthefy[text]"`.'
     ) from exc
 
 # short name -> HF model id (embedding backbones)
 MODELS = {
-    "minilm": "sentence-transformers/all-MiniLM-L6-v2",   # 384-d, fast baseline
-    "qwen0.6b": "Qwen/Qwen3-Embedding-0.6B",              # 1024-d, public, fast
-    "qwen4b": "Qwen/Qwen3-Embedding-4B",                  # 2560-d, powerful, public
-    "qwen8b": "Qwen/Qwen3-Embedding-8B",                  # 4096-d, public
-    "gemma": "google/embeddinggemma-300m",                # 768-d — GATED
-    "bge-m3": "BAAI/bge-m3",                              # 1024-d, public
-    "bge-large": "BAAI/bge-large-en-v1.5",               # 1024-d
+    "minilm": "sentence-transformers/all-MiniLM-L6-v2",  # 384-d, fast baseline
+    "qwen0.6b": "Qwen/Qwen3-Embedding-0.6B",  # 1024-d, public, fast
+    "qwen4b": "Qwen/Qwen3-Embedding-4B",  # 2560-d, powerful, public
+    "qwen8b": "Qwen/Qwen3-Embedding-8B",  # 4096-d, public
+    "gemma": "google/embeddinggemma-300m",  # 768-d — GATED
+    "bge-m3": "BAAI/bge-m3",  # 1024-d, public
+    "bge-large": "BAAI/bge-large-en-v1.5",  # 1024-d
 }
 
 # Kept for compatibility with the legacy ``synthefy_nori.text_features``
@@ -63,6 +62,7 @@ def _canon_cat(series: pd.Series) -> pd.Series:
         return str(value)
 
     return series.astype(object).map(canonicalize)
+
 
 def build_paragraphs(df: pd.DataFrame, text_columns) -> list[str]:
     """One column-prefixed paragraph per row: ``"col: value. col2: value2."``.
@@ -81,8 +81,9 @@ def build_paragraphs(df: pd.DataFrame, text_columns) -> list[str]:
     return (joined + ".").tolist()
 
 
-def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
-                  normalize: bool | None = None) -> Callable[[list[str]], np.ndarray]:
+def _make_encoder(
+    embedder, device=None, *, batch_size: int | None = None, normalize: bool | None = None
+) -> Callable[[list[str]], np.ndarray]:
     """Resolve ``embedder`` to a ``texts -> (n, dim) float32 ndarray`` callable.
 
     Accepts a short name / HF id (str), a preloaded SentenceTransformer-like object
@@ -92,8 +93,10 @@ def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
     # NB: check str first, since str has a (bytes) .encode method that would
     # otherwise masquerade as a SentenceTransformer-like encoder.
     if not isinstance(embedder, str) and callable(embedder) and not hasattr(embedder, "encode"):
+
         def _enc_call(texts):
             return np.asarray(embedder(texts), dtype=np.float32)
+
         return _enc_call
 
     st = embedder
@@ -118,15 +121,15 @@ def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
         if "Qwen" in model_id or "gemma" in model_id.lower():
             st.max_seq_length = min(getattr(st, "max_seq_length", 512) or 512, 512)
 
-    is_llm = bool(model_id) and (
-        "Qwen" in model_id or "gemma" in model_id.lower() or "bge" in model_id.lower())
+    is_llm = bool(model_id) and ("Qwen" in model_id or "gemma" in model_id.lower() or "bge" in model_id.lower())
     bs = batch_size or (8 if (model_id and "Qwen" in model_id) else 32 if is_llm else 256)
     norm = normalize if normalize is not None else is_llm  # cosine-normalize LLM encoders
 
     def _enc_st(texts):
-        return st.encode(texts, batch_size=bs, convert_to_numpy=True,
-                         show_progress_bar=False,
-                         normalize_embeddings=norm).astype(np.float32)
+        return st.encode(
+            texts, batch_size=bs, convert_to_numpy=True, show_progress_bar=False, normalize_embeddings=norm
+        ).astype(np.float32)
+
     return _enc_st
 
 
@@ -154,10 +157,18 @@ class MultimodalPreprocessor:
         categorical_encoding: ``"ordinal"`` (default) or ``"onehot"``.
     """
 
-    def __init__(self, text_columns, svd_dim: int | None = 128, embedder="minilm",
-                 device=None, seed: int = 0, max_cardinality: int = 100,
-                 normalize: bool | None = None, categorical_columns="auto",
-                 categorical_encoding: str = "ordinal"):
+    def __init__(
+        self,
+        text_columns,
+        svd_dim: int | None = 128,
+        embedder="minilm",
+        device=None,
+        seed: int = 0,
+        max_cardinality: int = 100,
+        normalize: bool | None = None,
+        categorical_columns="auto",
+        categorical_encoding: str = "ordinal",
+    ):
         # kept raw (None / str / list / Index); resolved to self.text_columns_ at fit
         self.text_columns = text_columns
         self.svd_dim = None if svd_dim is None else int(svd_dim)
@@ -201,9 +212,7 @@ class MultimodalPreprocessor:
     def _transform_tabular(self, df: pd.DataFrame) -> np.ndarray:
         if self._tabular_preprocessor is None:
             return np.empty((len(df), 0), dtype=np.float32)
-        return self._tabular_preprocessor.transform(
-            df[self.nontext_columns_]
-        ).to_numpy(dtype=np.float32)
+        return self._tabular_preprocessor.transform(df[self.nontext_columns_]).to_numpy(dtype=np.float32)
 
     # -- text (embed + train-fit SVD) --
     def _embed(self, df: pd.DataFrame) -> np.ndarray:
@@ -223,8 +232,8 @@ class MultimodalPreprocessor:
         if tc is None:
             return []
         if isinstance(tc, str):
-            tc = [tc]                       # a lone column name, not chars to iterate
-        cols = list(tc)                     # handles pandas Index / tuple / ndarray
+            tc = [tc]  # a lone column name, not chars to iterate
+        cols = list(tc)  # handles pandas Index / tuple / ndarray
         missing = [c for c in cols if c not in df.columns]
         if missing:
             raise ValueError(f"text_columns not found in the DataFrame: {missing}")
@@ -234,7 +243,8 @@ class MultimodalPreprocessor:
         if not isinstance(df, pd.DataFrame):
             raise TypeError(
                 "MultimodalPreprocessor requires a pandas DataFrame (so text "
-                f"columns can be located by name); got {type(df).__name__}.")
+                f"columns can be located by name); got {type(df).__name__}."
+            )
         self._encoder = None
         self.svd_ = None
         self.text_columns_ = self._resolve_text_columns(df)
@@ -254,7 +264,8 @@ class MultimodalPreprocessor:
             # embedding — fail loudly rather than silently degrade to pure tabular.
             raise ValueError(
                 f"embedder produced a zero-width embedding for text columns "
-                f"{self.text_columns_}; check the encoder / that the text is non-empty.")
+                f"{self.text_columns_}; check the encoder / that the text is non-empty."
+            )
 
         if self.svd_dim is None:
             # raw mode: append the full embedding, no reduction
@@ -277,13 +288,13 @@ class MultimodalPreprocessor:
         if not isinstance(df, pd.DataFrame):
             raise TypeError(
                 "MultimodalPreprocessor.transform requires a pandas DataFrame with "
-                f"the same columns seen at fit; got {type(df).__name__}.")
-        missing = [c for c in (self.nontext_columns_ + self.text_columns_)
-                   if c not in df.columns]
+                f"the same columns seen at fit; got {type(df).__name__}."
+            )
+        missing = [c for c in (self.nontext_columns_ + self.text_columns_) if c not in df.columns]
         if missing:
             raise ValueError(f"transform() is missing columns seen at fit: {missing}")
         Xnum = self._transform_tabular(df)
-        if not self.text_columns_:          # no text at all -> tabular only
+        if not self.text_columns_:  # no text at all -> tabular only
             return Xnum
         E = self._embed(df)
         # raw mode (svd_dim=None) appends the embedding directly; else SVD-transform

--- a/libs/synthefy/tests/test_featurize.py
+++ b/libs/synthefy/tests/test_featurize.py
@@ -58,9 +58,7 @@ def test_strict_modes_name_every_undeclared_non_numeric_column(categorical_colum
 
 
 def test_explicit_categorical_uses_top_k_and_other_without_query_leakage():
-    preprocessor = DataFramePreprocessor(
-        categorical_columns=["plan"], max_categorical_cardinality=2
-    )
+    preprocessor = DataFramePreprocessor(categorical_columns=["plan"], max_categorical_cardinality=2)
     train = pd.DataFrame({"plan": ["pro", "free", "pro", "rare"], "amount": [1, 2, 3, 4]})
     query = pd.DataFrame({"amount": [5, 6, 7], "plan": ["free", "new", None]})
 
@@ -94,9 +92,7 @@ def test_text_and_categorical_declarations_are_validated_before_text_import(monk
     monkeypatch.setattr(builtins, "__import__", fail_text_import)
     frame = pd.DataFrame({"body": ["a", "b"]})
     with pytest.raises(ValueError, match="must not overlap"):
-        DataFramePreprocessor(
-            categorical_columns=["body"], text_columns=["body"]
-        ).fit(frame)
+        DataFramePreprocessor(categorical_columns=["body"], text_columns=["body"]).fit(frame)
 
 
 def test_categorical_only_never_imports_text_dependencies(monkeypatch):
@@ -108,9 +104,7 @@ def test_categorical_only_never_imports_text_dependencies(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fail_text_import)
-    result = DataFramePreprocessor(categorical_columns=["plan"]).fit_transform(
-        pd.DataFrame({"plan": ["free", "pro"]})
-    )
+    result = DataFramePreprocessor(categorical_columns=["plan"]).fit_transform(pd.DataFrame({"plan": ["free", "pro"]}))
     assert _rows(result) == [[0.0], [1.0]]
 
 

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -82,9 +82,7 @@ def _ok_handler(predictions: List[Optional[float]], capture: Dict) -> Handler:
         capture["path"] = request.url.path
         capture["headers"] = request.headers
         capture["body"] = json.loads(request.content)
-        return httpx.Response(
-            200, json={"task": "regression", "predictions": predictions}
-        )
+        return httpx.Response(200, json={"task": "regression", "predictions": predictions})
 
     return handler
 
@@ -160,18 +158,18 @@ def test_botocore_stubber_accepts_the_streaming_request_shape():
         "ContentType": "application/json",
         "Accept": "application/json",
         "CustomAttributes": "synthefy-response-stream=v1",
-        "Body": b'{}',
+        "Body": b"{}",
     }
     stubber = Stubber(runtime)
     stubber.add_response(
         "invoke_endpoint_with_response_stream",
-        {"Body": {"PayloadPart": {"Bytes": b'{}'}}},
+        {"Body": {"PayloadPart": {"Bytes": b"{}"}}},
         request,
     )
 
     with stubber:
         response = runtime.invoke_endpoint_with_response_stream(**request)
-        assert response["Body"]["PayloadPart"]["Bytes"] == b'{}'
+        assert response["Body"]["PayloadPart"]["Bytes"] == b"{}"
         stubber.assert_no_pending_responses()
 
 
@@ -196,6 +194,7 @@ def test_aws_predict_streams_named_endpoint_with_canonical_body(monkeypatch):
         },
         separators=(",", ":"),
     ).encode("utf-8")
+
     class FakeEventStream:
         def __iter__(self):
             yield {"PayloadPart": {"Bytes": b" \n"}}
@@ -212,9 +211,7 @@ def test_aws_predict_streams_named_endpoint_with_canonical_body(monkeypatch):
         def close(self):
             pass
 
-    monkeypatch.setattr(
-        module, "_create_sagemaker_runtime_client", lambda **_kwargs: FakeRuntime()
-    )
+    monkeypatch.setattr(module, "_create_sagemaker_runtime_client", lambda **_kwargs: FakeRuntime())
 
     client = SynthefyNoriClient(
         mode="sagemaker",
@@ -282,9 +279,7 @@ def test_sagemaker_large_context_uses_the_shared_wire_and_report(monkeypatch):
         def close(self):
             pass
 
-    monkeypatch.setattr(
-        module, "_create_sagemaker_runtime_client", lambda **_kwargs: FakeRuntime()
-    )
+    monkeypatch.setattr(module, "_create_sagemaker_runtime_client", lambda **_kwargs: FakeRuntime())
     client = SynthefyNoriClient(
         mode="sagemaker",
         model="nori-30m",
@@ -432,9 +427,7 @@ def test_aws_model_error_preserves_original_container_status(monkeypatch):
     assert str(caught.value) == "invalid Nori request"
     assert caught.value.status_code == 400
     assert caught.value.request_id == "aws-request-123"
-    assert caught.value.response_body["error"]["log_stream_arn"].endswith(
-        "log-stream/test"
-    )
+    assert caught.value.response_body["error"]["log_stream_arn"].endswith("log-stream/test")
 
 
 def test_aws_constructor_and_predict_reject_transport_mismatches(monkeypatch):
@@ -472,9 +465,7 @@ def test_aws_constructor_and_predict_reject_transport_mismatches(monkeypatch):
     with pytest.raises(ValueError, match="endpoint_name is required"):
         SynthefyNoriClient(mode="sagemaker", model="nori-30m")
     with pytest.raises(ValueError, match="published Nori inference specification"):
-        SynthefyNoriClient(
-            mode="sagemaker", endpoint_name="nori-dev", model="custom"
-        )
+        SynthefyNoriClient(mode="sagemaker", endpoint_name="nori-dev", model="custom")
     with pytest.raises(ValueError, match="api_key is not used"):
         SynthefyNoriClient(
             mode="sagemaker",
@@ -483,13 +474,9 @@ def test_aws_constructor_and_predict_reject_transport_mismatches(monkeypatch):
             api_key="secret",
         )
 
-    client = SynthefyNoriClient(
-        mode="sagemaker", endpoint_name="nori-dev", model="nori-30m"
-    )
+    client = SynthefyNoriClient(mode="sagemaker", endpoint_name="nori-dev", model="nori-30m")
     with pytest.raises(ValueError, match="extra_headers"):
-        client.predict(
-            [[0.0], [1.0]], [0.0, 1.0], [[2.0]], extra_headers={"x-test": "no"}
-        )
+        client.predict([[0.0], [1.0]], [0.0, 1.0], [[2.0]], extra_headers={"x-test": "no"})
     with pytest.warns(UserWarning, match="Per-prediction timeout is ignored"):
         client.predict([[0.0], [1.0]], [0.0, 1.0], [[2.0]], timeout=60)
 
@@ -540,9 +527,7 @@ def test_null_prediction_returns_as_nan():
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     _attach_mock(client, _ok_handler([None], {}))
 
-    predictions = client.predict(
-        X_train=[[0.0], [1.0]], y_train=[0.0, 1.0], X_test=[[2.0]]
-    )
+    predictions = client.predict(X_train=[[0.0], [1.0]], y_train=[0.0, 1.0], X_test=[[2.0]])
 
     assert len(predictions) == 1 and math.isnan(predictions[0])
 
@@ -701,7 +686,9 @@ def test_invalid_categorical_encoding_raises():
     df = pd.DataFrame({"cat": ["x", "y"]})
     with pytest.raises(ValueError, match="categorical_encoding"):
         client.predict(
-            X_train=df, y_train=[1.0, 2.0], X_test=df,
+            X_train=df,
+            y_train=[1.0, 2.0],
+            X_test=df,
             categorical_encoding="hashing",
         )
 
@@ -775,13 +762,10 @@ def test_datetime_column_requires_explicit_conversion():
 
     with pytest.raises(ValueError, match="unsupported dtype"):
         client.predict(
-            X_train=pd.DataFrame(
-                {"a": [0.0, 1.0], "d": pd.to_datetime(["2024-01-01", "2024-01-02"])}
-            ),
+            X_train=pd.DataFrame({"a": [0.0, 1.0], "d": pd.to_datetime(["2024-01-01", "2024-01-02"])}),
             y_train=[1.0, 2.0],
             X_test=pd.DataFrame({"a": [2.0], "d": pd.to_datetime(["2024-01-03"])}),
         )
-
 
 
 def test_bool_columns_pass_through_as_numeric():
@@ -847,14 +831,9 @@ def test_numeric_category_dtype_is_respected_as_categorical():
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # must NOT warn / drop / explode
         client.predict(
-            X_train=pd.DataFrame(
-                {"a": [0.0, 1.0, 2.0],
-                 "r": pd.Categorical([1, 2, 3], categories=[1, 2, 3])}
-            ),
+            X_train=pd.DataFrame({"a": [0.0, 1.0, 2.0], "r": pd.Categorical([1, 2, 3], categories=[1, 2, 3])}),
             y_train=[1.0, 2.0, 3.0],
-            X_test=pd.DataFrame(
-                {"a": [5.0], "r": pd.Categorical([2], categories=[1, 2, 3])}
-            ),
+            X_test=pd.DataFrame({"a": [5.0], "r": pd.Categorical([2], categories=[1, 2, 3])}),
         )
     assert capture["body"]["X_train"] == [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]
     assert capture["body"]["X_test"] == [[5.0, 1.0]]
@@ -878,9 +857,7 @@ def test_timedelta_column_raises_unsupported():
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     with pytest.raises(ValueError, match="timedelta"):
         client.predict(
-            X_train=pd.DataFrame(
-                {"a": [0.0, 1.0], "d": pd.to_timedelta(["1 days", "2 days"])}
-            ),
+            X_train=pd.DataFrame({"a": [0.0, 1.0], "d": pd.to_timedelta(["1 days", "2 days"])}),
             y_train=[1.0, 2.0],
             X_test=pd.DataFrame({"a": [2.0], "d": pd.to_timedelta(["3 days"])}),
         )
@@ -914,9 +891,7 @@ def test_integer_category_with_nan_does_not_crash():
     _attach_mock(client, _ok_handler([1.0], capture))
 
     client.predict(
-        X_train=pd.DataFrame(
-            {"r": pd.Categorical([1, 2, None], categories=[1, 2, 3])}
-        ),
+        X_train=pd.DataFrame({"r": pd.Categorical([1, 2, None], categories=[1, 2, 3])}),
         y_train=[1.0, 2.0, 3.0],
         X_test=pd.DataFrame({"r": pd.Categorical([2], categories=[1, 2, 3])}),
     )
@@ -938,21 +913,16 @@ def test_one_hot_name_value_collision_raises_clearly():
     Xtr = pd.DataFrame({"a": ["b_x", "b_x"], "a_b": ["x", "y"]})
     Xte = pd.DataFrame({"a": ["b_x"], "a_b": ["x"]})
     with pytest.raises(ValueError, match="duplicate column names"):
-        client.predict(X_train=Xtr, y_train=[1.0, 2.0], X_test=Xte,
-                       categorical_encoding="onehot")
+        client.predict(X_train=Xtr, y_train=[1.0, 2.0], X_test=Xte, categorical_encoding="onehot")
 
 
 def test_period_column_raises_unsupported():
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     with pytest.raises(ValueError, match="unsupported dtype"):
         client.predict(
-            X_train=pd.DataFrame(
-                {"a": [0.0, 1.0], "p": pd.period_range("2024-01", periods=2, freq="M")}
-            ),
+            X_train=pd.DataFrame({"a": [0.0, 1.0], "p": pd.period_range("2024-01", periods=2, freq="M")}),
             y_train=[1.0, 2.0],
-            X_test=pd.DataFrame(
-                {"a": [2.0], "p": pd.period_range("2024-03", periods=1, freq="M")}
-            ),
+            X_test=pd.DataFrame({"a": [2.0], "p": pd.period_range("2024-03", periods=1, freq="M")}),
         )
 
 
@@ -1115,9 +1085,7 @@ def test_custom_http_endpoint_still_requires_and_sends_model():
     )
     _attach_mock(client, _ok_handler([1.0], capture))
 
-    preds = client.predict(
-        X_train=[[0.0], [1.0]], y_train=[0.0, 1.0], X_test=[[2.0]]
-    )
+    preds = client.predict(X_train=[[0.0], [1.0]], y_train=[0.0, 1.0], X_test=[[2.0]])
 
     assert preds == [1.0]
     assert capture["path"] == "/predict"
@@ -1251,9 +1219,7 @@ def test_mismatched_train_rows_raises(client):
 
 def test_feature_count_mismatch_raises(client):
     with pytest.raises(ValueError, match="features"):
-        client.predict(
-            X_train=[[1.0, 2.0]], y_train=[1.0], X_test=[[3.0, 4.0, 5.0]]
-        )
+        client.predict(X_train=[[1.0, 2.0]], y_train=[1.0], X_test=[[3.0, 4.0, 5.0]])
 
 
 def test_non_2d_x_train_raises(client):
@@ -1264,9 +1230,7 @@ def test_non_2d_x_train_raises(client):
 def test_empty_x_train_raises(client):
     # A 2D array with zero rows reaches the row-count guard.
     with pytest.raises(ValueError, match="at least one context row"):
-        client.predict(
-            X_train=np.empty((0, 2)), y_train=[], X_test=[[3.0, 4.0]]
-        )
+        client.predict(X_train=np.empty((0, 2)), y_train=[], X_test=[[3.0, 4.0]])
 
 
 def test_flat_empty_x_train_raises_dimensionality(client):
@@ -1277,9 +1241,7 @@ def test_flat_empty_x_train_raises_dimensionality(client):
 
 def test_ragged_x_train_raises(client):
     with pytest.raises(ValueError, match="X_train"):
-        client.predict(
-            X_train=[[1.0, 2.0], [3.0]], y_train=[1.0, 2.0], X_test=[[3.0, 4.0]]
-        )
+        client.predict(X_train=[[1.0, 2.0], [3.0]], y_train=[1.0, 2.0], X_test=[[3.0, 4.0]])
 
 
 # --------------------------------------------------------------------------- #
@@ -1322,9 +1284,7 @@ def test_retries_on_server_error_then_succeeds(monkeypatch):
         calls["n"] += 1
         if calls["n"] == 1:
             return httpx.Response(503, json={"error": "temporarily down"})
-        return httpx.Response(
-            200, json={"task": "regression", "predictions": [7.0]}
-        )
+        return httpx.Response(200, json={"task": "regression", "predictions": [7.0]})
 
     client = SynthefyNoriClient(api_key="test-key", max_retries=2, model="nori-30m")
     _attach_mock(client, handler)
@@ -1412,9 +1372,7 @@ def test_negative_retry_after_is_clamped_to_zero():
 
 
 def test_request_model_roundtrip():
-    req = NoriPredictRequest(
-        X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]]
-    )
+    req = NoriPredictRequest(X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]])
     assert req.model_dump() == {
         "X_train": [[1.0, 2.0]],
         "y_train": [3.0],
@@ -1423,22 +1381,20 @@ def test_request_model_roundtrip():
         # Optional serving-memory policy. None by default, and _predict_remote excludes it
         # from the payload when unset, so an existing caller's request is unchanged on the
         # wire -- see test_a_request_without_memory_does_not_send_the_field.
-            "memory_policy": None,
-            "output_type": None,
-            "quantiles": None,
-            "large_context_policy": None,
-            "large_context_threshold": None,
-            "large_context_seed": None,
-        }
+        "memory_policy": None,
+        "output_type": None,
+        "quantiles": None,
+        "large_context_policy": None,
+        "large_context_threshold": None,
+        "large_context_seed": None,
+    }
 
 
 def test_request_model_omits_unset_distribution_fields_on_the_wire():
     # The canonical wire serializer must stay
     # exactly what earlier client versions sent, so adding these fields cannot
     # change any existing request.
-    req = NoriPredictRequest(
-        X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]]
-    )
+    req = NoriPredictRequest(X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]])
     assert req.to_wire() == {
         "X_train": [[1.0, 2.0]],
         "y_train": [3.0],
@@ -1448,9 +1404,7 @@ def test_request_model_omits_unset_distribution_fields_on_the_wire():
 
 
 def test_response_model_parses_predictions():
-    resp = NoriPredictResponse(
-        **{"task": "regression", "predictions": [1.0, 2.0, 3.0]}
-    )
+    resp = NoriPredictResponse(**{"task": "regression", "predictions": [1.0, 2.0, 3.0]})
     assert resp.predictions == [1.0, 2.0, 3.0]
 
 
@@ -1471,9 +1425,7 @@ def test_local_predict_raises_helpful_error_without_package(monkeypatch):
 
     client = SynthefyNoriClient(mode="local", model="nori-30m")
     with pytest.raises(ImportError, match=r"synthefy-nori"):
-        client.predict(
-            X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]]
-        )
+        client.predict(X_train=[[1.0, 2.0]], y_train=[3.0], X_test=[[4.0, 5.0]])
 
 
 def test_local_loaders_do_not_mask_transitive_import_failures(monkeypatch):
@@ -1545,6 +1497,7 @@ def test_model_variant_resolves_gateway_and_local():
     # a raw gateway slug passes through unchanged
     craw = SynthefyNoriClient(api_key="k", model="synthefy/custom")
     assert craw.model == "synthefy/custom" and craw._local_variant is None
+
 
 def test_model_is_required_no_default():
     # There is no default model -- omitting model= raises (every request names a size).
@@ -1708,9 +1661,7 @@ def test_thinking_friendly_name_resolves_to_gateway_slug_remote():
     # In remote mode the friendly Thinking name maps to its gateway slug (uniform with nori-30m),
     # so callers never need the raw "synthefy/" prefix.
     capture: Dict = {}
-    client = SynthefyNoriClient(
-        api_key="k", model="nori-30m-thinking-medium"
-    )  # remote (default)
+    client = SynthefyNoriClient(api_key="k", model="nori-30m-thinking-medium")  # remote (default)
     assert client.model == "synthefy/nori-30m-thinking-medium"
     _attach_mock(client, _ok_handler([1.0], capture))
     client.predict(X_train=_XTR, y_train=_YTR, X_test=_XTE)
@@ -1787,9 +1738,7 @@ def test_remote_bank_strategy_raises_with_guidance():
     client = SynthefyNoriClient(api_key="k", model="nori-30m")
     _attach_mock(client, _ok_handler([1.0], capture))
     with pytest.raises(ValueError, match="snap-mean"):
-        client.predict(
-            X_train=_XTR, y_train=_YTR, X_test=_XTE, discretize="map-cell"
-        )
+        client.predict(X_train=_XTR, y_train=_YTR, X_test=_XTE, discretize="map-cell")
     assert "body" not in capture
 
 
@@ -1798,9 +1747,7 @@ def test_remote_levels_without_strategy_raises_with_guidance():
     client = SynthefyNoriClient(api_key="k", model="nori-30m")
     _attach_mock(client, _ok_handler([1.0], capture))
     with pytest.raises(ValueError, match='discretize="snap-mean"'):
-        client.predict(
-            X_train=_XTR, y_train=_YTR, X_test=_XTE, categorical_levels=[1, 2]
-        )
+        client.predict(X_train=_XTR, y_train=_YTR, X_test=_XTE, categorical_levels=[1, 2])
     assert "body" not in capture
 
 
@@ -1918,9 +1865,7 @@ def test_local_mode_preserves_strict_degradation_error_and_message(monkeypatch):
 
 
 def test_local_discretize_needs_newer_synthefy_nori(monkeypatch):
-    monkeypatch.setattr(
-        "synthefy.nori_client._load_local_predict", lambda: (lambda *a, **k: [1.0])
-    )
+    monkeypatch.setattr("synthefy.nori_client._load_local_predict", lambda: lambda *a, **k: [1.0])
     monkeypatch.setattr("synthefy.nori_client._local_discretize_available", lambda: False)
     client = SynthefyNoriClient(mode="local", model="nori-30m")
     with pytest.raises(ImportError, match=r"synthefy-nori"):
@@ -1950,9 +1895,7 @@ def test_local_discretize_real_inference():
 def _fake_torch(*, cuda_available=False, mps_available=False):
     return types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=lambda: cuda_available),
-        backends=types.SimpleNamespace(
-            mps=types.SimpleNamespace(is_available=lambda: mps_available)
-        ),
+        backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: mps_available)),
     )
 
 
@@ -1984,9 +1927,7 @@ def test_text_device_explicit_override_skips_auto_detection(monkeypatch):
 
     fake_torch = types.SimpleNamespace(
         cuda=types.SimpleNamespace(is_available=unexpected_probe),
-        backends=types.SimpleNamespace(
-            mps=types.SimpleNamespace(is_available=unexpected_probe)
-        ),
+        backends=types.SimpleNamespace(mps=types.SimpleNamespace(is_available=unexpected_probe)),
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
 
@@ -2014,9 +1955,7 @@ def test_text_device_is_forwarded_to_multimodal_preprocessor(monkeypatch):
         def transform(self, frame):
             return np.zeros((len(frame), 1), dtype=np.float32)
 
-    monkeypatch.setattr(
-        "synthefy.text_features.MultimodalPreprocessor", FakePreprocessor
-    )
+    monkeypatch.setattr("synthefy.text_features.MultimodalPreprocessor", FakePreprocessor)
     train = pd.DataFrame({"review": ["good", "bad"]})
     test = pd.DataFrame({"review": ["fine"]})
 
@@ -2038,6 +1977,7 @@ def test_text_device_is_forwarded_to_multimodal_preprocessor(monkeypatch):
 def _fake_embed(texts):
     """Deterministic 8-d embedding, so tests need no sentence-transformers/model."""
     import hashlib
+
     out = []
     for t in texts:
         h = hashlib.sha1(t.encode("utf-8")).digest()
@@ -2081,16 +2021,18 @@ def test_text_columns_embeds_client_side_and_sends_numeric():
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     _attach_mock(client, _ok_handler([1.0, 2.0], capture))
 
-    df_train = pd.DataFrame({
-        "x1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        "brand": ["a", "b", "a", "b", "a", "b"],           # categorical -> 1 col
-        "review": ["good", "bad", "ok", "great", "poor", "fine"],  # text -> SVD
-    })
-    df_test = pd.DataFrame({"x1": [1.5, 5.5], "brand": ["a", "b"],
-                            "review": ["nice", "awful"]})
+    df_train = pd.DataFrame(
+        {
+            "x1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "brand": ["a", "b", "a", "b", "a", "b"],  # categorical -> 1 col
+            "review": ["good", "bad", "ok", "great", "poor", "fine"],  # text -> SVD
+        }
+    )
+    df_test = pd.DataFrame({"x1": [1.5, 5.5], "brand": ["a", "b"], "review": ["nice", "awful"]})
 
-    preds = client.predict(df_train, [1., 2., 3., 4., 5., 6.], df_test,
-                           text_columns=["review"], svd_dim=4, embedder=_fake_embed)
+    preds = client.predict(
+        df_train, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], df_test, text_columns=["review"], svd_dim=4, embedder=_fake_embed
+    )
 
     assert preds == [1.0, 2.0]
     # x1 (numeric) + brand (1 categorical col) + 4 SVD text cols = 6 numeric features
@@ -2105,9 +2047,7 @@ def test_text_columns_accepts_a_pandas_index_declaration():
     capture: Dict = {}
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     _attach_mock(client, _ok_handler([1.0], capture))
-    train = pd.DataFrame(
-        {"amount": [1.0, 2.0, 3.0], "review": ["good", "bad", "fine"]}
-    )
+    train = pd.DataFrame({"amount": [1.0, 2.0, 3.0], "review": ["good", "bad", "fine"]})
     test = pd.DataFrame({"review": ["new"], "amount": [4.0]})
 
     client.predict(
@@ -2183,6 +2123,7 @@ def test_text_columns_require_a_choice_for_high_cardinality_tabular_columns():
             max_categorical_cardinality=2,
         )
 
+
 def test_text_columns_requires_dataframe():
     client = SynthefyNoriClient(api_key="test-key", model="nori-30m")
     _attach_mock(client, _ok_handler([1.0], {}))
@@ -2230,6 +2171,7 @@ def _dist_handler(
     ``echo_output_type=False`` simulates a deployment that predates distribution
     output: it ignores the request's ``output_type`` and answers with means.
     """
+
     def handler(request: httpx.Request) -> httpx.Response:
         capture["body"] = json.loads(request.content)
         body: Dict = {"task": "regression", "predictions": predictions}
@@ -2336,16 +2278,17 @@ def test_the_server_rejection_message_is_surfaced_unchanged():
     not duplicated, because a second copy of behaviour would drift in a way a schema comparison
     cannot see. This exercises one of those: cache=False with a cache-only field.
     """
-    detail = ("Invalid 'memory_policy': 1 validation error for MemoryPolicy\n  Value error, "
-              "cache=False cannot be combined with cache_dtype")
+    detail = (
+        "Invalid 'memory_policy': 1 validation error for MemoryPolicy\n  Value error, "
+        "cache=False cannot be combined with cache_dtype"
+    )
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(400, json={"error": {"detail": detail}})
 
     client = _client_with(handler)
     with pytest.raises(BadRequestError) as excinfo:
-        client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST,
-                       memory_policy={"cache": False, "cache_dtype": "int8"})
+        client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache": False, "cache_dtype": "int8"})
     assert "cannot be combined" in str(excinfo.value)
 
 
@@ -2359,13 +2302,16 @@ def test_an_unknown_field_is_now_caught_locally_without_a_round_trip():
 def test_the_request_model_accepts_both_shapes():
     from synthefy import MemoryPolicy, NoriPredictRequest
 
-    assert NoriPredictRequest(
-        X_train=_X_TRAIN, y_train=_Y_TRAIN, X_test=_X_TEST, memory_policy="exact"
-    ).memory_policy == "exact"
+    assert (
+        NoriPredictRequest(X_train=_X_TRAIN, y_train=_Y_TRAIN, X_test=_X_TEST, memory_policy="exact").memory_policy
+        == "exact"
+    )
     # A dict is COERCED into the typed model by pydantic, which is the point of the field
     # being MemoryPolicy: bounds, enums and unknown-field rejection happen before any request.
     coerced = NoriPredictRequest(
-        X_train=_X_TRAIN, y_train=_Y_TRAIN, X_test=_X_TEST,
+        X_train=_X_TRAIN,
+        y_train=_Y_TRAIN,
+        X_test=_X_TEST,
         memory_policy={"cache_dtype": "int8"},
     ).memory_policy
     assert isinstance(coerced, MemoryPolicy)
@@ -2379,9 +2325,7 @@ def test_the_request_model_accepts_both_shapes():
         memory_policy={"cache_dtype": "int8"},
     ).to_wire()["memory_policy"] == {"cache_dtype": "int8"}
     # Unset by default, so the field cannot change an existing caller's payload.
-    assert NoriPredictRequest(
-        X_train=_X_TRAIN, y_train=_Y_TRAIN, X_test=_X_TEST
-    ).memory_policy is None
+    assert NoriPredictRequest(X_train=_X_TRAIN, y_train=_Y_TRAIN, X_test=_X_TEST).memory_policy is None
 
 
 def test_local_mode_refuses_memory_on_an_old_synthefy_nori(monkeypatch):
@@ -2389,7 +2333,7 @@ def test_local_mode_refuses_memory_on_an_old_synthefy_nori(monkeypatch):
     from synthefy import nori_client as module
 
     monkeypatch.setattr(module, "_local_memory_policy_available", lambda: False)
-    monkeypatch.setattr(module, "_load_local_predict", lambda: (lambda *a, **k: [0.0, 0.0]))
+    monkeypatch.setattr(module, "_load_local_predict", lambda: lambda *a, **k: [0.0, 0.0])
     client = SynthefyNoriClient(model="nori-30m", mode="local")
     with pytest.raises(ImportError, match="0.13.0"):
         client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy="exact")
@@ -2447,10 +2391,15 @@ def test_a_policy_object_is_serialised_for_the_wire():
     capture: Dict = {}
     client = _client_with(_memory_handler(capture, _REPORT))
     # As a real MemoryPolicy looks: inputs set, resolve()'s outputs still None.
-    policy = _FakePolicy({
-        "cache": True, "cache_dtype": "int8", "gpu_budget_absolute_gb": None,
-        "rung": None, "est_cache_gb": None,
-    })
+    policy = _FakePolicy(
+        {
+            "cache": True,
+            "cache_dtype": "int8",
+            "gpu_budget_absolute_gb": None,
+            "rung": None,
+            "est_cache_gb": None,
+        }
+    )
     client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy=policy)
     sent = capture["body"]["memory_policy"]
     assert sent == {"cache": True, "cache_dtype": "int8"}
@@ -2468,14 +2417,13 @@ def test_feeding_a_resolved_report_back_in_is_caught_locally():
     """
     client = _client_with(_memory_handler({}, _REPORT))
     with pytest.raises(ValueError, match="rung"):
-        client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST,
-                       memory_policy={"cache": True, "rung": "resident_bf16"})
+        client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache": True, "rung": "resident_bf16"})
 
 
 def test_a_nonsense_memory_policy_type_is_rejected_locally():
     """One error type for every bad policy, from pydantic, before any request is sent."""
     client = _client_with(_memory_handler({}, _REPORT))
-    with pytest.raises(ValueError):   # pydantic ValidationError subclasses ValueError
+    with pytest.raises(ValueError):  # pydantic ValidationError subclasses ValueError
         client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy=object())
 
 
@@ -2510,8 +2458,7 @@ def test_the_real_memory_policy_round_trips_through_the_client():
 
     capture: Dict = {}
     client = _client_with(_memory_handler(capture, _REPORT))
-    client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST,
-                   memory_policy=MemoryPolicy(cache_dtype="int8", gpu_budget_frac=0.6))
+    client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy=MemoryPolicy(cache_dtype="int8", gpu_budget_frac=0.6))
     sent = capture["body"]["memory_policy"]
     assert sent["cache_dtype"] == "int8" and sent["gpu_budget_frac"] == 0.6
     assert "rung" not in sent, "an unresolved policy must not carry decided outputs"
@@ -2537,9 +2484,7 @@ _LARGE_CONTEXT_REPORT = {
 }
 
 
-def _large_context_handler(
-    capture: Dict, report: Optional[Dict] = None
-) -> Handler:
+def _large_context_handler(capture: Dict, report: Optional[Dict] = None) -> Handler:
     def handler(request: httpx.Request) -> httpx.Response:
         capture["body"] = json.loads(request.content)
         body = {"task": "regression", "predictions": [0.1, 0.2]}
@@ -2552,9 +2497,7 @@ def _large_context_handler(
 
 def test_large_context_wire_and_report_round_trip():
     capture: Dict = {}
-    client = _client_with(
-        _large_context_handler(capture, _LARGE_CONTEXT_REPORT)
-    )
+    client = _client_with(_large_context_handler(capture, _LARGE_CONTEXT_REPORT))
     predictions = client.predict(
         _X_TRAIN,
         _Y_TRAIN,
@@ -2731,9 +2674,7 @@ def test_client_rejects_large_context_on_thinking_before_network():
 
 
 def test_large_context_report_is_cleared_even_when_the_next_call_is_rejected():
-    client = _client_with(
-        _large_context_handler({}, _LARGE_CONTEXT_REPORT)
-    )
+    client = _client_with(_large_context_handler({}, _LARGE_CONTEXT_REPORT))
     client.predict(
         _X_TRAIN,
         _Y_TRAIN,
@@ -2770,9 +2711,7 @@ def test_large_context_request_model_is_bounded_and_omits_unset_fields():
     with pytest.raises(ValueError):
         NoriPredictRequest(**base, large_context_threshold=123)
     for policy in ("boost", "safeboost", "cluster_route[groups=16]"):
-        assert (
-            NoriPredictRequest(**base, large_context_policy=policy).to_wire()["large_context_policy"] == policy
-        )
+        assert NoriPredictRequest(**base, large_context_policy=policy).to_wire()["large_context_policy"] == policy
     with pytest.raises(ValueError):
         NoriPredictRequest(
             **base,
@@ -2995,9 +2934,7 @@ def test_output_type_is_validated_before_any_expensive_work():
     client = _remote_client()
     _attach_mock(client, _ok_handler([1.0], {}))
     with pytest.raises(ValueError, match="output_type must be one of"):
-        client.predict(
-            _XTR, _YTR, _XTE, output_type="nope", text_columns=["review"]
-        )
+        client.predict(_XTR, _YTR, _XTE, output_type="nope", text_columns=["review"])
 
 
 # ----------------------------------------------------- remote: wire format
@@ -3017,16 +2954,22 @@ def test_remote_quantiles_sends_the_levels_and_returns_level_major():
     capture: Dict = {}
     client = _remote_client()
     # Wire is row-major: one row per query row, one column per level.
-    _attach_mock(client, _dist_handler(
-        capture,
-        predictions=[1.0, 2.0],
-        quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0, 2.5]],
-        taus=_LEVELS,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            capture,
+            predictions=[1.0, 2.0],
+            quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0, 2.5]],
+            taus=_LEVELS,
+        ),
+    )
 
     lo, mid, hi = client.predict(
-        _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]],
-        output_type="quantiles", quantiles=_LEVELS,
+        _XTR,
+        _YTR,
+        [[2.0, 2.0], [3.0, 3.0]],
+        output_type="quantiles",
+        quantiles=_LEVELS,
     )
 
     assert capture["body"]["output_type"] == "quantiles"
@@ -3040,13 +2983,16 @@ def test_remote_quantiles_sends_the_levels_and_returns_level_major():
 def test_remote_quantiles_preserve_memory_policy_and_report():
     capture: Dict = {}
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        capture,
-        predictions=[1.0],
-        quantiles=[[0.5, 1.0, 1.5]],
-        taus=_LEVELS,
-        memory_report=_REPORT,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            capture,
+            predictions=[1.0],
+            quantiles=[[0.5, 1.0, 1.5]],
+            taus=_LEVELS,
+            memory_report=_REPORT,
+        ),
+    )
 
     client.predict(
         _XTR,
@@ -3065,29 +3011,41 @@ def test_remote_quantiles_preserve_the_requested_level_order():
     # The rows follow the caller's order, not sorted order (same as NoriRegressor).
     capture: Dict = {}
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        capture, predictions=[1.0],
-        quantiles=[[9.0, 1.0]], taus=[0.9, 0.1],
-    ))
-    hi, lo = client.predict(
-        _XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=[0.9, 0.1]
+    _attach_mock(
+        client,
+        _dist_handler(
+            capture,
+            predictions=[1.0],
+            quantiles=[[9.0, 1.0]],
+            taus=[0.9, 0.1],
+        ),
     )
+    hi, lo = client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=[0.9, 0.1])
     assert capture["body"]["quantiles"] == [0.9, 0.1]
     assert hi == [9.0] and lo == [1.0]
 
 
 def test_remote_quantiles_as_pandas_is_a_frame_keyed_by_level():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0, 2.0],
-        quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0, 2.5]], taus=_LEVELS,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0, 2.0],
+            quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0, 2.5]],
+            taus=_LEVELS,
+        ),
+    )
     X_test = pd.DataFrame({"a": [2.0, 3.0], "b": [2.0, 3.0]}, index=["r1", "r2"])
     y_train = pd.Series([1.0, 1.0, 2.0], name="price")
 
     out = client.predict(
-        pd.DataFrame(_XTR, columns=["a", "b"]), y_train, X_test,
-        output_type="quantiles", quantiles=_LEVELS, as_pandas=True,
+        pd.DataFrame(_XTR, columns=["a", "b"]),
+        y_train,
+        X_test,
+        output_type="quantiles",
+        quantiles=_LEVELS,
+        as_pandas=True,
     )
 
     assert isinstance(out, pd.DataFrame)
@@ -3101,15 +3059,18 @@ def test_remote_full_returns_the_whole_bank():
     capture: Dict = {}
     client = _remote_client()
     taus = [0.25, 0.5, 0.75]
-    _attach_mock(client, _dist_handler(
-        capture, predictions=[1.0, 2.0],
-        quantiles=[[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]], taus=taus,
-        output_type="full",
-    ))
-
-    out = client.predict(
-        _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="full"
+    _attach_mock(
+        client,
+        _dist_handler(
+            capture,
+            predictions=[1.0, 2.0],
+            quantiles=[[0.0, 1.0, 2.0], [1.0, 2.0, 3.0]],
+            taus=taus,
+            output_type="full",
+        ),
     )
+
+    out = client.predict(_XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="full")
 
     assert capture["body"]["output_type"] == "full"
     assert "quantiles" not in capture["body"]  # no levels needed for "full"
@@ -3121,16 +3082,24 @@ def test_remote_full_returns_the_whole_bank():
 
 def test_remote_full_as_pandas_gives_a_frame_and_a_series():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0, 2.0],
-        quantiles=[[0.0, 2.0], [1.0, 3.0]], taus=[0.25, 0.75],
-        output_type="full",
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0, 2.0],
+            quantiles=[[0.0, 2.0], [1.0, 3.0]],
+            taus=[0.25, 0.75],
+            output_type="full",
+        ),
+    )
     X_test = pd.DataFrame({"a": [2.0, 3.0], "b": [2.0, 3.0]}, index=[7, 8])
 
     out = client.predict(
-        pd.DataFrame(_XTR, columns=["a", "b"]), pd.Series(_YTR, name="y"), X_test,
-        output_type="full", as_pandas=True,
+        pd.DataFrame(_XTR, columns=["a", "b"]),
+        pd.Series(_YTR, name="y"),
+        X_test,
+        output_type="full",
+        as_pandas=True,
     )
 
     assert list(out["quantiles"].columns) == ["y[0.25]", "y[0.75]"]
@@ -3143,12 +3112,15 @@ def test_remote_full_as_pandas_gives_a_frame_and_a_series():
 def test_remote_median_returns_one_value_per_row():
     capture: Dict = {}
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        capture, predictions=[3.0, 4.0], output_type="median",
-    ))
-    preds = client.predict(
-        _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="median"
+    _attach_mock(
+        client,
+        _dist_handler(
+            capture,
+            predictions=[3.0, 4.0],
+            output_type="median",
+        ),
     )
+    preds = client.predict(_XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="median")
     assert capture["body"]["output_type"] == "median"
     assert preds == [3.0, 4.0]
 
@@ -3169,18 +3141,28 @@ def test_remote_deployment_that_ignores_output_type_raises(kwargs):
     # are indistinguishable from a real "median" result, so without the echo the
     # client would hand back a confidently wrong answer.
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0], echo_output_type=False,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0],
+            echo_output_type=False,
+        ),
+    )
     with pytest.raises(ValueError, match="predates distribution output"):
         client.predict(_XTR, _YTR, [[2.0, 2.0]], **kwargs)
 
 
 def test_remote_echoing_a_different_output_type_raises():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0], output_type="mean",
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0],
+            output_type="mean",
+        ),
+    )
     with pytest.raises(ValueError, match="honored output_type='mean' instead"):
         client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="median")
 
@@ -3189,9 +3171,7 @@ def test_remote_echo_without_a_quantile_block_raises():
     client = _remote_client()
     _attach_mock(client, _dist_handler({}, predictions=[1.0]))  # no quantiles/taus
     with pytest.raises(ValueError, match="returned no quantile block"):
-        client.predict(
-            _XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_remote_default_output_type_needs_no_echo():
@@ -3204,51 +3184,68 @@ def test_remote_default_output_type_needs_no_echo():
 
 def test_remote_malformed_quantile_block_shape_raises():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0, 2.0],
-        quantiles=[[0.5, 1.0, 1.5]],  # 1 row for 2 query rows
-        taus=_LEVELS,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0, 2.0],
+            quantiles=[[0.5, 1.0, 1.5]],  # 1 row for 2 query rows
+            taus=_LEVELS,
+        ),
+    )
     with pytest.raises(ValueError, match="quantile block of shape"):
         client.predict(
-            _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]],
-            output_type="quantiles", quantiles=_LEVELS,
+            _XTR,
+            _YTR,
+            [[2.0, 2.0], [3.0, 3.0]],
+            output_type="quantiles",
+            quantiles=_LEVELS,
         )
 
 
 def test_remote_level_count_mismatch_raises():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0], quantiles=[[0.5, 1.5]], taus=[0.1, 0.9],
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0],
+            quantiles=[[0.5, 1.5]],
+            taus=[0.1, 0.9],
+        ),
+    )
     with pytest.raises(ValueError, match="server returned 2"):
-        client.predict(
-            _XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_remote_null_quantiles_come_back_as_nan():
     # JSON has no NaN, so the server nulls non-finite values; they must land as
     # NaN rather than None objects inside a numeric result.
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0], quantiles=[[0.5, None, 1.5]], taus=_LEVELS,
-    ))
-    lo, mid, hi = client.predict(
-        _XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0],
+            quantiles=[[0.5, None, 1.5]],
+            taus=_LEVELS,
+        ),
     )
+    lo, mid, hi = client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS)
     assert lo == [0.5] and hi == [1.5]
     assert math.isnan(mid[0])
 
 
 def test_response_model_parses_the_distribution_fields():
-    resp = NoriPredictResponse(**{
-        "task": "regression",
-        "predictions": [1.0],
-        "output_type": "quantiles",
-        "quantiles": [[0.5, 1.0, 1.5]],
-        "taus": _LEVELS,
-    })
+    resp = NoriPredictResponse(
+        **{
+            "task": "regression",
+            "predictions": [1.0],
+            "output_type": "quantiles",
+            "quantiles": [[0.5, 1.0, 1.5]],
+            "taus": _LEVELS,
+        }
+    )
     assert resp.output_type == "quantiles"
     assert resp.quantiles == [[0.5, 1.0, 1.5]]
     assert resp.taus == _LEVELS
@@ -3264,12 +3261,14 @@ def _fake_regressor_class(seen: Dict, *, with_model=True, with_output_type=True)
     simulate a synthefy-nori too old for it (the client probes the signatures).
     """
     if with_model:
+
         def __init__(self, model=None, memory_policy=None):
             seen["init_count"] = seen.get("init_count", 0) + 1
             seen["init_model"] = model
             seen["init_memory_policy"] = memory_policy
             self.memory_policy = memory_policy
     else:
+
         def __init__(self):  # noqa: E306 - old build: no model= selector
             seen["init_count"] = seen.get("init_count", 0) + 1
             seen["init_model"] = "<absent>"
@@ -3279,9 +3278,12 @@ def _fake_regressor_class(seen: Dict, *, with_model=True, with_output_type=True)
         return self
 
     if with_output_type:
+
         def predict(self, X, *, output_type="mean", quantiles=None):
             seen["predict"] = {
-                "X": X, "output_type": output_type, "quantiles": quantiles,
+                "X": X,
+                "output_type": output_type,
+                "quantiles": quantiles,
             }
             n = len(X)
             if output_type == "quantiles":
@@ -3292,13 +3294,12 @@ def _fake_regressor_class(seen: Dict, *, with_model=True, with_output_type=True)
                 )
             if output_type == "full":
                 K = 3
-                Q = np.array(
-                    [[float(i) + k for k in range(K)] for i in range(n)], dtype=float
-                )
+                Q = np.array([[float(i) + k for k in range(K)] for i in range(n)], dtype=float)
                 taus = (np.arange(K, dtype=float) + 1.0) / (K + 1.0)
                 return {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)}
             return np.arange(n, dtype=float)
     else:
+
         def predict(self, X):  # noqa: E306 - old build: mean only
             return np.arange(len(X), dtype=float)
 
@@ -3325,8 +3326,11 @@ def test_local_quantiles_route_through_the_estimator_api(monkeypatch):
     client = _local_client_with_fake(monkeypatch, seen)
 
     lo, mid, hi = client.predict(
-        _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]],
-        output_type="quantiles", quantiles=_LEVELS,
+        _XTR,
+        _YTR,
+        [[2.0, 2.0], [3.0, 3.0]],
+        output_type="quantiles",
+        quantiles=_LEVELS,
     )
 
     assert seen["fit"][0] == _XTR and seen["fit"][1] == _YTR
@@ -3398,9 +3402,7 @@ def test_local_full_returns_the_bank_dict(monkeypatch):
 def test_local_median_also_uses_the_estimator(monkeypatch):
     seen: Dict = {}
     client = _local_client_with_fake(monkeypatch, seen)
-    preds = client.predict(
-        _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="median"
-    )
+    preds = client.predict(_XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]], output_type="median")
     assert seen["predict"]["output_type"] == "median"
     assert preds == [0.0, 1.0]
 
@@ -3428,8 +3430,11 @@ def test_local_quantiles_as_pandas_frame(monkeypatch):
 
     out = client.predict(
         pd.DataFrame(_XTR, columns=["a", "b"]),
-        pd.Series(_YTR, name="score"), X_test,
-        output_type="quantiles", quantiles=[0.1, 0.9], as_pandas=True,
+        pd.Series(_YTR, name="score"),
+        X_test,
+        output_type="quantiles",
+        quantiles=[0.1, 0.9],
+        as_pandas=True,
     )
 
     assert list(out.columns) == ["score[0.1]", "score[0.9]"]
@@ -3441,18 +3446,14 @@ def test_local_output_type_needs_a_newer_synthefy_nori(monkeypatch):
     seen: Dict = {}
     client = _local_client_with_fake(monkeypatch, seen, with_output_type=False)
     with pytest.raises(ImportError, match=r"output_type=.*added in 0\.6\.0"):
-        client.predict(
-            _XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_local_variant_selector_needs_a_newer_synthefy_nori(monkeypatch):
     seen: Dict = {}
     client = _local_client_with_fake(monkeypatch, seen, with_model=False)
     with pytest.raises(ImportError, match="model= selector"):
-        client.predict(
-            _XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_local_quantiles_missing_package_raises_install_hint(monkeypatch):
@@ -3466,9 +3467,7 @@ def test_local_quantiles_missing_package_raises_install_hint(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", fake_import)
     client = SynthefyNoriClient(mode="local", model="nori-30m")
     with pytest.raises(ImportError, match=r"synthefy-nori"):
-        client.predict(
-            _XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_local_unexpected_quantile_shape_raises(monkeypatch):
@@ -3487,9 +3486,7 @@ def test_local_unexpected_quantile_shape_raises(monkeypatch):
     monkeypatch.setattr("synthefy.nori_client._load_local_regressor", lambda: _Wrong)
     client = SynthefyNoriClient(mode="local", model="nori-30m")
     with pytest.raises(ValueError, match="quantile array of shape"):
-        client.predict(
-            _XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, _XTE, output_type="quantiles", quantiles=_LEVELS)
 
 
 @pytest.mark.slow
@@ -3503,9 +3500,7 @@ def test_local_quantiles_real_inference():
     y_train = X_train[:, 0] * 2.0 + rng.normal(scale=0.3, size=60)
     X_test = rng.normal(size=(8, 3))
 
-    lo, mid, hi = client.predict(
-        X_train, y_train, X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9]
-    )
+    lo, mid, hi = client.predict(X_train, y_train, X_test, output_type="quantiles", quantiles=[0.1, 0.5, 0.9])
     assert len(lo) == len(mid) == len(hi) == 8
     # A valid quantile function is non-decreasing in tau.
     assert all(a <= b <= c for a, b, c in zip(lo, mid, hi))
@@ -3517,7 +3512,7 @@ def test_local_quantiles_real_inference():
     Q = np.asarray(full["quantiles"])
     taus = np.asarray(full["taus"])
     assert Q.shape == (8, taus.shape[0])
-    assert np.all(np.diff(Q, axis=1) >= -1e-9)     # ascending per row
+    assert np.all(np.diff(Q, axis=1) >= -1e-9)  # ascending per row
     assert np.all((taus > 0.0) & (taus < 1.0))
     # "full"'s mean is the same quantity output_type="mean" collapses to.
     assert np.allclose(full["mean"], np.asarray(mean), atol=0.15)
@@ -3527,25 +3522,35 @@ def test_remote_drifted_quantile_levels_raise():
     # Columns are labeled from the request, so levels that came back different
     # would mean data at one tau labeled with another.
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0],
-        quantiles=[[0.5, 1.0, 1.5]], taus=[0.1, 0.5, 0.95],  # 0.9 -> 0.95
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0],
+            quantiles=[[0.5, 1.0, 1.5]],
+            taus=[0.1, 0.5, 0.95],  # 0.9 -> 0.95
+        ),
+    )
     with pytest.raises(ValueError, match="server returned"):
-        client.predict(
-            _XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS
-        )
+        client.predict(_XTR, _YTR, [[2.0, 2.0]], output_type="quantiles", quantiles=_LEVELS)
 
 
 def test_remote_ragged_quantile_block_raises_a_clear_error():
     client = _remote_client()
-    _attach_mock(client, _dist_handler(
-        {}, predictions=[1.0, 2.0],
-        quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0]],  # second row short
-        taus=_LEVELS,
-    ))
+    _attach_mock(
+        client,
+        _dist_handler(
+            {},
+            predictions=[1.0, 2.0],
+            quantiles=[[0.5, 1.0, 1.5], [1.5, 2.0]],  # second row short
+            taus=_LEVELS,
+        ),
+    )
     with pytest.raises(ValueError, match="rows of unequal length"):
         client.predict(
-            _XTR, _YTR, [[2.0, 2.0], [3.0, 3.0]],
-            output_type="quantiles", quantiles=_LEVELS,
+            _XTR,
+            _YTR,
+            [[2.0, 2.0], [3.0, 3.0]],
+            output_type="quantiles",
+            quantiles=_LEVELS,
         )

--- a/libs/synthefy/tests/test_nori_data_models.py
+++ b/libs/synthefy/tests/test_nori_data_models.py
@@ -64,9 +64,9 @@ def test_the_policy_is_frozen_so_a_shared_instance_cannot_be_mutated():
 
 def test_bounds_are_enforced_locally():
     with pytest.raises(ValueError):
-        MemoryPolicy(gpu_budget_frac=1.5)   # a fraction of VRAM cannot exceed 1
+        MemoryPolicy(gpu_budget_frac=1.5)  # a fraction of VRAM cannot exceed 1
     with pytest.raises(ValueError):
-        MemoryPolicy(gpu_budget_frac=0)     # exclusive minimum: 0 would mean "never cache"
+        MemoryPolicy(gpu_budget_frac=0)  # exclusive minimum: 0 would mean "never cache"
     assert MemoryPolicy(gpu_budget_absolute_gb=0).gpu_budget_absolute_gb == 0
 
 

--- a/libs/synthefy/tests/test_nori_ts_contract.py
+++ b/libs/synthefy/tests/test_nori_ts_contract.py
@@ -88,9 +88,7 @@ def test_predict_df_rejects_missing_timestamp_and_target():
     with pytest.raises(ValueError, match="timestamp"):
         forecaster.predict_df(pd.DataFrame({"target": [1.0, 2.0]}), prediction_length=3)
     with pytest.raises(ValueError, match="target column 'sales' not found"):
-        forecaster.predict_df(
-            _history(), prediction_length=3, target_column="sales"
-        )
+        forecaster.predict_df(_history(), prediction_length=3, target_column="sales")
 
 
 def test_predict_df_rejects_multiple_target_columns_clearly():
@@ -211,9 +209,7 @@ def test_predict_df_runs_through_public_synthefy_nori_client(monkeypatch):
 
     def predict(X_train, y_train, X_test, **kwargs):
         calls.append((X_train, y_train, X_test, kwargs))
-        return np.vstack(
-            [np.full(len(X_test), level, dtype=float) for level in kwargs["quantiles"]]
-        )
+        return np.vstack([np.full(len(X_test), level, dtype=float) for level in kwargs["quantiles"]])
 
     monkeypatch.setattr(client, "predict", predict)
     try:

--- a/libs/synthefy/tests/test_tsfeatures.py
+++ b/libs/synthefy/tests/test_tsfeatures.py
@@ -45,9 +45,7 @@ def test_generate_test_x_builds_a_contiguous_unknown_horizon():
     assert len(test) == 6
     assert test["target"].isna().all()
     timestamps = test.index.get_level_values("timestamp")
-    assert timestamps[0] == train.index.get_level_values("timestamp").max() + pd.Timedelta(
-        hours=1
-    )
+    assert timestamps[0] == train.index.get_level_values("timestamp").max() + pd.Timedelta(hours=1)
 
 
 def test_generate_test_x_uses_explicit_frequency_for_gappy_input():
@@ -125,9 +123,7 @@ def test_static_features_survive_train_and_horizon_transform():
 
 
 def test_canonical_generators_restart_for_each_series():
-    train = TimeSeriesDataFrame(
-        pd.concat([pd.DataFrame(_tsdf(item_id=item)) for item in (0, 1)])
-    )
+    train = TimeSeriesDataFrame(pd.concat([pd.DataFrame(_tsdf(item_id=item)) for item in (0, 1)]))
     test = generate_test_X(train, prediction_length=4, freq="h")
 
     transformed_train, transformed_test = FeatureTransformer(_features()).transform(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ markers = [
 [tool.ruff]
 target-version = "py39"
 line-length = 120
+extend-exclude = ["*.ipynb"]   # notebooks are formatted deliberately, not by the tree-wide gate
 
 [tool.ruff.lint]
 select = ["E9", "F821", "F822", "F823"]

--- a/src/synthefy_nori/_legacy_text_features.py
+++ b/src/synthefy_nori/_legacy_text_features.py
@@ -30,13 +30,13 @@ from sklearn.decomposition import TruncatedSVD
 
 # short name -> HF model id (embedding backbones)
 MODELS = {
-    "minilm": "sentence-transformers/all-MiniLM-L6-v2",   # 384-d, fast baseline
-    "qwen0.6b": "Qwen/Qwen3-Embedding-0.6B",              # 1024-d, public, fast
-    "qwen4b": "Qwen/Qwen3-Embedding-4B",                  # 2560-d, powerful, public
-    "qwen8b": "Qwen/Qwen3-Embedding-8B",                  # 4096-d, public
-    "gemma": "google/embeddinggemma-300m",                # 768-d — GATED
-    "bge-m3": "BAAI/bge-m3",                              # 1024-d, public
-    "bge-large": "BAAI/bge-large-en-v1.5",               # 1024-d
+    "minilm": "sentence-transformers/all-MiniLM-L6-v2",  # 384-d, fast baseline
+    "qwen0.6b": "Qwen/Qwen3-Embedding-0.6B",  # 1024-d, public, fast
+    "qwen4b": "Qwen/Qwen3-Embedding-4B",  # 2560-d, powerful, public
+    "qwen8b": "Qwen/Qwen3-Embedding-8B",  # 4096-d, public
+    "gemma": "google/embeddinggemma-300m",  # 768-d — GATED
+    "bge-m3": "BAAI/bge-m3",  # 1024-d, public
+    "bge-large": "BAAI/bge-large-en-v1.5",  # 1024-d
 }
 
 _MISSING = "__MISSING__"
@@ -49,12 +49,14 @@ def _canon_cat(s: pd.Series) -> pd.Series:
     ("5.0" -> "5"), so a column read as int in one split and float in another
     (e.g. a NaN promoted it) still maps to the same code; everything else via str.
     """
+
     def one(v):
         if v is None or (isinstance(v, float) and np.isnan(v)):
             return _MISSING
         if isinstance(v, float) and v.is_integer():
             return str(int(v))
         return str(v)
+
     return s.astype(object).map(one)
 
 
@@ -75,8 +77,9 @@ def build_paragraphs(df: pd.DataFrame, text_columns) -> list[str]:
     return (joined + ".").tolist()
 
 
-def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
-                  normalize: bool | None = None) -> Callable[[list[str]], np.ndarray]:
+def _make_encoder(
+    embedder, device=None, *, batch_size: int | None = None, normalize: bool | None = None
+) -> Callable[[list[str]], np.ndarray]:
     """Resolve ``embedder`` to a ``texts -> (n, dim) float32 ndarray`` callable.
 
     Accepts a short name / HF id (str), a preloaded SentenceTransformer-like object
@@ -86,8 +89,10 @@ def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
     # NB: check str first, since str has a (bytes) .encode method that would
     # otherwise masquerade as a SentenceTransformer-like encoder.
     if not isinstance(embedder, str) and callable(embedder) and not hasattr(embedder, "encode"):
+
         def _enc_call(texts):
             return np.asarray(embedder(texts), dtype=np.float32)
+
         return _enc_call
 
     st = embedder
@@ -111,15 +116,15 @@ def _make_encoder(embedder, device=None, *, batch_size: int | None = None,
         if "Qwen" in model_id or "gemma" in model_id.lower():
             st.max_seq_length = min(getattr(st, "max_seq_length", 512) or 512, 512)
 
-    is_llm = bool(model_id) and (
-        "Qwen" in model_id or "gemma" in model_id.lower() or "bge" in model_id.lower())
+    is_llm = bool(model_id) and ("Qwen" in model_id or "gemma" in model_id.lower() or "bge" in model_id.lower())
     bs = batch_size or (8 if (model_id and "Qwen" in model_id) else 32 if is_llm else 256)
     norm = normalize if normalize is not None else is_llm  # cosine-normalize LLM encoders
 
     def _enc_st(texts):
-        return st.encode(texts, batch_size=bs, convert_to_numpy=True,
-                         show_progress_bar=False,
-                         normalize_embeddings=norm).astype(np.float32)
+        return st.encode(
+            texts, batch_size=bs, convert_to_numpy=True, show_progress_bar=False, normalize_embeddings=norm
+        ).astype(np.float32)
+
     return _enc_st
 
 
@@ -145,9 +150,16 @@ class MultimodalPreprocessor:
             normalization). Very high-cardinality columns are better passed as text.
     """
 
-    def __init__(self, text_columns, svd_dim: int | None = 128, embedder="minilm",
-                 device=None, seed: int = 0, max_cardinality: int = 128,
-                 normalize: bool | None = None):
+    def __init__(
+        self,
+        text_columns,
+        svd_dim: int | None = 128,
+        embedder="minilm",
+        device=None,
+        seed: int = 0,
+        max_cardinality: int = 128,
+        normalize: bool | None = None,
+    ):
         # kept raw (None / str / list / Index); resolved to self.text_columns_ at fit
         self.text_columns = text_columns
         self.svd_dim = None if svd_dim is None else int(svd_dim)
@@ -223,8 +235,8 @@ class MultimodalPreprocessor:
         if tc is None:
             return []
         if isinstance(tc, str):
-            tc = [tc]                       # a lone column name, not chars to iterate
-        cols = list(tc)                     # handles pandas Index / tuple / ndarray
+            tc = [tc]  # a lone column name, not chars to iterate
+        cols = list(tc)  # handles pandas Index / tuple / ndarray
         missing = [c for c in cols if c not in df.columns]
         if missing:
             raise ValueError(f"text_columns not found in the DataFrame: {missing}")
@@ -234,7 +246,8 @@ class MultimodalPreprocessor:
         if not isinstance(df, pd.DataFrame):
             raise TypeError(
                 "MultimodalPreprocessor requires a pandas DataFrame (so text "
-                f"columns can be located by name); got {type(df).__name__}.")
+                f"columns can be located by name); got {type(df).__name__}."
+            )
         self._encoder = None
         self.svd_ = None
         self.text_columns_ = self._resolve_text_columns(df)
@@ -254,7 +267,8 @@ class MultimodalPreprocessor:
             # embedding — fail loudly rather than silently degrade to pure tabular.
             raise ValueError(
                 f"embedder produced a zero-width embedding for text columns "
-                f"{self.text_columns_}; check the encoder / that the text is non-empty.")
+                f"{self.text_columns_}; check the encoder / that the text is non-empty."
+            )
 
         if self.svd_dim is None:
             # raw mode: append the full embedding, no reduction
@@ -277,13 +291,13 @@ class MultimodalPreprocessor:
         if not isinstance(df, pd.DataFrame):
             raise TypeError(
                 "MultimodalPreprocessor.transform requires a pandas DataFrame with "
-                f"the same columns seen at fit; got {type(df).__name__}.")
-        missing = [c for c in (self.nontext_columns_ + self.text_columns_)
-                   if c not in df.columns]
+                f"the same columns seen at fit; got {type(df).__name__}."
+            )
+        missing = [c for c in (self.nontext_columns_ + self.text_columns_) if c not in df.columns]
         if missing:
             raise ValueError(f"transform() is missing columns seen at fit: {missing}")
         Xnum = self._transform_tabular(df)
-        if not self.text_columns_:          # no text at all -> tabular only
+        if not self.text_columns_:  # no text at all -> tabular only
             return Xnum
         E = self._embed(df)
         # raw mode (svd_dim=None) appends the embedding directly; else SVD-transform

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -63,16 +63,12 @@ def _as_device(device):
     resolved = torch.device(device)
     if resolved.type == "cuda":
         if not torch.cuda.is_available():
-            raise RuntimeError(
-                f"device={str(resolved)!r} was requested, but CUDA is not "
-                "available to PyTorch."
-            )
+            raise RuntimeError(f"device={str(resolved)!r} was requested, but CUDA is not available to PyTorch.")
         if resolved.index is not None:
             device_count = torch.cuda.device_count()
             if resolved.index >= device_count:
                 raise RuntimeError(
-                    f"device={str(resolved)!r} was requested, but only "
-                    f"{device_count} CUDA device(s) are visible."
+                    f"device={str(resolved)!r} was requested, but only {device_count} CUDA device(s) are visible."
                 )
     if resolved.type == "mps" and not _mps_available():
         mps = getattr(torch.backends, "mps", None)
@@ -86,8 +82,7 @@ def _as_device(device):
     return resolved
 
 
-def _resolve_model_path(model_path: str | None, token: str | bool | None = None,
-                        model: str | None = None) -> str:
+def _resolve_model_path(model_path: str | None, token: str | bool | None = None, model: str | None = None) -> str:
     if model_path is not None:
         return model_path
     from synthefy_nori.hf import download_checkpoint
@@ -537,9 +532,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         if self._predictor is None:
             from synthefy_nori.inference.predictor import NoriPredictor
 
-            resolved_device = (
-                self.device_ if hasattr(self, "device_") else _as_device(self.device)
-            )
+            resolved_device = self.device_ if hasattr(self, "device_") else _as_device(self.device)
             self._predictor = NoriPredictor(
                 device=resolved_device,
                 model_path=_resolve_model_path(self.model_path, self.token, self.model),
@@ -635,18 +628,14 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             return self._predict_distribution(X, output_type=output_type, quantiles=quantiles)
         if output_type == "main":
             raise NotImplementedError(
-                "output_type='main' is not supported. Use 'mean', 'median', "
-                "'mode', 'quantiles', or 'full'."
+                "output_type='main' is not supported. Use 'mean', 'median', 'mode', 'quantiles', or 'full'."
             )
         if output_type not in ("mean", "median", "mode"):
             raise ValueError(
-                f"Unknown output_type={output_type!r}; expected one of "
-                "'mean', 'median', 'mode', 'quantiles', 'full'."
+                f"Unknown output_type={output_type!r}; expected one of 'mean', 'median', 'mode', 'quantiles', 'full'."
             )
         if quantiles is not None:
-            raise ValueError(
-                "quantiles= is only valid with output_type='quantiles'."
-            )
+            raise ValueError("quantiles= is only valid with output_type='quantiles'.")
 
         # Drive the predictor's distribution-collapse from output_type. "mean"
         # uses the regressor's configured collapse so the default path is
@@ -659,8 +648,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 quantile_collapse=self.quantile_collapse,
                 bar_point_estimator=self.bar_point_estimator,
             )
-        return self._predict_point(
-            X, quantile_collapse="median", bar_point_estimator=output_type)
+        return self._predict_point(X, quantile_collapse="median", bar_point_estimator=output_type)
 
     def _predict_point(self, X, *, quantile_collapse: str, bar_point_estimator: str):
         """One point-prediction pass with an explicit collapse, predictor state
@@ -680,11 +668,10 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         try:
             predictor.quantile_collapse = quantile_collapse
             predictor.bar_point_estimator = bar_point_estimator
-            if large_context_applies(len(self.X_train_), self.large_context_policy,
-                               self.large_context_threshold):
+            if large_context_applies(len(self.X_train_), self.large_context_policy, self.large_context_threshold):
                 pred = self._large_context_predict(
-                    predictor, X_test, y_norm,
-                    decoder=(quantile_collapse, bar_point_estimator))
+                    predictor, X_test, y_norm, decoder=(quantile_collapse, bar_point_estimator)
+                )
             else:
                 pred = predictor.predict(self.X_train_, y_norm, X_test)
         finally:
@@ -694,8 +681,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         pred = np.asarray(pred, dtype=np.float64).squeeze()
         return pred * self.y_std_ + self.y_mean_
 
-    def _large_context_predict(self, predictor, X_test: np.ndarray, y_norm: np.ndarray,
-                         *, decoder: tuple):
+    def _large_context_predict(self, predictor, X_test: np.ndarray, y_norm: np.ndarray, *, decoder: tuple):
         """Predict through ``large_context_policy`` instead of one full-context call.
 
         The :class:`~synthefy_nori.inference.policies.Problem` is built once per ``fit``
@@ -729,8 +715,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # repetition the rest of this path exists to remove.
         if self._large_context_budget_features is None:
             self._large_context_budget_features = predictor.budget_n_features(self.X_train_)
-        window = predictor.max_context_rows(
-            self.X_train_, budget_n_features=self._large_context_budget_features)
+        window = predictor.max_context_rows(self.X_train_, budget_n_features=self._large_context_budget_features)
         max_nori_calls = getattr(self, "large_context_max_calls", None)
         if self._large_context_problem is None or self._large_context_problem.window != window:
             previous = self._large_context_problem
@@ -754,8 +739,10 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # includes defaults, and follows in-place dict changes between calls.
         memory_scope = MemoryPolicy.coerce(self.memory_policy).model_dump_json()
         pred, self.large_context_report_ = run_policy(
-            self._large_context_problem, X_test,
-            policy_spec=self.large_context_policy, seed=self.large_context_seed,
+            self._large_context_problem,
+            X_test,
+            policy_spec=self.large_context_policy,
+            seed=self.large_context_seed,
             cache_scope=("decoder", decoder, "memory_policy", memory_scope),
         )
         return pred
@@ -785,14 +772,11 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             # X is ignored for context embeddings; do not touch it so a
             # missing/mismatched X cannot raise. The predictor synthesizes a
             # dummy query from the context.
-            return predictor.get_embeddings(
-                self.X_train_, y_norm, None, data_source=data_source)
+            return predictor.get_embeddings(self.X_train_, y_norm, None, data_source=data_source)
         if X is None:
-            raise ValueError(
-                "get_embeddings requires X for data_source='test'.")
+            raise ValueError("get_embeddings requires X for data_source='test'.")
         X_test = self._prepare_query_features(X)
-        return predictor.get_embeddings(
-            self.X_train_, y_norm, X_test, data_source=data_source)
+        return predictor.get_embeddings(self.X_train_, y_norm, X_test, data_source=data_source)
 
     def _predict_distribution(self, X, *, output_type: str, quantiles: list[float] | None):
         """Return the model's predictive distribution as quantiles.
@@ -811,8 +795,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # combine their quantile banks. Silently ignoring the policy and answering from
         # a memory-trimmed full context would hand back numbers the caller believes
         # came from their policy.
-        if large_context_applies(len(self.X_train_), self.large_context_policy,
-                           self.large_context_threshold):
+        if large_context_applies(len(self.X_train_), self.large_context_policy, self.large_context_threshold):
             raise LargeContextUnsupportedOutputError(
                 f"large_context_policy={self.large_context_policy!r} cannot serve "
                 f"output_type={output_type!r} (nor a discretize strategy that decodes "
@@ -825,8 +808,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         if output_type == "quantiles":
             if not quantiles:
                 raise ValueError(
-                    "output_type='quantiles' requires quantiles=[...] with at "
-                    "least one tau level in (0, 1)."
+                    "output_type='quantiles' requires quantiles=[...] with at least one tau level in (0, 1)."
                 )
             q_levels = np.asarray(quantiles, dtype=np.float64)
             if np.any((q_levels <= 0.0) | (q_levels >= 1.0)):
@@ -859,8 +841,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         taus = np.asarray(predictor.regression_quantiles, dtype=np.float64)
         if taus.shape != (K,):
             raise RuntimeError(
-                "Checkpoint quantile metadata does not match decoder output: "
-                f"{taus.shape[0]} levels for {K} columns."
+                f"Checkpoint quantile metadata does not match decoder output: {taus.shape[0]} levels for {K} columns."
             )
 
         if output_type == "full":
@@ -868,7 +849,9 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 "quantiles": Q,
                 "taus": taus,
                 "mean": quantile_dist_mean_numpy(
-                    Q, taus, enforce_monotone_first=False,
+                    Q,
+                    taus,
+                    enforce_monotone_first=False,
                 ),
             }
 
@@ -898,19 +881,14 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # validate before the (expensive) forward pass; discretize_predictions
         # re-checks as the canonical gate for direct module users
         if method not in DISCRETIZE_METHODS:
-            raise ValueError(
-                f"Unknown discretize method {method!r}; expected one of "
-                f"{DISCRETIZE_METHODS}."
-            )
+            raise ValueError(f"Unknown discretize method {method!r}; expected one of {DISCRETIZE_METHODS}.")
         if not hasattr(self, "X_train_"):
             raise ValueError("Call fit(X, y) before predict(X).")
         lattice = target_levels(self.y_train_ if levels is None else levels)
         if method in SNAP_METHODS or method == "prior-match":
             collapse = "median" if method == "snap-median" else "mean"
-            point = self._predict_point(
-                X, quantile_collapse=collapse, bar_point_estimator=collapse)
-            return discretize_predictions(
-                method, lattice, point=point, y_train=self.y_train_)
+            point = self._predict_point(X, quantile_collapse=collapse, bar_point_estimator=collapse)
+            return discretize_predictions(method, lattice, point=point, y_train=self.y_train_)
         try:
             dist = self._predict_distribution(X, output_type="full", quantiles=None)
         except LargeContextUnsupportedOutputError:
@@ -924,8 +902,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 "bar_distribution checkpoint does not expose. Use "
                 "discretize='snap-mean', 'snap-median', or 'prior-match' instead."
             ) from err
-        return discretize_predictions(
-            method, lattice, Q=dist["quantiles"], taus=dist["taus"])
+        return discretize_predictions(method, lattice, Q=dist["quantiles"], taus=dist["taus"])
 
 
 def infer(

--- a/src/synthefy_nori/configs/__init__.py
+++ b/src/synthefy_nori/configs/__init__.py
@@ -27,6 +27,7 @@ DEFAULT_INFERENCE_CONFIG = "default_inference.json"
 #: The bundled training/architecture config — a different phase, not an inference config.
 DEFAULT_MODEL_CONFIG = "model_base.json"
 
+
 def config_path(filename: str = DEFAULT_INFERENCE_CONFIG) -> str:
     """Return an absolute path for a bundled config file.
 

--- a/src/synthefy_nori/discretize.py
+++ b/src/synthefy_nori/discretize.py
@@ -33,6 +33,7 @@ Discretization is strictly opt-in: nothing here runs unless the caller passes
 ``discretize=`` / ``categorical_levels=`` to ``NoriRegressor.predict`` /
 ``infer`` (or uses these helpers directly).
 """
+
 from __future__ import annotations
 
 import warnings
@@ -40,11 +41,15 @@ import warnings
 import numpy as np
 
 DISCRETIZE_METHODS = (
-    "map-cell", "median-cell", "snap-mean", "snap-median",
-    "expected-level", "prior-match",
+    "map-cell",
+    "median-cell",
+    "snap-mean",
+    "snap-median",
+    "expected-level",
+    "prior-match",
 )
-SNAP_METHODS = ("snap-mean", "snap-median")   # need only a point prediction
-CONTINUOUS_METHODS = ("expected-level",)      # output is NOT on the lattice
+SNAP_METHODS = ("snap-mean", "snap-median")  # need only a point prediction
+CONTINUOUS_METHODS = ("expected-level",)  # output is NOT on the lattice
 DEFAULT_DISCRETIZE_METHOD = "map-cell"  # accuracy-optimal; what the bare flag means
 
 # One-paragraph explanation per strategy — importable for CLIs/UIs/agents and
@@ -206,9 +211,7 @@ def discretize_predictions(
     ``Q`` and its ``taus``. ``expected-level`` returns CONTINUOUS values.
     """
     if method not in DISCRETIZE_METHODS:
-        raise ValueError(
-            f"Unknown discretize method {method!r}; expected one of {DISCRETIZE_METHODS}."
-        )
+        raise ValueError(f"Unknown discretize method {method!r}; expected one of {DISCRETIZE_METHODS}.")
     levels = np.asarray(levels, dtype=np.float64).ravel()
     levels = np.unique(levels[np.isfinite(levels)])
     if levels.size == 0:

--- a/src/synthefy_nori/evaluation/__init__.py
+++ b/src/synthefy_nori/evaluation/__init__.py
@@ -11,20 +11,26 @@ def __getattr__(name):
     """Lazy imports to avoid dependency issues at import time."""
     if name == "DatasetRegistry":
         from synthefy_nori.evaluation.datasets import DatasetRegistry
+
         return DatasetRegistry
     if name == "DatasetEntry":
         from synthefy_nori.evaluation.datasets import DatasetEntry
+
         return DatasetEntry
     if name == "ModelRegistry":
         from synthefy_nori.evaluation.models import ModelRegistry
+
         return ModelRegistry
     if name == "ModelEntry":
         from synthefy_nori.evaluation.models import ModelEntry
+
         return ModelEntry
     if name == "EvalRunner":
         from synthefy_nori.evaluation.runner import EvalRunner
+
         return EvalRunner
     if name == "EvalAnalyzer":
         from synthefy_nori.evaluation.analysis import EvalAnalyzer
+
         return EvalAnalyzer
     raise AttributeError(f"module 'evaluation' has no attribute {name!r}")

--- a/src/synthefy_nori/evaluation/analysis.py
+++ b/src/synthefy_nori/evaluation/analysis.py
@@ -34,18 +34,13 @@ class EvalAnalyzer:
 
     @staticmethod
     def _safe_name(text: str) -> str:
-        return (
-            text.replace(" ", "_")
-            .replace("/", "_")
-            .replace("(", "")
-            .replace(")", "")
-            .replace(":", "_")
-        )
+        return text.replace(" ", "_").replace("/", "_").replace("(", "").replace(")", "").replace(":", "_")
 
     @staticmethod
     def _import_matplotlib():
         try:
             import matplotlib.pyplot as plt
+
             return plt
         except Exception as e:
             print(f"[EvalAnalyzer] Plot generation skipped (matplotlib unavailable): {e}")
@@ -129,8 +124,10 @@ class EvalAnalyzer:
         if metric not in df.columns:
             return pd.DataFrame()
         return df.pivot_table(
-            index=["source", "dataset"], columns="model",
-            values=metric, aggfunc="first",
+            index=["source", "dataset"],
+            columns="model",
+            values=metric,
+            aggfunc="first",
         ).sort_index()
 
     # --- Head-to-head comparison ---
@@ -147,9 +144,15 @@ class EvalAnalyzer:
         wins_b = int((m["delta"] < -0.001).sum())
         ties = len(m) - wins_a - wins_b
         return {
-            "model_a": model_a, "model_b": model_b, "metric": metric,
-            "n_datasets": len(m), "wins_a": wins_a, "wins_b": wins_b, "ties": ties,
-            "mean_delta": float(m["delta"].mean()), "std_delta": float(m["delta"].std()),
+            "model_a": model_a,
+            "model_b": model_b,
+            "metric": metric,
+            "n_datasets": len(m),
+            "wins_a": wins_a,
+            "wins_b": wins_b,
+            "ties": ties,
+            "mean_delta": float(m["delta"].mean()),
+            "std_delta": float(m["delta"].std()),
             "per_dataset": m.sort_values("delta", ascending=False).to_dict("records"),
         }
 
@@ -235,7 +238,9 @@ class EvalAnalyzer:
         if focus_model not in pivot.columns:
             return pd.DataFrame()
 
-        meta_cols = [c for c in ["source", "dataset", "n_train", "n_test", "n_features", "n_classes"] if c in sub.columns]
+        meta_cols = [
+            c for c in ["source", "dataset", "n_train", "n_test", "n_features", "n_classes"] if c in sub.columns
+        ]
         meta = sub[sub["model"] == focus_model][meta_cols].drop_duplicates(["source", "dataset"])
 
         comp = pivot.reset_index().merge(meta, on=["source", "dataset"], how="left")
@@ -353,12 +358,7 @@ class EvalAnalyzer:
         if df.empty or metric not in df.columns:
             return None
 
-        pivot = (
-            df.groupby(["source", "model"])[metric]
-            .mean()
-            .unstack("model")
-            .sort_index()
-        )
+        pivot = df.groupby(["source", "model"])[metric].mean().unstack("model").sort_index()
         if pivot.empty:
             return None
 
@@ -492,11 +492,7 @@ class EvalAnalyzer:
             axes = [axes]
 
         for ax, col in zip(axes, bucket_cols):
-            g = (
-                comp_df.groupby(col, observed=False)["delta_vs_best_other"]
-                .agg(["mean", "count"])
-                .dropna()
-            )
+            g = comp_df.groupby(col, observed=False)["delta_vs_best_other"].agg(["mean", "count"]).dropna()
             if g.empty:
                 ax.set_title(f"{col} (no data)")
                 continue
@@ -604,15 +600,9 @@ class EvalAnalyzer:
                 continue
             metric = self._primary_metric(task_type)
             files = [
-                self.plot_metric_leaderboard(
-                    task_type, metric, out / f"{task_type}_{metric}_leaderboard.png"
-                ),
-                self.plot_source_grouped_bars(
-                    task_type, metric, out / f"{task_type}_{metric}_by_source_bars.png"
-                ),
-                self.plot_pairwise_heatmap(
-                    task_type, metric, out / f"{task_type}_{metric}_pairwise_heatmap.png"
-                ),
+                self.plot_metric_leaderboard(task_type, metric, out / f"{task_type}_{metric}_leaderboard.png"),
+                self.plot_source_grouped_bars(task_type, metric, out / f"{task_type}_{metric}_by_source_bars.png"),
+                self.plot_pairwise_heatmap(task_type, metric, out / f"{task_type}_{metric}_pairwise_heatmap.png"),
             ]
             created.extend([f for f in files if f])
 
@@ -639,15 +629,25 @@ class EvalAnalyzer:
 
                 files = [
                     self.plot_focus_loss_topk(
-                        comp, focus, task_type, metric, top_k=top_k,
+                        comp,
+                        focus,
+                        task_type,
+                        metric,
+                        top_k=top_k,
                         output_path=out / f"{task_type}_{focus_safe}_hardest_topk.png",
                     ),
                     self.plot_focus_bucket_analysis(
-                        comp, focus, task_type, metric,
+                        comp,
+                        focus,
+                        task_type,
+                        metric,
                         output_path=out / f"{task_type}_{focus_safe}_bucket_analysis.png",
                     ),
                     self.plot_focus_scatter(
-                        comp, focus, task_type, metric,
+                        comp,
+                        focus,
+                        task_type,
+                        metric,
                         output_path=out / f"{task_type}_{focus_safe}_difficulty_scatter.png",
                     ),
                 ]
@@ -678,9 +678,9 @@ class EvalAnalyzer:
         # --- Regression aggregate ---
         reg_df = self._clean("regression")
         if not reg_df.empty:
-            print(f"\n{'='*80}\n  REGRESSION (aggregate)\n{'='*80}")
+            print(f"\n{'=' * 80}\n  REGRESSION (aggregate)\n{'=' * 80}")
             print(f"  {'Model':<30} {'R2':>8} {'RMSE':>8} {'MAE':>8} {'N':>5}")
-            print(f"  {'-'*63}")
+            print(f"  {'-' * 63}")
             for model in models:
                 m = reg_df[reg_df["model"] == model]
                 if m.empty:
@@ -702,9 +702,9 @@ class EvalAnalyzer:
         # Latency
         if "latency_ms" in self.df.columns:
             clean = self._clean()
-            print(f"\n{'='*80}\n  LATENCY\n{'='*80}")
+            print(f"\n{'=' * 80}\n  LATENCY\n{'=' * 80}")
             print(f"  {'Model':<30} {'Mean ms':>10} {'Median ms':>11} {'Throughput':>14}")
-            print(f"  {'-'*67}")
+            print(f"  {'-' * 67}")
             for model in models:
                 m = clean[clean["model"] == model]
                 if m.empty:
@@ -715,7 +715,7 @@ class EvalAnalyzer:
                 thr_s = f"{thr:>12.0f} s/s" if np.isfinite(thr) else f"{'N/A':>14}"
                 print(f"  {model:<30} {ml:>10.1f} {mdl:>11.1f} {thr_s}")
 
-        print(f"\n{'='*80}\n")
+        print(f"\n{'=' * 80}\n")
 
     def _print_per_source(self, df, models, task_type):
         """Print per-source aggregate table (e.g. OpenML-CC18 avg, TabArena avg)."""
@@ -785,10 +785,7 @@ class EvalAnalyzer:
             # Simplified: one row per dataset, one block of metrics per model
             # For readability, show primary metric per model + best marker
             primary = metric_cols[0]  # auc or r2
-            hdr = (
-                f"  {'Dataset':<{name_w}}"
-                f"  {'Train':>8}  {'Test':>8}  {'Total':>8}  {'Feat':>6}"
-            )
+            hdr = f"  {'Dataset':<{name_w}}  {'Train':>8}  {'Test':>8}  {'Total':>8}  {'Feat':>6}"
             for m in models:
                 hdr += f"  {model_short[m]:>20}"
             print(hdr)

--- a/src/synthefy_nori/evaluation/cli.py
+++ b/src/synthefy_nori/evaluation/cli.py
@@ -17,35 +17,47 @@ def _parse_checkpoint(raw: str) -> tuple[str, str]:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Evaluate Nori checkpoints")
-    parser.add_argument("--checkpoint", action="append", default=[],
-                        help="Checkpoint path or label:path. Repeatable.")
+    parser.add_argument("--checkpoint", action="append", default=[], help="Checkpoint path or label:path. Repeatable.")
     parser.add_argument("--device", default="cuda:0")
     parser.add_argument("--output-dir", default="results/eval")
     parser.add_argument("--tabarena-reg-dir", default="cache/tabarena_reg")
     parser.add_argument("--talent-reg-dir", default="cache/talent_reg")
-    parser.add_argument("--openml-reg", action="store_true",
-                        help="Include the curated OpenML regression suite (downloads from OpenML)")
-    parser.add_argument("--download-benchmarks", action="store_true",
-                        help="Download the TabArena and TALENT regression CSV caches from OpenML first")
+    parser.add_argument(
+        "--openml-reg", action="store_true", help="Include the curated OpenML regression suite (downloads from OpenML)"
+    )
+    parser.add_argument(
+        "--download-benchmarks",
+        action="store_true",
+        help="Download the TabArena and TALENT regression CSV caches from OpenML first",
+    )
     parser.add_argument("--custom-reg-dir", default=None)
     parser.add_argument("--reg-config", default=config_path(DEFAULT_INFERENCE_CONFIG))
     parser.add_argument("--sources", nargs="+", default=None)
     parser.add_argument("--max-train-samples", type=int, default=50000)
     parser.add_argument("--max-predict-samples", type=int, default=50000)
-    parser.add_argument("--max-elements-budget", type=int, default=8_000_000,
-                        help="SYNTHEFY_MAX_ELEMENTS_BUDGET for inference chunking/subsampling. "
-                             "The 8M default targets large GPUs (>=80GB) and stays under CUDA "
-                             "kernel grid limits on the largest test sets; lower it (e.g. "
-                             "2000000) on smaller GPUs. An explicit env var wins.")
-    parser.add_argument("--gpu-mem-gb", type=float, default=None,
-                        help="Enable the memory-model train-row cap for smaller GPUs (e.g. 24). "
-                             "Default: uncapped — train rows bounded only by --max-train-samples.")
+    parser.add_argument(
+        "--max-elements-budget",
+        type=int,
+        default=8_000_000,
+        help="SYNTHEFY_MAX_ELEMENTS_BUDGET for inference chunking/subsampling. "
+        "The 8M default targets large GPUs (>=80GB) and stays under CUDA "
+        "kernel grid limits on the largest test sets; lower it (e.g. "
+        "2000000) on smaller GPUs. An explicit env var wins.",
+    )
+    parser.add_argument(
+        "--gpu-mem-gb",
+        type=float,
+        default=None,
+        help="Enable the memory-model train-row cap for smaller GPUs (e.g. 24). "
+        "Default: uncapped — train rows bounded only by --max-train-samples.",
+    )
     parser.add_argument("--warmup", type=int, default=0)
     parser.add_argument("--no-cache", action="store_true")
     parser.add_argument("--cache-dir", default="cache/eval_cache")
     args = parser.parse_args(argv)
 
     import os
+
     os.environ.setdefault("SYNTHEFY_MAX_ELEMENTS_BUDGET", str(args.max_elements_budget))
 
     from synthefy_nori.evaluation.datasets import DatasetRegistry

--- a/src/synthefy_nori/evaluation/datasets.py
+++ b/src/synthefy_nori/evaluation/datasets.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
+
 # Keep in sync with synthefy_nori.inference.predictor.NA_PLACEHOLDER (not
 # imported: this module must stay importable without pulling in torch).
 NA_PLACEHOLDER = "__MISSING__"
@@ -49,16 +50,12 @@ def encode_categorical_column(col, classes=None, *, unknown_value=None):
         codes = np.searchsorted(classes, arr)
         bounded = np.minimum(codes, max(len(classes) - 1, 0))
         known = (
-            np.zeros(arr.shape, dtype=bool)
-            if len(classes) == 0
-            else (codes < len(classes)) & (classes[bounded] == arr)
+            np.zeros(arr.shape, dtype=bool) if len(classes) == 0 else (codes < len(classes)) & (classes[bounded] == arr)
         )
         if not np.all(known):
             if unknown_value is None:
                 unknown = np.unique(arr[~known]).tolist()
-                raise ValueError(
-                    f"categorical values are absent from the fitted vocabulary: {unknown}"
-                )
+                raise ValueError(f"categorical values are absent from the fitted vocabulary: {unknown}")
             codes = np.where(known, codes, int(unknown_value))
     return codes.astype(np.int64), classes
 
@@ -66,6 +63,7 @@ def encode_categorical_column(col, classes=None, *, unknown_value=None):
 @dataclass
 class DatasetEntry:
     """A single evaluation dataset."""
+
     name: str
     source: str
     task_type: str  # always "regression"
@@ -89,17 +87,19 @@ class DatasetEntry:
 
     def summary(self):
         return {
-            "name": self.name, "source": self.source,
-            "task_type": self.task_type, "n_train": self.n_train,
-            "n_test": self.n_test, "n_features": self.n_features,
+            "name": self.name,
+            "source": self.source,
+            "task_type": self.task_type,
+            "n_train": self.n_train,
+            "n_test": self.n_test,
+            "n_features": self.n_features,
         }
 
 
 class DatasetRegistry:
     """Central registry that loads and caches datasets from multiple sources."""
 
-    def __init__(self, cache_dir="./cache/eval_datasets", max_train_samples=50000,
-                 random_state=42):
+    def __init__(self, cache_dir="./cache/eval_datasets", max_train_samples=50000, random_state=42):
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.max_train_samples = max_train_samples
@@ -310,17 +310,12 @@ class DatasetRegistry:
 
             df = X
             df["target"] = y
-            train_df, test_df = train_test_split(
-                df, test_size=0.3, random_state=self.random_state
-            )
+            train_df, test_df = train_test_split(df, test_size=0.3, random_state=self.random_state)
 
             os.makedirs(dataset_dir, exist_ok=True)
             train_df.to_csv(train_path, index=False)
             test_df.to_csv(test_path, index=False)
-            print(
-                f"  [OK] {dataset_name}: {len(train_df)} train, "
-                f"{len(test_df)} test (did={did})"
-            )
+            print(f"  [OK] {dataset_name}: {len(train_df)} train, {len(test_df)} test (did={did})")
             return "downloaded"
         except Exception as e:
             print(f"  [FAIL] Error downloading {dataset_name} (did={did}): {e}")
@@ -345,6 +340,7 @@ class DatasetRegistry:
         if show_progress:
             try:
                 from tqdm import tqdm
+
                 it = tqdm(ids, desc="OpenML regression", unit="dataset")
             except ImportError:
                 pass
@@ -387,6 +383,7 @@ class DatasetRegistry:
             return list_path
         try:
             from importlib.resources import files
+
             packaged = files("synthefy_nori.evaluation.benchmark_lists") / packaged_name
             if packaged.is_file():
                 return str(packaged)
@@ -513,17 +510,17 @@ class DatasetRegistry:
             n_failed = numeric_y.isna().sum() - y_series.isna().sum()
             frac_failed = n_failed / max(len(y_series), 1)
             if frac_failed > 0.5:
-                print(f"  [FAIL] {dataset_name} (did={did}): {frac_failed:.0%} of "
-                      f"target values are non-numeric (got: {y_series.unique()[:5].tolist()}). "
-                      f"This is not a usable regression target.")
+                print(
+                    f"  [FAIL] {dataset_name} (did={did}): {frac_failed:.0%} of "
+                    f"target values are non-numeric (got: {y_series.unique()[:5].tolist()}). "
+                    f"This is not a usable regression target."
+                )
                 return "failed"
 
             df = X_df.copy()
             df["target"] = y_series.values
 
-            train_df, test_df = train_test_split(
-                df, test_size=0.3, random_state=self.random_state
-            )
+            train_df, test_df = train_test_split(df, test_size=0.3, random_state=self.random_state)
 
             os.makedirs(dataset_dir, exist_ok=True)
             train_df.to_csv(train_path, index=False)
@@ -551,14 +548,14 @@ class DatasetRegistry:
                 train_df, test_df = train_test_split(train_df, test_size=0.2, random_state=self.random_state)
             X_train, y_train = train_df.iloc[:, :-1], train_df.iloc[:, -1]
             X_test, y_test = test_df.iloc[:, :-1], test_df.iloc[:, -1]
-            return self._make_entry_from_df(X_train, y_train, name, source,
-                                            X_test=X_test, y_test=y_test)
+            return self._make_entry_from_df(X_train, y_train, name, source, X_test=X_test, y_test=y_test)
         except Exception as e:
             print(f"  [{source}] Error loading {name}: {e}")
             return None
 
     def _load_openml_dataset_by_id(self, dataset_id, source):
         import openml
+
         dataset = openml.datasets.get_dataset(dataset_id, download_data=True)
         target = dataset.default_target_attribute
         if target is None:
@@ -601,12 +598,7 @@ class DatasetRegistry:
         train_medians = X.median()
         X = X.fillna(train_medians).fillna(0.0).astype(np.float32)
         if X_test is not None:
-            X_test = (
-                X_test.apply(pd.to_numeric, errors="coerce")
-                .fillna(train_medians)
-                .fillna(0.0)
-                .astype(np.float32)
-            )
+            X_test = X_test.apply(pd.to_numeric, errors="coerce").fillna(train_medians).fillna(0.0).astype(np.float32)
 
         numeric_y = pd.to_numeric(y, errors="coerce")
         n_coerced = int(numeric_y.isna().sum() - y.isna().sum())
@@ -632,8 +624,7 @@ class DatasetRegistry:
                 frac_test = n_coerced_test / max(len(y_test), 1)
                 if frac_test > 0.5:
                     warnings.warn(
-                        f"[{source}/{name}] Skipping: {frac_test:.0%} of test regression "
-                        f"targets are non-numeric."
+                        f"[{source}/{name}] Skipping: {frac_test:.0%} of test regression targets are non-numeric."
                     )
                     return None
                 warnings.warn(
@@ -661,7 +652,8 @@ class DatasetRegistry:
 
         if X_test_arr is None:
             X_arr, X_test_arr, y_arr, y_test_arr = train_test_split(
-                X_arr, y_arr, test_size=0.2, random_state=self.random_state)
+                X_arr, y_arr, test_size=0.2, random_state=self.random_state
+            )
 
         if X_arr.shape[0] > self.max_train_samples:
             rng = np.random.RandomState(self.random_state)
@@ -672,8 +664,12 @@ class DatasetRegistry:
             return None
 
         return DatasetEntry(
-            name=name, source=source, task_type="regression",
-            X_train=X_arr, y_train=y_arr,
-            X_test=X_test_arr, y_test=y_test_arr,
+            name=name,
+            source=source,
+            task_type="regression",
+            X_train=X_arr,
+            y_train=y_arr,
+            X_test=X_test_arr,
+            y_test=y_test_arr,
             metadata={"n_train_original": X_arr.shape[0], "n_features_original": X_arr.shape[1]},
         )

--- a/src/synthefy_nori/evaluation/models.py
+++ b/src/synthefy_nori/evaluation/models.py
@@ -30,6 +30,7 @@ def package_config_path(filename: str) -> str:
 # Base model wrapper
 # ---------------------------------------------------------------------------
 
+
 class BaseModelWrapper(ABC):
     """Abstract base for all model wrappers in the eval pipeline."""
 
@@ -57,6 +58,7 @@ class BaseModelWrapper(ABC):
 # Model wrapper
 # ---------------------------------------------------------------------------
 
+
 class NoriWrapper(BaseModelWrapper):
     """Wrapper around NoriPredictor for unified eval."""
 
@@ -67,11 +69,11 @@ class NoriWrapper(BaseModelWrapper):
         device: str = "cuda:0",
         reg_config_path: str | None = None,
         base_config_path: Optional[str] = None,
-        augmentations: tuple|list|None = None,
+        augmentations: tuple | list | None = None,
         yj_skew_threshold: float = 10.0,
-        quantile_collapse: str = 'mean',
+        quantile_collapse: str = "mean",
         bar_temperature: float = 1.0,
-        bar_point_estimator: str = 'mean',
+        bar_point_estimator: str = "mean",
         memory_policy=None,
     ):
         self._name = model_name
@@ -144,11 +146,7 @@ class NoriWrapper(BaseModelWrapper):
         predictor.memory_report_ = None
         regression_head = getattr(predictor, "regression_head", None)
         if regression_head is None:
-            regression_head = (
-                "mse"
-                if int(getattr(predictor, "num_reg_quantiles", 1)) == 1
-                else "pinball"
-            )
+            regression_head = "mse" if int(getattr(predictor, "num_reg_quantiles", 1)) == 1 else "pinball"
         if regression_head != "pinball":
             raise NotImplementedError(
                 "predict_distribution needs the pinball (quantile-head) checkpoint; "
@@ -207,8 +205,7 @@ class NoriEnsembleWrapper(BaseModelWrapper):
     model-load overhead per dataset.
     """
 
-    def __init__(self, model_name: str, components: list,
-                 weights: list | None = None):
+    def __init__(self, model_name: str, components: list, weights: list | None = None):
         if not components:
             raise ValueError("NoriEnsembleWrapper requires at least one component")
         self._name = model_name
@@ -255,9 +252,11 @@ class NoriEnsembleWrapper(BaseModelWrapper):
 # Model Entry and Registry
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ModelEntry:
     """Metadata about a registered model."""
+
     name: str
     wrapper: BaseModelWrapper
     model_type: str  # "synthefy", "synthefy_ensemble", "custom"
@@ -295,9 +294,9 @@ class ModelRegistry:
         description="",
         augmentations=None,
         yj_skew_threshold: float = 10.0,
-        quantile_collapse: str = 'mean',
+        quantile_collapse: str = "mean",
         bar_temperature: float = 1.0,
-        bar_point_estimator: str = 'mean',
+        bar_point_estimator: str = "mean",
     ):
         device = device or self.device
         wrapper = NoriWrapper(
@@ -312,11 +311,15 @@ class ModelRegistry:
             bar_temperature=bar_temperature,
             bar_point_estimator=bar_point_estimator,
         )
-        self.register(ModelEntry(
-            name=name, wrapper=wrapper, model_type="synthefy",
-            description=description,
-            metadata={"model_path": model_path, "device": device},
-        ))
+        self.register(
+            ModelEntry(
+                name=name,
+                wrapper=wrapper,
+                model_type="synthefy",
+                description=description,
+                metadata={"model_path": model_path, "device": device},
+            )
+        )
 
     def add_synthefy_ensemble(
         self,
@@ -356,12 +359,18 @@ class ModelRegistry:
             components.append(wrapper)
 
         ens = NoriEnsembleWrapper(ensemble_name, components, weights=weights)
-        self.register(ModelEntry(
-            name=ensemble_name, wrapper=ens, model_type="synthefy_ensemble",
-            description=description or f"Ensemble of {len(components)} Synthefy checkpoints",
-            metadata={"components": [c.model_path for c in components],
-                      "weights": (weights if weights else [1.0/len(components)]*len(components))},
-        ))
+        self.register(
+            ModelEntry(
+                name=ensemble_name,
+                wrapper=ens,
+                model_type="synthefy_ensemble",
+                description=description or f"Ensemble of {len(components)} Synthefy checkpoints",
+                metadata={
+                    "components": [c.model_path for c in components],
+                    "weights": (weights if weights else [1.0 / len(components)] * len(components)),
+                },
+            )
+        )
 
     def cleanup_all(self):
         for entry in self._models.values():

--- a/src/synthefy_nori/evaluation/runner.py
+++ b/src/synthefy_nori/evaluation/runner.py
@@ -23,11 +23,13 @@ import numpy as np
 import pandas as pd
 import torch
 from sklearn.metrics import r2_score, mean_absolute_error
+
 try:
     from sklearn.metrics import root_mean_squared_error as rmse_score
 except ImportError:
     from sklearn.metrics import mean_squared_error
     import functools
+
     rmse_score = functools.partial(mean_squared_error, squared=False)
 
 from synthefy_nori.evaluation.datasets import DatasetEntry, DatasetRegistry
@@ -38,6 +40,7 @@ from synthefy_nori.inference.degradation import SvdFallbackWarning, strict_pipel
 # ---------------------------------------------------------------------------
 # Metrics
 # ---------------------------------------------------------------------------
+
 
 def compute_reg_metrics(y_true, y_pred):
     """Compute all regression metrics."""
@@ -58,9 +61,11 @@ def compute_reg_metrics(y_true, y_pred):
 # Result container
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class EvalResult:
     """Result of evaluating one model on one dataset."""
+
     model_name: str
     dataset_name: str
     dataset_source: str
@@ -93,6 +98,7 @@ class EvalResult:
 # ---------------------------------------------------------------------------
 # Eval Runner
 # ---------------------------------------------------------------------------
+
 
 class EvalRunner:
     """Runs evaluation across all models and datasets."""
@@ -142,18 +148,15 @@ class EvalRunner:
     # Cache helpers
     # ------------------------------------------------------------------
 
-    def _cache_key(self, model_name: str, dataset_name: str, source: str,
-                   task_type: str) -> str:
+    def _cache_key(self, model_name: str, dataset_name: str, source: str, task_type: str) -> str:
         """Deterministic cache key from evaluation parameters."""
-        raw = (f"{model_name}|{dataset_name}|{source}|{task_type}"
-               f"|max={self.max_samples}|memcap={self.gpu_mem_gb}")
+        raw = f"{model_name}|{dataset_name}|{source}|{task_type}|max={self.max_samples}|memcap={self.gpu_mem_gb}"
         return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
     def _cache_path(self, key: str) -> Path:
         return self._cache_dir / f"{key}.json"
 
-    def _cache_get(self, model_name: str, dataset_name: str, source: str,
-                   task_type: str) -> Optional[EvalResult]:
+    def _cache_get(self, model_name: str, dataset_name: str, source: str, task_type: str) -> Optional[EvalResult]:
         """Return cached EvalResult or None."""
         if self.no_cache or model_name in self.no_cache_models:
             return None
@@ -188,8 +191,7 @@ class EvalRunner:
             return
         if result.error is not None:
             return
-        key = self._cache_key(result.model_name, result.dataset_name,
-                              result.dataset_source, result.task_type)
+        key = self._cache_key(result.model_name, result.dataset_name, result.dataset_source, result.task_type)
         data = result.to_dict()
         self._cache_path(key).write_text(json.dumps(data, default=str))
 
@@ -205,8 +207,9 @@ class EvalRunner:
             n += 1
         return n
 
-    def _run_one_model(self, model_name: str, model_entry: ModelEntry,
-                       all_datasets: List[DatasetEntry], start_idx: int, total: int):
+    def _run_one_model(
+        self, model_name: str, model_entry: ModelEntry, all_datasets: List[DatasetEntry], start_idx: int, total: int
+    ):
         """Run one model across all datasets; returns results + cache stats."""
         local_results = []
         local_hits = 0
@@ -225,10 +228,9 @@ class EvalRunner:
                 local_hits += 1
                 if self.verbose:
                     metric_str = "  ".join(
-                        f"{k}={v:.4f}" for k, v in cached.metrics.items()
-                        if isinstance(v, float) and np.isfinite(v))
-                    print(f"{prefix} {ds.source}/{ds.name} ({ds.task_type}): "
-                          f"{metric_str}  [CACHED]")
+                        f"{k}={v:.4f}" for k, v in cached.metrics.items() if isinstance(v, float) and np.isfinite(v)
+                    )
+                    print(f"{prefix} {ds.source}/{ds.name} ({ds.task_type}): {metric_str}  [CACHED]")
                 continue
 
             local_misses += 1
@@ -237,10 +239,10 @@ class EvalRunner:
             self._cache_put(result)
 
             if self.verbose and result.error is None:
-                metric_str = "  ".join(f"{k}={v:.4f}" for k, v in result.metrics.items()
-                                       if isinstance(v, float) and np.isfinite(v))
-                print(f"{prefix} {ds.source}/{ds.name} ({ds.task_type}): "
-                      f"{metric_str}  [{result.latency_ms:.0f}ms]")
+                metric_str = "  ".join(
+                    f"{k}={v:.4f}" for k, v in result.metrics.items() if isinstance(v, float) and np.isfinite(v)
+                )
+                print(f"{prefix} {ds.source}/{ds.name} ({ds.task_type}): {metric_str}  [{result.latency_ms:.0f}ms]")
             elif result.error:
                 print(f"{prefix} {ds.source}/{ds.name}: ERROR - {result.error[:120]}")
 
@@ -268,14 +270,15 @@ class EvalRunner:
         all_datasets = list(self.datasets.datasets.values())
 
         if dataset_names:
-            all_datasets = [d for d in all_datasets if d.name in dataset_names
-                           or f"{d.source}/{d.name}" in dataset_names]
+            all_datasets = [
+                d for d in all_datasets if d.name in dataset_names or f"{d.source}/{d.name}" in dataset_names
+            ]
         if sources:
             all_datasets = [d for d in all_datasets if d.source in sources]
 
         total = len(models) * len(all_datasets)
         cache_status = "OFF" if self.no_cache else f"ON ({self._cache_dir})"
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"  Nori Evaluation")
         print(f"  Models: {len(models)}  |  Datasets: {len(all_datasets)}  |  Total runs: {total}")
         print(f"  Cache: {cache_status}")
@@ -284,7 +287,7 @@ class EvalRunner:
             print("  Single-GPU parallel override: ON")
         if self.no_cache_models:
             print(f"  Cache bypass: {', '.join(sorted(self.no_cache_models))}")
-        print(f"{'='*70}\n")
+        print(f"{'=' * 70}\n")
 
         model_entries = []
         for i, model_name in enumerate(models):
@@ -386,7 +389,7 @@ class EvalRunner:
         weights, optimizer state, and fragmentation.
         """
         n_groups = max((n_features + features_per_group - 1) // features_per_group, 1)
-        mem_bytes = gpu_mem_gb * (1024 ** 3) * 0.45
+        mem_bytes = gpu_mem_gb * (1024**3) * 0.45
 
         # Empirical calibration from OOM failures on 80GB H100:
         #   Fashion-MNIST (784 feat, 10K samp) -> 16.8 GiB alloc => ~4600 bytes/sample/group
@@ -403,7 +406,7 @@ class EvalRunner:
         b = per_sample_bytes
         c = -mem_bytes
         discriminant = b * b - 4 * a * c
-        max_total = int((-b + discriminant ** 0.5) / (2 * a))
+        max_total = int((-b + discriminant**0.5) / (2 * a))
 
         max_train = max(max_total - n_test, 200)
         return max_train
@@ -414,8 +417,7 @@ class EvalRunner:
         if self.gpu_mem_gb:
             # Memory-capped mode for smaller GPUs: bound train rows with the
             # memory model so high-dim / large-N datasets do not OOM.
-            mem_max = self._compute_max_train(
-                ds.n_test, ds.n_features, gpu_mem_gb=self.gpu_mem_gb)
+            mem_max = self._compute_max_train(ds.n_test, ds.n_features, gpu_mem_gb=self.gpu_mem_gb)
             max_train = min(max_train, mem_max)
         X_train, y_train = self._subsample_train(ds.X_train, ds.y_train, max_train)
 
@@ -435,31 +437,29 @@ class EvalRunner:
             # Set CUDA device to match the model's device so that any
             # implicit cuda ops (torch.zeros, autocast, etc.) land on
             # the correct GPU instead of defaulting to cuda:0.
-            model_device = getattr(wrapper, 'device', None) or getattr(wrapper, '_device', None)
+            model_device = getattr(wrapper, "device", None) or getattr(wrapper, "_device", None)
             if model_device is not None:
                 dev = torch.device(model_device) if isinstance(model_device, str) else model_device
-                if dev.type == 'cuda':
+                if dev.type == "cuda":
                     torch.cuda.set_device(dev)
 
             # Warmup (for GPU timing stability)
             for _ in range(self.warmup_runs):
                 with strict_pipeline(SvdFallbackWarning):
                     wrapper.predict_regression(
-                        X_train[:min(100, len(X_train))],
-                        y_train[:min(100, len(y_train))],
-                        ds.X_test[:min(10, ds.n_test)],
+                        X_train[: min(100, len(X_train))],
+                        y_train[: min(100, len(y_train))],
+                        ds.X_test[: min(10, ds.n_test)],
                     )
 
             # Timed run — synchronize on the model's device, not the default device
-            model_device = getattr(wrapper, 'device', None) or getattr(wrapper, '_device', None)
+            model_device = getattr(wrapper, "device", None) or getattr(wrapper, "_device", None)
             if torch.cuda.is_available() and model_device is not None:
                 torch.cuda.synchronize(model_device)
             t_start = time.perf_counter()
 
             with strict_pipeline(SvdFallbackWarning):
-                y_pred = wrapper.predict_regression(
-                    X_train, y_train, ds.X_test
-                )
+                y_pred = wrapper.predict_regression(X_train, y_train, ds.X_test)
             if torch.cuda.is_available() and model_device is not None:
                 torch.cuda.synchronize(model_device)
             t_end = time.perf_counter()

--- a/src/synthefy_nori/hf.py
+++ b/src/synthefy_nori/hf.py
@@ -24,8 +24,8 @@ DEFAULT_CHECKPOINT_FILENAME = os.environ.get(
 # variant. An unknown name is treated as a raw repo id, so an explicit ``"org/repo"`` still works.
 NORI_MODELS = {
     "nori-6m": DEFAULT_MODEL_REPO_ID,  # ~6M base (honors SYNTHEFY_NORI_HF_REPO)
-    "nori-30m": "Synthefy/Nori-30M",   # ~29.2M scaling-law variant
-    "nori-100m": "Synthefy/Nori-100M", # ~98.3M scaling-law variant
+    "nori-30m": "Synthefy/Nori-30M",  # ~29.2M scaling-law variant
+    "nori-100m": "Synthefy/Nori-100M",  # ~98.3M scaling-law variant
 }
 
 

--- a/src/synthefy_nori/inference/degradation.py
+++ b/src/synthefy_nori/inference/degradation.py
@@ -84,6 +84,6 @@ def strict_pipeline(*categories: type[Warning]):
     next one.
     """
     with warnings.catch_warnings():
-        for category in (categories or (DegradedPipelineWarning,)):
+        for category in categories or (DegradedPipelineWarning,):
             warnings.simplefilter("error", category)
         yield

--- a/src/synthefy_nori/inference/inference_method.py
+++ b/src/synthefy_nori/inference/inference_method.py
@@ -55,11 +55,7 @@ class DistributedInference:
         mix_precision: bool = True,
     ):
         self.model = load_model(model) if isinstance(model, str) else model
-        self.requested_device = (
-            torch.device(f"cuda:{device}")
-            if isinstance(device, int)
-            else torch.device(device)
-        )
+        self.requested_device = torch.device(f"cuda:{device}") if isinstance(device, int) else torch.device(device)
         if self.requested_device.type != "cuda":
             raise ValueError("distributed inference requires a CUDA device")
         self.mix_precision = bool(mix_precision)
@@ -125,8 +121,7 @@ class DistributedInference:
             y_train = y_train[:, 0]
         if y_train.ndim != 1 or y_train.shape[0] != x_train.shape[0]:
             raise ValueError(
-                "distributed inference labels must have shape [rows] or [rows, 1] "
-                "and match the context rows"
+                "distributed inference labels must have shape [rows] or [rows, 1] and match the context rows"
             )
         if x_train.shape[1] != x_test.shape[1]:
             raise ValueError("distributed inference train/test feature counts must match")
@@ -179,10 +174,13 @@ class DistributedInference:
                 x_context_batch = x_context.unsqueeze(0).expand(batch, -1, -1)
                 y_context_batch = y_context.unsqueeze(0).expand(batch, -1)
                 x_all = torch.cat((x_context_batch, x_query.unsqueeze(1)), dim=1)
-                with torch.autocast(
-                    self.device.type,
-                    enabled=self.mix_precision,
-                ), torch.inference_mode():
+                with (
+                    torch.autocast(
+                        self.device.type,
+                        enabled=self.mix_precision,
+                    ),
+                    torch.inference_mode(),
+                ):
                     output = model(
                         x=x_all,
                         y=y_context_batch,
@@ -198,11 +196,7 @@ class DistributedInference:
                 torch.cuda.empty_cache()
 
             local_outputs = torch.cat(outputs, dim=0) if outputs else None
-            local_indices = (
-                torch.cat(indices, dim=0)
-                if indices
-                else torch.empty(0, dtype=torch.long)
-            )
+            local_indices = torch.cat(indices, dim=0) if indices else torch.empty(0, dtype=torch.long)
             gathered_outputs = [None for _ in range(self.world_size)]
             gathered_indices = [None for _ in range(self.world_size)]
             dist.all_gather_object(gathered_outputs, local_outputs)

--- a/src/synthefy_nori/inference/large_context.py
+++ b/src/synthefy_nori/inference/large_context.py
@@ -41,6 +41,7 @@ from synthefy_nori.inference.policies import (
     resolve_policy,
 )
 
+
 class LargeContextUnsupportedOutputError(NotImplementedError):
     """A large-context policy cannot produce the output the caller asked for.
 
@@ -189,7 +190,8 @@ def run_policy(
         # Reachable as predict(X) on an empty frame. Without this, cluster_route dies
         # inside MiniBatchKMeans on an empty query set with nothing naming the cause.
         return np.zeros(0, dtype=np.float64), _report(
-            name, problem, problem.window, full_context=False, reused_train_state=False)
+            name, problem, problem.window, full_context=False, reused_train_state=False
+        )
     window = problem.window
     if problem.n_train <= window:
         # Nothing to select: the whole table already fits one call. Every policy would
@@ -204,8 +206,7 @@ def run_policy(
             stacklevel=2,
         )
         preds = problem.predict_arrays(problem.X_train, problem.y_train, problem.X_test)
-        return preds, _report(name, problem, window, full_context=True,
-                              reused_train_state=False)
+        return preds, _report(name, problem, window, full_context=True, reused_train_state=False)
 
     # Whether THIS call actually read train-derived state, not merely whether some is
     # on hand. "Is the cache non-empty?" answers the wrong question in both directions:
@@ -228,8 +229,7 @@ def run_policy(
     return preds, report
 
 
-def _report(name: str, problem: Problem, window: int, *, full_context: bool,
-            reused_train_state: bool) -> dict:
+def _report(name: str, problem: Problem, window: int, *, full_context: bool, reused_train_state: bool) -> dict:
     return {
         "policy": name,
         "window": window,
@@ -253,9 +253,10 @@ def predictor_call_fn(predictor) -> Callable[..., np.ndarray]:
     Kept as a closure over the predictor alone (not the surrounding predict call) so a
     long-lived :class:`Problem` holding this does not pin a query block alive.
     """
+
     def one_call(X_context, y_context, X_query) -> np.ndarray:
         out = predictor.predict(X_context, y_context, X_query)
-        if hasattr(out, "detach"):       # a torch tensor: np.asarray() would raise on CUDA
+        if hasattr(out, "detach"):  # a torch tensor: np.asarray() would raise on CUDA
             out = out.detach().cpu().numpy()
         return np.asarray(out, dtype=np.float64).reshape(-1)
 

--- a/src/synthefy_nori/inference/memory_policy.py
+++ b/src/synthefy_nori/inference/memory_policy.py
@@ -67,6 +67,7 @@ the predictor. Resolution is pure arithmetic — no torch allocations, no device
 — so every rung boundary is unit-testable on CPU rather than only exercised by
 whoever happens to run a 500k-row table on a big card.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -88,14 +89,19 @@ CacheDtype = Literal["bf16", "int8"]
 CACHE_DTYPE_CHOICES: tuple[str, ...] = ("bf16", "int8")
 
 RUNGS: tuple[str, ...] = (
-    "no_cache", "resident_bf16", "resident_int8", "offload_bf16", "offload_int8",
-    "context_row_chunk", "plain_loop",
+    "no_cache",
+    "resident_bf16",
+    "resident_int8",
+    "offload_bf16",
+    "offload_int8",
+    "context_row_chunk",
+    "plain_loop",
 )
 
 # --- unit + shape constants (no bare numbers in the arithmetic below) ---------
 
 #: Bytes per GiB, for every GB figure in this module.
-BYTES_PER_GIB = 1024 ** 3
+BYTES_PER_GIB = 1024**3
 
 #: The cache stores one key AND one value vector per (layer, group, row).
 KV_TENSORS_PER_ROW = 2
@@ -126,14 +132,19 @@ FIT_ROW_CHUNK_ON_OOM = 2048
 #: dropped — the failure mode where a caller spells everything correctly and still
 #: gets none of what they asked for.
 CACHE_ONLY_FIELDS: tuple[str, ...] = (
-    "cache_dtype", "allow_quantization", "offload_to_host", "context_row_chunk",
+    "cache_dtype",
+    "allow_quantization",
+    "offload_to_host",
+    "context_row_chunk",
     # adaptive_query_chunk is passed only to forward_cached_regression, so it is
     # inert on the plain loop as well -- it belongs here for the same reason.
     "adaptive_query_chunk",
     # The budgets bound where the CACHE is placed. With no cache to place, tuning
     # them does nothing, which is the same silent no-op as the levers above.
-    "gpu_budget_frac", "gpu_budget_absolute_gb",
-    "host_budget_frac", "host_budget_absolute_gb",
+    "gpu_budget_frac",
+    "gpu_budget_absolute_gb",
+    "host_budget_frac",
+    "host_budget_absolute_gb",
 )
 
 #: Stand-in when the device cannot be introspected (CPU inference, or a device string
@@ -336,8 +347,8 @@ def int8_footprint_gb(est_cache_gb: float, *, bytes_per_element: int, head_dim: 
 #: cgroup v2 then v1. A container's memory ceiling lives here and NOWHERE that
 #: ``sysconf`` can see.
 _CGROUP_LIMIT_PATHS = (
-    "/sys/fs/cgroup/memory.max",                     # v2
-    "/sys/fs/cgroup/memory/memory.limit_in_bytes",   # v1
+    "/sys/fs/cgroup/memory.max",  # v2
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # v1
 )
 
 #: v1 spells "unlimited" as a huge sentinel rather than a word. Anything at or above
@@ -374,7 +385,7 @@ def _cgroup_memory_limit_gb() -> float:
                 raw = limit_file.read().strip()
         except (OSError, ValueError):
             continue
-        if raw == "max":            # v2's "no limit"
+        if raw == "max":  # v2's "no limit"
             continue
         try:
             value = int(raw)
@@ -424,133 +435,146 @@ class MemoryPolicy(BaseModel):
     cache: bool = Field(
         True,
         description="Build a key/value cache over the context rows at all. False re-reads "
-                    "the whole context for every batch of query rows instead: correct, but "
-                    "several times slower on a large query set, and it may have to drop "
-                    "context rows to fit.",
+        "the whole context for every batch of query rows instead: correct, but "
+        "several times slower on a large query set, and it may have to drop "
+        "context rows to fit.",
     )
     reuse_context_cache: bool = Field(
         True,
         description="Retain and reuse the encoded context across separate predict() calls "
-                    "on this estimator when the context and cache parameters are exactly "
-                    "unchanged. False still uses the K/V cache within each prediction, but "
-                    "does not retain context-derived state afterwards. Shared serving "
-                    "processes force this off; local fit-once/predict-many use keeps it on.",
+        "on this estimator when the context and cache parameters are exactly "
+        "unchanged. False still uses the K/V cache within each prediction, but "
+        "does not retain context-derived state afterwards. Shared serving "
+        "processes force this off; local fit-once/predict-many use keeps it on.",
     )
     cache_dtype: CacheDtype = Field(
         "bf16",
         description="Precision the K/V cache STARTS at. bf16 is bit-exact and is the "
-                    "default; set 'int8' to quantize from the outset (~1.9x smaller, "
-                    "|dR2| ~ 6e-6) when you would rather trade that for context. "
-                    "Whether bf16 may be downgraded under memory pressure is a "
-                    "separate question — see allow_quantization.",
+        "default; set 'int8' to quantize from the outset (~1.9x smaller, "
+        "|dR2| ~ 6e-6) when you would rather trade that for context. "
+        "Whether bf16 may be downgraded under memory pressure is a "
+        "separate question — see allow_quantization.",
     )
     allow_quantization: bool = Field(
         True,
         description="May the cache be quantized to int8 when full precision would "
-                    "NOT stay resident? This is the only way int8 gets used by "
-                    "default, and it is strictly better than offloading (which costs "
-                    "40-175% latency). False keeps every rung bit-exact — the "
-                    "'exact' preset — at the cost of offloading sooner.",
+        "NOT stay resident? This is the only way int8 gets used by "
+        "default, and it is strictly better than offloading (which costs "
+        "40-175% latency). False keeps every rung bit-exact — the "
+        "'exact' preset — at the cost of offloading sooner.",
     )
     gpu_budget_frac: float = Field(
-        DEFAULT_GPU_BUDGET_FRAC, gt=0, le=1,
+        DEFAULT_GPU_BUDGET_FRAC,
+        gt=0,
+        le=1,
         description="Share of TOTAL VRAM the resident cache may occupy before we "
-                    "offload. A fraction so one setting is portable across GPUs. "
-                    "Total rather than free VRAM: free is racy, and budgeting against "
-                    "it would make the same call take different rungs on different "
-                    "runs.",
+        "offload. A fraction so one setting is portable across GPUs. "
+        "Total rather than free VRAM: free is racy, and budgeting against "
+        "it would make the same call take different rungs on different "
+        "runs.",
     )
     gpu_budget_absolute_gb: float | None = Field(
-        None, ge=0,
+        None,
+        ge=0,
         description="Hard VRAM ceiling in GiB, overriding gpu_budget_frac. For a "
-                    "co-tenanted GPU, where a fixed cap is the requirement and a "
-                    "share of the card is the wrong unit. None = use the fraction; "
-                    "0 = never keep the cache in GPU memory. 0 is deliberately "
-                    "legal, not a typo guard: it is a real request, and it is also "
-                    "the value the resolved budget can take.",
+        "co-tenanted GPU, where a fixed cap is the requirement and a "
+        "share of the card is the wrong unit. None = use the fraction; "
+        "0 = never keep the cache in GPU memory. 0 is deliberately "
+        "legal, not a typo guard: it is a real request, and it is also "
+        "the value the resolved budget can take.",
     )
     offload_to_host: bool = Field(
         True,
         description="May the cache be moved to host RAM (streamed back per layer) "
-                    "when it cannot stay resident? Bit-exact transport, but 40-175% "
-                    "slower. False reproduces the legacy behaviour of skipping the "
-                    "cache entirely instead, which is slower still.",
+        "when it cannot stay resident? Bit-exact transport, but 40-175% "
+        "slower. False reproduces the legacy behaviour of skipping the "
+        "cache entirely instead, which is slower still.",
     )
     host_budget_frac: float = Field(
-        DEFAULT_HOST_BUDGET_FRAC, gt=0, le=1,
+        DEFAULT_HOST_BUDGET_FRAC,
+        gt=0,
+        le=1,
         description="Share of total physical RAM the offloaded cache may occupy. A "
-                    "fraction because a flat GB default is a latent bug: 128 GB "
-                    "'fits' on a 32 GB laptop by arithmetic, so offload proceeds and "
-                    "the kernel OOM-kills the process instead of the policy falling "
-                    "to the plain loop.",
+        "fraction because a flat GB default is a latent bug: 128 GB "
+        "'fits' on a 32 GB laptop by arithmetic, so offload proceeds and "
+        "the kernel OOM-kills the process instead of the policy falling "
+        "to the plain loop.",
     )
     host_budget_absolute_gb: float | None = Field(
-        None, ge=0,
+        None,
+        ge=0,
         description="Hard host-RAM ceiling in GiB, overriding host_budget_frac. "
-                    "None = use the fraction; 0 = never offload. 0 is deliberately "
-                    "legal: it is also what a platform that will not report its RAM "
-                    "resolves to, and that case has to degrade to 'no offload' rather "
-                    "than fail.",
+        "None = use the fraction; 0 = never offload. 0 is deliberately "
+        "legal: it is also what a platform that will not report its RAM "
+        "resolves to, and that case has to degrade to 'no offload' rather "
+        "than fail.",
     )
     context_row_chunk: int | None = Field(
         None,
         gt=0,
         description="Bound the fit-time build working set to this many context rows "
-                    f"(bit-exact). None = off, with {FIT_ROW_CHUNK_ON_OOM} engaged "
-                    "automatically after an OOM. Pinning a value uses it from the "
-                    "first attempt — which also costs you that escalation, since "
-                    "there is then nothing left to escalate to.",
+        f"(bit-exact). None = off, with {FIT_ROW_CHUNK_ON_OOM} engaged "
+        "automatically after an OOM. Pinning a value uses it from the "
+        "first attempt — which also costs you that escalation, since "
+        "there is then nothing left to escalate to.",
     )
     adaptive_query_chunk: bool = Field(
         True,
         description="On a decode OOM, halve the QUERY chunk and retry instead of "
-                    "raising. Distinct from context_row_chunk, which caps CONTEXT rows "
-                    "during prefill.",
+        "raising. Distinct from context_row_chunk, which caps CONTEXT rows "
+        "during prefill.",
     )
     elements_budget: int | None = Field(
         None,
         gt=0,
         description="Per-forward element cap driving query chunk size and context "
-                    "subsampling. None = derive it from available VRAM. Upstream of "
-                    "everything else here: the cached path engages only when the "
-                    "query set exceeds the chunk size this implies, so raising it far "
-                    "enough disables the cache knobs by making inference stop "
-                    "chunking at all.",
+        "subsampling. None = derive it from available VRAM. Upstream of "
+        "everything else here: the cached path engages only when the "
+        "query set exceeds the chunk size this implies, so raising it far "
+        "enough disables the cache knobs by making inference stop "
+        "chunking at all.",
     )
     allow_subsample: bool = Field(
         True,
         description="Permit dropping context rows when the request will not fit "
-                    "otherwise. False makes that an error instead of a silent "
-                    "accuracy loss.",
+        "otherwise. False makes that an error instead of a silent "
+        "accuracy loss.",
     )
 
     # --- populated by resolve(); None on an unresolved policy ----------------
     rung: str | None = Field(
         None,
         description="Which fallback the server used, in decreasing memory cost: "
-                    "resident_bf16 (cache in GPU memory, exact), resident_int8 (quantized), "
-                    "offload_bf16 / offload_int8 (cache in host RAM, streamed back per layer, "
-                    "exact transport), context_row_chunk (cache built in row chunks), "
-                    "plain_loop (no cache; the context re-read per query batch), no_cache "
-                    "(the cached path did not apply). Decided per request, not requestable.")
+        "resident_bf16 (cache in GPU memory, exact), resident_int8 (quantized), "
+        "offload_bf16 / offload_int8 (cache in host RAM, streamed back per layer, "
+        "exact transport), context_row_chunk (cache built in row chunks), "
+        "plain_loop (no cache; the context re-read per query batch), no_cache "
+        "(the cached path did not apply). Decided per request, not requestable.",
+    )
     est_cache_gb: float | None = Field(
-        None, ge=0,
-        description="Full-precision cache footprint for this request's context, in GiB. Reported, not set.")
+        None, ge=0, description="Full-precision cache footprint for this request's context, in GiB. Reported, not set."
+    )
     resident_gb: float | None = Field(
-        None, ge=0,
+        None,
+        ge=0,
         description="Footprint at the chosen precision (GiB) — the figure actually "
-                    "compared against the budget. Reported, not set.")
+        "compared against the budget. Reported, not set.",
+    )
     query_chunk: int | None = Field(
-        None, gt=0,
+        None,
+        gt=0,
         description="Query rows per decode forward, as the cached path was entered "
-                    "with. Reported, not set. NOTE: a decode OOM may halve this "
-                    "further inside the model, and that further reduction is not "
-                    "currently reported here.")
+        "with. Reported, not set. NOTE: a decode OOM may halve this "
+        "further inside the model, and that further reduction is not "
+        "currently reported here.",
+    )
     dropped_context_rows: int = Field(
-        0, ge=0,
+        0,
+        ge=0,
         description="Context rows the caller had to subsample away to fit. Non-zero "
-                    "only on the plain_loop rung; recorded so a shrunk context is "
-                    "visible in memory_report_ rather than inferred from the score.")
+        "only on the plain_loop rung; recorded so a shrunk context is "
+        "visible in memory_report_ rather than inferred from the score.",
+    )
 
     @model_validator(mode="after")
     def _check_rung(self) -> "MemoryPolicy":
@@ -583,8 +607,7 @@ class MemoryPolicy(BaseModel):
         """
         if self.rung is not None or self.cache:
             return self
-        if ("reuse_context_cache" in self.model_fields_set
-                and self.reuse_context_cache):
+        if "reuse_context_cache" in self.model_fields_set and self.reuse_context_cache:
             raise ValueError(
                 "cache=False cannot be combined with reuse_context_cache=True: "
                 "there is no K/V cache to retain across calls. Set "
@@ -626,8 +649,10 @@ class MemoryPolicy(BaseModel):
         if self.rung is not None:
             return self
         given = self.model_fields_set
-        for frac, absolute in (("gpu_budget_frac", "gpu_budget_absolute_gb"),
-                               ("host_budget_frac", "host_budget_absolute_gb")):
+        for frac, absolute in (
+            ("gpu_budget_frac", "gpu_budget_absolute_gb"),
+            ("host_budget_frac", "host_budget_absolute_gb"),
+        ):
             if frac in given and absolute in given:
                 warn_once(
                     f"{frac} is ignored because {absolute} is also set and takes "
@@ -635,8 +660,7 @@ class MemoryPolicy(BaseModel):
                     f"between GPUs, the absolute for a hard cap on a shared one.",
                 )
         if "offload_to_host" in given and not self.offload_to_host:
-            dead = sorted(f for f in ("host_budget_frac", "host_budget_absolute_gb")
-                          if f in given)
+            dead = sorted(f for f in ("host_budget_frac", "host_budget_absolute_gb") if f in given)
             if dead:
                 warn_once(
                     f"{dead} is ignored because offload_to_host=False disables host "
@@ -644,8 +668,7 @@ class MemoryPolicy(BaseModel):
                 )
         # A cache that is configured never to be usable: statically decidable, so say
         # so rather than letting every call quietly take the slowest rung.
-        if (self.cache and not self.offload_to_host
-                and self.gpu_budget_absolute_gb == 0):
+        if self.cache and not self.offload_to_host and self.gpu_budget_absolute_gb == 0:
             warn_once(
                 "cache=True but gpu_budget_absolute_gb=0 with offload_to_host=False "
                 "means the cache can never be placed, so every call will take the "
@@ -657,10 +680,12 @@ class MemoryPolicy(BaseModel):
         # and only succeeds within the host budget, so a host budget at or below the
         # GPU budget makes offload unreachable. The fractional case depends on the
         # box, so resolve() carries the same check for it.
-        if (self.offload_to_host
-                and self.gpu_budget_absolute_gb is not None
-                and self.host_budget_absolute_gb is not None
-                and self.host_budget_absolute_gb <= self.gpu_budget_absolute_gb):
+        if (
+            self.offload_to_host
+            and self.gpu_budget_absolute_gb is not None
+            and self.host_budget_absolute_gb is not None
+            and self.host_budget_absolute_gb <= self.gpu_budget_absolute_gb
+        ):
             warn_once(
                 f"offload_to_host=True cannot engage: host_budget_absolute_gb="
                 f"{self.host_budget_absolute_gb} is not above gpu_budget_absolute_gb="
@@ -668,8 +693,7 @@ class MemoryPolicy(BaseModel):
                 f"is also too big to offload. Raise the host budget above the GPU "
                 f"budget for offload to be reachable.",
             )
-        if ("allow_quantization" in given and not self.allow_quantization
-                and self.cache_dtype == "int8"):
+        if "allow_quantization" in given and not self.allow_quantization and self.cache_dtype == "int8":
             raise ValueError(
                 "allow_quantization=False with cache_dtype='int8' is contradictory: "
                 "the first forbids quantizing, the second asks for a quantized cache "
@@ -736,8 +760,7 @@ class MemoryPolicy(BaseModel):
         if isinstance(value, str):
             if value not in MEMORY_PRESETS:
                 raise ValueError(
-                    f"unknown memory preset {value!r}; expected one of "
-                    f"{MEMORY_PRESETS}, a dict, or a MemoryPolicy"
+                    f"unknown memory preset {value!r}; expected one of {MEMORY_PRESETS}, a dict, or a MemoryPolicy"
                 )
             if value == "exact":
                 # Never trade accuracy: offload (bit-exact) rather than quantize.
@@ -745,11 +768,8 @@ class MemoryPolicy(BaseModel):
             if value == "max_context":
                 # Fit the largest table possible; start quantized to free VRAM at once.
                 return cls(cache_dtype="int8")
-            return cls(cache=False, reuse_context_cache=False)     # "off"
-        raise TypeError(
-            f"memory must be a preset name, dict, MemoryPolicy or None, "
-            f"got {type(value).__name__}"
-        )
+            return cls(cache=False, reuse_context_cache=False)  # "off"
+        raise TypeError(f"memory must be a preset name, dict, MemoryPolicy or None, got {type(value).__name__}")
 
     @classmethod
     def coerce_for_service(
@@ -817,9 +837,8 @@ class MemoryPolicy(BaseModel):
         clamped: list[str] = []
         ceilings = {
             "host_budget_frac": max_host_budget_frac,
-            "host_budget_absolute_gb": max_host_budget_frac * (
-                total_host_ram_gb() if total_ram_gb is None else total_ram_gb
-            ),
+            "host_budget_absolute_gb": max_host_budget_frac
+            * (total_host_ram_gb() if total_ram_gb is None else total_ram_gb),
         }
         if isinstance(value, dict):
             value = dict(value)  # never mutate the caller's parsed request body
@@ -831,7 +850,7 @@ class MemoryPolicy(BaseModel):
                 # has already skipped them -- and `clamped` then came back empty, which the
                 # response documents as "honoured verbatim". A quote mark defeated the rail.
                 if numeric is None:
-                    continue                    # not numeric at all -> pydantic's error
+                    continue  # not numeric at all -> pydantic's error
                 if numeric > ceilings[field]:
                     value[field] = ceilings[field]
                     clamped.append(field)
@@ -926,17 +945,21 @@ class MemoryPolicy(BaseModel):
         gpu_budget_gb = self.gpu_budget(vram)
         host_budget_gb = self.host_budget(ram)
         bf16_gb = est_cache_gb
-        int8_gb = int8_footprint_gb(
-            est_cache_gb, bytes_per_element=bytes_per_element, head_dim=head_dim)
+        int8_gb = int8_footprint_gb(est_cache_gb, bytes_per_element=bytes_per_element, head_dim=head_dim)
 
-        def decided(rung: str, dtype: str, offload: bool, resident: float,
-                    cache: bool, budgets: bool = True) -> "MemoryPolicy":
+        def decided(
+            rung: str, dtype: str, offload: bool, resident: float, cache: bool, budgets: bool = True
+        ) -> "MemoryPolicy":
             return self._revalidated_copy(
-                cache=cache, cache_dtype=dtype, offload_to_host=offload,
+                cache=cache,
+                cache_dtype=dtype,
+                offload_to_host=offload,
                 reuse_context_cache=bool(cache and self.reuse_context_cache),
                 gpu_budget_absolute_gb=gpu_budget_gb if budgets else None,
                 host_budget_absolute_gb=host_budget_gb if budgets else None,
-                rung=rung, est_cache_gb=est_cache_gb, resident_gb=resident,
+                rung=rung,
+                est_cache_gb=est_cache_gb,
+                resident_gb=resident,
             )
 
         if not self.cache or not cache_eligible:
@@ -944,8 +967,7 @@ class MemoryPolicy(BaseModel):
             # consulted. Report the budgets as None rather than a number computed
             # from a VRAM figure nobody looked at -- a diagnostic that states
             # "budget 9.6 GiB" on an 80 GB card is worse than one that says nothing.
-            return decided("no_cache", self.cache_dtype, False, 0.0, cache=False,
-                           budgets=False)
+            return decided("no_cache", self.cache_dtype, False, 0.0, cache=False, budgets=False)
 
         # Precisions this request may use, cheapest-accuracy-cost first. Starting at
         # int8 means bf16 is not a candidate at all — the caller asked for the smaller
@@ -981,11 +1003,9 @@ class MemoryPolicy(BaseModel):
         # rule 6a compared them at construction time and warned there; saying it again
         # here makes one root cause produce two warnings.
         already_warned_at_construction = (
-            self.gpu_budget_absolute_gb is not None
-            and self.host_budget_absolute_gb is not None
+            self.gpu_budget_absolute_gb is not None and self.host_budget_absolute_gb is not None
         )
-        if (self.offload_to_host and host_budget_gb <= gpu_budget_gb
-                and not already_warned_at_construction):
+        if self.offload_to_host and host_budget_gb <= gpu_budget_gb and not already_warned_at_construction:
             warn_once(
                 f"This request needed to spill out of VRAM, but offload_to_host could "
                 f"not help: the host budget ({host_budget_gb:.1f} GiB) is not larger "
@@ -997,9 +1017,14 @@ class MemoryPolicy(BaseModel):
         worst_dtype, worst_footprint = candidates[-1]
         return decided("plain_loop", worst_dtype, False, worst_footprint, cache=False)
 
-    def escalated(self, rung: str, *, context_row_chunk: int | None = None,
-                  dropped_context_rows: int | None = None,
-                  query_chunk: int | None = None) -> "MemoryPolicy":
+    def escalated(
+        self,
+        rung: str,
+        *,
+        context_row_chunk: int | None = None,
+        dropped_context_rows: int | None = None,
+        query_chunk: int | None = None,
+    ) -> "MemoryPolicy":
         """Return a copy recording an escalation the caller made after an OOM.
 
         Args:

--- a/src/synthefy_nori/inference/policies.py
+++ b/src/synthefy_nori/inference/policies.py
@@ -73,6 +73,7 @@ imputes here to match `evaluation.harness._apply_impute`, while the production p
 passes `impute=False` — `NoriPredictor` owns missing-value handling there, and imputing
 first would change what the model sees relative to an ordinary `predict`.
 """
+
 from __future__ import annotations
 
 import importlib
@@ -141,7 +142,7 @@ def r2(y_true, y_pred) -> float:
     y_true = np.asarray(y_true, dtype=np.float64)
     y_pred = np.asarray(y_pred, dtype=np.float64)
     mask = np.isfinite(y_true) & np.isfinite(y_pred)
-    if int(mask.sum()) < 2:      # R^2 needs the variance of >= 2 points
+    if int(mask.sum()) < 2:  # R^2 needs the variance of >= 2 points
         return float("nan")
     return float(r2_score(y_true[mask], y_pred[mask]))
 
@@ -219,7 +220,7 @@ class SharedTrainState(dict):
         return default
 
     def __getitem__(self, key):
-        value = dict.__getitem__(self, key)   # a miss raises before it can be counted
+        value = dict.__getitem__(self, key)  # a miss raises before it can be counted
         self._count(key)
         return value
 
@@ -252,9 +253,7 @@ def _nearest_centroid(points: np.ndarray, centroids: np.ndarray, chunk: int = 20
     out = np.empty(len(points), dtype=int)
     for s in range(0, len(points), chunk):
         block = points[s : s + chunk]
-        out[s : s + chunk] = np.argmin(
-            ((block[:, None, :] - centroids[None]) ** 2).sum(-1), axis=1
-        )
+        out[s : s + chunk] = np.argmin(((block[:, None, :] - centroids[None]) ** 2).sum(-1), axis=1)
     return out
 
 
@@ -293,9 +292,7 @@ class Problem:
         self.embedder, self.query_chunk = embedder, query_chunk
         self.impute = impute
         if max_nori_calls is not None and (
-            isinstance(max_nori_calls, bool)
-            or not isinstance(max_nori_calls, int)
-            or max_nori_calls < 1
+            isinstance(max_nori_calls, bool) or not isinstance(max_nori_calls, int) or max_nori_calls < 1
         ):
             raise ValueError("max_nori_calls must be a positive integer or None")
         self.max_nori_calls = max_nori_calls
@@ -381,13 +378,9 @@ class Problem:
         lineage = []
         problem = self
         while problem is not None:
-            if (
-                problem.max_nori_calls is not None
-                and problem.nori_calls >= problem.max_nori_calls
-            ):
+            if problem.max_nori_calls is not None and problem.nori_calls >= problem.max_nori_calls:
                 raise LargeContextCallLimitError(
-                    f"large-context policy exceeded the "
-                    f"{problem.max_nori_calls}-call limit"
+                    f"large-context policy exceeded the {problem.max_nori_calls}-call limit"
                 )
             lineage.append(problem)
             problem = problem._parent
@@ -405,9 +398,7 @@ class Problem:
         X_query = np.asarray(X_query)
         self._count_call()
         if len(X_query) <= self.query_chunk:
-            return np.asarray(
-                self.predict_fn(X_context, y_context, X_query), dtype=np.float64
-            ).reshape(-1)
+            return np.asarray(self.predict_fn(X_context, y_context, X_query), dtype=np.float64).reshape(-1)
         out = np.empty(len(X_query), dtype=np.float64)
         for s in range(0, len(X_query), self.query_chunk):
             out[s : s + self.query_chunk] = np.asarray(
@@ -482,8 +473,7 @@ class Problem:
         """
         view = self.train_state.get("select_view")
         if view is None:
-            view = self.train_state["select_view"] = apply_medians(
-                self.train_medians, self.X_train)
+            view = self.train_state["select_view"] = apply_medians(self.train_medians, self.X_train)
         return view
 
     def routing_space(self) -> tuple[np.ndarray, np.ndarray]:
@@ -498,13 +488,15 @@ class Problem:
             # select_view is the same array in the feature path, so share whichever
             # exists rather than allocating a second copy of the imputed train block.
             train = self.train_state["routing_train"] = (
-                self.embed("train") if self.embedder is not None else self.select_view)
+                self.embed("train") if self.embedder is not None else self.select_view
+            )
         if self._routing_test is None:
             # The cached train medians, applied to the query block only -- NOT
             # median_impute(X_train, X_test)[1], which re-derives them and builds a full
             # imputed copy of the train block for the caller to throw away.
-            self._routing_test = (self.embed("test") if self.embedder is not None
-                                  else apply_medians(self.train_medians, self.X_test))
+            self._routing_test = (
+                self.embed("test") if self.embedder is not None else apply_medians(self.train_medians, self.X_test)
+            )
         return train, self._routing_test
 
     def adopt_train_state(self, other: "Problem") -> None:
@@ -523,9 +515,9 @@ class Problem:
             )
         self.train_state = other.train_state
 
-    def with_queries(self, X_test: np.ndarray,
-                     run_seed: Optional[int] = None,
-                     cache_scope: Optional[tuple] = None) -> "Problem":
+    def with_queries(
+        self, X_test: np.ndarray, run_seed: Optional[int] = None, cache_scope: Optional[tuple] = None
+    ) -> "Problem":
         """This same fitted table, pointed at a new query block.
 
         Everything derived from `(X_train, y_train)` alone carries over — the imputed
@@ -553,10 +545,15 @@ class Problem:
         """
         fresh = Problem(
             self.predict_fn,
-            self.X_train, self.y_train,
-            np.asarray(X_test), None,
-            window=self.window, seed=self.seed, embedder=self.embedder,
-            query_chunk=self.query_chunk, impute=self.impute,
+            self.X_train,
+            self.y_train,
+            np.asarray(X_test),
+            None,
+            window=self.window,
+            seed=self.seed,
+            embedder=self.embedder,
+            query_chunk=self.query_chunk,
+            impute=self.impute,
             max_nori_calls=self.max_nori_calls,
         )
         # BY REFERENCE, both of them: the view is throwaway, so anything it derives
@@ -575,8 +572,7 @@ class Problem:
         only, never as regression input (embed-recycle postmortem)."""
         if self.embedder is None:
             raise ValueError("no embedder was supplied to this Problem")
-        cached = (self.train_state.get("embed_train") if which == "train"
-                  else self._embed_test)
+        cached = self.train_state.get("embed_train") if which == "train" else self._embed_test
         if cached is not None:
             return cached
         fit = getattr(self.embedder, "fit_context", None)
@@ -742,11 +738,9 @@ def _boost_stage(problem: Problem, shard, labels, later):
     forward so the next stage can grade it out-of-fold. Both are imputed from the SAME
     context statistics, which is why it is one call and one impute rather than two.
     """
-    X_ctx, X_test, X_later = problem.impute_from_context(
-        problem.X_train[shard], problem.X_test, problem.X_train[later]
-    )
+    X_ctx, X_test, X_later = problem.impute_from_context(problem.X_train[shard], problem.X_test, problem.X_train[later])
     h = problem.predict_arrays(X_ctx, labels, np.vstack([X_test, X_later]))
-    return h[: problem.n_test], h[problem.n_test:]
+    return h[: problem.n_test], h[problem.n_test :]
 
 
 def replay_chain(problem: Problem, stages) -> np.ndarray:
@@ -771,8 +765,7 @@ def replay_chain(problem: Problem, stages) -> np.ndarray:
 
 
 @register_policy("safeboost")
-def safeboost(problem: Problem, rng: np.random.Generator, nu: float = 0.5,
-              shards: Optional[int] = None) -> np.ndarray:
+def safeboost(problem: Problem, rng: np.random.Generator, nu: float = 0.5, shards: Optional[int] = None) -> np.ndarray:
     """Residual boosting with an out-of-fold guard on every correction.
 
     Shard the table, predict from shard 1 at full weight, then let each later shard
@@ -811,7 +804,7 @@ def safeboost(problem: Problem, rng: np.random.Generator, nu: float = 0.5,
     # have no later shard left to validate it, so it would go in unguarded.
     for k in range(len(chain) - 1):
         shard, nxt = chain[k], chain[k + 1]
-        later = np.concatenate(chain[k + 1:])
+        later = np.concatenate(chain[k + 1 :])
         labels = problem.y_train[shard] - F_train[shard]
         h_test, h_later = _boost_stage(problem, shard, labels, later)
         weight = 1.0 if k == 0 else nu
@@ -832,8 +825,9 @@ def safeboost(problem: Problem, rng: np.random.Generator, nu: float = 0.5,
 
 
 @register_policy("boost")
-def boost(problem: Problem, rng: np.random.Generator, nu: float = 0.5,
-          shards: Optional[int] = None, patience: int = 3) -> np.ndarray:
+def boost(
+    problem: Problem, rng: np.random.Generator, nu: float = 0.5, shards: Optional[int] = None, patience: int = 3
+) -> np.ndarray:
     """Plain residual boosting — **measured negative on the mean; prefer `safeboost`**.
 
     Each stage grades the running fit on a fresh shard, learns the residual pattern,
@@ -867,8 +861,7 @@ def boost(problem: Problem, rng: np.random.Generator, nu: float = 0.5,
     best_test, best_len, best_oof, stale = F_test.copy(), 0, -np.inf, 0
     for k, shard in enumerate(chain):
         labels = problem.y_train[shard] - F_train[shard]
-        later = (np.concatenate(chain[k + 1:]) if k + 1 < len(chain)
-                 else np.empty(0, dtype=int))
+        later = np.concatenate(chain[k + 1 :]) if k + 1 < len(chain) else np.empty(0, dtype=int)
         h_test, h_later = _boost_stage(problem, shard, labels, later)
         F_test = F_test + nu * h_test
         stages.append((shard, labels, nu))
@@ -1072,8 +1065,7 @@ def resolve_policy(spec: str | Policy) -> tuple[str, Policy]:
 
     if params:
         signature = inspect.signature(fn)
-        takes_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD
-                           for p in signature.parameters.values())
+        takes_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values())
         unknown = set() if takes_kwargs else set(params) - set(signature.parameters)
         if unknown:
             raise ValueError(f"policy {text!r} has no parameter(s) {sorted(unknown)}")

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -10,7 +10,8 @@ from synthefy_nori.inference.preprocess import (
     HighDimFeatureSelector,
     MaxFeatureSubsampler,
     MADWinsorizer,
-    PolynomialInteractionGenerator)
+    PolynomialInteractionGenerator,
+)
 from synthefy_nori.inference.degradation import ContextSubsampledWarning, DegradedPipelineWarning
 from synthefy_nori.inference.memory_policy import (
     FIT_ROW_CHUNK_ON_OOM,
@@ -42,29 +43,33 @@ logger = logging.getLogger(__name__)
 
 NA_PLACEHOLDER = "__MISSING__"
 
+
 class NoriPredictor:
     """Nori model inferencer, supporting tasks such as classification, regression, and missing value prediction."""
-    def __init__(self,
-                 device:torch.device,
-                 model_path:str = None,
-                 inference_config: list|str = None,
-                 mix_precision:bool=True,
-                 outlier_remove_std: float=12,
-                 softmax_temperature:float=0.9,
-                 mask_prediction:bool=False,
-                 categorical_features_indices:List[int]|None=None,
-                 inference_with_DDP: bool = False,
-                 seed:int=0,
-                 model: torch.nn.Module = None,
-                 augmentations: tuple|list|None = None,
-                 yj_skew_threshold: float = 10.0,
-                 quantile_collapse: str = 'mean',
-                 bar_temperature: float = 1.0,
-                 bar_point_estimator: str = 'mean',
-                 discrete_y_snap_max_unique: int = 0,
-                 memory_policy: "MemoryPolicy | dict | str | None" = None,
-                 skip_unused_feature_decoder: bool = True,
-                 native_rms_norm: bool | None = None):
+
+    def __init__(
+        self,
+        device: torch.device,
+        model_path: str = None,
+        inference_config: list | str = None,
+        mix_precision: bool = True,
+        outlier_remove_std: float = 12,
+        softmax_temperature: float = 0.9,
+        mask_prediction: bool = False,
+        categorical_features_indices: List[int] | None = None,
+        inference_with_DDP: bool = False,
+        seed: int = 0,
+        model: torch.nn.Module = None,
+        augmentations: tuple | list | None = None,
+        yj_skew_threshold: float = 10.0,
+        quantile_collapse: str = "mean",
+        bar_temperature: float = 1.0,
+        bar_point_estimator: str = "mean",
+        discrete_y_snap_max_unique: int = 0,
+        memory_policy: "MemoryPolicy | dict | str | None" = None,
+        skip_unused_feature_decoder: bool = True,
+        native_rms_norm: bool | None = None,
+    ):
         """
         init NoriPredictor
 
@@ -97,27 +102,26 @@ class NoriPredictor:
         """
         if isinstance(inference_config, str):
             if os.path.isfile(inference_config):
-                with open(inference_config, 'r') as f:
+                with open(inference_config, "r") as f:
                     inference_config = json.load(f)
             else:
                 raise ValueError(f"inference_config is not a config file path: {inference_config}")
         for inference_config_item in inference_config:
             retrieval_config = inference_config_item.get("retrieval_config")
             if retrieval_config and retrieval_config.get("use_retrieval"):
-                raise ValueError(
-                    "retrieval inference has been removed; omit retrieval_config "
-                    "and use the full context"
-                )
+                raise ValueError("retrieval inference has been removed; omit retrieval_config and use the full context")
         self.model_path = model_path
         self.device = device
         # Route GPU SVD (preprocess._TorchTruncatedSVD) to this predictor's
         # device so high-dim SVD runs on the same GPU as the model.
         try:
             import synthefy_nori.inference.preprocess as _pp
+
             _pp._GPU_SVD_DEVICE = device
         except Exception as _e:
-            print(f"WARNING: could not route GPU SVD to {device} "
-                  f"({type(_e).__name__}: {_e}); using default SVD device.")
+            print(
+                f"WARNING: could not route GPU SVD to {device} ({type(_e).__name__}: {_e}); using default SVD device."
+            )
         self.mix_precision = mix_precision
         self.categorical_features_indices = categorical_features_indices
         self.seed = seed
@@ -167,13 +171,10 @@ class NoriPredictor:
         #              is ~+10% on forward+backward, but inference is dominated
         #              by the 16 CPU preprocessing pipelines, so little of it
         #              survives. Do NOT cite a large inference speedup here.
-        self.native_rms_norm = (
-            None if native_rms_norm is None else bool(native_rms_norm))
-        self.inference_with_DDP=inference_with_DDP
+        self.native_rms_norm = None if native_rms_norm is None else bool(native_rms_norm)
+        self.inference_with_DDP = inference_with_DDP
         if self.inference_with_DDP and self.mask_prediction:
-            raise ValueError(
-                "inference_with_DDP does not support mask_prediction"
-            )
+            raise ValueError("inference_with_DDP does not support mask_prediction")
         # Optional inference-time augmentations. Currently supports:
         #   'yj': Yeo-Johnson target transform ensemble — fit PowerTransformer
         #         on y_train, predict in transformed space, inverse-transform,
@@ -202,8 +203,7 @@ class NoriPredictor:
         #                     out-of-bulk prediction.
         # All strategies are zero-retrain: they only change how the K-way
         # quantile head is collapsed to a single prediction.
-        valid_collapse = ('mean', 'median', 'trimmed_mean', 'huber_mean',
-                            'tail_aware', 'qdist', 'qdist_simple')
+        valid_collapse = ("mean", "median", "trimmed_mean", "huber_mean", "tail_aware", "qdist", "qdist_simple")
         if quantile_collapse not in valid_collapse:
             raise ValueError(f"quantile_collapse must be one of {valid_collapse}, got {quantile_collapse!r}")
         self.quantile_collapse = quantile_collapse
@@ -214,17 +214,17 @@ class NoriPredictor:
         # Bar-distribution inference controls (only used when the loaded model
         # was trained with regression_loss='bar_distribution', auto-detected
         # via model.regression_loss). Ignored for pinball/MSE/etc. checkpoints.
-        valid_bar = ('mean', 'mode', 'median')
+        valid_bar = ("mean", "mode", "median")
         if bar_point_estimator not in valid_bar:
             raise ValueError(f"bar_point_estimator must be one of {valid_bar}, got {bar_point_estimator!r}")
         self.bar_temperature = float(bar_temperature)
         self.bar_point_estimator = bar_point_estimator
 
-        device_type = device.type if isinstance(device, torch.device) else str(device).split(':')[0]
-        if device_type == 'cpu':
+        device_type = device.type if isinstance(device, torch.device) else str(device).split(":")[0]
+        if device_type == "cpu":
             self.mix_precision = False
             print("Mixed precision is not supported for CPU inference, so it has been automatically disabled")
-        elif device_type == 'mps' and self.mix_precision:
+        elif device_type == "mps" and self.mix_precision:
             # MPS autocast uses float16, while Nori's CPU path and checkpoint
             # weights use float32. The reduced precision can materially change
             # regression quality even when every output remains finite.
@@ -235,10 +235,7 @@ class NoriPredictor:
             self.model = model
         else:
             self.model = load_model(model_path=model_path, mask_prediction=mask_prediction)
-        if (
-            self.mask_prediction
-            and getattr(self._bare_model(), "feature_decoder", None) is None
-        ):
+        if self.mask_prediction and getattr(self._bare_model(), "feature_decoder", None) is None:
             raise ValueError(
                 "mask_prediction=True requires a model with feature_decoder; "
                 "the supplied model explicitly omits that head"
@@ -252,23 +249,25 @@ class NoriPredictor:
     def build_preprocess_pipeline(self):
         self.preprocess_pipelines = []
         self.preprocess_configs = []
-    
+
         random.seed(self.seed)
         rand_gen = np.random.default_rng(self.seed)
-        self.seeds = [random.randint(0, 10000) for _ in range(self.n_estimators*self.preprocess_num)]
+        self.seeds = [random.randint(0, 10000) for _ in range(self.n_estimators * self.preprocess_num)]
         start_idx = rand_gen.integers(0, 1000)
         all_shifts = list(range(start_idx, start_idx + self.n_estimators))
         self.all_shifts = rand_gen.choice(all_shifts, size=self.n_estimators, replace=False)
-    
+
         if self.mask_prediction:
             for inference_config_item in self.inference_config:
-                if len(inference_config_item['RebalanceFeatureDistribution']['worker_tags']) > 0:
-                    for i, v in enumerate(inference_config_item['RebalanceFeatureDistribution']['worker_tags']):
-                        if v == 'power':
-                            print("WARNING: Missing value imputation does not currently support the preprocessing method of power! Using the default worker_tags method")
-                            inference_config_item['RebalanceFeatureDistribution']['worker_tags'].pop(i)
-                            inference_config_item['RebalanceFeatureDistribution']['worker_tags'].append(None)
-                inference_config_item['RebalanceFeatureDistribution']['discrete_flag'] = True
+                if len(inference_config_item["RebalanceFeatureDistribution"]["worker_tags"]) > 0:
+                    for i, v in enumerate(inference_config_item["RebalanceFeatureDistribution"]["worker_tags"]):
+                        if v == "power":
+                            print(
+                                "WARNING: Missing value imputation does not currently support the preprocessing method of power! Using the default worker_tags method"
+                            )
+                            inference_config_item["RebalanceFeatureDistribution"]["worker_tags"].pop(i)
+                            inference_config_item["RebalanceFeatureDistribution"]["worker_tags"].append(None)
+                inference_config_item["RebalanceFeatureDistribution"]["discrete_flag"] = True
 
         for idx in range(self.n_estimators):
             pipeline = []
@@ -279,35 +278,37 @@ class NoriPredictor:
             # Self-gates: passthrough on low-dim datasets, identical to today's
             # behavior. Activates only when n_features > threshold OR
             # binary_frac >= threshold.
-            if 'HighDimFeatureSelector' in inference_config_item:
-                pipeline.append(HighDimFeatureSelector(**inference_config_item['HighDimFeatureSelector']))
+            if "HighDimFeatureSelector" in inference_config_item:
+                pipeline.append(HighDimFeatureSelector(**inference_config_item["HighDimFeatureSelector"]))
             # MaxFeatureSubsampler runs BEFORE poly generator so poly pairs are
             # drawn from the subsampled feature set (matches TabPFN semantics:
             # each estimator sees ≤ max_features original columns).
-            if 'MaxFeatureSubsampler' in inference_config_item:
-                pipeline.append(MaxFeatureSubsampler(**inference_config_item['MaxFeatureSubsampler']))
-            if 'PolynomialInteractionGenerator' in inference_config_item:
-                pipeline.append(PolynomialInteractionGenerator(**inference_config_item['PolynomialInteractionGenerator']))
+            if "MaxFeatureSubsampler" in inference_config_item:
+                pipeline.append(MaxFeatureSubsampler(**inference_config_item["MaxFeatureSubsampler"]))
+            if "PolynomialInteractionGenerator" in inference_config_item:
+                pipeline.append(
+                    PolynomialInteractionGenerator(**inference_config_item["PolynomialInteractionGenerator"])
+                )
 
             pipeline.append(FilterValidFeatures())
 
             # MAD winsorization: clip per-column at ±N MAD from median, matching
             # the training-side safety winsorization. Runs BEFORE rebalance so
             # subsequent transforms see clipped values.
-            if 'MADWinsorizer' in inference_config_item:
-                pipeline.append(MADWinsorizer(**inference_config_item['MADWinsorizer']))
+            if "MADWinsorizer" in inference_config_item:
+                pipeline.append(MADWinsorizer(**inference_config_item["MADWinsorizer"]))
 
-            if 'RebalanceFeatureDistribution' in inference_config_item:
-                pipeline.append(RebalanceFeatureDistribution(**inference_config_item['RebalanceFeatureDistribution']))
-            if 'CategoricalFeatureEncoder' in inference_config_item:
-                pipeline.append(CategoricalFeatureEncoder(**inference_config_item['CategoricalFeatureEncoder']))
-            if inference_config_item.get('FingerprintFeatureEncoder', False):
+            if "RebalanceFeatureDistribution" in inference_config_item:
+                pipeline.append(RebalanceFeatureDistribution(**inference_config_item["RebalanceFeatureDistribution"]))
+            if "CategoricalFeatureEncoder" in inference_config_item:
+                pipeline.append(CategoricalFeatureEncoder(**inference_config_item["CategoricalFeatureEncoder"]))
+            if inference_config_item.get("FingerprintFeatureEncoder", False):
                 pipeline.append(FingerprintFeatureEncoder())
-            if 'FeatureShuffler' in inference_config_item:
-                shuffler = FeatureShuffler(**inference_config_item['FeatureShuffler'])
+            if "FeatureShuffler" in inference_config_item:
+                shuffler = FeatureShuffler(**inference_config_item["FeatureShuffler"])
                 shuffler.offset = self.all_shifts[idx]
                 pipeline.append(shuffler)
-            
+
             self.preprocess_pipelines.append(pipeline)
 
     def _check_n_features(self, X, reset):
@@ -318,10 +319,9 @@ class NoriPredictor:
         else:
             if self.n_features_in_ != n_features:
                 raise ValueError(
-                    f"X has {n_features} features, "
-                    f"but this estimator is expecting {self.n_features_in_} features."
+                    f"X has {n_features} features, but this estimator is expecting {self.n_features_in_} features."
                 )
-    
+
     def validate_data(self, x=None, y=None, reset=True, validate_separately=False, **check_params):
         """
         {'accept_sparse': False, 'dtype': None, 'ensure_all_finite': 'allow-nan'}
@@ -339,12 +339,12 @@ class NoriPredictor:
             return x
 
         return None
-    
-    def convert_x_dtypes(self, x:np.ndarray, dtypes:Literal["float32", "float64"] = "float64"):
+
+    def convert_x_dtypes(self, x: np.ndarray, dtypes: Literal["float32", "float64"] = "float64"):
         NUMERIC_DTYPE_KINDS = "?bBiufm"
         OBJECT_DTYPE_KINDS = "OV"
         STRING_DTYPE_KINDS = "SaU"
-        
+
         if x.dtype.kind in NUMERIC_DTYPE_KINDS:
             x = pd.DataFrame(x, copy=False, dtype=dtypes)
         elif x.dtype.kind in OBJECT_DTYPE_KINDS:
@@ -357,7 +357,7 @@ class NoriPredictor:
         if len(integer_columns) > 0:
             x[integer_columns] = x[integer_columns].astype(dtypes)
         return x
-    
+
     def _drop_high_cardinality_string_columns(
         self,
         x_train: pd.DataFrame,
@@ -388,9 +388,7 @@ class NoriPredictor:
             unknown_value=-1,
             encoded_missing_value=np.nan,
         )
-        encoded_cols = list(
-            x_train.select_dtypes(include=["category", "string", "bool"]).columns
-        )
+        encoded_cols = list(x_train.select_dtypes(include=["category", "string", "bool"]).columns)
         string_cols = list(x_train.select_dtypes(include=["string", "object"]).columns)
         x_train_fit = x_train.copy()
         if string_cols:
@@ -463,8 +461,7 @@ class NoriPredictor:
         """
         if isinstance(pipe[id_step], HighDimFeatureSelector):
             return self.preprocess_num - 1
-        return sum(1 for s in pipe[:id_step]
-                   if not isinstance(s, HighDimFeatureSelector))
+        return sum(1 for s in pipe[:id_step] if not isinstance(s, HighDimFeatureSelector))
 
     def _fit_transform_step_inductive(
         self,
@@ -486,13 +483,9 @@ class NoriPredictor:
 
         if isinstance(step, FilterValidFeatures):
             x_train_out, categorical_idx = step.transform(x_train)
-            train_invalid = (
-                None if step.invalid_features is None else step.invalid_features.copy()
-            )
+            train_invalid = None if step.invalid_features is None else step.invalid_features.copy()
             x_test_out, categorical_idx = step.transform(x_test)
-            test_invalid = (
-                None if step.invalid_features is None else step.invalid_features.copy()
-            )
+            test_invalid = None if step.invalid_features is None else step.invalid_features.copy()
             if train_invalid is None:
                 step.invalid_features = test_invalid
             elif test_invalid is None:
@@ -505,8 +498,7 @@ class NoriPredictor:
         x_test_out, categorical_idx = step.transform(x_test)
         return x_train_out, x_test_out, categorical_idx
 
-    
-    def get_categorical_features_indices(self, x:np.ndarray):
+    def get_categorical_features_indices(self, x: np.ndarray):
         if x.shape[0] < self.min_seq_len_for_category_infer:
             return []
         categorical_idx = []
@@ -560,8 +552,9 @@ class NoriPredictor:
         seen.add(key)
         logger.log(level, "%s", message)
 
-    def predict(self, x_train:np.ndarray, y_train:np.ndarray, x_test:np.ndarray,
-                return_distribution: bool = False) -> np.ndarray:
+    def predict(
+        self, x_train: np.ndarray, y_train: np.ndarray, x_test: np.ndarray, return_distribution: bool = False
+    ) -> np.ndarray:
         """
         Perform regression inference using the Nori model
 
@@ -593,7 +586,7 @@ class NoriPredictor:
         # setting this threshold explicitly) — the raw conditional mean
         # is the R²-optimal point output, and benchmarking showed lattice
         # snapping costs ~0.05 R² on K≤10 targets.
-        if getattr(self, 'discrete_y_snap_max_unique', 0) > 0:
+        if getattr(self, "discrete_y_snap_max_unique", 0) > 0:
             preds = self._maybe_snap_discrete_y(y_train, preds)
         return preds
 
@@ -613,12 +606,12 @@ class NoriPredictor:
         return output
 
     def _reject_nonfinite_output(
-            self,
-            out: torch.Tensor,
-            *,
-            path: str,
-            n_train: int,
-            n_test: int,
+        self,
+        out: torch.Tensor,
+        *,
+        path: str,
+        n_train: int,
+        n_test: int,
     ) -> torch.Tensor:
         """Raise when the model emits NaN/inf, instead of zero-filling it.
 
@@ -648,8 +641,7 @@ class NoriPredictor:
             "that scores at chance while reporting success."
         )
 
-    def _maybe_snap_discrete_y(self, y_train: np.ndarray,
-                                 preds: np.ndarray) -> np.ndarray:
+    def _maybe_snap_discrete_y(self, y_train: np.ndarray, preds: np.ndarray) -> np.ndarray:
         """Snap regression predictions to nearest training y value when
         training y is discrete (low unique count).
 
@@ -680,15 +672,11 @@ class NoriPredictor:
             left_idx = np.clip(idx - 1, 0, len(unique_sorted) - 1)
             d_right = np.abs(preds_arr - unique_sorted[idx])
             d_left = np.abs(preds_arr - unique_sorted[left_idx])
-            chosen = np.where(d_left < d_right, unique_sorted[left_idx],
-                                unique_sorted[idx])
-            return chosen.reshape(np.asarray(preds).shape).astype(
-                np.asarray(preds).dtype
-            )
+            chosen = np.where(d_left < d_right, unique_sorted[left_idx], unique_sorted[idx])
+            return chosen.reshape(np.asarray(preds).shape).astype(np.asarray(preds).dtype)
         except Exception as _e:
             # Fail open — never break inference because of the snap helper.
-            print(f"WARNING: discrete-y snap failed "
-                  f"({type(_e).__name__}: {_e}); returning unsnapped predictions.")
+            print(f"WARNING: discrete-y snap failed ({type(_e).__name__}: {_e}); returning unsnapped predictions.")
             return preds
 
     def _bare_model(self):
@@ -749,11 +737,7 @@ class NoriPredictor:
             # default scalar head was MSE; width > 1 identified pinball. A
             # historical one-level pinball head cannot be distinguished, which
             # is why current checkpoints persist regression_loss explicitly.
-            regression_loss = (
-                "mse"
-                if int(getattr(model, "num_reg_quantiles", 1)) == 1
-                else "pinball"
-            )
+            regression_loss = "mse" if int(getattr(model, "num_reg_quantiles", 1)) == 1 else "pinball"
         return str(regression_loss)
 
     @property
@@ -797,7 +781,7 @@ class NoriPredictor:
             output = output.unsqueeze(0)
 
         if num_reg_quantiles > 1:
-            if regression_loss == 'bar_distribution':
+            if regression_loss == "bar_distribution":
                 num_bars = int(getattr(model_ref, "num_bars", num_reg_quantiles))
                 lo = float(getattr(model_ref, "bar_borders_low", -10.0))
                 hi = float(getattr(model_ref, "bar_borders_high", 10.0))
@@ -807,13 +791,23 @@ class NoriPredictor:
                 stored_borders = getattr(model_ref, "bar_borders_buffer", None)
                 if output.ndim == 1 and output.shape[0] == num_bars:
                     # Single test row with num_bars logits
-                    output = self._apply_bar_distribution_decode(
-                        output.unsqueeze(0), num_bars, lo, hi,
-                        borders=stored_borders,
-                    ).squeeze(0).unsqueeze(0)
+                    output = (
+                        self._apply_bar_distribution_decode(
+                            output.unsqueeze(0),
+                            num_bars,
+                            lo,
+                            hi,
+                            borders=stored_borders,
+                        )
+                        .squeeze(0)
+                        .unsqueeze(0)
+                    )
                 elif output.shape[-1] == num_bars:
                     output = self._apply_bar_distribution_decode(
-                        output, num_bars, lo, hi,
+                        output,
+                        num_bars,
+                        lo,
+                        hi,
                         borders=stored_borders,
                     )
             else:
@@ -829,7 +823,11 @@ class NoriPredictor:
         return output
 
     def _apply_bar_distribution_decode(
-        self, logits: torch.Tensor, num_bars: int, lo: float, hi: float,
+        self,
+        logits: torch.Tensor,
+        num_bars: int,
+        lo: float,
+        hi: float,
         borders: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Decode [..., num_bars] logits to [...] point estimate.
@@ -848,18 +846,22 @@ class NoriPredictor:
             borders = borders.to(device=logits.device, dtype=logits.dtype)
         else:
             borders = torch.linspace(
-                lo, hi, num_bars + 1, device=logits.device, dtype=logits.dtype,
+                lo,
+                hi,
+                num_bars + 1,
+                device=logits.device,
+                dtype=logits.dtype,
             )
         bin_centers = 0.5 * (borders[:-1] + borders[1:])  # [num_bars]
-        T = float(getattr(self, 'bar_temperature', 1.0))
+        T = float(getattr(self, "bar_temperature", 1.0))
         if T <= 0:
             T = 1.0
         probs = torch.softmax(logits.float() / T, dim=-1)
-        mode = getattr(self, 'bar_point_estimator', 'mean')
-        if mode == 'mode':
+        mode = getattr(self, "bar_point_estimator", "mean")
+        if mode == "mode":
             idx = probs.argmax(dim=-1)
             return bin_centers[idx]
-        if mode == 'median':
+        if mode == "median":
             cdf = probs.cumsum(dim=-1)
             idx = (cdf >= 0.5).int().argmax(dim=-1)  # first bin where CDF crosses 0.5
             return bin_centers[idx]
@@ -878,48 +880,47 @@ class NoriPredictor:
           huber_mean    — Huber-weighted mean with center = τ=0.5 quantile,
                           scale = MAD of quantile values
         """
-        mode = getattr(self, 'quantile_collapse', 'mean')
+        mode = getattr(self, "quantile_collapse", "mean")
         K = q.shape[-1]
         if K <= 1:
             return q.mean(dim=-1)
         # MPS does not implement float64 tensors. Float32 still keeps every
         # level in the released 999-quantile grid distinct; retain float64 on
         # CPU/CUDA so their existing integration precision is unchanged.
-        tau_dtype = (
-            torch.float32
-            if q.device.type == 'mps'
-            else torch.float64
-        )
-        if mode == 'mean':
+        tau_dtype = torch.float32 if q.device.type == "mps" else torch.float64
+        if mode == "mean":
             from synthefy_nori.model.quantile_dist import quantile_dist_mean_simple
+
             tau_levels = torch.as_tensor(
                 self.regression_quantiles,
                 device=q.device,
                 dtype=tau_dtype,
             )
             return quantile_dist_mean_simple(
-                q, tau_levels, enforce_monotone_first=True,
+                q,
+                tau_levels,
+                enforce_monotone_first=True,
             )
-        if mode == 'median':
+        if mode == "median":
             # For an even-sized bank there is no single middle level. Average
             # the two central predictions; choosing K // 2 alone makes K=2
             # return the upper endpoint instead of its median.
             middle = K // 2
             if K % 2:
                 return q[..., middle]
-            return q[..., middle - 1:middle + 1].mean(dim=-1)
-        if mode == 'trimmed_mean':
+            return q[..., middle - 1 : middle + 1].mean(dim=-1)
+        if mode == "trimmed_mean":
             # Keep at least one value. The historical max(1, ...) made K=2
             # trim both endpoints and reduce an empty tensor to NaN.
             trim = min(max(1, int(K * 0.05)), (K - 1) // 2)
             if trim == 0:
                 return q.mean(dim=-1)
-            return q[..., trim:K - trim].mean(dim=-1)
-        if mode == 'huber_mean':
+            return q[..., trim : K - trim].mean(dim=-1)
+        if mode == "huber_mean":
             # Sort defensively against quantile crossing — q should already be
             # monotonic in τ for a well-trained pinball head.
             q_sorted, _ = q.sort(dim=-1)
-            center = q_sorted[..., K // 2:K // 2 + 1]
+            center = q_sorted[..., K // 2 : K // 2 + 1]
             mad = (q_sorted - center).abs().median(dim=-1, keepdim=True).values
             mad = torch.clamp(mad, min=1e-8)
             dev = (q_sorted - center) / mad
@@ -930,7 +931,7 @@ class NoriPredictor:
                 k_huber / dev.abs().clamp(min=k_huber),
             )
             return (q_sorted * w).sum(dim=-1) / w.sum(dim=-1).clamp(min=1e-8)
-        if mode == 'tail_aware':
+        if mode == "tail_aware":
             # Use the shape of the predicted quantile distribution to detect
             # rows where the model is signaling an out-of-bulk prediction.
             # For such rows, collapse to the heavy-side quantile instead of
@@ -944,9 +945,9 @@ class NoriPredictor:
             #   RIGHT_HEAVY if right_weight > SKEW_RATIO * left_weight
             # Both require spread > MIN_SPREAD_RATIO × (batch-median spread)
             # so a uniformly-tiny quantile spread can't accidentally trigger.
-            lo_idx = max(0, int(round(K * 0.01)))           # τ≈0.01
-            mid_idx = K // 2                                 # τ=0.5
-            hi_idx = min(K - 1, int(round(K * 0.99)) - 1)    # τ≈0.99
+            lo_idx = max(0, int(round(K * 0.01)))  # τ≈0.01
+            mid_idx = K // 2  # τ=0.5
+            hi_idx = min(K - 1, int(round(K * 0.99)) - 1)  # τ≈0.99
             q_lo = q[..., lo_idx]
             q_mid = q[..., mid_idx]
             q_hi = q[..., hi_idx]
@@ -959,47 +960,56 @@ class NoriPredictor:
             left_heavy = (left_w.abs() > SKEW_RATIO * right_w.abs().clamp(min=1e-8)) & (spread > spread_thresh)
             right_heavy = (right_w.abs() > SKEW_RATIO * left_w.abs().clamp(min=1e-8)) & (spread > spread_thresh)
             from synthefy_nori.model.quantile_dist import quantile_dist_mean_simple
+
             tau_levels = torch.as_tensor(
                 self.regression_quantiles,
                 device=q.device,
                 dtype=tau_dtype,
             )
             mean_est = quantile_dist_mean_simple(
-                q, tau_levels, enforce_monotone_first=True,
+                q,
+                tau_levels,
+                enforce_monotone_first=True,
             )
             result = torch.where(left_heavy, q_lo.to(mean_est.dtype), mean_est)
             result = torch.where(right_heavy, q_hi.to(mean_est.dtype), result)
             return result
-        if mode == 'qdist':
+        if mode == "qdist":
             # Quantile-distribution decoder: sort + analytical mean with
             # exp tail extrapolation. K should be ≥ ~100 for stable tail fit.
             # Falls back to qdist_simple at K < 8.
             from synthefy_nori.model.quantile_dist import quantile_dist_mean_batch
+
             tau_levels = np.asarray(
                 self.regression_quantiles,
                 dtype=np.float64,
             )
             return quantile_dist_mean_batch(
-                q, tau_levels, enforce_monotone_first=True, tail_outer_n=20,
+                q,
+                tau_levels,
+                enforce_monotone_first=True,
+                tail_outer_n=20,
             )
-        if mode == 'qdist_simple':
+        if mode == "qdist_simple":
             # Quantile-distribution decoder, pure-torch (no tail correction).
             # Faster, fully on-device. Use when tail extrapolation isn't needed
             # (e.g. K=999 already covers 99.9% of mass).
             from synthefy_nori.model.quantile_dist import quantile_dist_mean_simple
+
             tau_levels = torch.as_tensor(
                 self.regression_quantiles,
                 device=q.device,
                 dtype=tau_dtype,
             )
             return quantile_dist_mean_simple(
-                q, tau_levels, enforce_monotone_first=True,
+                q,
+                tau_levels,
+                enforce_monotone_first=True,
             )
         # Should be unreachable (validated in __init__), but fall back safely.
         return q.mean(dim=-1)
 
-    def _effective_budget_n_features(self, n_features: int,
-                                     x_train: np.ndarray) -> int:
+    def _effective_budget_n_features(self, n_features: int, x_train: np.ndarray) -> int:
         """Feature count the model actually sees after a HighDimFeatureSelector
         in the inference config reduces dimensionality.
 
@@ -1013,25 +1023,24 @@ class NoriPredictor:
         for item in self.inference_config:
             if not isinstance(item, dict):
                 continue
-            hdf = item.get('HighDimFeatureSelector')
+            hdf = item.get("HighDimFeatureSelector")
             if not hdf:
                 continue
-            strategy = hdf.get('strategy', 'passthrough')
-            thr = int(hdf.get('n_features_threshold', 128))
-            bthr = float(hdf.get('binary_threshold', 0.5))
+            strategy = hdf.get("strategy", "passthrough")
+            thr = int(hdf.get("n_features_threshold", 128))
+            bthr = float(hdf.get("binary_threshold", 0.5))
             if binary_frac is None:
                 try:
-                    bm = HighDimFeatureSelector._detect_binary_cols(
-                        np.asarray(x_train, dtype=np.float64))
+                    bm = HighDimFeatureSelector._detect_binary_cols(np.asarray(x_train, dtype=np.float64))
                     binary_frac = float(bm.mean()) if n_features else 0.0
                 except Exception:
                     binary_frac = 0.0
             if not ((n_features > thr) or (binary_frac >= bthr)):
                 continue
-            if strategy == 'svd_all':
-                eff = min(eff, int(hdf.get('svd_components', 64)))
-            elif strategy in ('corr', 'mi', 'extratrees'):
-                eff = min(eff, int(hdf.get('top_k', 256)))
+            if strategy == "svd_all":
+                eff = min(eff, int(hdf.get("svd_components", 64)))
+            elif strategy in ("corr", "mi", "extratrees"):
+                eff = min(eff, int(hdf.get("top_k", 256)))
             # svd_binary output size is data-dependent (n_nonbinary +
             # components) — leave the budget conservative (no reduction).
         return max(1, eff)
@@ -1084,8 +1093,7 @@ class NoriPredictor:
         n_features = x_train.shape[1] if x_train.ndim > 1 else 1
         return self._effective_budget_n_features(n_features, x_train)
 
-    def max_context_rows(self, x_train: np.ndarray, *,
-                         budget_n_features: int | None = None) -> int:
+    def max_context_rows(self, x_train: np.ndarray, *, budget_n_features: int | None = None) -> int:
         """Context rows one call can take for this table before subsampling engages.
 
         Mirrors the budget arithmetic in :meth:`_predict_reg_single` exactly: returns
@@ -1206,11 +1214,11 @@ class NoriPredictor:
         try:
             dev = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
             if dev.type == "cuda" and torch.cuda.is_available():
-                return torch.cuda.get_device_properties(dev).total_memory / (1024 ** 3)
+                return torch.cuda.get_device_properties(dev).total_memory / (1024**3)
             if dev.type == "mps" and torch.backends.mps.is_available():
                 recommended = getattr(torch.mps, "recommended_max_memory", None)
                 if callable(recommended):
-                    return recommended() / (1024 ** 3)
+                    return recommended() / (1024**3)
         except Exception:
             pass
         return None
@@ -1223,15 +1231,17 @@ class NoriPredictor:
         """
         return max(256, (max_elements // max(budget_n_features, 1)) - n_train)
 
-    def PostProcessInModel(self, feature_pred:torch.tensor, config: dict) -> torch.tensor:
+    def PostProcessInModel(self, feature_pred: torch.tensor, config: dict) -> torch.tensor:
         # Revert preprocess in model forward
-        feature_pred = feature_pred / torch.sqrt(config['features_per_group'] / config['num_used_features'].to(self.device))
-        feature_pred = feature_pred*config['std_for_normalization'] + config['mean_for_normalization']
+        feature_pred = feature_pred / torch.sqrt(
+            config["features_per_group"] / config["num_used_features"].to(self.device)
+        )
+        feature_pred = feature_pred * config["std_for_normalization"] + config["mean_for_normalization"]
         feature_pred = einops.rearrange(feature_pred, "b s f n -> s b (f n)").squeeze(1).float().cpu().numpy()
-        if config['n_x_padding'] > 0:
-            feature_pred = feature_pred[:,:-config['n_x_padding']]
+        if config["n_x_padding"] > 0:
+            feature_pred = feature_pred[:, : -config["n_x_padding"]]
         return feature_pred
-    
+
     def PostProcess(
         self,
         feature_pred: np.ndarray,
@@ -1249,7 +1259,7 @@ class NoriPredictor:
                 else:
                     raise NotImplementedError
             elif isinstance(step, CategoricalFeatureEncoder):
-                if step.encoding_strategy != 'onehot':
+                if step.encoding_strategy != "onehot":
                     if step.category_mappings is not None:
                         categorical_indices = list(step.category_mappings.keys())
                         feature_pred[:, categorical_indices] = np.round(feature_pred[:, categorical_indices])
@@ -1263,43 +1273,64 @@ class NoriPredictor:
                 else:
                     if len(step.categorical_features) == 0 or step.transformer is None:
                         continue
-                    cont_features_indices = [idx for idx in range(feature_pred.shape[1]) if idx not in step.categorical_features]
-                    
+                    cont_features_indices = [
+                        idx for idx in range(feature_pred.shape[1]) if idx not in step.categorical_features
+                    ]
+
                     assert np.array_equal(step.categorical_features, np.arange(len(step.categorical_features)))
                     start_idx = 0
-                    for idx, out_category in enumerate(step.transformer.named_transformers_['one_hot_encoder'].categories_):
+                    for idx, out_category in enumerate(
+                        step.transformer.named_transformers_["one_hot_encoder"].categories_
+                    ):
                         assert len(out_category) >= 2
                         if not np.any(np.isnan(out_category)):
-                            if len(out_category) == 2: # e.g. [3, 5.5]
-                                feature_pred[:,start_idx] = np.round(np.clip(feature_pred[:,start_idx], a_min=0, a_max=1))
+                            if len(out_category) == 2:  # e.g. [3, 5.5]
+                                feature_pred[:, start_idx] = np.round(
+                                    np.clip(feature_pred[:, start_idx], a_min=0, a_max=1)
+                                )
                                 start_idx += 1
                             else:
-                                arr = feature_pred[:, start_idx:start_idx+len(out_category)]
-                                feature_pred[:, start_idx:start_idx+len(out_category)] = (arr == arr.max(axis=1, keepdims=True)).astype(float)
+                                arr = feature_pred[:, start_idx : start_idx + len(out_category)]
+                                feature_pred[:, start_idx : start_idx + len(out_category)] = (
+                                    arr == arr.max(axis=1, keepdims=True)
+                                ).astype(float)
                                 start_idx += len(out_category)
                         else:
-                            if len(out_category) == 2: # e.g. [0, nan]
-                                feature_pred[:,start_idx] = 0
+                            if len(out_category) == 2:  # e.g. [0, nan]
+                                feature_pred[:, start_idx] = 0
                                 start_idx += 1
                             else:
-                                arr = feature_pred[:, start_idx:start_idx+len(out_category)-1]
-                                feature_pred[:, start_idx:start_idx+len(out_category)-1] = (arr == arr.max(axis=1, keepdims=True)).astype(float)
-                                feature_pred[:, start_idx+len(out_category)-1] = 0
+                                arr = feature_pred[:, start_idx : start_idx + len(out_category) - 1]
+                                feature_pred[:, start_idx : start_idx + len(out_category) - 1] = (
+                                    arr == arr.max(axis=1, keepdims=True)
+                                ).astype(float)
+                                feature_pred[:, start_idx + len(out_category) - 1] = 0
                                 start_idx += len(out_category)
-                    feature_pred = np.column_stack([step.transformer.named_transformers_['one_hot_encoder'].inverse_transform(feature_pred[:, step.categorical_features]), feature_pred[:, cont_features_indices]])
-                    
+                    feature_pred = np.column_stack(
+                        [
+                            step.transformer.named_transformers_["one_hot_encoder"].inverse_transform(
+                                feature_pred[:, step.categorical_features]
+                            ),
+                            feature_pred[:, cont_features_indices],
+                        ]
+                    )
+
             elif isinstance(step, RebalanceFeatureDistribution):
-                if step.svd_tag == 'svd' and step.svd_n_comp > 0:
-                    feature_pred = feature_pred[:, :-step.svd_n_comp]
-                if step.worker_tags[0] in ["quantile_uniform_10", "quantile_uniform_5", "quantile_uniform_all_data"] and step.n_quantile_features > 0:
-                    feature_pred = feature_pred[:, :-step.n_quantile_features]
+                if step.svd_tag == "svd" and step.svd_n_comp > 0:
+                    feature_pred = feature_pred[:, : -step.svd_n_comp]
+                if (
+                    step.worker_tags[0] in ["quantile_uniform_10", "quantile_uniform_5", "quantile_uniform_all_data"]
+                    and step.n_quantile_features > 0
+                ):
+                    feature_pred = feature_pred[:, : -step.n_quantile_features]
                 elif step.worker_tags[0] == "power":
-                    raise ValueError(f"Missing value imputation does not currently support the preprocessing method of power!")
+                    raise ValueError(
+                        f"Missing value imputation does not currently support the preprocessing method of power!"
+                    )
                 if step.feature_indices is not None:
                     inv_p = np.argsort(step.feature_indices)
                     feature_pred = feature_pred[:, inv_p]
 
-                    
             elif isinstance(step, FilterValidFeatures):
                 invalid_mask = np.asarray(step.invalid_indices, dtype=bool)
                 if np.any(invalid_mask):
@@ -1357,10 +1388,14 @@ class NoriPredictor:
         context = np.stack([chunk[:n_context] for chunk in chunks]).mean(axis=0)
         query = np.concatenate([chunk[n_context:] for chunk in chunks], axis=0)
         return np.concatenate([context, query], axis=0)
-        
-    def get_embeddings(self, x_train: np.ndarray, y_train: np.ndarray,
-                       x_test: np.ndarray | None = None,
-                       data_source: Literal["test", "train"] = "test") -> np.ndarray:
+
+    def get_embeddings(
+        self,
+        x_train: np.ndarray,
+        y_train: np.ndarray,
+        x_test: np.ndarray | None = None,
+        data_source: Literal["test", "train"] = "test",
+    ) -> np.ndarray:
         """Thin wrapper applying the execution overrides once for the call.
 
         Entering the context manager per query chunk would walk model.modules()
@@ -1371,9 +1406,13 @@ class NoriPredictor:
         with self._execution_overrides():
             return self._get_embeddings_impl(x_train, y_train, x_test, data_source)
 
-    def _get_embeddings_impl(self, x_train: np.ndarray, y_train: np.ndarray,
-                             x_test: np.ndarray | None = None,
-                             data_source: Literal["test", "train"] = "test") -> np.ndarray:
+    def _get_embeddings_impl(
+        self,
+        x_train: np.ndarray,
+        y_train: np.ndarray,
+        x_test: np.ndarray | None = None,
+        data_source: Literal["test", "train"] = "test",
+    ) -> np.ndarray:
         """Extract per-row Nori embeddings for a context/query split.
 
         Runs each preprocessing pipeline (the inference ensemble) through the
@@ -1395,12 +1434,17 @@ class NoriPredictor:
             for ``data_source="train"``.
         """
         if data_source not in ("test", "train"):
-            raise ValueError(
-                f"data_source must be 'test' or 'train', got {data_source!r}.")
+            raise ValueError(f"data_source must be 'test' or 'train', got {data_source!r}.")
 
         x_train, y_train = self.validate_data(
-            x_train, y_train, reset=True, validate_separately=False,
-            accept_sparse=False, dtype=None, ensure_all_finite=False)
+            x_train,
+            y_train,
+            reset=True,
+            validate_separately=False,
+            accept_sparse=False,
+            dtype=None,
+            ensure_all_finite=False,
+        )
         if data_source == "train":
             # Context embeddings ignore the query rows entirely (the train branch
             # below uses a dummy query drawn from the context). Replace whatever
@@ -1410,22 +1454,21 @@ class NoriPredictor:
             x_test = x_train[:1]
         else:
             if x_test is None:
-                raise ValueError(
-                    "get_embeddings requires x_test for data_source='test'.")
+                raise ValueError("get_embeddings requires x_test for data_source='test'.")
             x_test = self.validate_data(
-                x_test, reset=False, validate_separately=False,
-                accept_sparse=False, dtype=None, ensure_all_finite=False)
+                x_test, reset=False, validate_separately=False, accept_sparse=False, dtype=None, ensure_all_finite=False
+            )
 
         x_train_base, x_test_base, categorical_idx = self._prepare_inductive_features(
-            x_train, x_test,
+            x_train,
+            x_test,
         )
 
         n_train = len(y_train)
         n_test = len(x_test)
         # Chunk the query rows along the same element budget the predictor uses,
         # so wide/large tables don't OOM while embedding.
-        budget_n_features = self._effective_budget_n_features(
-            x_train.shape[1] if x_train.ndim > 1 else 1, x_train)
+        budget_n_features = self._effective_budget_n_features(x_train.shape[1] if x_train.ndim > 1 else 1, x_train)
         max_elements = self._resolve_max_elements_budget()
 
         # Context-size guard. Chunking below only splits the QUERY rows; every
@@ -1468,9 +1511,11 @@ class NoriPredictor:
             categorical_idx_ = categorical_idx.copy()
             for id_step, step in enumerate(pipe):
                 x_train_, x_test_, categorical_idx_ = self._fit_transform_step_inductive(
-                    step, x_train_, x_test_, categorical_idx_,
-                    self.seeds[id_pipe * self.preprocess_num
-                               + self._seed_step_index(pipe, id_step)],
+                    step,
+                    x_train_,
+                    x_test_,
+                    categorical_idx_,
+                    self.seeds[id_pipe * self.preprocess_num + self._seed_step_index(pipe, id_step)],
                     y_train=y_,
                 )
 
@@ -1492,11 +1537,14 @@ class NoriPredictor:
                 bare_model.to(self.device)
                 torch.manual_seed(self.seed)
                 torch.cuda.manual_seed_all(self.seed)
-                with torch.autocast(
-                    device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
-                    enabled=self.mix_precision), torch.inference_mode():
-                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train,
-                                     task_type='reg', return_embeddings=True)
+                with (
+                    torch.autocast(
+                        device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                        enabled=self.mix_precision,
+                    ),
+                    torch.inference_mode(),
+                ):
+                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train, task_type="reg", return_embeddings=True)
                 per_pipeline.append(emb[0, :n_train].float().cpu().numpy())
                 continue
 
@@ -1511,11 +1559,14 @@ class NoriPredictor:
                 bare_model.to(self.device)
                 torch.manual_seed(self.seed)
                 torch.cuda.manual_seed_all(self.seed)
-                with torch.autocast(
-                    device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
-                    enabled=self.mix_precision), torch.inference_mode():
-                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train,
-                                     task_type='reg', return_embeddings=True)
+                with (
+                    torch.autocast(
+                        device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                        enabled=self.mix_precision,
+                    ),
+                    torch.inference_mode(),
+                ):
+                    emb = bare_model(x=x_all, y=y_all, eval_pos=n_train, task_type="reg", return_embeddings=True)
                 chunks.append(emb[0, n_train:].float().cpu().numpy())
             per_pipeline.append(np.concatenate(chunks, axis=0))
 
@@ -1577,6 +1628,7 @@ class NoriPredictor:
         if distributed_inference is None:
             predict_single = self._predict_reg_single
         else:
+
             def predict_single(
                 x_train_single,
                 y_train_single,
@@ -1603,13 +1655,14 @@ class NoriPredictor:
             y_train,
             x_test,
         )
-        if 'yj' not in self.augmentations:
+        if "yj" not in self.augmentations:
             return base_pred
 
         # Conditional YJ gate: only apply if y_train is sufficiently skewed.
         # Use bias=False for unbiased estimator; robust to NaN via nan_to_num.
         try:
             from scipy import stats as _stats
+
             y_np = np.asarray(y_train, dtype=np.float64)
             y_np = y_np[np.isfinite(y_np)]
             if len(y_np) < 10:
@@ -1627,9 +1680,9 @@ class NoriPredictor:
             import warnings as _warnings
 
             y_train_arr = np.asarray(y_train, dtype=np.float64).reshape(-1, 1)
-            pt = PowerTransformer(method='yeo-johnson', standardize=True)
+            pt = PowerTransformer(method="yeo-johnson", standardize=True)
             with _warnings.catch_warnings():
-                _warnings.simplefilter('ignore')
+                _warnings.simplefilter("ignore")
                 y_train_yj = pt.fit_transform(y_train_arr).ravel()
 
             # Predict in YJ-transformed target space
@@ -1639,19 +1692,18 @@ class NoriPredictor:
                 x_test,
             )
             # base_pred may be torch.Tensor; normalize to numpy for transform
-            pred_yj_np = pred_yj_space.detach().cpu().numpy() if torch.is_tensor(pred_yj_space) else np.asarray(pred_yj_space)
+            pred_yj_np = (
+                pred_yj_space.detach().cpu().numpy() if torch.is_tensor(pred_yj_space) else np.asarray(pred_yj_space)
+            )
 
             # Clip in-transformed-space before inverse to avoid explosion
             y_tr_min, y_tr_max = y_train_yj.min(), y_train_yj.max()
             clip_range = (y_tr_max - y_tr_min) * 3.0 + 1e-6
-            pred_yj_np_clipped = np.clip(
-                pred_yj_np, y_tr_min - clip_range, y_tr_max + clip_range
-            )
+            pred_yj_np_clipped = np.clip(pred_yj_np, y_tr_min - clip_range, y_tr_max + clip_range)
 
             with _warnings.catch_warnings():
-                _warnings.simplefilter('ignore')
-                pred_inv = pt.inverse_transform(
-                    pred_yj_np_clipped.reshape(-1, 1)).ravel()
+                _warnings.simplefilter("ignore")
+                pred_inv = pt.inverse_transform(pred_yj_np_clipped.reshape(-1, 1)).ravel()
 
             # Convert base_pred to numpy for averaging
             base_np = base_pred.detach().cpu().numpy() if torch.is_tensor(base_pred) else np.asarray(base_pred)
@@ -1676,13 +1728,22 @@ class NoriPredictor:
             # and turn strict_pipeline() back into a silent degradation on this path.
             raise
         except Exception as _e:
-            print(f"  [YJ] augmentation failed ({type(_e).__name__}: {_e}), "
-                  f"falling back to identity-only prediction")
+            print(f"  [YJ] augmentation failed ({type(_e).__name__}: {_e}), falling back to identity-only prediction")
             return base_pred
 
-    def _get_or_build_context(self, bare_model, id_pipe, *, x_train_t, y_train_t,
-                              cache_dtype, offload_kv_cache, fit_row_chunk,
-                              reuse_context_cache, cache_entries=1):
+    def _get_or_build_context(
+        self,
+        bare_model,
+        id_pipe,
+        *,
+        x_train_t,
+        y_train_t,
+        cache_dtype,
+        offload_kv_cache,
+        fit_row_chunk,
+        reuse_context_cache,
+        cache_entries=1,
+    ):
         """Build the per-pipe context (train) K/V cache, reusing it across predict()
         calls whose context and cache params are unchanged.
 
@@ -1715,10 +1776,15 @@ class NoriPredictor:
         8 verification clones. Each entry is a full K/V cache, so capacity is bounded
         only by the caller's explicit, memory-aware choice.
         """
+
         def _build():
             return bare_model.build_context_cache(
-                x_train_t, y_train_t, cache_dtype=cache_dtype,
-                offload_kv_cache=offload_kv_cache, fit_row_chunk=fit_row_chunk)
+                x_train_t,
+                y_train_t,
+                cache_dtype=cache_dtype,
+                offload_kv_cache=offload_kv_cache,
+                fit_row_chunk=fit_row_chunk,
+            )
 
         if not reuse_context_cache:
             # A policy can change between calls (the shared engine re-declares one
@@ -1747,10 +1813,8 @@ class NoriPredictor:
         for position, (hit_key, hit_x, hit_y, hit_bundle) in enumerate(entries):
             # Cheap scalar key first, then the O(N_train*F) byte compare -- a param
             # change short-circuits without touching the tensors.
-            if (hit_key == key
-                    and self._same_context(hit_x, x_train_t)
-                    and self._same_context(hit_y, y_train_t)):
-                if position:                    # promote: this pool is in active rotation
+            if hit_key == key and self._same_context(hit_x, x_train_t) and self._same_context(hit_y, y_train_t):
+                if position:  # promote: this pool is in active rotation
                     entries.insert(0, entries.pop(position))
                 # Honour a capacity shrink on the hit path too. Returning early here is
                 # how a drop from 3 to 1 used to retain all three K/V bundles for as
@@ -1759,7 +1823,7 @@ class NoriPredictor:
                 # above runs first, so the entry being returned always survives.
                 del entries[capacity:]
                 return hit_bundle
-        bundle = _build()                       # cache only on a successful build
+        bundle = _build()  # cache only on a successful build
         entries = cache.setdefault(id_pipe, entries)
         # Keep our OWN contiguous copies to verify future calls against. Clones, not
         # the caller's tensors: x_train_t is a slice of the concatenated train+test
@@ -1784,12 +1848,15 @@ class NoriPredictor:
         # bundles only when they are individually huge, which is precisely when
         # retaining them is what breaks the run.
         if self._evict_context_cache_for(cache, bundle, keep_pipe=id_pipe):
-            entries.insert(0, (
-                key,
-                x_train_t.detach().clone(memory_format=torch.contiguous_format),
-                y_train_t.detach().clone(memory_format=torch.contiguous_format),
-                bundle,
-            ))
+            entries.insert(
+                0,
+                (
+                    key,
+                    x_train_t.detach().clone(memory_format=torch.contiguous_format),
+                    y_train_t.detach().clone(memory_format=torch.contiguous_format),
+                    bundle,
+                ),
+            )
             # Evict from the cold end. Shrinking capacity between calls (the shared
             # engine re-declares its policy per request) is honoured here rather than
             # needing its own path: the list is trimmed to whatever the CURRENT call
@@ -1832,7 +1899,7 @@ class NoriPredictor:
 
         try:
             walk(bundle)
-        except Exception:                       # never let accounting break a predict
+        except Exception:  # never let accounting break a predict
             return 0
         return total
 
@@ -1860,7 +1927,7 @@ class NoriPredictor:
                     return int(recommended() * frac)
         except Exception:
             pass
-        return None                             # cannot measure -> leave behaviour unchanged
+        return None  # cannot measure -> leave behaviour unchanged
 
     def _evict_context_cache_for(self, cache: dict, incoming, *, keep_pipe=None) -> bool:
         """Drop cached bundles (oldest first, across every pipe) until ``incoming``
@@ -1885,7 +1952,7 @@ class NoriPredictor:
         """
         budget = self._context_cache_budget_bytes()
         if budget is None:
-            return True                         # no device limit -> exactly the old behaviour
+            return True  # no device limit -> exactly the old behaviour
         incoming_bytes = self._bundle_device_bytes(incoming)
         if incoming_bytes > budget:
             # The branch that fixes topo_2_1: a 15.2 GiB bundle against a 0.25 x 143 GiB
@@ -1893,11 +1960,7 @@ class NoriPredictor:
             # is held so the forward pass gets the whole card.
             cache.clear()
             return False
-        total = sum(
-            self._bundle_device_bytes(entry[3])
-            for entries in cache.values()
-            for entry in entries
-        )
+        total = sum(self._bundle_device_bytes(entry[3]) for entries in cache.values() for entry in entries)
         # Dict preserves pipe insertion order, and each per-pipe list is
         # most-recently-used-first (see _get_or_build_context), so popping from the
         # END of the first pipe's list, then the next pipe's, evicts oldest-first
@@ -1954,16 +2017,16 @@ class NoriPredictor:
         and the integer dtypes alike. Shape, dtype and device are checked separately
         so that two tables of equal byte length but different layout cannot match.
         """
-        if (cached.shape != candidate.shape
-                or cached.dtype != candidate.dtype
-                or cached.device != candidate.device):
+        if cached.shape != candidate.shape or cached.dtype != candidate.dtype or cached.device != candidate.device:
             return False
         if cached.numel() == 0:
             return True
-        return bool(torch.equal(
-            cached.contiguous().view(torch.uint8),
-            candidate.detach().contiguous().view(torch.uint8),
-        ))
+        return bool(
+            torch.equal(
+                cached.contiguous().view(torch.uint8),
+                candidate.detach().contiguous().view(torch.uint8),
+            )
+        )
 
     def _predict_reg_single(
         self,
@@ -2005,7 +2068,7 @@ class NoriPredictor:
         n_features = x_train.shape[1] if x_train.ndim > 1 else 1
         n_samples_train = x_train.shape[0]
         n_samples_test = x_test.shape[0]
-        
+
         # If the number of elements is too large, we must chunk the test set to avoid OOM.
         # The default is VRAM-aware: anchored at 2M elements for a ~24GB GPU (the
         # historical conservative value) and scaled linearly with total VRAM, so a
@@ -2029,10 +2092,8 @@ class NoriPredictor:
                 # Name whichever setting actually forbade it. Reporting the env var to
                 # someone who set memory_policy={"allow_subsample": False} sends them hunting
                 # a variable they never set.
-                _source = ("SYNTHEFY_FORBID_SUBSAMPLE=1" if _forbid_env
-                           else "memory_policy={'allow_subsample': False}")
-                _remedy = ("Raise memory_policy={'elements_budget': N} for full context, or "
-                           "allow subsampling.")
+                _source = "SYNTHEFY_FORBID_SUBSAMPLE=1" if _forbid_env else "memory_policy={'allow_subsample': False}"
+                _remedy = "Raise memory_policy={'elements_budget': N} for full context, or allow subsampling."
                 raise ContextTooLargeError(
                     f"{_source}: context subsampling required but forbidden "
                     f"(n_train={n_samples_train}, eff_features={budget_n_features}, "
@@ -2067,17 +2128,27 @@ class NoriPredictor:
             x_train = x_train[idx]
             y_train = y_train[idx]
             n_samples_train = len(x_train)
-            
+
         np_rng = np.random.default_rng(self.seed)
-        
-        x_train, y_train = self.validate_data(x_train, y_train, reset=True, validate_separately=False, accept_sparse=False, dtype=None, ensure_all_finite=False)
-        x_test = self.validate_data(x_test, reset=False, validate_separately=False, accept_sparse=False, dtype=None, ensure_all_finite=False)
+
+        x_train, y_train = self.validate_data(
+            x_train,
+            y_train,
+            reset=True,
+            validate_separately=False,
+            accept_sparse=False,
+            dtype=None,
+            ensure_all_finite=False,
+        )
+        x_test = self.validate_data(
+            x_test, reset=False, validate_separately=False, accept_sparse=False, dtype=None, ensure_all_finite=False
+        )
 
         x_train_base, x_test_base, categorical_idx = self._prepare_inductive_features(
             x_train,
             x_test,
         )
-    
+
         outputs = []
         mask_predictions = []
         for id_pipe, pipe in enumerate(self.preprocess_pipelines):
@@ -2092,7 +2163,7 @@ class NoriPredictor:
                     x_train_,
                     x_test_,
                     categorical_idx_,
-                    self.seeds[id_pipe*self.preprocess_num+self._seed_step_index(pipe, id_step)],
+                    self.seeds[id_pipe * self.preprocess_num + self._seed_step_index(pipe, id_step)],
                     y_train=y_,
                 )
 
@@ -2104,9 +2175,9 @@ class NoriPredictor:
             if self.inference_with_DDP:
                 assert distributed_inference is not None
                 output = distributed_inference.inference(
-                    x_[:len(y_train)],
+                    x_[: len(y_train)],
                     y_,
-                    x_[len(y_train):],
+                    x_[len(y_train) :],
                 )
                 outputs.append(output)
             if not self.inference_with_DDP:
@@ -2135,8 +2206,7 @@ class NoriPredictor:
                 # keying off self.mask_prediction wrongly enters the cached path
                 # and the model raises NotImplementedError under chunking. Use the
                 # model's real flag so such ckpts fall to the plain chunked loop.
-                model_mask_pred = bool(getattr(bare_model, "mask_prediction",
-                                               self.mask_prediction))
+                model_mask_pred = bool(getattr(bare_model, "mask_prediction", self.mask_prediction))
                 # Serving-memory policy. The ladder and the reasoning behind its
                 # ORDER live in ``synthefy_nori.inference.memory_policy``; here we
                 # only supply the measurements it needs and record what it picked.
@@ -2182,7 +2252,9 @@ class NoriPredictor:
                     use_cached = policy.cache
                 else:
                     policy = policy.resolve(
-                        est_cache_gb=0.0, bytes_per_element=1, head_dim=1,
+                        est_cache_gb=0.0,
+                        bytes_per_element=1,
+                        head_dim=1,
                         cache_eligible=False,
                     )
                 # Announce the opening rung. WARNING when it is already a fallback
@@ -2190,8 +2262,10 @@ class NoriPredictor:
                 # should see by default; INFO on the fast rungs so a normal run stays
                 # quiet but is still explainable after the fact.
                 self._log_once_per_call(
-                    "rung", logging.WARNING if policy.is_degraded else logging.INFO,
-                    f"Nori serving-memory rung: {policy.describe()}")
+                    "rung",
+                    logging.WARNING if policy.is_degraded else logging.INFO,
+                    f"Nori serving-memory rung: {policy.describe()}",
+                )
 
                 cached_done = False
                 if use_cached:
@@ -2210,7 +2284,15 @@ class NoriPredictor:
                         fit_chunk_attempts.append(FIT_ROW_CHUNK_ON_OOM)
                     for attempt_fit_chunk in fit_chunk_attempts:
                         try:
-                            with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
+                            with (
+                                torch.autocast(
+                                    device_type=self.device.type
+                                    if isinstance(self.device, torch.device)
+                                    else self.device,
+                                    enabled=self.mix_precision,
+                                ),
+                                torch.inference_mode(),
+                            ):
                                 # Cross-call context amortization: build the O(N_train)
                                 # per-layer K/V cache once and reuse it across predict()
                                 # calls whose context (x_train/y_train) is unchanged --
@@ -2221,7 +2303,8 @@ class NoriPredictor:
                                 # pair) and memoizes the build. See _get_or_build_context.
                                 n_ctx = len(y_train)
                                 ctx_bundle = self._get_or_build_context(
-                                    bare_model, id_pipe,
+                                    bare_model,
+                                    id_pipe,
                                     x_train_t=x_[:n_ctx].unsqueeze(0),
                                     y_train_t=y_[:n_ctx].unsqueeze(0),
                                     cache_dtype=policy.cache_dtype,
@@ -2231,25 +2314,23 @@ class NoriPredictor:
                                     cache_entries=self.context_cache_entries,
                                 )
                                 output = bare_model.apply_context_cache(
-                                    x_[n_ctx:].unsqueeze(0), ctx_bundle,
+                                    x_[n_ctx:].unsqueeze(0),
+                                    ctx_bundle,
                                     row_chunk_size=chunk_size,
                                     adaptive_query_chunk=policy.adaptive_query_chunk,
                                 )
                             output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
                             output = self._reject_nonfinite_output(
-                                output, path=f"cached ({policy.rung})",
-                                n_train=n_samples_train, n_test=n_samples_test)
+                                output, path=f"cached ({policy.rung})", n_train=n_samples_train, n_test=n_samples_test
+                            )
                             outputs.append(output)
                             cached_done = True
                             if attempt_fit_chunk is not None and pinned is None:
-                                policy = policy.escalated(
-                                    "context_row_chunk",
-                                    context_row_chunk=attempt_fit_chunk)
-                                logger.warning(
-                                    "Nori recovered on rung %s", policy.describe())
+                                policy = policy.escalated("context_row_chunk", context_row_chunk=attempt_fit_chunk)
+                                logger.warning("Nori recovered on rung %s", policy.describe())
                             policy = policy.escalated(
-                                policy.rung, dropped_context_rows=dropped_context_rows,
-                                query_chunk=chunk_size)
+                                policy.rung, dropped_context_rows=dropped_context_rows, query_chunk=chunk_size
+                            )
                             self.memory_report_ = policy.model_dump()
                             break
                         except NotImplementedError as exc:
@@ -2278,7 +2359,9 @@ class NoriPredictor:
                             )
                             logger.warning(
                                 "Nori OOM on rung %s (fit_row_chunk=%s); %s",
-                                policy.rung, attempt_fit_chunk, next_step,
+                                policy.rung,
+                                attempt_fit_chunk,
+                                next_step,
                             )
                 if not cached_done:
                     # Every cached rung failed, or the policy never chose one. This
@@ -2287,14 +2370,16 @@ class NoriPredictor:
                     # reads as an unexplained accuracy regression to whoever is
                     # looking at the numbers later.
                     if policy.rung != "no_cache":
-                        policy = policy.escalated(
-                            "plain_loop", dropped_context_rows=dropped_context_rows)
+                        policy = policy.escalated("plain_loop", dropped_context_rows=dropped_context_rows)
                         msg = (
                             f"Nori fell back to the plain chunked loop: "
                             f"{policy.describe()}. Every query chunk now recomputes "
                             f"the context K/V, several times slower"
-                            + (f"; {dropped_context_rows} context rows were DROPPED "
-                               f"to fit" if dropped_context_rows else "")
+                            + (
+                                f"; {dropped_context_rows} context rows were DROPPED to fit"
+                                if dropped_context_rows
+                                else ""
+                            )
                             + ". Raise memory_policy={'gpu_budget_frac': ...} / "
                             "'host_budget_frac' / 'elements_budget', or read "
                             "predictor.memory_report_ for what was chosen."
@@ -2302,42 +2387,50 @@ class NoriPredictor:
                         self._log_once_per_call("plain_loop", logging.WARNING, msg)
                         self._warn_once_per_call("plain_loop", msg, RuntimeWarning)
                     else:
-                        policy = policy.escalated(
-                            policy.rung, dropped_context_rows=dropped_context_rows)
+                        policy = policy.escalated(policy.rung, dropped_context_rows=dropped_context_rows)
                     self.memory_report_ = policy.model_dump()
-
 
                 # Chunk the test data (skipped entirely if the cached path ran)
                 all_outputs = []
-                for i in ([] if cached_done else range(0, n_samples_test, chunk_size)):
+                for i in [] if cached_done else range(0, n_samples_test, chunk_size):
                     end_idx = min(i + chunk_size, n_samples_test)
                     x_chunk_test = x_[len(y_train) + i : len(y_train) + end_idx]
-                    
+
                     # Recombine train + test chunk
-                    x_chunk_combined = torch.cat([x_[:len(y_train)], x_chunk_test], dim=0)
-                    
+                    x_chunk_combined = torch.cat([x_[: len(y_train)], x_chunk_test], dim=0)
+
                     # Create dummy y for test chunk
                     y_chunk_test = torch.zeros(end_idx - i, dtype=y_.dtype, device=y_.device)
-                    y_chunk_combined = torch.cat([y_[:len(y_train)], y_chunk_test], dim=0)
+                    y_chunk_combined = torch.cat([y_[: len(y_train)], y_chunk_test], dim=0)
 
                     self.model.to(self.device)
-                    with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
+                    with (
+                        torch.autocast(
+                            device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                            enabled=self.mix_precision,
+                        ),
+                        torch.inference_mode(),
+                    ):
                         x_in = x_chunk_combined.unsqueeze(0)
                         y_in = y_chunk_combined.unsqueeze(0)
 
-                        chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type='reg')
+                        chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type="reg")
 
                     if self.mask_prediction:
-                        process_config = chunk_output['process_config']
-                        chunk_output_feature_pred = self.PostProcessInModel(chunk_output['feature_pred'], process_config)
-                        source_row_indices = np.concatenate((
-                            np.arange(len(y_train), dtype=np.int64),
-                            np.arange(
-                                len(y_train) + i,
-                                len(y_train) + end_idx,
-                                dtype=np.int64,
-                            ),
-                        ))
+                        process_config = chunk_output["process_config"]
+                        chunk_output_feature_pred = self.PostProcessInModel(
+                            chunk_output["feature_pred"], process_config
+                        )
+                        source_row_indices = np.concatenate(
+                            (
+                                np.arange(len(y_train), dtype=np.int64),
+                                np.arange(
+                                    len(y_train) + i,
+                                    len(y_train) + end_idx,
+                                    dtype=np.int64,
+                                ),
+                            )
+                        )
                         chunk_output_feature_pred = self.PostProcess(
                             chunk_output_feature_pred,
                             pipe,
@@ -2345,14 +2438,14 @@ class NoriPredictor:
                             source_row_indices=source_row_indices,
                         )
                         pipeline_mask_chunks.append(chunk_output_feature_pred)
-                        chunk_output = chunk_output['reg_output']
+                        chunk_output = chunk_output["reg_output"]
 
                     chunk_output = self._unwrap_model_output(chunk_output, task_type="reg").squeeze(0)
                     chunk_output = self._reject_nonfinite_output(
-                        chunk_output, path="plain chunked loop",
-                        n_train=n_samples_train, n_test=end_idx - i)
+                        chunk_output, path="plain chunked loop", n_train=n_samples_train, n_test=end_idx - i
+                    )
                     all_outputs.append(chunk_output)
-                    
+
                 # Concatenate all test chunks (cached path already appended above)
                 if not cached_done:
                     output = torch.cat(all_outputs, dim=0)
@@ -2364,7 +2457,7 @@ class NoriPredictor:
                             len(y_train),
                         )
                     )
-            
+
         output = torch.stack(outputs).mean(dim=0)
         if return_distribution:
             # Return the ensemble-averaged decoder output BEFORE collapse: the
@@ -2374,7 +2467,7 @@ class NoriPredictor:
             return output
         output = self._collapse_regression_output(output)
         mask_prediction = np.stack(mask_predictions).mean(axis=0) if mask_predictions != [] else None
-        
+
         if self.mask_prediction:
             return output, mask_prediction
         else:

--- a/src/synthefy_nori/inference/preprocess.py
+++ b/src/synthefy_nori/inference/preprocess.py
@@ -13,9 +13,9 @@ from sklearn.preprocessing import (
     FunctionTransformer,
     PowerTransformer,
     StandardScaler,
-    QuantileTransformer, 
+    QuantileTransformer,
     MinMaxScaler,
-    RobustScaler
+    RobustScaler,
 )
 from sklearn.pipeline import FeatureUnion, Pipeline
 from sklearn.impute import SimpleImputer
@@ -97,8 +97,7 @@ class _TorchTruncatedSVD(BaseEstimator, TransformerMixin):
     ignored so it slots into sklearn Pipelines unchanged.
     """
 
-    def __init__(self, n_components=2, *, random_state=None, algorithm=None,
-                 n_iter=None, n_oversamples=None):
+    def __init__(self, n_components=2, *, random_state=None, algorithm=None, n_iter=None, n_oversamples=None):
         self.n_components = int(n_components)
         self.random_state = random_state
         self.algorithm = algorithm
@@ -107,8 +106,7 @@ class _TorchTruncatedSVD(BaseEstimator, TransformerMixin):
 
     def _sklearn_fallback(self, X):
         algo = self.algorithm or "randomized"
-        m = TruncatedSVD(n_components=self.n_components, algorithm=algo,
-                         random_state=self.random_state)
+        m = TruncatedSVD(n_components=self.n_components, algorithm=algo, random_state=self.random_state)
         out = m.fit_transform(X)
         self.components_ = m.components_
         return out
@@ -127,7 +125,9 @@ class _TorchTruncatedSVD(BaseEstimator, TransformerMixin):
             dev = _resolve_svd_device()
             Xt = torch.from_numpy(Xnp).to(dev)
             U, S, Vh = torch.linalg.svd(Xt, full_matrices=False)
-            U = U[:, :k]; S = S[:k]; Vh = Vh[:k]
+            U = U[:, :k]
+            S = S[:k]
+            Vh = Vh[:k]
             # svd_flip, u_based_decision=True (sklearn's default for both solvers):
             # sign each component so the largest-|.| entry of its U column is +.
             idx = U.abs().argmax(dim=0)
@@ -155,11 +155,12 @@ class _TorchTruncatedSVD(BaseEstimator, TransformerMixin):
                 pass
         return Xnp @ self.components_.T
 
+
 class SelectiveInversePipeline(Pipeline):
     def __init__(self, steps, skip_inverse=None):
         super().__init__(steps)
         self.skip_inverse = skip_inverse or []
-    
+
     def inverse_transform(self, X):
         """inverse_transform that skips the configured steps."""
         if X.shape[1] == 0:
@@ -170,27 +171,25 @@ class SelectiveInversePipeline(Pipeline):
                 check_is_fitted(transformer)
             except Exception:
                 continue
-            
+
             if name in self.skip_inverse:
                 continue
-                
-            if hasattr(transformer, 'inverse_transform'):
+
+            if hasattr(transformer, "inverse_transform"):
                 X = transformer.inverse_transform(X)
                 if np.any(np.isnan(X)):
                     print(f"After reverse RebalanceFeatureDistribution of {name}, there is nan")
         return X
 
+
 class RobustPowerTransformer(PowerTransformer):
     """PowerTransformer with automatic feature reversion when variance or value constraints fail."""
 
-    def __init__(self, var_tolerance: float = 1e-3,
-                 max_abs_value: float = 100,
-                 **kwargs: Any) -> None:
+    def __init__(self, var_tolerance: float = 1e-3, max_abs_value: float = 100, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.var_tolerance = var_tolerance
         self.max_abs_value = max_abs_value
         self.restore_indices_: np.ndarray | None = None
-
 
     def fit(self, X, y=None):
         fitted = super().fit(X, y)
@@ -198,7 +197,7 @@ class RobustPowerTransformer(PowerTransformer):
         return fitted
 
     def fit_transform(self, X, y=None):
-        Z = super().fit_transform(X,y)
+        Z = super().fit_transform(X, y)
         self.restore_indices_ = self._should_revert(Z)
         return Z
 
@@ -225,9 +224,7 @@ class RobustPowerTransformer(PowerTransformer):
         "Overload_yeo_johnson_optimize to avoid crashes caused by values such as NaN and Inf."
         try:
             with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"overflow encountered",
-                                        category=RuntimeWarning)
+                warnings.filterwarnings("ignore", message=r"overflow encountered", category=RuntimeWarning)
                 return super()._yeo_johnson_optimize(x)  # type: ignore
         except Exception as e:
             return np.nan
@@ -237,6 +234,7 @@ class RobustPowerTransformer(PowerTransformer):
         if np.isnan(lmbda):
             return x
         return super()._yeo_johnson_transform(x, lmbda)  # type: ignore
+
 
 class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
     """TabPFN-style per-column adaptive preprocessor.
@@ -284,7 +282,8 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
             return 0.0
         try:
             from scipy.stats import skew as _scipy_skew
-            return float(_scipy_skew(x, bias=False, nan_policy='omit'))
+
+            return float(_scipy_skew(x, bias=False, nan_policy="omit"))
         except Exception:
             return 0.0
 
@@ -292,10 +291,10 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
     def _categorize(cls, x_col: np.ndarray) -> str:
         x_finite = x_col[np.isfinite(x_col)]
         if len(x_finite) < 3:
-            return 'identity'
+            return "identity"
         n_unique = int(len(np.unique(x_finite)))
         if n_unique < 10:
-            return 'ordinal'
+            return "ordinal"
         skew_val = cls._skew(x_finite)
         x_min, x_max = float(np.min(x_finite)), float(np.max(x_finite))
         # Heavy positive-skew (income/price/count distributions): use log1p
@@ -306,61 +305,68 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
         if x_min >= 0:
             fp = cls._fp_skew(x_finite)
             if fp > 5.0:
-                return 'positive_heavy_skew'
+                return "positive_heavy_skew"
         if abs(skew_val) > 1.1:
             if x_min >= 0:
                 if x_max <= 1.0:
-                    return 'skewed_pos_01'
-                return 'skewed_pos'
-            return 'skewed'
+                    return "skewed_pos_01"
+                return "skewed_pos"
+            return "skewed"
         # Shapiro normality on a sample (it's expensive on large N)
         try:
             from scipy.stats import shapiro
+
             sub = x_finite[:3000] if len(x_finite) > 3000 else x_finite
             stat = float(shapiro(sub).statistic)
             if stat > 0.95:
-                return 'normal'
+                return "normal"
         except Exception:
             pass
-        return 'other'
+        return "other"
 
     def _make_transformer(self, cat: str):
         """Return a fresh sklearn transformer for the given column category."""
-        if cat in ('identity', 'ordinal', 'normal'):
+        if cat in ("identity", "ordinal", "normal"):
             return FunctionTransformer()
-        if cat == 'skewed_pos_01':
+        if cat == "skewed_pos_01":
             # exp pulls (0,1)-bounded right-skew into broader range; identity inverse via log.
             return FunctionTransformer(
-                func=np.exp, inverse_func=np.log, check_inverse=False,
+                func=np.exp,
+                inverse_func=np.log,
+                check_inverse=False,
             )
         # scikit-learn PowerTransformer (Yeo-Johnson) for skewed columns.
         # (Verified numerically identical to the previously-optional
         # SafePowerTransformer on the winsorized feature ranges seen here.)
         _PowerImpl = PowerTransformer
-        if cat == 'positive_heavy_skew':
+        if cat == "positive_heavy_skew":
             # log1p first (textbook for heavy positive skew: income/price/counts),
             # then standardize. yeo-johnson under-fits very heavy tails.
-            return Pipeline([
-                ('log1p', FunctionTransformer(func=np.log1p, inverse_func=np.expm1, check_inverse=False)),
-                ('std', StandardScaler()),
-            ])
-        if cat == 'skewed_pos':
+            return Pipeline(
+                [
+                    ("log1p", FunctionTransformer(func=np.log1p, inverse_func=np.expm1, check_inverse=False)),
+                    ("std", StandardScaler()),
+                ]
+            )
+        if cat == "skewed_pos":
             # Box-cox needs strictly positive input; ensure with MinMax→(0.1,1).
-            return Pipeline([
-                ('mm', MinMaxScaler(feature_range=(0.1, 1.0), clip=True)),
-                ('bc', _PowerImpl(method='box-cox', standardize=True)),
-            ])
-        if cat == 'skewed':
-            return _PowerImpl(method='yeo-johnson', standardize=True)
+            return Pipeline(
+                [
+                    ("mm", MinMaxScaler(feature_range=(0.1, 1.0), clip=True)),
+                    ("bc", _PowerImpl(method="box-cox", standardize=True)),
+                ]
+            )
+        if cat == "skewed":
+            return _PowerImpl(method="yeo-johnson", standardize=True)
         # 'other'
         return CappedQuantileTransformer(
-            output_distribution='normal',
+            output_distribution="normal",
             n_quantiles=self.n_quantiles,
             random_state=self.random_state,
             subsample=int(1e6),
         )
 
-    def fit(self, X: np.ndarray, y=None) -> 'AdaptiveColumnTransformer':
+    def fit(self, X: np.ndarray, y=None) -> "AdaptiveColumnTransformer":
         X = np.asarray(X, dtype=np.float64)
         n_samples, n_features = X.shape
         self.column_categories_: list[str] = []
@@ -376,23 +382,22 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
         # applies to all rows. SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE=0 -> exact legacy.
         cap = int(os.environ.get("SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE", "2000"))
         if cap > 0 and n_samples > cap:
-            fit_idx = np.random.default_rng(self.random_state).choice(
-                n_samples, size=cap, replace=False)
+            fit_idx = np.random.default_rng(self.random_state).choice(n_samples, size=cap, replace=False)
             X_fit = X[fit_idx]
         else:
             X_fit = X
         for i in range(n_features):
-            cat = self._categorize(X[:, i])          # exact: full column
+            cat = self._categorize(X[:, i])  # exact: full column
             t = self._make_transformer(cat)
-            fit_col = X_fit[:, i:i + 1]               # cheap: fit on subsample
+            fit_col = X_fit[:, i : i + 1]  # cheap: fit on subsample
             try:
                 # sklearn ColumnTransformer-style: fit a 2D slice
                 t.fit(fit_col)
             except Exception:
                 # Degenerate column (all-NaN, all-equal): fall back to identity
                 t = FunctionTransformer()
-                t.fit(X[:, i:i + 1])
-                cat = 'identity'
+                t.fit(X[:, i : i + 1])
+                cat = "identity"
             self.column_categories_.append(cat)
             self.column_transformers_.append(t)
         return self
@@ -408,8 +413,8 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
         out = np.empty_like(X, dtype=np.float64)
         for i, t in enumerate(self.column_transformers_):
             try:
-                col = t.transform(X[:, i:i + 1])
-                out[:, i:i + 1] = np.asarray(col, dtype=np.float64)
+                col = t.transform(X[:, i : i + 1])
+                out[:, i : i + 1] = np.asarray(col, dtype=np.float64)
             except Exception:
                 # Test-time corrupted column (all NaN, etc.): fall back to median fill 0
                 out[:, i] = 0.0
@@ -425,8 +430,8 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
         out = np.empty_like(X, dtype=np.float64)
         for i, t in enumerate(self.column_transformers_):
             try:
-                if hasattr(t, 'inverse_transform'):
-                    out[:, i:i + 1] = t.inverse_transform(X[:, i:i + 1])
+                if hasattr(t, "inverse_transform"):
+                    out[:, i : i + 1] = t.inverse_transform(X[:, i : i + 1])
                 else:
                     out[:, i] = X[:, i]
             except Exception:
@@ -437,18 +442,21 @@ class AdaptiveColumnTransformer(BaseEstimator, TransformerMixin):
 class BasePreprocess:
     """Abstract base class for preprocessing class"""
 
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs)->list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         """Fit the preprocessing model to the data"""
         raise NotImplementedError
-    
-    def transform(self, x:np.ndarray, **kwargs)->tuple[np.ndarray, list[int]]:
+
+    def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         """Transform the data using the fitted preprocessing model"""
         raise NotImplementedError
-    
-    def fit_transform(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs)->tuple[np.ndarray, list[int]]:
+
+    def fit_transform(
+        self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs
+    ) -> tuple[np.ndarray, list[int]]:
         """Fit the preprocessing model to the data and transform the data"""
         self.fit(x, categorical_features, seed, **kwargs)
         return self.transform(x, **kwargs)
+
 
 def infer_random_state(
     random_state: int | np.random.RandomState | np.random.Generator | None,
@@ -457,18 +465,19 @@ def infer_random_state(
     if random_state is None:
         np_rng = np.random.default_rng()
         return int(np_rng.integers(0, MAXINT_RANDOM_SEED)), np_rng
-        
+
     if isinstance(random_state, (int, np.integer)):
         return int(random_state), np.random.default_rng(random_state)
-        
+
     if isinstance(random_state, np.random.RandomState):
         seed = int(random_state.randint(0, MAXINT_RANDOM_SEED))
         return seed, np.random.default_rng(seed)
-        
+
     if isinstance(random_state, np.random.Generator):
         return int(random_state.integers(0, MAXINT_RANDOM_SEED)), random_state
-        
+
     raise ValueError(f"Invalid random_state {random_state}")
+
 
 class FilterValidFeatures(BasePreprocess):
     def __init__(self):
@@ -478,7 +487,9 @@ class FilterValidFeatures(BasePreprocess):
         self.invalid_features: list[int] | None = None
 
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, y:np.ndarray | None = None, **kwargs) -> list[int]:
+    def fit(
+        self, x: np.ndarray, categorical_features: list[int], seed: int, y: np.ndarray | None = None, **kwargs
+    ) -> list[int]:
         self.categorical_idx = categorical_features
         self.valid_features = np.asarray(
             (x[0:1, :] == x).mean(axis=0) < 1.0,
@@ -500,7 +511,7 @@ class FilterValidFeatures(BasePreprocess):
             all_nan_train = np.all(nan_train, axis=0)
             nan_test = np.isnan(x[eval_pos:, :])
             all_nan_test = np.all(nan_test, axis=0)
-            
+
             features_nan = all_nan_train | all_nan_test
             self.valid_features = self.valid_features & ~features_nan
             self.invalid_indices = self.invalid_indices | features_nan
@@ -509,15 +520,13 @@ class FilterValidFeatures(BasePreprocess):
             raise ValueError("All features are constant! Please check your data.")
 
         self.categorical_idx = [
-            index
-            for index, idx in enumerate(np.where(self.valid_features)[0])
-            if idx in categorical_features
+            index for index, idx in enumerate(np.where(self.valid_features)[0]) if idx in categorical_features
         ]
 
         return self.categorical_idx
-    
+
     @override
-    def transform(self, x:np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         assert self.valid_features is not None, "You must call fit first to get effective_features"
         self.invalid_features = x[:, self.invalid_indices]
         return x[:, self.valid_features], self.categorical_idx
@@ -548,8 +557,7 @@ class MADWinsorizer(BasePreprocess):
         eliminate valid categorical values.
     """
 
-    def __init__(self, *, n_mad: float = 6.0, skip_categorical: bool = True,
-                  soft_log_clip: bool = False):
+    def __init__(self, *, n_mad: float = 6.0, skip_categorical: bool = True, soft_log_clip: bool = False):
         self.n_mad = float(n_mad)
         self.skip_categorical = bool(skip_categorical)
         # Replace hard clip at boundary with soft logarithmic clip.
@@ -590,7 +598,7 @@ class MADWinsorizer(BasePreprocess):
         if x.shape[1] != len(self.median_):
             # Shape changed (e.g., upstream filter dropped columns). Skip
             # winsorization rather than crash; this is a safety fallback.
-            return x.astype(np.float32), kwargs.get('categorical_features', [])
+            return x.astype(np.float32), kwargs.get("categorical_features", [])
         if self.soft_log_clip:
             # Soft logarithmic clip: values beyond bounds are mapped to
             # bound + sign(excess) * log1p(|excess|). Preserves ordering
@@ -622,7 +630,7 @@ class FeatureShuffler(BasePreprocess):
 
     def __init__(
         self,
-        mode: Literal['rotate', 'shuffle', 'latin'] | None = "shuffle",
+        mode: Literal["rotate", "shuffle", "latin"] | None = "shuffle",
         offset: int = 0,
     ):
         super().__init__()
@@ -633,7 +641,7 @@ class FeatureShuffler(BasePreprocess):
         self.categorical_indices = None
 
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         n_features = x.shape[1]
         self.random_seed = seed
 
@@ -662,17 +670,18 @@ class FeatureShuffler(BasePreprocess):
 
         is_categorical = np.isin(np.arange(n_features), categorical_features)
         self.categorical_indices = np.where(is_categorical[self.feature_indices])[0].tolist()
-        
+
         return self.categorical_indices
 
     @override
-    def transform(self, x:np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         if self.feature_indices is None:
             raise RuntimeError("Please call the fit method first to initialize")
         if len(self.feature_indices) != x.shape[1]:
             raise ValueError("The number of features in the input data does not match the training data")
-            
+
         return x[:, self.feature_indices], self.categorical_indices or []
+
 
 class CategoricalFeatureEncoder(BasePreprocess):
     """
@@ -681,7 +690,10 @@ class CategoricalFeatureEncoder(BasePreprocess):
 
     def __init__(
         self,
-        encoding_strategy: Literal['ordinal', 'ordinal_strict_feature_shuffled', 'ordinal_shuffled', 'onehot', 'numeric', 'none']|None = "ordinal",
+        encoding_strategy: Literal[
+            "ordinal", "ordinal_strict_feature_shuffled", "ordinal_shuffled", "onehot", "numeric", "none"
+        ]
+        | None = "ordinal",
     ):
         super().__init__()
         self.encoding_strategy = encoding_strategy
@@ -723,9 +735,7 @@ class CategoricalFeatureEncoder(BasePreprocess):
             if Xt.size >= 1_000_000:
                 ct = None
             else:
-                categorical_features = list(range(Xt.shape[1]))[
-                    ct.output_indices_["one_hot_encoder"]
-                ]
+                categorical_features = list(range(Xt.shape[1]))[ct.output_indices_["one_hot_encoder"]]
         else:
             raise ValueError(
                 f"Unknown categorical transform {self.encoding_strategy}",
@@ -736,12 +746,12 @@ class CategoricalFeatureEncoder(BasePreprocess):
         return categorical_features
 
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         self.random_seed = seed
         return self._fit_impl(x, categorical_features)
 
     @override
-    def transform(self, x:np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         if self.transformer is None:
             return x, self.categorical_features or []
 
@@ -757,7 +767,9 @@ class CategoricalFeatureEncoder(BasePreprocess):
         return Xt, categorical_features
 
     @override
-    def fit_transform(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def fit_transform(
+        self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs
+    ) -> tuple[np.ndarray, list[int]]:
         self.fit(x, categorical_features, seed, **kwargs)
         return self.transform(x, **kwargs)
 
@@ -768,43 +780,57 @@ class CategoricalFeatureEncoder(BasePreprocess):
             return 0
         return int(np.unique(column, return_counts=True)[1].min())
 
-    def _create_transformer(self, data: np.ndarray, categorical_columns: list[int]) -> tuple[ColumnTransformer | None, list[int]]:
+    def _create_transformer(
+        self, data: np.ndarray, categorical_columns: list[int]
+    ) -> tuple[ColumnTransformer | None, list[int]]:
         """Create an appropriate column transformer"""
         if self.encoding_strategy.startswith("ordinal"):
-            suffix = self.encoding_strategy[len("ordinal"):]
-            
+            suffix = self.encoding_strategy[len("ordinal") :]
+
             if "feature_shuffled" in suffix:
                 categorical_columns = [
-                    idx for idx in categorical_columns 
-                    if self._is_valid_common_category(data[:, idx], suffix)
+                    idx for idx in categorical_columns if self._is_valid_common_category(data[:, idx], suffix)
                 ]
             remainder_columns = [idx for idx in range(data.shape[1]) if idx not in categorical_columns]
             self.feature_indices = categorical_columns + remainder_columns
-                
+
             return ColumnTransformer(
-                [("ordinal_encoder", OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=np.nan), categorical_columns)],
-                remainder="passthrough"
+                [
+                    (
+                        "ordinal_encoder",
+                        OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=np.nan),
+                        categorical_columns,
+                    )
+                ],
+                remainder="passthrough",
             ), categorical_columns
-            
+
         elif self.encoding_strategy == "onehot":
             return ColumnTransformer(
-                [("one_hot_encoder", OneHotEncoder(drop="if_binary", sparse_output=False, handle_unknown="ignore"), categorical_columns)],
-                remainder="passthrough"
+                [
+                    (
+                        "one_hot_encoder",
+                        OneHotEncoder(drop="if_binary", sparse_output=False, handle_unknown="ignore"),
+                        categorical_columns,
+                    )
+                ],
+                remainder="passthrough",
             ), categorical_columns
-            
+
         elif self.encoding_strategy in ("numeric", "none"):
             return None, categorical_columns
-            
+
         raise ValueError(f"Unsupported encoding strategy: {self.encoding_strategy}")
 
     def _is_valid_common_category(self, column: np.ndarray, suffix: str) -> bool:
         """Check whether the input data meets the common category conditions"""
         min_count = self.get_least_common_category_count(column)
         unique_count = len(np.unique(column))
-        
+
         if "strict_feature_shuffled" in suffix:
             return min_count >= 10 and unique_count < (len(column) // 10)
         return min_count >= 10
+
 
 class QTx(QuantileTransformer):
     """
@@ -833,13 +859,12 @@ class QTx(QuantileTransformer):
         if isinstance(rs, np.random.Generator):
             rs = np.random.RandomState(int(rs.integers(0, 2**32)))
         elif hasattr(rs, "bit_generator"):
-            raise ValueError(
-                f"Unsupported random_state type: {type(rs)}"
-            )
+            raise ValueError(f"Unsupported random_state type: {type(rs)}")
         self.random_state = rs
 
         # delegate to parent
         return super().fit(X, y)
+
 
 class KDIX(KDITransformer):
     """
@@ -854,7 +879,7 @@ class KDIX(KDITransformer):
 
     def fit(self, X, y=None):
         # accept both numpy and torch
-        if hasattr(X, "detach"):   # torch.Tensor case
+        if hasattr(X, "detach"):  # torch.Tensor case
             base = X.cpu().numpy()
         else:
             base = np.asarray(X)
@@ -890,14 +915,14 @@ class KDIX(KDITransformer):
 
 class RebalanceFeatureDistribution(BasePreprocess):
     def __init__(
-            self,
-            *,
-            worker_tags: list[str] | None = None,
-            discrete_flag: bool = False,
-            original_flag: bool = False,
-            svd_tag: Literal['svd'] | None = None,
-            joined_svd_feature: bool = True,
-            joined_log_normal: bool = True,
+        self,
+        *,
+        worker_tags: list[str] | None = None,
+        discrete_flag: bool = False,
+        original_flag: bool = False,
+        svd_tag: Literal["svd"] | None = None,
+        joined_svd_feature: bool = True,
+        joined_log_normal: bool = True,
     ):
         super().__init__()
         self.worker_tags = worker_tags if worker_tags is not None else ["quantile"]
@@ -912,27 +937,29 @@ class RebalanceFeatureDistribution(BasePreprocess):
         self.n_quantile_features = 0
 
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         self.random_state = seed
         n_samples, n_features = x.shape
-        worker, self.dis_ix = self._set(n_samples,n_features,categorical_features)
+        worker, self.dis_ix = self._set(n_samples, n_features, categorical_features)
         worker.fit(x)
         self.worker = worker
         return self.dis_ix
 
     @override
-    def transform(self, x:np.ndarray, **kwargs) -> np.ndarray:
+    def transform(self, x: np.ndarray, **kwargs) -> np.ndarray:
         assert self.worker is not None
         return self.worker.transform(x), self.dis_ix  # type: ignore
 
     @override
-    def fit_transform(self, x:np.ndarray, categorical_features:list[int], seed:int, *, y:np.ndarray, **kwargs)->tuple[np.ndarray, list[int]]:
+    def fit_transform(
+        self, x: np.ndarray, categorical_features: list[int], seed: int, *, y: np.ndarray, **kwargs
+    ) -> tuple[np.ndarray, list[int]]:
         """Fit the preprocessing model to the data and transform the data"""
         assert y is not None, "The input y cannot be None"
-        x_train_ = x[:len(y)]
-        x_test_ = x[len(y):]
+        x_train_ = x[: len(y)]
+        x_test_ = x[len(y) :]
         if x_train_.shape[1] != x_test_.shape[1]:
-            x_test_ = x_test_[:, :x_train_.shape[1]]
+            x_test_ = x_test_[:, : x_train_.shape[1]]
         categorical_idx_ = self.fit(x_train_, categorical_features, seed)
         x_train_, categorical_idx_ = self.transform(x_train_)
         x_test_, categorical_idx_ = self.transform(x_test_)
@@ -940,10 +967,12 @@ class RebalanceFeatureDistribution(BasePreprocess):
 
         return (x_, categorical_idx_)
 
-    def _set(self,n_samples: int,
+    def _set(
+        self,
+        n_samples: int,
         n_features: int,
         categorical_features: list[int],
-        ):
+    ):
         static_seed, rng = infer_random_state(self.random_state)
         all_ix = list(range(n_features))
         workers = []
@@ -964,27 +993,40 @@ class RebalanceFeatureDistribution(BasePreprocess):
         for worker_tag in self.worker_tags:
             # print(f"== worker_tag: \033[31m{worker_tag}\033[0m")
             if worker_tag == "logNormal":
-                sworker = Pipeline(steps=[
-                                        ("save_standard", Pipeline(steps=[
-                                            ("i2n_pre",
-                                             FunctionTransformer(
-                                                 func=_inf_to_nan,
-                                                 inverse_func=_identity, check_inverse=False)),
-                                            ("fill_missing_pre",
-                                             SimpleImputer(missing_values=np.nan, strategy="mean",
-                                                           keep_empty_features=True)),
-                                            ("feature_shift",
-                                             FunctionTransformer(func=_shift_to_nonnegative)),
-                                            ("add_epsilon", FunctionTransformer(func=_add_epsilon)),
-                                            ("logNormal", FunctionTransformer(np.log, validate=False)),
-                                            ("i2n_post",
-                                             FunctionTransformer(
-                                                 func=_inf_to_nan,
-                                                 inverse_func=_identity, check_inverse=False)),
-                                            ("fill_missing_post",
-                                             SimpleImputer(missing_values=np.nan, strategy="mean",
-                                                           keep_empty_features=True))])),
-                                        ])
+                sworker = Pipeline(
+                    steps=[
+                        (
+                            "save_standard",
+                            Pipeline(
+                                steps=[
+                                    (
+                                        "i2n_pre",
+                                        FunctionTransformer(
+                                            func=_inf_to_nan, inverse_func=_identity, check_inverse=False
+                                        ),
+                                    ),
+                                    (
+                                        "fill_missing_pre",
+                                        SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True),
+                                    ),
+                                    ("feature_shift", FunctionTransformer(func=_shift_to_nonnegative)),
+                                    ("add_epsilon", FunctionTransformer(func=_add_epsilon)),
+                                    ("logNormal", FunctionTransformer(np.log, validate=False)),
+                                    (
+                                        "i2n_post",
+                                        FunctionTransformer(
+                                            func=_inf_to_nan, inverse_func=_identity, check_inverse=False
+                                        ),
+                                    ),
+                                    (
+                                        "fill_missing_post",
+                                        SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True),
+                                    ),
+                                ]
+                            ),
+                        ),
+                    ]
+                )
                 # trans_ixs = cont_ix
             elif worker_tag == "quantile_uniform_10":
                 sworker = CappedQuantileTransformer(
@@ -1005,42 +1047,48 @@ class RebalanceFeatureDistribution(BasePreprocess):
                     random_state=static_seed,
                     subsample=n_samples,
                 )
-            elif worker_tag == 'power':
-                self.feature_indices = categorical_features+cont_ix
+            elif worker_tag == "power":
+                self.feature_indices = categorical_features + cont_ix
                 self.dis_ix = dis_ix
                 nan_to_mean_transformer = SimpleImputer(
-                                                    missing_values=np.nan,
-                                                    strategy="mean",
-                                                    keep_empty_features=True,
-                                                )
-            
-                sworker = SelectiveInversePipeline(
-                                steps=[
-                                    ("power_transformer", RobustPowerTransformer(standardize=False)),
-                                    ("inf_to_nan_1", FunctionTransformer(
-                                                        func=_inf_to_nan,
-                                                        inverse_func=_identity,
-                                                        check_inverse=False,
-                                                    )),
-                                    ("nan_to_mean_1", nan_to_mean_transformer),
-                                    ("scaler", StandardScaler()),
-                                    ("inf_to_nan_2", FunctionTransformer(
-                                                        func=_inf_to_nan,
-                                                        inverse_func=_identity,
-                                                        check_inverse=False,
-                                                    )),
-                                    ("nan_to_mean_2", nan_to_mean_transformer),
-                                ],
-                        skip_inverse=['nan_to_mean_1', 'nan_to_mean_2']
+                    missing_values=np.nan,
+                    strategy="mean",
+                    keep_empty_features=True,
                 )
 
-            elif worker_tag=="quantile_norm_10":
+                sworker = SelectiveInversePipeline(
+                    steps=[
+                        ("power_transformer", RobustPowerTransformer(standardize=False)),
+                        (
+                            "inf_to_nan_1",
+                            FunctionTransformer(
+                                func=_inf_to_nan,
+                                inverse_func=_identity,
+                                check_inverse=False,
+                            ),
+                        ),
+                        ("nan_to_mean_1", nan_to_mean_transformer),
+                        ("scaler", StandardScaler()),
+                        (
+                            "inf_to_nan_2",
+                            FunctionTransformer(
+                                func=_inf_to_nan,
+                                inverse_func=_identity,
+                                check_inverse=False,
+                            ),
+                        ),
+                        ("nan_to_mean_2", nan_to_mean_transformer),
+                    ],
+                    skip_inverse=["nan_to_mean_1", "nan_to_mean_2"],
+                )
+
+            elif worker_tag == "quantile_norm_10":
                 sworker = QTx(
                     output_distribution="normal",
                     n_quantiles=max(n_samples // 10, 2),
                     random_state=static_seed,
                 )
-            elif worker_tag=="quantile_norm_5":
+            elif worker_tag == "quantile_norm_5":
                 sworker = QTx(
                     output_distribution="normal",
                     n_quantiles=max(n_samples // 5, 2),
@@ -1053,7 +1101,7 @@ class RebalanceFeatureDistribution(BasePreprocess):
                     random_state=static_seed,
                     subsample=n_samples,
                 )
-            elif worker_tag=="norm_and_kdi":
+            elif worker_tag == "norm_and_kdi":
                 sworker = FeatureUnion(
                     [
                         (
@@ -1071,9 +1119,9 @@ class RebalanceFeatureDistribution(BasePreprocess):
                     ],
                 )
 
-            elif worker_tag=="robust":
+            elif worker_tag == "robust":
                 sworker = RobustScaler(unit_variance=True)
-            elif worker_tag=="adaptive":
+            elif worker_tag == "adaptive":
                 # Per-column adaptive routing (TabPFN-style). Each numeric
                 # feature is categorized at fit-time by its distribution and
                 # routed through the appropriate transform: identity for
@@ -1084,11 +1132,11 @@ class RebalanceFeatureDistribution(BasePreprocess):
                     random_state=static_seed,
                     n_quantiles=max(n_samples // 10, 2),
                 )
-            elif worker_tag=="squash":
+            elif worker_tag == "squash":
                 # Robust scaling for outlier / heavy-tail features:
                 # median-centred, IQR-scaled to unit variance.
                 sworker = RobustScaler(unit_variance=True)
-            elif worker_tag=="kdi_uni":
+            elif worker_tag == "kdi_uni":
                 sworker = KDIX(alpha=1.0, output_distribution="uniform")
             elif worker_tag is None:
                 sworker = FunctionTransformer(_identity)
@@ -1098,7 +1146,7 @@ class RebalanceFeatureDistribution(BasePreprocess):
             elif worker_tag.startswith("kdi_norm_alpha_"):
                 alpha = float(worker_tag.split("_")[-1])
                 sworker = KDIX(alpha=alpha, output_distribution="normal")
-            elif worker_tag=="kdi_norm":
+            elif worker_tag == "kdi_norm":
                 sworker = KDIX(alpha=1.0, output_distribution="normal")
             else:
                 sworker = FunctionTransformer(_identity)
@@ -1106,22 +1154,63 @@ class RebalanceFeatureDistribution(BasePreprocess):
                 self.n_quantile_features = len(trans_ixs)
             workers.append((f"feat_transform_{worker_tag}", sworker, trans_ixs))
 
-        CT_worker = ColumnTransformer(workers,remainder="drop",sparse_threshold=0.0)
+        CT_worker = ColumnTransformer(workers, remainder="drop", sparse_threshold=0.0)
         if self.svd_tag == "svd" and n_features >= 2:
-            svd_worker = FeatureUnion([
+            svd_worker = FeatureUnion(
+                [
                     ("default", FunctionTransformer(func=_identity)),
-                    ("svd",Pipeline(steps=[
-                                    ("save_standard",Pipeline(steps=[
-                                    ("i2n_pre", FunctionTransformer(func=_inf_to_nan,inverse_func=_identity, check_inverse=False)),
-                                    ("fill_missing_pre", SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True)),
-                                    ("standard", StandardScaler(with_mean=False)) ,
-                                    ("i2n_post", FunctionTransformer(func=_inf_to_nan,inverse_func=_identity, check_inverse=False)),
-                                    ("fill_missing_post", SimpleImputer(missing_values=np.nan, strategy="mean", keep_empty_features=True))])),
-                                    ("svd",_TorchTruncatedSVD(algorithm="arpack",n_components=max(1,min(n_samples // 10 + 1,n_features // 2)),random_state=static_seed))]))
-                    ])
-            self.svd_n_comp = max(1,min(n_samples // 10 + 1,n_features // 2))
+                    (
+                        "svd",
+                        Pipeline(
+                            steps=[
+                                (
+                                    "save_standard",
+                                    Pipeline(
+                                        steps=[
+                                            (
+                                                "i2n_pre",
+                                                FunctionTransformer(
+                                                    func=_inf_to_nan, inverse_func=_identity, check_inverse=False
+                                                ),
+                                            ),
+                                            (
+                                                "fill_missing_pre",
+                                                SimpleImputer(
+                                                    missing_values=np.nan, strategy="mean", keep_empty_features=True
+                                                ),
+                                            ),
+                                            ("standard", StandardScaler(with_mean=False)),
+                                            (
+                                                "i2n_post",
+                                                FunctionTransformer(
+                                                    func=_inf_to_nan, inverse_func=_identity, check_inverse=False
+                                                ),
+                                            ),
+                                            (
+                                                "fill_missing_post",
+                                                SimpleImputer(
+                                                    missing_values=np.nan, strategy="mean", keep_empty_features=True
+                                                ),
+                                            ),
+                                        ]
+                                    ),
+                                ),
+                                (
+                                    "svd",
+                                    _TorchTruncatedSVD(
+                                        algorithm="arpack",
+                                        n_components=max(1, min(n_samples // 10 + 1, n_features // 2)),
+                                        random_state=static_seed,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    ),
+                ]
+            )
+            self.svd_n_comp = max(1, min(n_samples // 10 + 1, n_features // 2))
             worker = Pipeline([("worker", CT_worker), ("svd_worker", svd_worker)])
-        else:   
+        else:
             self.svd_n_comp = 0
             worker = CT_worker
 
@@ -1132,29 +1221,30 @@ class RebalanceFeatureDistribution(BasePreprocess):
 # Large constant for hash normalization
 _HASH_MODULUS = 10**12
 
+
 def float_hash_arr(input_array: np.ndarray) -> float:
     """
     Generate a normalized floating-point hash value from a numpy array.
-    
+
     This function computes a SHA256 hash of the array's byte representation,
     converts it to an integer, and normalizes it to a float between 0 and 1.
-    
+
     Args:
         input_array: Input numpy array to be hashed
-        
+
     Returns:
         Normalized hash value in the range [0, 1)
     """
     # Convert array to bytes and compute SHA256 hash
     array_bytes = input_array.tobytes()
     hash_hex = hashlib.sha256(array_bytes).hexdigest()
-    
+
     # Convert hex digest to integer
     hash_int = int(hash_hex, 16)
-    
+
     # Normalize to [0, 1) range using modulus operation
     normalized_hash = (hash_int % _HASH_MODULUS) / _HASH_MODULUS
-    
+
     return normalized_hash
 
 
@@ -1165,37 +1255,37 @@ class FingerprintFeatureEncoder(BasePreprocess):
     For test data: Uses first computed hash even if collisions occur.
     For training data: Resolves hash collisions through iterative rehashing.
     """
-    
+
     def __init__(self, rng_seed: int | np.random.Generator | None = None):
         super().__init__()
         # self.rng_seed = rng_seed
         self.salt_value = None
         self.categorical_features = None
-    
+
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         """Initialize random salt and return categorical feature indices."""
         _, rng = infer_random_state(seed)
         self.salt_value = int(rng.integers(0, 65536))  # 2^16 range
         self.categorical_features = categorical_features
         return categorical_features.copy()
-    
+
     @override
-    def transform(self, x:np.ndarray, is_test:bool=False, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def transform(self, x: np.ndarray, is_test: bool = False, **kwargs) -> tuple[np.ndarray, list[int]]:
         """
         Transform input by appending fingerprint column.
-        
+
         Args:
             X_data: Input array of shape (n_samples, n_features)
             is_test: Whether processing test data (affects collision handling)
-            
+
         Returns:
             Transformed array with fingerprint column and updated categorical indices
         """
         # print(f"add finger")
         if self.salt_value is None:
             raise RuntimeError("Must call fit() before transform()")
-        
+
         n_samples = x.shape[0]
         fingerprint_col = np.zeros(n_samples, dtype=x.dtype)
 
@@ -1222,12 +1312,13 @@ class FingerprintFeatureEncoder(BasePreprocess):
 
                 fingerprint_col[idx] = hash_val
                 existing_hashes.add(hash_val)
-        
+
         # Append fingerprint column and update categorical indices
         transformed = np.column_stack([x, fingerprint_col.reshape(-1, 1)])
         # cat_indices_updated = list(range(x.shape[1]))  # Original features remain categorical
-        
+
         return transformed, self.categorical_features
+
 
 class HighDimFeatureSelector(BasePreprocess):
     """Conditional high-dimensional feature selector / projector.
@@ -1291,7 +1382,7 @@ class HighDimFeatureSelector(BasePreprocess):
     def __init__(
         self,
         *,
-        strategy: Literal['corr', 'mi', 'extratrees', 'svd_binary', 'svd_all', 'passthrough'] = 'passthrough',
+        strategy: Literal["corr", "mi", "extratrees", "svd_binary", "svd_all", "passthrough"] = "passthrough",
         top_k: int = 256,
         n_features_threshold: int = 128,
         binary_threshold: float = 0.5,
@@ -1334,7 +1425,7 @@ class HighDimFeatureSelector(BasePreprocess):
     def _topk_indices(scores: np.ndarray, top_k: int) -> np.ndarray:
         n = len(scores)
         k = max(1, min(top_k, n))
-        idx = np.argsort(-scores, kind='stable')[:k]
+        idx = np.argsort(-scores, kind="stable")[:k]
         return np.sort(idx)
 
     @staticmethod
@@ -1414,7 +1505,7 @@ class HighDimFeatureSelector(BasePreprocess):
         x = np.asarray(x, dtype=np.float64)
         n_samples, n_features = x.shape
 
-        if self.strategy == 'passthrough' or n_features == 0:
+        if self.strategy == "passthrough" or n_features == 0:
             return self._activate_passthrough(categorical_features)
 
         binary_mask = self._detect_binary_cols(x)
@@ -1426,31 +1517,36 @@ class HighDimFeatureSelector(BasePreprocess):
         rng = np.random.default_rng(int(seed) % (2**32))
         seed_int = int(seed) % (2**31)
 
-        if self.strategy == 'svd_binary':
+        if self.strategy == "svd_binary":
             if binary_frac < self.binary_threshold or int(binary_mask.sum()) < 2:
                 return self._activate_passthrough(categorical_features)
             x_binary = x[:, binary_mask]
             x_binary = np.where(np.isnan(x_binary), 0.0, x_binary)
-            n_components = max(1, min(
-                self.svd_components,
-                int(binary_mask.sum()) - 1,
-                n_samples - 1,
-            ))
+            n_components = max(
+                1,
+                min(
+                    self.svd_components,
+                    int(binary_mask.sum()) - 1,
+                    n_samples - 1,
+                ),
+            )
             try:
                 self.svd_model_ = _TorchTruncatedSVD(n_components=n_components, random_state=seed_int)
                 self.svd_model_.fit(x_binary)
             except Exception as exc:
                 self._svd_degraded(
-                    "fit", exc,
+                    "fit",
+                    exc,
                     f"passthrough of all {n_features} raw columns "
-                    f"({int(binary_mask.sum())} binary columns left unprojected)")
+                    f"({int(binary_mask.sum())} binary columns left unprojected)",
+                )
                 return self._activate_passthrough(categorical_features)
             self.svd_binary_mask_ = binary_mask
             self.svd_keep_idx_ = np.where(~binary_mask)[0]
             self.passthrough_ = False
             return self._remap_categorical_svd_binary(categorical_features)
 
-        if self.strategy == 'svd_all':
+        if self.strategy == "svd_all":
             x_imp = np.where(np.isnan(x), 0.0, x)
             # Rank must be supported by the ROWS, not merely bounded by them.
             #
@@ -1475,18 +1571,18 @@ class HighDimFeatureSelector(BasePreprocess):
             # n_samples - 1 is kept as a VALIDITY bound (mean-centering costs one degree
             # of freedom) and is separate from the rows-support term, so
             # svd_rows_per_component=1 reproduces the previous rank exactly.
-            n_components = max(1, min(self.svd_components,
-                                      n_features - 1,
-                                      n_samples - 1,
-                                      n_samples // self.svd_rows_per_component))
+            n_components = max(
+                1, min(self.svd_components, n_features - 1, n_samples - 1, n_samples // self.svd_rows_per_component)
+            )
             try:
                 self.svd_model_ = _TorchTruncatedSVD(n_components=n_components, random_state=seed_int)
                 self.svd_model_.fit(x_imp)
             except Exception as exc:
                 self._svd_degraded(
-                    "fit", exc,
-                    f"passthrough of all {n_features} raw columns "
-                    f"(no reduction to {n_components} components)")
+                    "fit",
+                    exc,
+                    f"passthrough of all {n_features} raw columns (no reduction to {n_components} components)",
+                )
                 return self._activate_passthrough(categorical_features)
             self.svd_binary_mask_ = np.ones(n_features, dtype=bool)
             self.svd_keep_idx_ = np.array([], dtype=int)
@@ -1503,13 +1599,13 @@ class HighDimFeatureSelector(BasePreprocess):
         if finite_y.sum() < max(10, self.top_k // 4):
             return self._activate_passthrough(categorical_features)
 
-        if self.strategy == 'corr':
+        if self.strategy == "corr":
             scores = self._compute_corr_scores(x, y_arr)
             self.selected_idx_ = self._topk_indices(scores, self.top_k)
             self.passthrough_ = False
             return self._remap_categorical(categorical_features)
 
-        if self.strategy == 'mi':
+        if self.strategy == "mi":
             try:
                 from sklearn.feature_selection import mutual_info_regression
             except Exception:
@@ -1524,7 +1620,7 @@ class HighDimFeatureSelector(BasePreprocess):
             self.passthrough_ = False
             return self._remap_categorical(categorical_features)
 
-        if self.strategy == 'extratrees':
+        if self.strategy == "extratrees":
             try:
                 from sklearn.ensemble import ExtraTreesRegressor
             except Exception:
@@ -1551,9 +1647,9 @@ class HighDimFeatureSelector(BasePreprocess):
     def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         if self.passthrough_:
             return x, self.categorical_features_
-        if self.strategy in ('corr', 'mi', 'extratrees'):
+        if self.strategy in ("corr", "mi", "extratrees"):
             return x[:, self.selected_idx_], self.categorical_features_
-        if self.strategy in ('svd_binary', 'svd_all'):
+        if self.strategy in ("svd_binary", "svd_all"):
             x_arr = np.asarray(x, dtype=np.float64)
             x_in = x_arr[:, self.svd_binary_mask_]
             x_in = np.where(np.isnan(x_in), 0.0, x_in)
@@ -1562,18 +1658,21 @@ class HighDimFeatureSelector(BasePreprocess):
             except Exception as exc:
                 # SVD test-time failure: fall back to keep cols (or zeros if svd_all).
                 # Never silently — a zero column makes the model predict from nothing.
-                if self.strategy == 'svd_all':
+                if self.strategy == "svd_all":
                     self._svd_degraded(
-                        "transform", exc,
-                        f"a single all-zero column for {x_arr.shape[0]} rows "
-                        f"(all {x_in.shape[1]} features dropped)")
+                        "transform",
+                        exc,
+                        f"a single all-zero column for {x_arr.shape[0]} rows (all {x_in.shape[1]} features dropped)",
+                    )
                     return np.zeros((x_arr.shape[0], 1), dtype=np.float32), []
                 self._svd_degraded(
-                    "transform", exc,
+                    "transform",
+                    exc,
                     f"dropping the {x_in.shape[1]} SVD-projected columns, keeping the "
-                    f"{len(self.svd_keep_idx_)} non-binary ones")
+                    f"{len(self.svd_keep_idx_)} non-binary ones",
+                )
                 return x_arr[:, self.svd_keep_idx_].astype(np.float32), self.categorical_features_
-            if self.strategy == 'svd_all':
+            if self.strategy == "svd_all":
                 return x_svd.astype(np.float32), []
             x_keep = x_arr[:, self.svd_keep_idx_]
             out = np.concatenate([x_keep, x_svd], axis=1).astype(np.float32)
@@ -1612,9 +1711,7 @@ class MaxFeatureSubsampler(BasePreprocess):
             # No subsampling needed
             self.selected_idx = np.arange(n_features)
         else:
-            self.selected_idx = np.sort(
-                rng.choice(n_features, size=self.max_features, replace=False)
-            )
+            self.selected_idx = np.sort(rng.choice(n_features, size=self.max_features, replace=False))
         # Map categorical indices to new index space
         if categorical_features:
             idx_set = set(int(i) for i in self.selected_idx)
@@ -1637,7 +1734,7 @@ class PolynomialInteractionGenerator(BasePreprocess):
     Generates polynomial interaction features through randomized pairwise combinations
     with standardized preprocessing and memory-efficient implementation.
     """
-    
+
     def __init__(
         self,
         *,
@@ -1656,9 +1753,7 @@ class PolynomialInteractionGenerator(BasePreprocess):
         # When set, the step becomes a no-op for inputs with > N features (the
         # high-dim route disables poly so we don't add 10 noisy product
         # features on top of 1024 fingerprint columns).
-        self.disable_above_n_features = (
-            int(disable_above_n_features) if disable_above_n_features is not None else None
-        )
+        self.disable_above_n_features = int(disable_above_n_features) if disable_above_n_features is not None else None
         self.disabled_: bool = False
 
         self.primary_factor_indices: np.ndarray | None = None
@@ -1667,7 +1762,7 @@ class PolynomialInteractionGenerator(BasePreprocess):
         self.categorical_features = None
 
     @override
-    def fit(self, x:np.ndarray, categorical_features:list[int], seed:int, **kwargs) -> list[int]:
+    def fit(self, x: np.ndarray, categorical_features: list[int], seed: int, **kwargs) -> list[int]:
         """Configure polynomial feature generation parameters from training data."""
         assert x.ndim == 2, "Input matrix must be 2-dimensional"
 
@@ -1677,40 +1772,34 @@ class PolynomialInteractionGenerator(BasePreprocess):
         if x.size == 0:
             self.disabled_ = False
             return list(categorical_features)
-        if (self.disable_above_n_features is not None
-                and x.shape[1] > self.disable_above_n_features):
+        if self.disable_above_n_features is not None and x.shape[1] > self.disable_above_n_features:
             self.disabled_ = True
             self.categorical_features = list(categorical_features)
             return list(categorical_features)
         self.disabled_ = False
 
         feature_count = x.shape[1]
-        
+
         # Calculate maximum possible interaction combinations
         max_possible_combinations = (feature_count * (feature_count + 1)) // 2
-        
+
         # print(f"max_possible_combinations: {max_possible_combinations}")
         # Determine actual interaction count with constraint
         actual_interaction_count = (
-            min(self.max_interactions, max_possible_combinations) 
-            if self.max_interactions is not None 
+            min(self.max_interactions, max_possible_combinations)
+            if self.max_interactions is not None
             else max_possible_combinations
         )
-        
+
         # Standardize features before interaction generation
         normalized_data = self.feature_normalizer.fit_transform(x)
-        
+
         # Generate randomized factor pairs efficiently
         self._generate_interaction_pairs(feature_count, actual_interaction_count, random_engine)
         self.categorical_features = categorical_features
         return categorical_features
-    
-    def _generate_interaction_pairs(
-        self, 
-        total_features: int, 
-        required_pairs: int, 
-        rng: np.random.Generator
-    ) -> None:
+
+    def _generate_interaction_pairs(self, total_features: int, required_pairs: int, rng: np.random.Generator) -> None:
         """Efficiently generate unique factor pairs for polynomial feature creation."""
         self.primary_factor_indices = rng.choice(
             np.arange(total_features),
@@ -1733,7 +1822,7 @@ class PolynomialInteractionGenerator(BasePreprocess):
                     self.secondary_factor_indices[i] = rng.choice(allowed_b)
 
     @override
-    def transform(self, x:np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
+    def transform(self, x: np.ndarray, **kwargs) -> tuple[np.ndarray, list[int]]:
         """Apply polynomial feature transformation to input data."""
         assert x.ndim == 2, "Input matrix must be 2-dimensional"
 
@@ -1744,14 +1833,14 @@ class PolynomialInteractionGenerator(BasePreprocess):
 
         # Standardize input features
         standardized_features = self.feature_normalizer.transform(x)
-        
+
         # Generate polynomial interaction features
         interaction_features = (
-            standardized_features[:, self.primary_factor_indices] * 
-            standardized_features[:, self.secondary_factor_indices]
+            standardized_features[:, self.primary_factor_indices]
+            * standardized_features[:, self.secondary_factor_indices]
         )
-        
+
         # Combine original and interaction features
         transformed_output = np.column_stack([standardized_features, interaction_features])
-        
+
         return transformed_output, self.categorical_features

--- a/src/synthefy_nori/interpretability/shapiq.py
+++ b/src/synthefy_nori/interpretability/shapiq.py
@@ -16,8 +16,7 @@ def _require_shapiq():
         import shapiq  # noqa: F401
     except ImportError as exc:  # pragma: no cover
         raise ImportError(
-            "shapiq is required for interpretability. Install with: "
-            'pip install "synthefy-nori[interpretability]"'
+            'shapiq is required for interpretability. Install with: pip install "synthefy-nori[interpretability]"'
         ) from exc
     return shapiq
 

--- a/src/synthefy_nori/model/encoders.py
+++ b/src/synthefy_nori/model/encoders.py
@@ -3,19 +3,20 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 from synthefy_nori.model.layer import EncoderBaseLayer, MLP
-from typing import Any,Literal
+from typing import Any, Literal
 from torch.nn.init import orthogonal_
 import numpy as np
 import einops
 
 
-def calc_mean(x:torch.Tensor, dim:int):
+def calc_mean(x: torch.Tensor, dim: int):
     finite = torch.isfinite(x)
     num = torch.sum(finite, dim=dim).clip(min=1)
     values = torch.where(finite, x, torch.zeros_like(x))
     return torch.sum(values, dim=dim) / num, num
 
-def calc_std(x:torch.Tensor, dim:int, mean_v:torch.Tensor|None = None, value_num:torch.Tensor|None=None ):
+
+def calc_std(x: torch.Tensor, dim: int, mean_v: torch.Tensor | None = None, value_num: torch.Tensor | None = None):
     if mean_v is None or value_num is None:
         mean_v, value_num = calc_mean(x, dim)
     finite = torch.isfinite(x)
@@ -26,64 +27,67 @@ def calc_std(x:torch.Tensor, dim:int, mean_v:torch.Tensor|None = None, value_num
     )
     return torch.sqrt(torch.sum(squared_error, dim=dim) / (value_num - 1).clip(min=1))
 
-def drop_outliers(
-                    x:torch.Tensor, 
-                    std_sigma:float=4,
-                    eval_pos:int=-1,
-                    lower:torch.Tensor|None = None,
-                    upper:torch.Tensor|None = None,
-                    dim:int=1
-                    ):
-        # assert len(x.shape)==3, "x.shape must be B,S,F" 
 
-        if lower is None:
-            data = x[:,:eval_pos].clone()
-            data_mean, value_num = calc_mean(data, dim=dim)
-            data_std = calc_std(data, dim=dim, mean_v=data_mean, value_num=value_num)
-            cut_off = data_std * std_sigma
-            lower, upper = data_mean - cut_off, data_mean + cut_off
-            
-            data[torch.logical_or(data > upper, data < lower)] = np.nan
-            data_mean, value_num = calc_mean(data, dim=dim)
-            data_std = calc_std(data, dim=dim, mean_v=data_mean, value_num=value_num)
-            cut_off = data_std * std_sigma
-            lower, upper = data_mean - cut_off, data_mean + cut_off
-        
-        x = torch.maximum(-torch.log(1 + torch.abs(x)) + lower, x)
-        x = torch.minimum(torch.log(1 + torch.abs(x)) + upper, x)
-        
-        return x, lower, upper
-    
+def drop_outliers(
+    x: torch.Tensor,
+    std_sigma: float = 4,
+    eval_pos: int = -1,
+    lower: torch.Tensor | None = None,
+    upper: torch.Tensor | None = None,
+    dim: int = 1,
+):
+    # assert len(x.shape)==3, "x.shape must be B,S,F"
+
+    if lower is None:
+        data = x[:, :eval_pos].clone()
+        data_mean, value_num = calc_mean(data, dim=dim)
+        data_std = calc_std(data, dim=dim, mean_v=data_mean, value_num=value_num)
+        cut_off = data_std * std_sigma
+        lower, upper = data_mean - cut_off, data_mean + cut_off
+
+        data[torch.logical_or(data > upper, data < lower)] = np.nan
+        data_mean, value_num = calc_mean(data, dim=dim)
+        data_std = calc_std(data, dim=dim, mean_v=data_mean, value_num=value_num)
+        cut_off = data_std * std_sigma
+        lower, upper = data_mean - cut_off, data_mean + cut_off
+
+    x = torch.maximum(-torch.log(1 + torch.abs(x)) + lower, x)
+    x = torch.minimum(torch.log(1 + torch.abs(x)) + upper, x)
+
+    return x, lower, upper
+
+
 def normalize_mean0_std1(
-                        x:torch.Tensor, 
-                        eval_pos:int=-1,
-                        clip:bool=True,
-                        dim:int=1,
-                        mean: torch.Tensor | None = None,
-                        std: torch.Tensor | None = None
-                        ):
+    x: torch.Tensor,
+    eval_pos: int = -1,
+    clip: bool = True,
+    dim: int = 1,
+    mean: torch.Tensor | None = None,
+    std: torch.Tensor | None = None,
+):
     if mean is None:
-        mean, value_num = calc_mean(x[:,:eval_pos], dim=dim)
-        std = calc_std(x[:,:eval_pos], dim=dim, mean_v=mean, value_num=value_num) + 1e-20
-        
+        mean, value_num = calc_mean(x[:, :eval_pos], dim=dim)
+        std = calc_std(x[:, :eval_pos], dim=dim, mean_v=mean, value_num=value_num) + 1e-20
+
         if x.shape[1] == 1 or eval_pos == 1:
             std[:] = 1.0
     x = (x - mean.unsqueeze(1).expand_as(x)) / std.unsqueeze(1).expand_as(x)
     if clip:
         x = torch.clip(x, min=-100, max=100)
     return x, mean, std
-    
+
 
 class LinearEncoder(nn.Module):
     """linear input encoder"""
+
     def __init__(
-                self,
-                num_features: int,
-                emsize: int,
-                nan_to_zero: bool = False,
-                bias: bool = True,
-                in_keys:list[str]=['data'],
-                out_key:str='data',
+        self,
+        num_features: int,
+        emsize: int,
+        nan_to_zero: bool = False,
+        bias: bool = True,
+        in_keys: list[str] = ["data"],
+        out_key: str = "data",
     ):
         """Initialize the LinearEncoder.
 
@@ -98,21 +102,22 @@ class LinearEncoder(nn.Module):
         self.nan_to_zero = nan_to_zero
         self.in_keys = in_keys
         self.out_key = out_key
-        
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
+
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
         missing_keys = [key for key in self.in_keys if key not in input]
         assert not missing_keys, f"Missing encoder inputs: {missing_keys}"
-        x = [input[key] for key in self.in_keys] 
-        x = torch.cat(x, dim=-1) # type: ignore
+        x = [input[key] for key in self.in_keys]
+        x = torch.cat(x, dim=-1)  # type: ignore
         if self.nan_to_zero:
             x = torch.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
-            
+
         input[self.out_key] = self.layer(x)
         return input
 
+
 class RBFembedding(nn.Module):
     def __init__(
-        self, 
+        self,
         embedding_size: int = 96,
         exponent_digits: int = 1,
         token_embed_dim: int = 32,
@@ -123,7 +128,7 @@ class RBFembedding(nn.Module):
         use_learn_embeddings: bool = False,
         as_tokenizer: bool = False,
         use_original_features: bool = False,
-        dtype: torch.dtype = torch.float32
+        dtype: torch.dtype = torch.float32,
     ):
         super().__init__()
         self.dtype = dtype
@@ -145,25 +150,25 @@ class RBFembedding(nn.Module):
             self.register_buffer("sigma", sigma)
 
         if exponent_digits > 0:
-            self.sign_embedding = nn.Embedding(2, token_embed_dim, dtype=dtype)       # 0:+, 1:-
-            self.exp_sign_embedding = nn.Embedding(2, token_embed_dim, dtype=dtype)   # 0:exp+, 1:exp-
-            self.exp_digit_embedding = nn.Embedding(10, token_embed_dim, dtype=dtype) # 0-9
-            
+            self.sign_embedding = nn.Embedding(2, token_embed_dim, dtype=dtype)  # 0:+, 1:-
+            self.exp_sign_embedding = nn.Embedding(2, token_embed_dim, dtype=dtype)  # 0:exp+, 1:exp-
+            self.exp_digit_embedding = nn.Embedding(10, token_embed_dim, dtype=dtype)  # 0-9
+
             if not use_learn_embeddings:
                 self.sign_embedding.weight.requires_grad = False
                 self.exp_sign_embedding.weight.requires_grad = False
                 self.exp_digit_embedding.weight.requires_grad = False
-            
+
             ctrl_in_dim = (exponent_digits + 2) * token_embed_dim
             self.gate_mlp = nn.Sequential(
                 nn.Linear(ctrl_in_dim, 4 * token_embed_dim, dtype=dtype),
                 nn.GELU(),
-                nn.Linear(4 * token_embed_dim, 2 * n_kernels, dtype=dtype)
+                nn.Linear(4 * token_embed_dim, 2 * n_kernels, dtype=dtype),
             )
         else:
             self.sign_embedding = self.exp_sign_embedding = self.exp_digit_embedding = None
             self.gate_mlp = None
-        
+
         self.norm = nn.LayerNorm(n_kernels, dtype=dtype)
         if self.use_original_features:
             self.out_layer = nn.Linear(n_kernels + 1, embedding_size, dtype=dtype)
@@ -218,7 +223,7 @@ class RBFembedding(nn.Module):
         causes Inductor CantSplit in the backward pass.
         """
         abs_x = torch.abs(x_work)
-        is_zero = (abs_x == 0)
+        is_zero = abs_x == 0
         safe = torch.where(is_zero, torch.ones_like(abs_x), abs_x)
         exp_f = torch.floor(torch.log10(safe))
         max_exp = 10**self.exponent_digits - 1
@@ -242,42 +247,43 @@ class RBFembedding(nn.Module):
             x_scaled = x_work
 
         centers = self.centers.to(work_dtype)
-        diff = x_scaled.unsqueeze(-1) - centers.view((1,)*x_scaled.dim() + (self.n_kernels,))
-        rbf = torch.exp(-(diff ** 2) / (2 * (self.sigma ** 2))).to(self.dtype)
+        diff = x_scaled.unsqueeze(-1) - centers.view((1,) * x_scaled.dim() + (self.n_kernels,))
+        rbf = torch.exp(-(diff**2) / (2 * (self.sigma**2))).to(self.dtype)
 
         if self.gate_mlp is not None:
             sign_idx = (x_work < 0).to(torch.long)
             exp_sign_idx = (exp_i < 0).to(torch.long)
             abs_exp = exp_i.abs()
-            sign_emb = self.sign_embedding(sign_idx)            # (S, F, D)
+            sign_emb = self.sign_embedding(sign_idx)  # (S, F, D)
             exp_sign_emb = self.exp_sign_embedding(exp_sign_idx)
             exp_digit_emb_list = []
             for power in range(self.exponent_digits):
-                digit = (abs_exp // (10 ** power)) % 10
+                digit = (abs_exp // (10**power)) % 10
                 exp_digit_emb_list.append(self.exp_digit_embedding(digit))
-            exp_digits_emb = torch.stack(exp_digit_emb_list[::-1], dim=-2)     # (S,F,e,D)
+            exp_digits_emb = torch.stack(exp_digit_emb_list[::-1], dim=-2)  # (S,F,e,D)
             exp_digits_emb_flat = einops.rearrange(exp_digits_emb, "... e D -> ... (e D)")
             ctrl = torch.cat([sign_emb, exp_sign_emb, exp_digits_emb_flat], dim=-1).to(self.dtype)
-            gamma_beta = self.gate_mlp(ctrl)                # (S, F, 2*k)
+            gamma_beta = self.gate_mlp(ctrl)  # (S, F, 2*k)
             gamma, beta = torch.split(gamma_beta, self.n_kernels, dim=-1)
-            gamma = torch.sigmoid(gamma)                    # (S, F, k), 0~1
-            beta = torch.tanh(beta)                         # (S, F, k), -1~1
+            gamma = torch.sigmoid(gamma)  # (S, F, k), 0~1
+            beta = torch.tanh(beta)  # (S, F, k), -1~1
             # rbf = self.norm(rbf)
             rbf = rbf * gamma + beta
             rbf = self.norm(rbf)
         if self.use_original_features:
             rbf = torch.cat([rbf, x.unsqueeze(-1)], dim=-1)
-        out = self.out_layer(rbf.to(self.dtype))            # (S, F, embedding_size)
+        out = self.out_layer(rbf.to(self.dtype))  # (S, F, embedding_size)
         return out.reshape(S, -1) if not self.as_tokenizer else out
-    
+
+
 class PBLDEmbedding(nn.Module):
     """Periodic + Linear + DenseNet embedding (inspired by RealMLP).
     For each scalar x:
       periodic = cos(2pi * w * x + b)  ->  Linear + residual  ->  LayerNorm
       output = Linear(concat(x, periodic))  ->  [embedding_size]
     All params shared across features (ICL-compatible)."""
-    def __init__(self, embedding_size=96, n_frequencies=48, as_tokenizer=False,
-                 dtype=torch.float32):
+
+    def __init__(self, embedding_size=96, n_frequencies=48, as_tokenizer=False, dtype=torch.float32):
         super().__init__()
         self.as_tokenizer = as_tokenizer
         self.n_frequencies = n_frequencies
@@ -302,21 +308,22 @@ class PBLDEmbedding(nn.Module):
 
 class MaskEmbEncoder(nn.Module):
     """
-    For masked features, use the mask vector to obtain their representations; 
+    For masked features, use the mask vector to obtain their representations;
     for numerical features, use a nonlinear network to obtain their representations
     """
+
     def __init__(
-                self,
-                num_features: int,
-                emsize: int,
-                mask_embedding_size: int,
-                numeric_embed_type: str = "linear",
-                RBF_config: dict|None = None,
-                PBLD_config: dict|None = None,
-                nan_to_zero: bool = False,
-                bias: bool = True,
-                in_keys: list[str] = ['data'],
-                out_key: str = 'data',
+        self,
+        num_features: int,
+        emsize: int,
+        mask_embedding_size: int,
+        numeric_embed_type: str = "linear",
+        RBF_config: dict | None = None,
+        PBLD_config: dict | None = None,
+        nan_to_zero: bool = False,
+        bias: bool = True,
+        in_keys: list[str] = ["data"],
+        out_key: str = "data",
     ):
         """Initialize the MaskEmbEncoder.
 
@@ -342,7 +349,7 @@ class MaskEmbEncoder(nn.Module):
             nn.ReLU(),
             nn.Linear(self.embedding_dim // 2, self.embedding_dim, bias=bias),
             nn.LayerNorm(self.embedding_dim),
-            nn.ReLU()
+            nn.ReLU(),
         )
 
         self.numeric_embed_type = numeric_embed_type
@@ -353,25 +360,25 @@ class MaskEmbEncoder(nn.Module):
                 nn.ReLU(),
                 nn.Linear(self.embedding_dim // 2, self.embedding_dim),
                 nn.LayerNorm(self.embedding_dim),
-                nn.ReLU()
+                nn.ReLU(),
             )
         elif numeric_embed_type == "RBF":
             self.numeric_mlp = RBFembedding(
                 embedding_size=self.embedding_dim,
                 exponent_digits=1,
-                token_embed_dim=RBF_config['token_embed_dim'],
-                n_kernels=RBF_config['n_kernels'],
-                sigma=RBF_config['sigma'],
-                use_learn_sigma=RBF_config['use_learn_sigma'],
-                use_learn_embeddings=RBF_config['use_learn_embeddings'],
+                token_embed_dim=RBF_config["token_embed_dim"],
+                n_kernels=RBF_config["n_kernels"],
+                sigma=RBF_config["sigma"],
+                use_learn_sigma=RBF_config["use_learn_sigma"],
+                use_learn_embeddings=RBF_config["use_learn_embeddings"],
                 center_range=(0.0, 10.0),
-                use_original_features=RBF_config['use_original_features'],
+                use_original_features=RBF_config["use_original_features"],
                 as_tokenizer=True,
             )
         elif numeric_embed_type == "PBLD":
             self.numeric_mlp = PBLDEmbedding(
                 embedding_size=self.embedding_dim,
-                n_frequencies=PBLD_config.get('n_frequencies', 48) if PBLD_config else 48,
+                n_frequencies=PBLD_config.get("n_frequencies", 48) if PBLD_config else 48,
                 as_tokenizer=True,
             )
         else:
@@ -383,21 +390,21 @@ class MaskEmbEncoder(nn.Module):
             nn.LayerNorm(self.embedding_dim),
             nn.ReLU(),
             nn.Linear(self.embedding_dim, self.embedding_dim, bias=bias),
-            nn.LayerNorm(self.embedding_dim)
+            nn.LayerNorm(self.embedding_dim),
         )
         self.nan_to_zero = nan_to_zero
-    
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
+
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
         missing_keys = [key for key in self.in_keys if key not in input]
         assert not missing_keys, f"Missing encoder inputs: {missing_keys}"
         x = [input[key] for key in self.in_keys]
-        x = torch.cat(x, dim=-1) # type: ignore
+        x = torch.cat(x, dim=-1)  # type: ignore
         batch_size, seq_len, group, feature_num = x.shape
 
         x = x.unsqueeze(-1)
         is_mask = torch.isnan(x)
         x = x.masked_fill(is_mask, 0.0)
-        
+
         x_emb = self.numeric_mlp(x)
 
         if self.nan_to_zero:
@@ -414,24 +421,26 @@ class MaskEmbEncoder(nn.Module):
 
         sample_representation = self.fusion_network(concat_vector)
         output = sample_representation.view(batch_size, seq_len, group, -1)
-        
+
         input[self.out_key] = output
         return input
 
+
 class NanEncoder(nn.Module):
     """Encoder stage that deals with NaN and infinite values in the input"""
+
     def __init__(
         self,
         nan_value: float = -2.0,
         inf_value: float = 2.0,
         neg_info_value: float = 4.0,
-        in_keys:list[str]=['data'],
-        out_key:str='nan_encoding'
+        in_keys: list[str] = ["data"],
+        out_key: str = "nan_encoding",
     ):
         """Initialize the NanEncoder.
 
         Args:
-            keep_nans: Flag to maintain NaN values as individual indicators. 
+            keep_nans: Flag to maintain NaN values as individual indicators.
         """
         super().__init__()
         self.nan_value = nan_value
@@ -439,10 +448,10 @@ class NanEncoder(nn.Module):
         self.neg_info_value = neg_info_value
         self.in_keys = in_keys
         self.out_key = out_key
-        
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
-        x:torch.Tensor = input[self.in_keys[0]] # type: ignore
-        eval_pos = input['eval_pos']
+
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
+        x: torch.Tensor = input[self.in_keys[0]]  # type: ignore
+        eval_pos = input["eval_pos"]
 
         # Context-cache "frozen stats" path, same contract as NormalizationEncoder's:
         # the imputation fill is the CONTEXT column mean, so query rows arriving
@@ -454,13 +463,13 @@ class NanEncoder(nn.Module):
         # infinity must not poison the fill for every other missing value in its
         # column. A column with no finite context value receives the neutral fill 0;
         # the original-value mask restores that column to missing before embedding.
-        frozen_mean = input.get('_frozen_nan_mean')
+        frozen_mean = input.get("_frozen_nan_mean")
         if frozen_mean is not None:
             mean_value = frozen_mean
         else:
-            mean_value, _ = calc_mean(x[:,:eval_pos,:], dim=1)
+            mean_value, _ = calc_mean(x[:, :eval_pos, :], dim=1)
         # Expose the fill actually used so build_context_cache can capture it.
-        input['_nan_mean'] = mean_value
+        input["_nan_mean"] = mean_value
 
         # The data channel consistently treats NaN and both infinities as missing.
         # Keep the signed indicator as a separate channel for encoder configurations
@@ -471,29 +480,30 @@ class NanEncoder(nn.Module):
         is_neg_inf = torch.isinf(x) & (x < 0)
         is_nonfinite = is_nan | is_pos_inf | is_neg_inf
         nans_indicator = torch.where(
-            is_nan, self.nan_value,
-            torch.where(is_pos_inf, self.inf_value,
-            torch.where(is_neg_inf, self.neg_info_value,
-            torch.zeros_like(x))))
+            is_nan,
+            self.nan_value,
+            torch.where(is_pos_inf, self.inf_value, torch.where(is_neg_inf, self.neg_info_value, torch.zeros_like(x))),
+        )
 
         # Replace NaN/Inf with context mean (functional, no clone + masked assign)
         fill = mean_value.unsqueeze(1).expand_as(x)
         x = torch.where(is_nonfinite, fill, x)
 
         input[self.in_keys[0]] = x
-        input[self.out_key ] = nans_indicator
+        input[self.out_key] = nans_indicator
         return input
-        
-    
+
+
 class ValidFeatureEncoder(nn.Module):
     """Valid feature encoder"""
+
     def __init__(
         self,
         num_features: int,
-        nan_normalize: bool=True,
-        sqrt_normalize: bool=True,
-        in_keys:list[str]=['data'],
-        out_key:str='data'
+        nan_normalize: bool = True,
+        sqrt_normalize: bool = True,
+        in_keys: list[str] = ["data"],
+        out_key: str = "data",
     ):
         """Initialize the ValidFeatureEncoder.
 
@@ -509,28 +519,24 @@ class ValidFeatureEncoder(nn.Module):
         self.in_keys = in_keys
         self.out_key = out_key
         self.valid_feature_num = None
-    
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
-        x:torch.Tensor = input[self.in_keys[0]]  # type: ignore
-        frozen_valid_feature_num = input.get('_frozen_valid_feature_num')
+
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
+        x: torch.Tensor = input[self.in_keys[0]]  # type: ignore
+        frozen_valid_feature_num = input.get("_frozen_valid_feature_num")
         if frozen_valid_feature_num is None:
-            eval_pos = int(input['eval_pos'])
+            eval_pos = int(input["eval_pos"])
             context = x[:, :eval_pos]
-            original_mask = input.get('mask')
-            if (self.in_keys[0] == 'data'
-                    and isinstance(original_mask, torch.Tensor)
-                    and original_mask.shape == x.shape):
+            original_mask = input.get("mask")
+            if self.in_keys[0] == "data" and isinstance(original_mask, torch.Tensor) and original_mask.shape == x.shape:
                 context = torch.where(
                     original_mask[:, :eval_pos].to(torch.bool),
-                    torch.full_like(context, float('nan')),
+                    torch.full_like(context, float("nan")),
                     context,
                 )
             finite = torch.isfinite(context)
             finite_count = finite.sum(dim=1)
-            finite_min = torch.where(
-                finite, context, torch.full_like(context, float('inf'))).amin(dim=1)
-            finite_max = torch.where(
-                finite, context, torch.full_like(context, float('-inf'))).amax(dim=1)
+            finite_min = torch.where(finite, context, torch.full_like(context, float("inf"))).amin(dim=1)
+            finite_max = torch.where(finite, context, torch.full_like(context, float("-inf"))).amax(dim=1)
             valid_feature = (finite_count > 1) & (finite_min != finite_max)
             valid_feature_num = torch.clip(valid_feature.sum(-1).unsqueeze(-1), min=1)
         else:
@@ -539,7 +545,7 @@ class ValidFeatureEncoder(nn.Module):
         # Store on self for backward compat (inference predictor reads it),
         # and also pass through dict for compile-friendly access.
         self.valid_feature_num = valid_feature_num.detach()
-        input['_valid_feature_num'] = valid_feature_num
+        input["_valid_feature_num"] = valid_feature_num
 
         if self.nan_normalize:
             if self.sqrt_normalize:
@@ -557,7 +563,7 @@ class ValidFeatureEncoder(nn.Module):
 
         input[self.out_key] = x
         return input
-    
+
 
 class EmbYEncoderStep(nn.Module):
     """A simple linear input encoder step."""
@@ -567,8 +573,8 @@ class EmbYEncoderStep(nn.Module):
         *,
         emsize: int,
         n_classes: int = 10,
-        in_keys: list[str] = ['data'],
-        out_key: str = 'data',
+        in_keys: list[str] = ["data"],
+        out_key: str = "data",
     ):
         """Initialize the EmbYEncoderStep.
 
@@ -577,9 +583,11 @@ class EmbYEncoderStep(nn.Module):
             n_classes: Number of classes
         """
         super().__init__()
-        
+
         # Ensure the embedding dimension is large enough to support orthogonal initialization.
-        assert emsize > n_classes + 1, (f"emsize ({emsize}) must be >= n_classes+1 ({n_classes+1}) for orthogonal initialization")
+        assert emsize > n_classes + 1, (
+            f"emsize ({emsize}) must be >= n_classes+1 ({n_classes + 1}) for orthogonal initialization"
+        )
 
         # Generate an orthogonal matrix of size (n_classes + 1) × emsize
         ortho_matrix = torch.empty(n_classes + 1, emsize)
@@ -587,7 +595,7 @@ class EmbYEncoderStep(nn.Module):
 
         # Decompose the matrix: the first n_classes rows are used for y_embedding, and the last row is used for y_mask.
         y_embed_weights = ortho_matrix[:n_classes, :]  # Shape (n_classes, emsize)
-        y_mask_weight = ortho_matrix[n_classes:n_classes+1, :]  # Shape (1, emsize)
+        y_mask_weight = ortho_matrix[n_classes : n_classes + 1, :]  # Shape (1, emsize)
 
         self.y_embedding = nn.Embedding(n_classes, emsize)
         self.y_embedding.weight.data = y_embed_weights.clone()
@@ -597,20 +605,23 @@ class EmbYEncoderStep(nn.Module):
         self.in_keys = in_keys
         self.out_key = out_key
         if len(self.in_keys) > 1:
-            print("\033[30;43mWarning: The EmbYEncoderStepl function is only for processing Y, and in_keys must contain exactly one key.\033[0m")
-        
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
+            print(
+                "\033[30;43mWarning: The EmbYEncoderStepl function is only for processing Y, and in_keys must contain exactly one key.\033[0m"
+            )
+
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
         y = input[self.in_keys[0]]
-        eval_pos = input['eval_pos']
-        y = y.int() # type: ignore
-        y_train = y[:,:eval_pos]
+        eval_pos = input["eval_pos"]
+        y = y.int()  # type: ignore
+        y_train = y[:, :eval_pos]
         y_test = torch.zeros_like(y[:, eval_pos:], dtype=torch.int)
         y_train_emb = self.y_embedding(y_train)
         y_test_emb = self.y_mask(y_test)
         y_emb = torch.cat([y_train_emb, y_test_emb], dim=1)
-        
+
         input[self.out_key] = y_emb
         return input
+
 
 class MulticlassTargetEncoder(nn.Module):
     """Use the target's index as the class value, with each class corresponding to an index.
@@ -620,51 +631,49 @@ class MulticlassTargetEncoder(nn.Module):
     implementation avoids per-batch Python loops and torch.unique so that
     torch.compile can trace through this module without a graph break.
     """
+
     MAX_CLASSES: int = 10  # model hard-cap (matches decoder width)
 
-    def __init__(
-        self,
-        in_keys:list[str]=['data'],
-        out_key:str='data'
-    ):
+    def __init__(self, in_keys: list[str] = ["data"], out_key: str = "data"):
         super().__init__()
         self.in_keys = in_keys
         self.out_key = out_key
 
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
-        x:torch.Tensor = input[self.in_keys[0]]  # type: ignore  [B, S, 1]
-        eval_pos = input['eval_pos']
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
+        x: torch.Tensor = input[self.in_keys[0]]  # type: ignore  [B, S, 1]
+        eval_pos = input["eval_pos"]
         max_cls = self.MAX_CLASSES
 
         # Which classes appear in each batch's context?  [B, max_cls] bool
         # Broadcasting: ctx[:, :, :, None] == arange[None, None, None, max_cls]
-        ctx = x[:, :eval_pos, :]                                      # [B, ep, 1]
+        ctx = x[:, :eval_pos, :]  # [B, ep, 1]
         class_ids = torch.arange(max_cls, device=x.device, dtype=x.dtype)  # [max_cls]
-        class_present = (ctx == class_ids).any(dim=1)                   # [B, max_cls]
+        class_present = (ctx == class_ids).any(dim=1)  # [B, max_cls]
 
         # Exclusive prefix-sum: ranks[b, c] = #present classes with index < c
-        cum = class_present.to(torch.long).cumsum(dim=1)               # [B, max_cls]
+        cum = class_present.to(torch.long).cumsum(dim=1)  # [B, max_cls]
         ranks = torch.zeros_like(cum)
-        ranks[:, 1:] = cum[:, :-1]                                    # [B, max_cls]
+        ranks[:, 1:] = cum[:, :-1]  # [B, max_cls]
 
         # Look up the rank for every position
-        x_idx = x[:, :, 0].to(torch.long).clamp(0, max_cls - 1)      # [B, S]
-        x_ranked = torch.gather(ranks, 1, x_idx).unsqueeze(-1)        # [B, S, 1]
+        x_idx = x[:, :, 0].to(torch.long).clamp(0, max_cls - 1)  # [B, S]
+        x_ranked = torch.gather(ranks, 1, x_idx).unsqueeze(-1)  # [B, S, 1]
 
         input[self.out_key] = x_ranked.to(x.dtype)
         return input
 
+
 class NormalizationEncoder(nn.Module):
     """normalize encoder"""
+
     def __init__(
-                self, 
-                train_only:bool,
-                normalize_x:bool,
-                remove_outliers:bool,
-                std_sigma:float=4.0,
-                in_keys:list[str]=['data'],
-                out_key:str='data'
-                
+        self,
+        train_only: bool,
+        normalize_x: bool,
+        remove_outliers: bool,
+        std_sigma: float = 4.0,
+        in_keys: list[str] = ["data"],
+        out_key: str = "data",
     ):
         super().__init__()
         self.train_only = train_only
@@ -676,9 +685,9 @@ class NormalizationEncoder(nn.Module):
         self.mean = None
         self.std = None
 
-    def forward(self, input:dict[str, torch.Tensor|int])->dict[str, torch.Tensor]:
+    def forward(self, input: dict[str, torch.Tensor | int]) -> dict[str, torch.Tensor]:
         x = input[self.in_keys[0]]
-        eval_pos = input['eval_pos']
+        eval_pos = input["eval_pos"]
         # A negative slice endpoint excludes the final row. `train_only=False`
         # means all rows, including that final row, participate in the statistics.
         pos = eval_pos if self.train_only else x.shape[1]
@@ -690,33 +699,31 @@ class NormalizationEncoder(nn.Module):
         # stats are bit-identical to the transductive path, which also normalizes
         # test rows with train stats. `drop_outliers`/`normalize_mean0_std1`
         # already skip their eval_pos computation when given lower/upper/mean/std.
-        frozen = input.get('_frozen_norm_stats')
+        frozen = input.get("_frozen_norm_stats")
         captured: dict[str, torch.Tensor] = {}
         if self.remove_outliers:
-            lower = frozen.get('lower') if frozen else None
-            upper = frozen.get('upper') if frozen else None
-            x, lower, upper = drop_outliers(
-                x, eval_pos=pos, std_sigma=self.std_sigma, lower=lower, upper=upper)
-            captured['lower'], captured['upper'] = lower, upper
+            lower = frozen.get("lower") if frozen else None
+            upper = frozen.get("upper") if frozen else None
+            x, lower, upper = drop_outliers(x, eval_pos=pos, std_sigma=self.std_sigma, lower=lower, upper=upper)
+            captured["lower"], captured["upper"] = lower, upper
         if self.normalize_x:
-            mean = frozen.get('mean') if frozen else None
-            std = frozen.get('std') if frozen else None
+            mean = frozen.get("mean") if frozen else None
+            std = frozen.get("std") if frozen else None
             x, mean, std = normalize_mean0_std1(x, eval_pos=pos, mean=mean, std=std)
             # Store on self for backward compat (inference predictor reads it),
             # and also pass through dict for compile-friendly access.
             self.mean = mean.detach()
             self.std = std.detach()
-            input['_norm_mean'] = mean
-            input['_norm_std'] = std
-            captured['mean'], captured['std'] = mean, std
+            input["_norm_mean"] = mean
+            input["_norm_std"] = std
+            captured["mean"], captured["std"] = mean, std
 
         input[self.out_key] = x
         # Expose the stats actually used so build_context_cache can capture them
         # for later frozen reuse (the values are train-derived whether freshly
         # computed here or passed in via `_frozen_norm_stats`).
-        input['_norm_stats'] = captured
+        input["_norm_stats"] = captured
         return input
-
 
 
 def get_x_encoder(
@@ -726,20 +733,20 @@ def get_x_encoder(
     mask_embedding_size: int,
     encoder_use_bias: bool,
     numeric_embed_type: str = "linear",
-    RBF_config: dict|None = None,
-    PBLD_config: dict|None = None,
-    in_keys: list = ['data'],
+    RBF_config: dict | None = None,
+    PBLD_config: dict | None = None,
+    in_keys: list = ["data"],
     nan_to_zero: bool = False,
 ):
     assert isinstance(in_keys, list), "The type of in_keys must be a list!"
     inputs_to_merge = {}
     for in_key in in_keys:
-        inputs_to_merge[in_key] = {'dim': num_features}
+        inputs_to_merge[in_key] = {"dim": num_features}
 
     encoder_steps = []
     encoder_steps += [
-        # The masked features (i.e., features with None values) are directly mapped to 
-        # vectors via the embedding matrix, while the numerical features obtain their 
+        # The masked features (i.e., features with None values) are directly mapped to
+        # vectors via the embedding matrix, while the numerical features obtain their
         # embedding representations through a nonlinear transformation matrix.
         MaskEmbEncoder(
             num_features=sum([i["dim"] for i in inputs_to_merge.values()]),
@@ -753,32 +760,26 @@ def get_x_encoder(
             numeric_embed_type=numeric_embed_type,
         ),
     ]
-    return nn.Sequential(*encoder_steps,)
+    return nn.Sequential(
+        *encoder_steps,
+    )
 
 
 def get_cls_y_encoder(
-    *,
-    num_inputs: int,
-    embedding_size: int,
-    nan_handling_y_encoder: bool,
-    max_num_classes: int
+    *, num_inputs: int, embedding_size: int, nan_handling_y_encoder: bool, max_num_classes: int
 ) -> nn.Module:
     steps = []
     inputs_to_merge = [{"name": "data", "dim": num_inputs}]
     if nan_handling_y_encoder:
-        steps += [NanEncoder(in_keys=['data'], out_key='nan_encoding')]
+        steps += [NanEncoder(in_keys=["data"], out_key="nan_encoding")]
         inputs_to_merge += [{"name": "nan_indicators", "dim": num_inputs}]
 
     if max_num_classes >= 2:
         steps += [MulticlassTargetEncoder()]
 
-    steps += [
-            EmbYEncoderStep(
-                emsize=embedding_size,
-                n_classes=max_num_classes
-        )
-    ]
+    steps += [EmbYEncoderStep(emsize=embedding_size, n_classes=max_num_classes)]
     return nn.Sequential(*steps)
+
 
 def get_reg_y_encoder(
     *,
@@ -790,7 +791,7 @@ def get_reg_y_encoder(
     steps = []
     inputs_to_merge = [{"name": "data", "dim": num_inputs}]
     if nan_handling_y_encoder:
-        steps += [NanEncoder(in_keys=['data'], out_key='nan_encoding')]
+        steps += [NanEncoder(in_keys=["data"], out_key="nan_encoding")]
         inputs_to_merge += [{"name": "nan_encoding", "dim": num_inputs}]
 
     in_keys = [item["name"] for item in inputs_to_merge]
@@ -801,7 +802,7 @@ def get_reg_y_encoder(
             emsize=embedding_size,
             nan_to_zero=not nan_handling_y_encoder,
             in_keys=in_keys,
-            out_key='data'
+            out_key="data",
         ),
     ]
     return nn.Sequential(*steps)
@@ -815,14 +816,14 @@ def preprocesss_4_x(
     normalize_x: bool,
     remove_outliers: bool,
     normalize_by_used_features: bool,
-    ):
+):
     """feature preprocess"""
     preprocess_steps = []
 
     if nan_handling_enabled:
         # Obtain the positions of non-finite values and replace those data-channel
         # values with the corresponding finite context mean for normalization.
-        preprocess_steps += [NanEncoder(in_keys=['data'], out_key='nan_encoding')]
+        preprocess_steps += [NanEncoder(in_keys=["data"], out_key="nan_encoding")]
 
     preprocess_steps += [
         NormalizationEncoder(

--- a/src/synthefy_nori/model/kv_cache_scaling.py
+++ b/src/synthefy_nori/model/kv_cache_scaling.py
@@ -17,6 +17,7 @@ GPU high-water-mark stays ~flat in N (weights + per-chunk activations + a staged
 slice), while the O(N) cache lives in host RAM. Compute is unchanged; this is a
 memory lever only.
 """
+
 from __future__ import annotations
 
 import torch
@@ -45,9 +46,16 @@ class ScalableSeqKV:
     the GPU copy is transient. ``self["batch"]``/``self["groups"]`` are plain ints.
     """
 
-    def __init__(self, kv: torch.Tensor, batch: int, groups: int, *,
-                 quantize: bool = False, offload: bool = False,
-                 device: torch.device | None = None):
+    def __init__(
+        self,
+        kv: torch.Tensor,
+        batch: int,
+        groups: int,
+        *,
+        quantize: bool = False,
+        offload: bool = False,
+        device: torch.device | None = None,
+    ):
         self.batch = int(batch)
         self.groups = int(groups)
         self.device = torch.device(device) if device is not None else kv.device
@@ -79,10 +87,17 @@ class ScalableSeqKV:
         raise KeyError(key)
 
     @classmethod
-    def from_row_slices(cls, slices, batch: int, groups: int, *,
-                        quantize: bool = False, offload: bool = False,
-                        device: torch.device | None = None,
-                        dtype: torch.dtype | None = None) -> "ScalableSeqKV":
+    def from_row_slices(
+        cls,
+        slices,
+        batch: int,
+        groups: int,
+        *,
+        quantize: bool = False,
+        offload: bool = False,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> "ScalableSeqKV":
         """Build from row-axis slices, folding each one in as it arrives.
 
         ``__init__`` takes the finished tensor, which means the fit-time row-chunked
@@ -151,7 +166,6 @@ class ScalableSeqKV:
             obj._kv = torch.cat(kv_parts, dim=1)
         return obj
 
-
     def resident_gpu_bytes(self) -> int:
         """Bytes this cache holds resident on the GPU (0 if offloaded)."""
         if self.offloaded:
@@ -161,8 +175,9 @@ class ScalableSeqKV:
         return self._kv.numel() * self._kv.element_size()
 
 
-def scale_caches(caches: list[dict], *, quantize: bool = False, offload: bool = False,
-                 device: torch.device | None = None) -> list[dict]:
+def scale_caches(
+    caches: list[dict], *, quantize: bool = False, offload: bool = False, device: torch.device | None = None
+) -> list[dict]:
     """Wrap each layer cache's ``seq_kv`` in a ScalableSeqKV (in place). No-op
     when quantize=offload=False. Returns the same list for convenience."""
     if not (quantize or offload):
@@ -171,10 +186,14 @@ def scale_caches(caches: list[dict], *, quantize: bool = False, offload: bool = 
         skv = layer_cache.get("seq_kv")
         if skv is None or isinstance(skv, ScalableSeqKV):
             continue
-        if "kv" not in skv:   # delta/isab cache is the O(M) landmark memory, already tiny
+        if "kv" not in skv:  # delta/isab cache is the O(M) landmark memory, already tiny
             continue
         layer_cache["seq_kv"] = ScalableSeqKV(
-            skv["kv"], skv["batch"], skv["groups"],
-            quantize=quantize, offload=offload, device=device,
+            skv["kv"],
+            skv["batch"],
+            skv["groups"],
+            quantize=quantize,
+            offload=offload,
+            device=device,
         )
     return caches

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -15,7 +15,7 @@ from torch.amp import autocast
 
 from typing_extensions import override
 
-Activation = Literal['gelu']
+Activation = Literal["gelu"]
 
 _ALLOW_CUDNN_SDP = os.environ.get("SYNTHEFY_NORI_ALLOW_CUDNN_SDP", "0") == "1"
 _SDPA_BACKENDS_WITHOUT_CUDNN = [
@@ -25,16 +25,18 @@ _SDPA_BACKENDS_WITHOUT_CUDNN = [
 ]
 
 ACTIVATION_FN: dict[str, Callable[[torch.Tensor], torch.Tensor]] = {
-    'gelu': nn.GELU(),
-    'relu': nn.ReLU(),
-    'silu': nn.SiLU(),
+    "gelu": nn.GELU(),
+    "relu": nn.ReLU(),
+    "silu": nn.SiLU(),
 }
+
 
 class LayerNormMixedPrecision(nn.LayerNorm):
     """
-    When the embedding dimension is below 512, use half precision for computation to improve performance. 
+    When the embedding dimension is below 512, use half precision for computation to improve performance.
     If the embedding dimension exceeds 512, it may cause training instability.
     """
+
     def forward(self, input: torch.Tensor):
         if input.dtype == torch.float16 and sum(self.normalized_shape) < 512:
             with autocast(device_type="cuda" if input.is_cuda else "cpu", enabled=False):
@@ -42,10 +44,11 @@ class LayerNormMixedPrecision(nn.LayerNorm):
         else:
             return super().forward(input)
 
+
 class RMSNorm(nn.Module):
     """RMSNorm — faster than LayerNorm, no mean computation."""
-    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=False,
-                 device=None, dtype=None):
+
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=False, device=None, dtype=None):
         super().__init__()
         if isinstance(normalized_shape, int):
             normalized_shape = (normalized_shape,)
@@ -58,13 +61,11 @@ class RMSNorm(nn.Module):
         if elementwise_affine:
             self.weight = nn.Parameter(torch.ones(self.normalized_shape, device=device, dtype=dtype))
         else:
-            self.register_parameter('weight', None)
+            self.register_parameter("weight", None)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.use_native:
-            return nn.functional.rms_norm(
-                x, self.normalized_shape, weight=self.weight, eps=self.eps
-            )
+            return nn.functional.rms_norm(x, self.normalized_shape, weight=self.weight, eps=self.eps)
         rms = x.pow(2).mean(-1, keepdim=True).add(self.eps).rsqrt()
         x = x * rms
         if self.weight is not None:
@@ -75,8 +76,8 @@ class RMSNorm(nn.Module):
 class SwiGLUMLP(nn.Module):
     """SwiGLU gated FFN: (SiLU(xW_gate) * xW_up) @ W_down.
     Uses hidden=2/3 of original to match param count."""
-    def __init__(self, in_features, hidden_size, out_features, has_bias,
-                 device, dtype):
+
+    def __init__(self, in_features, hidden_size, out_features, has_bias, device, dtype):
         super().__init__()
         swiglu_hidden = int(2 * hidden_size / 3)
         self.w_gate = nn.Linear(in_features, swiglu_hidden, bias=has_bias, device=device, dtype=dtype)
@@ -90,25 +91,28 @@ class SwiGLUMLP(nn.Module):
 
 class MLP(torch.nn.Module):
     """Multi-Layer Perceptron"""
-    def __init__(self, 
-                 in_features: int, 
-                 hidden_size:int, 
-                 out_features: int, 
-                 has_bias:bool, 
-                 device: torch.device | None, 
-                 dtype: torch.dtype | None,  
-                 activation: Activation = 'gelu', 
-                 depth:int=2):
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_size: int,
+        out_features: int,
+        has_bias: bool,
+        device: torch.device | None,
+        dtype: torch.dtype | None,
+        activation: Activation = "gelu",
+        depth: int = 2,
+    ):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.activation = activation
         self.layers = []
-       
+
         if depth == 1:
             self.layers.append(nn.Linear(in_features, out_features, bias=has_bias, device=device, dtype=dtype))
         else:
-             # input layer
+            # input layer
             self.layers.append(nn.Linear(in_features, hidden_size, bias=has_bias, device=device, dtype=dtype))
             self.layers.append(ACTIVATION_FN[self.activation])
             # hidden layers
@@ -119,7 +123,7 @@ class MLP(torch.nn.Module):
             self.layers.append(nn.Linear(hidden_size, out_features, bias=has_bias, device=device, dtype=dtype))
             torch.nn.init.normal_(self.layers[-1].weight, std=0.02)
         self.mlp = nn.Sequential(*self.layers)
-        
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.mlp(x)
 
@@ -254,21 +258,18 @@ class QASSMaxScaling(nn.Module):
         # enough. Inference autocasts to fp16 on CUDA (the trainer uses bf16,
         # which has the range to hide this), so the overflow only ever showed
         # up at long-context inference. See issue #439.
-        log_n = torch.tensor(
-            math.log(float(max(key_len, 2))), device=q.device, dtype=q.dtype
-        )
+        log_n = torch.tensor(math.log(float(max(key_len, 2))), device=q.device, dtype=q.dtype)
         if self.qass_mode == "log_only":
             return q * log_n.view(1, 1, 1, 1)
         assert self.base_mlp is not None
-        base_delta = self.base_mlp(log_n.view(1, 1)).view(
-            1, 1, self.num_heads, self.head_dim
-        )
+        base_delta = self.base_mlp(log_n.view(1, 1)).view(1, 1, self.num_heads, self.head_dim)
         base_scale = log_n.view(1, 1, 1, 1) * (1.0 + torch.tanh(base_delta))
         if self.qass_mode == "base_only":
             return q * base_scale
         assert self.gate_mlp is not None
         gate_scale = 1.0 + torch.tanh(self.gate_mlp(q))
         return q * base_scale * gate_scale
+
 
 class MultiheadAttention(torch.nn.Module):
     def __init__(
@@ -278,8 +279,8 @@ class MultiheadAttention(torch.nn.Module):
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
         qkv_combined: bool = True,
-        dropout:float=0,
-        recompute:bool=False,
+        dropout: float = 0,
+        recompute: bool = False,
         use_qassmax: bool = False,
         use_logn_attention: bool = False,
         use_learnable_attn_temperature: bool = False,
@@ -314,13 +315,16 @@ class MultiheadAttention(torch.nn.Module):
             # Init at 1.0 so step-0 behavior matches standard attention.
             # Use abs() in forward to keep positive — gradient is well-defined
             # everywhere except 0, which is practically never visited.
-            self.attn_temperature = nn.Parameter(torch.ones(1, device=device,
-                                                             dtype=dtype if dtype else torch.float32))
+            self.attn_temperature = nn.Parameter(torch.ones(1, device=device, dtype=dtype if dtype else torch.float32))
         else:
             self.attn_temperature = None
 
-        self.out_proj_weight = torch.nn.Parameter(torch.empty(self.num_heads, self.head_dim, self.embed_dim, device=self.device, dtype=self.dtype))
-        self.qkv_proj_weight = torch.nn.Parameter(torch.empty(3, self.num_heads, self.head_dim, self.embed_dim, device=device, dtype=dtype))
+        self.out_proj_weight = torch.nn.Parameter(
+            torch.empty(self.num_heads, self.head_dim, self.embed_dim, device=self.device, dtype=self.dtype)
+        )
+        self.qkv_proj_weight = torch.nn.Parameter(
+            torch.empty(3, self.num_heads, self.head_dim, self.embed_dim, device=device, dtype=dtype)
+        )
 
         torch.nn.init.normal_(self.out_proj_weight, std=0.02)
         nn.init.xavier_uniform_(self.qkv_proj_weight)
@@ -339,7 +343,7 @@ class MultiheadAttention(torch.nn.Module):
             if use_qassmax
             else None
         )
-        
+
         if recompute:
             self.forward = partial(checkpoint, self.forward, use_reentrant=False)  # type: ignore
 
@@ -347,7 +351,7 @@ class MultiheadAttention(torch.nn.Module):
         if self.qassmax is None:
             return q
         return self.qassmax(q, key_len)
-    
+
     def _apply_extra_attn_scale(self, q: torch.Tensor, n_keys: int) -> torch.Tensor:
         """Pre-multiply Q by (temperature * logN factor) so SDPA's internal
         1/sqrt(d) scaling combines to the desired final attention scale.
@@ -404,10 +408,10 @@ class MultiheadAttention(torch.nn.Module):
         return kv
 
     def project_kv_cache(
-            self,
-            x_kv: torch.Tensor,
-            *,
-            copy_first_head_kv: bool = False,
+        self,
+        x_kv: torch.Tensor,
+        *,
+        copy_first_head_kv: bool = False,
     ) -> dict[str, torch.Tensor | int]:
         """Project and cache K/V for qkv_combined=False attention.
 
@@ -432,11 +436,11 @@ class MultiheadAttention(torch.nn.Module):
         return {"kv": kv.contiguous(), "batch": B, "groups": S}
 
     def forward_with_kv_cache(
-            self,
-            x: torch.Tensor,
-            kv_cache: dict[str, torch.Tensor | int],
-            *,
-            calculate_sample_attention: bool = False,
+        self,
+        x: torch.Tensor,
+        kv_cache: dict[str, torch.Tensor | int],
+        *,
+        calculate_sample_attention: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Run cross-attention using a projected train K/V cache."""
         if self.qkv_combined:
@@ -470,12 +474,14 @@ class MultiheadAttention(torch.nn.Module):
         )
         return out.reshape(B, S, *out.shape[1:]), sample_attention
 
-    def compute_attention_by_torch(self, qkv:torch.Tensor|None, q:torch.Tensor|None, kv:torch.Tensor|None, attn_mask:torch.Tensor|None) -> torch.Tensor:
-        '''Compute attention with PyTorch scaled_dot_product_attention (supports attn_mask).'''
+    def compute_attention_by_torch(
+        self, qkv: torch.Tensor | None, q: torch.Tensor | None, kv: torch.Tensor | None, attn_mask: torch.Tensor | None
+    ) -> torch.Tensor:
+        """Compute attention with PyTorch scaled_dot_product_attention (supports attn_mask)."""
         if qkv is not None:
             q, k, v = qkv.unbind(dim=-3)
         elif kv is not None and q is not None:
-            k,v = kv.unbind(dim=-3)
+            k, v = kv.unbind(dim=-3)
         else:
             raise ValueError("When qkv is None, q and kv cannot both be None at the same time")
         assert q is not None and k is not None and v is not None, "q, k, and v must not be None"
@@ -494,11 +500,7 @@ class MultiheadAttention(torch.nn.Module):
         # backend has been slow/intermittently broken for Nori's dynamic table
         # sizes and small head_dim=16. Exclude it only for this call rather than
         # mutating process-wide torch backend state at import time.
-        backend_context = (
-            nullcontext()
-            if _ALLOW_CUDNN_SDP
-            else sdpa_kernel(_SDPA_BACKENDS_WITHOUT_CUDNN)
-        )
+        backend_context = nullcontext() if _ALLOW_CUDNN_SDP else sdpa_kernel(_SDPA_BACKENDS_WITHOUT_CUDNN)
         with backend_context:
             attention_outputs = torch.nn.functional.scaled_dot_product_attention(
                 q.transpose(1, 2),
@@ -522,19 +524,21 @@ class MultiheadAttention(torch.nn.Module):
         return ps
 
     @override
-    def forward(self,
-                x: torch.Tensor, 
-                x_kv: Optional[torch.Tensor] = None, 
-                copy_first_head_kv: bool = False,
-                attn_mask: torch.Tensor | None = None, 
-                calculate_sample_attention:bool=False, 
-                calculate_feature_attention:bool=False) -> tuple[torch.Tensor,torch.Tensor | None,torch.Tensor | None]:
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_kv: Optional[torch.Tensor] = None,
+        copy_first_head_kv: bool = False,
+        attn_mask: torch.Tensor | None = None,
+        calculate_sample_attention: bool = False,
+        calculate_feature_attention: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         """
         x: [batch_size, seq_len, feature, embed_dim]
         kv: Optional[batch_size, seq_len_kv, feature, embed_dim] — only needed if qkv_combined=False
         copy_first_head: Reuse the results from the first attention head
         """
-        # feature attention: [B S F E]  
+        # feature attention: [B S F E]
         # item attention: [B F S E]
         # B, T, C = x.shape
         B, S, _, _ = x.shape
@@ -542,12 +546,12 @@ class MultiheadAttention(torch.nn.Module):
 
         x = x.reshape(-1, *x.shape[-2:])
         BS, F, E = x.shape
-        
+
         qkv = None
         q = None
         kv = None
-        feature_attention=None
-        sample_attention=None
+        feature_attention = None
+        sample_attention = None
         # batch_size = None
         # seqlen = None
         if self.qkv_combined:
@@ -562,16 +566,14 @@ class MultiheadAttention(torch.nn.Module):
             x_kv = x_kv.reshape(-1, *x_kv.shape[-2:])
             q = torch.einsum("... s, h d s -> ... h d", x, self.q_proj_weight)
             if copy_first_head_kv:
-                kv_weights = self.kv_proj_weight[:,:1]
+                kv_weights = self.kv_proj_weight[:, :1]
                 kv = torch.einsum("... s, j h d s -> ... j h d", x_kv, kv_weights)
             else:
                 kv = torch.einsum("... s, j h d s -> ... j h d", x_kv, self.kv_proj_weight)
             if self.use_qassmax:
                 q = self.apply_qassmax(q, kv.shape[1])
 
-        kv_perhead = kv if kv is None else self._kv_for_kernel(
-            kv, needs_explicit_heads=False
-        )
+        kv_perhead = kv if kv is None else self._kv_for_kernel(kv, needs_explicit_heads=False)
         atten_out = self.compute_attention_by_torch(qkv, q, kv_perhead, attn_mask)
 
         atten_out = atten_out.reshape(BS, F, self.num_heads, self.head_dim)
@@ -591,36 +593,39 @@ class MultiheadAttention(torch.nn.Module):
             self.out_proj_weight,
         )
 
-        return out.reshape(B, S, *out.shape[1:]),feature_attention,sample_attention
+        return out.reshape(B, S, *out.shape[1:]), feature_attention, sample_attention
+
 
 class EncoderBaseLayer(nn.Module):
     "Base encoder layer of the Transformer model"
-    def __init__(self,
-                 nhead: int,
-                 embed_dim: int,
-                 hid_dim:int,
-                 dropout: float=0,
-                 pre_norm: bool=False,
-                 activation: str='gelu',
-                 layer_norm_eps: float=1e-5,
-                 device: torch.device|None=None,
-                 dtype: torch.dtype|None=None,
-                 recompute_attn: bool=False,
-                 mlp_use_residual:bool=False,
-                 layer_arch: str = 'fmfmsm',
-                 seq_attn_isolated: bool = False,
-                 seq_attn_serial: bool = False,
-                 self_share_all_kv_heads: bool = False,
-                 cross_share_all_kv_heads: bool = True,
-                 use_qassmax: bool = False,
-                 norm_type: str = 'layernorm',
-                 deepnorm_alpha: float|None = None,
-                 use_logn_attention: bool = False,
-                 use_learnable_attn_temperature: bool = False,
-                 attn_n_ref: float = 1024.0,
-                 # Appended, not inserted — this signature is not keyword-only.
-                 qass_mode: str|None = None,
-                 ):
+
+    def __init__(
+        self,
+        nhead: int,
+        embed_dim: int,
+        hid_dim: int,
+        dropout: float = 0,
+        pre_norm: bool = False,
+        activation: str = "gelu",
+        layer_norm_eps: float = 1e-5,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        recompute_attn: bool = False,
+        mlp_use_residual: bool = False,
+        layer_arch: str = "fmfmsm",
+        seq_attn_isolated: bool = False,
+        seq_attn_serial: bool = False,
+        self_share_all_kv_heads: bool = False,
+        cross_share_all_kv_heads: bool = True,
+        use_qassmax: bool = False,
+        norm_type: str = "layernorm",
+        deepnorm_alpha: float | None = None,
+        use_logn_attention: bool = False,
+        use_learnable_attn_temperature: bool = False,
+        attn_n_ref: float = 1024.0,
+        # Appended, not inserted — this signature is not keyword-only.
+        qass_mode: str | None = None,
+    ):
         super().__init__()
         if mlp_use_residual:
             raise ValueError(
@@ -643,21 +648,20 @@ class EncoderBaseLayer(nn.Module):
         self.layer_arch = layer_arch
         self.head_dim = self.embed_dim // self.nhead
         self.recompute_attn = recompute_attn
-        
+
         self.feature_attentions = []
         self.sequence_attentions = []
         self.mlp = []
-        self.feature_attn_num = 1           # feature attention number
-        self.seq_attn_num = 1             # sequence attention number
-        self.mlp_num = 1                    # mlp number
-        if layer_arch == 'fmfmsm':
+        self.feature_attn_num = 1  # feature attention number
+        self.seq_attn_num = 1  # sequence attention number
+        self.mlp_num = 1  # mlp number
+        if layer_arch == "fmfmsm":
             self.feature_attn_num = 2
             self.mlp_num = 3
-        
+
         self.norm_type = norm_type
         if deepnorm_alpha is not None:
-            self.register_buffer('deepnorm_alpha',
-                                 torch.tensor(deepnorm_alpha, dtype=torch.float32))
+            self.register_buffer("deepnorm_alpha", torch.tensor(deepnorm_alpha, dtype=torch.float32))
         else:
             self.deepnorm_alpha = None
         self.self_share_all_kv_heads = self_share_all_kv_heads
@@ -671,43 +675,43 @@ class EncoderBaseLayer(nn.Module):
 
         # attention+MLP
         self.feature_attentions = nn.ModuleList(
-                                                    [
-                                                        MultiheadAttention(
-                                                                embed_dim=self.embed_dim,
-                                                                num_heads=self.nhead,
-                                                                device=self.device,
-                                                                dtype=self.dtype,
-                                                                qkv_combined=True,
-                                                                dropout=self.dropout,
-                                                                recompute=self.recompute_attn,
-                                                                use_qassmax=False,
-                                                                use_logn_attention=use_logn_attention,
-                                                                use_learnable_attn_temperature=use_learnable_attn_temperature,
-                                                                attn_n_ref=attn_n_ref,
-                                                        )
-                                                        for _ in range(self.feature_attn_num)
-                                                    ]
-                                                )
+            [
+                MultiheadAttention(
+                    embed_dim=self.embed_dim,
+                    num_heads=self.nhead,
+                    device=self.device,
+                    dtype=self.dtype,
+                    qkv_combined=True,
+                    dropout=self.dropout,
+                    recompute=self.recompute_attn,
+                    use_qassmax=False,
+                    use_logn_attention=use_logn_attention,
+                    use_learnable_attn_temperature=use_learnable_attn_temperature,
+                    attn_n_ref=attn_n_ref,
+                )
+                for _ in range(self.feature_attn_num)
+            ]
+        )
         self.sequence_attentions = nn.ModuleList(
-                                                    [
-                                                        MultiheadAttention(
-                                                            embed_dim=self.embed_dim,
-                                                            num_heads=self.nhead,
-                                                            device=self.device,
-                                                            dtype=self.dtype,
-                                                            qkv_combined=False,
-                                                            dropout=self.dropout,
-                                                            recompute=self.recompute_attn,
-                                                            use_qassmax=use_qassmax,
-                                                            qass_mode=qass_mode,
-                                                            use_logn_attention=use_logn_attention,
-                                                            use_learnable_attn_temperature=use_learnable_attn_temperature,
-                                                            attn_n_ref=attn_n_ref,
-                                                        )
-                                                        for _ in range(self.seq_attn_num)
-                                                    ]
-                                                )
-        if self.activation == 'swiglu':
+            [
+                MultiheadAttention(
+                    embed_dim=self.embed_dim,
+                    num_heads=self.nhead,
+                    device=self.device,
+                    dtype=self.dtype,
+                    qkv_combined=False,
+                    dropout=self.dropout,
+                    recompute=self.recompute_attn,
+                    use_qassmax=use_qassmax,
+                    qass_mode=qass_mode,
+                    use_logn_attention=use_logn_attention,
+                    use_learnable_attn_temperature=use_learnable_attn_temperature,
+                    attn_n_ref=attn_n_ref,
+                )
+                for _ in range(self.seq_attn_num)
+            ]
+        )
+        if self.activation == "swiglu":
             mlp_creator = lambda: SwiGLUMLP(
                 in_features=self.embed_dim,
                 hidden_size=self.hid_dim,
@@ -728,39 +732,24 @@ class EncoderBaseLayer(nn.Module):
                 depth=2,
             )
         self.mlp = nn.ModuleList([mlp_creator() for _ in range(self.mlp_num)])
-        
+
         self.layer_steps = []
-        if self.layer_arch == 'fmfmsm':
+        if self.layer_arch == "fmfmsm":
             assert len(self.feature_attentions) >= 2 and len(self.sequence_attentions) >= 1 and len(self.mlp) >= 3
             self.layer_steps = [
-                                partial(
-                                    self.call_features_attention,
-                                    index=0
-                                ),
-                                self.mlp[0],
-                                partial(
-                                    self.call_features_attention,
-                                    index=1
-                                ),
-                                self.mlp[1],
-                                partial(
-                                    self.call_sequence_attention,
-                                    index=0
-                                ),
-                                self.mlp[2]
+                partial(self.call_features_attention, index=0),
+                self.mlp[0],
+                partial(self.call_features_attention, index=1),
+                self.mlp[1],
+                partial(self.call_sequence_attention, index=0),
+                self.mlp[2],
             ]
-        elif self.layer_arch == 'smf':
+        elif self.layer_arch == "smf":
             assert len(self.feature_attentions) >= 1 and len(self.sequence_attentions) >= 1 and len(self.mlp) >= 1
             self.layer_steps = [
-                                partial(
-                                    self.call_sequence_attention,
-                                    index=0
-                                ),
-                                self.mlp[0],
-                                partial(
-                                    self.call_features_attention,
-                                    index=0
-                                )
+                partial(self.call_sequence_attention, index=0),
+                self.mlp[0],
+                partial(self.call_features_attention, index=0),
             ]
         else:
             raise ValueError(f"Unsupport layr arch: {self.layer_arch}")
@@ -787,35 +776,41 @@ class EncoderBaseLayer(nn.Module):
             ),
             None,
         )
-    
-        if self.norm_type == 'rmsnorm':
-            norm_creator = lambda: RMSNorm(self.embed_dim, eps=self.layer_norm_eps,
-                                           elementwise_affine=False, device=self.device, dtype=self.dtype)
+
+        if self.norm_type == "rmsnorm":
+            norm_creator = lambda: RMSNorm(
+                self.embed_dim, eps=self.layer_norm_eps, elementwise_affine=False, device=self.device, dtype=self.dtype
+            )
         else:
-            norm_creator = lambda: LayerNormMixedPrecision(normalized_shape=self.embed_dim, eps=self.layer_norm_eps,
-                                                           elementwise_affine=False, device=self.device, dtype=self.dtype)
+            norm_creator = lambda: LayerNormMixedPrecision(
+                normalized_shape=self.embed_dim,
+                eps=self.layer_norm_eps,
+                elementwise_affine=False,
+                device=self.device,
+                dtype=self.dtype,
+            )
         self.layer_norms = nn.ModuleList([norm_creator() for _ in range(len(self.layer_steps))])
-    
-    def create_attn_mask(self, q_mask:torch.Tensor, k_mask:torch.Tensor)->torch.Tensor:
+
+    def create_attn_mask(self, q_mask: torch.Tensor, k_mask: torch.Tensor) -> torch.Tensor:
         """
         Create attention mask
-        
+
         Args:
             q_mask (torch.Tensor): Query sequence mask, with shape [batch_size, head_count, q_seq_len]
             k_mask (torch.Tensor): Key sequence mask, with shape   [batch_size, head_count, k_seq_len]
-        
+
         Returns:
             torch.Tensor: attention mask, with shape [batch_size, head_count, q_seq_len, k_seq_len]
         """
         _, _, q_seq_len = q_mask.shape
         _, _, k_seq_len = k_mask.shape
-        
+
         q_mask_bool = q_mask.bool()  # [batch_size, head_count, q_seq_len]
         k_mask_bool = k_mask.bool()  # [batch_size, head_count, k_seq_len]
-        
+
         q_expanded = q_mask_bool.unsqueeze(-1)
         k_expanded = k_mask_bool.unsqueeze(-2)
-        
+
         # PyTorch SDPA's boolean-mask contract is True == participates in
         # attention (the opposite of nn.MultiheadAttention's key-padding mask).
         # Return the valid pairs directly; inverting them makes every padded
@@ -824,46 +819,57 @@ class EncoderBaseLayer(nn.Module):
         _, _, q_seq_len, k_seq_len = attn_mask.shape
         attn_mask = attn_mask.reshape(-1, q_seq_len, k_seq_len)
         attn_mask = attn_mask.unsqueeze(1).expand(-1, self.nhead, -1, -1)
-        
+
         return attn_mask
 
-    def call_features_attention(self, x: torch.Tensor, feature_atten_mask: torch.Tensor | None, eval_pos: int,
-                                index: int = 0,calculate_feature_attention:bool=False):
+    def call_features_attention(
+        self,
+        x: torch.Tensor,
+        feature_atten_mask: torch.Tensor | None,
+        eval_pos: int,
+        index: int = 0,
+        calculate_feature_attention: bool = False,
+    ):
         assert len(self.feature_attentions) > index
         attn_mask = None
         if feature_atten_mask is not None:
             attn_mask = self.create_attn_mask(feature_atten_mask, feature_atten_mask)
         return self.feature_attentions[index](
-                                x,
-                                x_kv=None,
-                                attn_mask=attn_mask,
-                                calculate_feature_attention=calculate_feature_attention
-                            )
+            x, x_kv=None, attn_mask=attn_mask, calculate_feature_attention=calculate_feature_attention
+        )
 
-    def call_sequence_attention(self, x: torch.Tensor, feature_atten_mask: torch.Tensor | None, eval_pos: int,
-                                index: int = 0,calculate_sample_attention:bool=False):
+    def call_sequence_attention(
+        self,
+        x: torch.Tensor,
+        feature_atten_mask: torch.Tensor | None,
+        eval_pos: int,
+        index: int = 0,
+        calculate_sample_attention: bool = False,
+    ):
         assert len(self.sequence_attentions) > index
-        sample_attention=None
-        index1 = index*2 if self.seq_attn_isolated else index
-        index2 = index1+1 if self.seq_attn_isolated else index1
-        assert index2 < len(self.sequence_attentions), f"Error: index2({index2}) >= len(self.sequence_attentions)({len(self.sequence_attentions)})"
+        sample_attention = None
+        index1 = index * 2 if self.seq_attn_isolated else index
+        index2 = index1 + 1 if self.seq_attn_isolated else index1
+        assert index2 < len(self.sequence_attentions), (
+            f"Error: index2({index2}) >= len(self.sequence_attentions)({len(self.sequence_attentions)})"
+        )
 
         x_train = self.sequence_attentions[index1](
-                        x = x[:, :eval_pos].transpose(1, 2),
-                        x_kv = x[:, :eval_pos].transpose(1, 2),
-                        copy_first_head_kv = True if self.self_share_all_kv_heads else False,
-                    )[0].transpose(1, 2)
+            x=x[:, :eval_pos].transpose(1, 2),
+            x_kv=x[:, :eval_pos].transpose(1, 2),
+            copy_first_head_kv=True if self.self_share_all_kv_heads else False,
+        )[0].transpose(1, 2)
 
         if eval_pos < x.shape[1]:
             # KV source: updated x_train when serial, original context otherwise
             kv = x_train.transpose(1, 2) if self.seq_attn_serial else x[:, :eval_pos].transpose(1, 2)
-            x_test,_,sample_attention = self.sequence_attentions[index2](
-                                                    x=x[:, eval_pos:].transpose(1, 2),
-                                                    x_kv=kv,
-                                                    copy_first_head_kv=True if self.cross_share_all_kv_heads else False,
-                                                    calculate_sample_attention=calculate_sample_attention
-                                                )
-            x_test=x_test.transpose(1, 2)
+            x_test, _, sample_attention = self.sequence_attentions[index2](
+                x=x[:, eval_pos:].transpose(1, 2),
+                x_kv=kv,
+                copy_first_head_kv=True if self.cross_share_all_kv_heads else False,
+                calculate_sample_attention=calculate_sample_attention,
+            )
+            x_test = x_test.transpose(1, 2)
             return torch.cat([x_train, x_test], dim=1), None, sample_attention
         else:
             return x_train, None, None
@@ -874,12 +880,12 @@ class EncoderBaseLayer(nn.Module):
         return residual + update
 
     def _run_non_sequence_step(
-            self,
-            x: torch.Tensor,
-            *,
-            step_idx: int,
-            feature_atten_mask: torch.Tensor | None,
-            eval_pos: int,
+        self,
+        x: torch.Tensor,
+        *,
+        step_idx: int,
+        feature_atten_mask: torch.Tensor | None,
+        eval_pos: int,
     ) -> torch.Tensor:
         sublayer = self.layer_steps[step_idx]
         layer_norm = self.layer_norms[step_idx]
@@ -907,9 +913,9 @@ class EncoderBaseLayer(nn.Module):
                 out = out[0]
         return layer_norm(out + residual)
 
-    def _project_kv_cache_rowchunked(self, attn_mod, x_kv_src, copy_kv, row_chunk,
-                                     *, norm=None, offload=False, quantize=False,
-                                     device=None):
+    def _project_kv_cache_rowchunked(
+        self, attn_mod, x_kv_src, copy_kv, row_chunk, *, norm=None, offload=False, quantize=False, device=None
+    ):
         """Build attn_mod's K/V cache over the row axis in chunks.
 
         Mirrors ``project_kv_cache(full)`` bit-for-bit (K/V are per-row
@@ -956,21 +962,35 @@ class EncoderBaseLayer(nn.Module):
                 rows = x_kv_src[:, sl]
                 if norm is not None:
                     rows = norm(rows)
-                yield attn_mod.project_kv_cache(
-                    rows.transpose(1, 2), copy_first_head_kv=copy_kv)["kv"]
+                yield attn_mod.project_kv_cache(rows.transpose(1, 2), copy_first_head_kv=copy_kv)["kv"]
 
         if not (quantize or offload):
             # Nothing to fold in; the plain dict is what the uninstrumented path uses.
-            return {"kv": torch.cat(list(_row_slices()), dim=1),
-                    "batch": B, "groups": groups}
+            return {"kv": torch.cat(list(_row_slices()), dim=1), "batch": B, "groups": groups}
         return ScalableSeqKV.from_row_slices(
-            _row_slices(), B, groups, quantize=quantize, offload=offload,
-            device=device or x_kv_src.device, dtype=x_kv_src.dtype,
+            _row_slices(),
+            B,
+            groups,
+            quantize=quantize,
+            offload=offload,
+            device=device or x_kv_src.device,
+            dtype=x_kv_src.dtype,
         )
 
     def _forward_train_cache_memsaving(
-            self, x_train, feature_atten_mask, pre_seq_steps, seq_step,
-            post_seq_steps, index1, index2, row_chunk, quantize, offload, device):
+        self,
+        x_train,
+        feature_atten_mask,
+        pre_seq_steps,
+        seq_step,
+        post_seq_steps,
+        index1,
+        index2,
+        row_chunk,
+        quantize,
+        offload,
+        device,
+    ):
         """Memory-bounded fit-time cache build (TabPFN-3-style, non-serial only).
 
         Keeps only ONE full-N K/V tensor resident: the self-attention cache.
@@ -992,8 +1012,8 @@ class EncoderBaseLayer(nn.Module):
                 xc = x_train[:, sl]
                 for st in steps:
                     xc = self._run_non_sequence_step(
-                        xc, step_idx=st, feature_atten_mask=feature_atten_mask,
-                        eval_pos=xc.shape[1])
+                        xc, step_idx=st, feature_atten_mask=feature_atten_mask, eval_pos=xc.shape[1]
+                    )
                 x_train[:, sl] = xc
 
         # pre-seq per-row steps (fmfmsm) -- must finish for all rows before we
@@ -1008,40 +1028,40 @@ class EncoderBaseLayer(nn.Module):
 
         def _proj(mod, copy_kv, **scale):
             return self._project_kv_cache_rowchunked(
-                mod, x_train, copy_kv, row_chunk, norm=norm, device=device, **scale)
+                mod, x_train, copy_kv, row_chunk, norm=norm, device=device, **scale
+            )
 
         train_cache = _proj(seq_attn_train, self.self_share_all_kv_heads)
-        test_cache = _proj(seq_attn_test, self.cross_share_all_kv_heads,
-                           quantize=quantize, offload=offload)
+        test_cache = _proj(seq_attn_test, self.cross_share_all_kv_heads, quantize=quantize, offload=offload)
 
         # Self-attention as chunked cached-query reads + post steps, in place.
         for r0 in range(0, N, row_chunk):
             sl = slice(r0, min(r0 + row_chunk, N))
             xr = x_train[:, sl]
             if self.pre_norm:
-                attn_r = seq_attn_train.forward_with_kv_cache(
-                    seq_norm(xr).transpose(1, 2), train_cache)[0].transpose(1, 2)
+                attn_r = seq_attn_train.forward_with_kv_cache(seq_norm(xr).transpose(1, 2), train_cache)[0].transpose(
+                    1, 2
+                )
                 xr = self._residual_add(xr, attn_r)
             else:
-                attn_r = seq_attn_train.forward_with_kv_cache(
-                    xr.transpose(1, 2), train_cache)[0].transpose(1, 2)
+                attn_r = seq_attn_train.forward_with_kv_cache(xr.transpose(1, 2), train_cache)[0].transpose(1, 2)
                 xr = seq_norm(attn_r + xr)
             for st in post_seq_steps:
                 xr = self._run_non_sequence_step(
-                    xr, step_idx=st, feature_atten_mask=feature_atten_mask,
-                    eval_pos=xr.shape[1])
+                    xr, step_idx=st, feature_atten_mask=feature_atten_mask, eval_pos=xr.shape[1]
+                )
             x_train[:, sl] = xr
         del train_cache
         return x_train, {"seq_kv": test_cache}
 
     def forward_train_cache(
-            self,
-            x_train: torch.Tensor,
-            feature_atten_mask: torch.Tensor | None = None,
-            fit_row_chunk: int | None = None,
-            quantize_kv_cache: bool = False,
-            offload_kv_cache: bool = False,
-            device=None,
+        self,
+        x_train: torch.Tensor,
+        feature_atten_mask: torch.Tensor | None = None,
+        fit_row_chunk: int | None = None,
+        quantize_kv_cache: bool = False,
+        offload_kv_cache: bool = False,
+        device=None,
     ) -> tuple[torch.Tensor, dict[str, dict[str, torch.Tensor | int]]]:
         """Run the train rows through one layer and cache train K/V for tests.
 
@@ -1056,20 +1076,18 @@ class EncoderBaseLayer(nn.Module):
         serial falls back to the standard monolithic path.
         """
 
-        if self.layer_arch == 'fmfmsm':
+        if self.layer_arch == "fmfmsm":
             pre_seq_steps = (0, 1, 2, 3)
             seq_step = 4
             post_seq_steps = (5,)
             seq_index = 0
-        elif self.layer_arch == 'smf':
+        elif self.layer_arch == "smf":
             pre_seq_steps = ()
             seq_step = 0
             post_seq_steps = (1, 2)
             seq_index = 0
         else:
-            raise NotImplementedError(
-                "Cached inference currently supports layer_arch='fmfmsm' and 'smf'"
-            )
+            raise NotImplementedError("Cached inference currently supports layer_arch='fmfmsm' and 'smf'")
 
         index1 = seq_index * 2 if self.seq_attn_isolated else seq_index
         index2 = index1 + 1 if self.seq_attn_isolated else index1
@@ -1091,14 +1109,24 @@ class EncoderBaseLayer(nn.Module):
             )
         if fit_row_chunk:
             return self._forward_train_cache_memsaving(
-                x_train, feature_atten_mask, pre_seq_steps, seq_step,
-                post_seq_steps, index1, index2, fit_row_chunk,
-                quantize_kv_cache, offload_kv_cache, device)
+                x_train,
+                feature_atten_mask,
+                pre_seq_steps,
+                seq_step,
+                post_seq_steps,
+                index1,
+                index2,
+                fit_row_chunk,
+                quantize_kv_cache,
+                offload_kv_cache,
+                device,
+            )
 
         eval_pos = x_train.shape[1]
         for step_idx in pre_seq_steps:
             x_train = self._run_non_sequence_step(
-                x_train, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos)
+                x_train, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos
+            )
 
         seq_attn_train = self.sequence_attentions[index1]
         seq_attn_test = self.sequence_attentions[index2]
@@ -1134,35 +1162,35 @@ class EncoderBaseLayer(nn.Module):
 
         for step_idx in post_seq_steps:
             x_train = self._run_non_sequence_step(
-                x_train, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos)
+                x_train, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos
+            )
         return x_train, {"seq_kv": seq_kv_cache}
 
     def forward_test_with_cache(
-            self,
-            x_test: torch.Tensor,
-            cache: dict[str, dict[str, torch.Tensor | int]],
-            feature_atten_mask: torch.Tensor | None = None,
+        self,
+        x_test: torch.Tensor,
+        cache: dict[str, dict[str, torch.Tensor | int]],
+        feature_atten_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Run test rows through one layer using train K/V from forward_train_cache."""
-        if self.layer_arch == 'fmfmsm':
+        if self.layer_arch == "fmfmsm":
             pre_seq_steps = (0, 1, 2, 3)
             seq_step = 4
             post_seq_steps = (5,)
             seq_index = 0
-        elif self.layer_arch == 'smf':
+        elif self.layer_arch == "smf":
             pre_seq_steps = ()
             seq_step = 0
             post_seq_steps = (1, 2)
             seq_index = 0
         else:
-            raise NotImplementedError(
-                "Cached inference currently supports layer_arch='fmfmsm' and 'smf'"
-            )
+            raise NotImplementedError("Cached inference currently supports layer_arch='fmfmsm' and 'smf'")
 
         eval_pos = x_test.shape[1]
         for step_idx in pre_seq_steps:
             x_test = self._run_non_sequence_step(
-                x_test, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos)
+                x_test, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos
+            )
 
         index1 = seq_index * 2 if self.seq_attn_isolated else seq_index
         index2 = index1 + 1 if self.seq_attn_isolated else index1
@@ -1188,10 +1216,13 @@ class EncoderBaseLayer(nn.Module):
 
         for step_idx in post_seq_steps:
             x_test = self._run_non_sequence_step(
-                x_test, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos)
+                x_test, step_idx=step_idx, feature_atten_mask=feature_atten_mask, eval_pos=eval_pos
+            )
         return x_test
 
-    def forward(self, x: torch.Tensor, feature_atten_mask: torch.Tensor, eval_pos: int,**kwargs) -> tuple[torch.Tensor,torch.Tensor | None,torch.Tensor | None]:
+    def forward(
+        self, x: torch.Tensor, feature_atten_mask: torch.Tensor, eval_pos: int, **kwargs
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
         calculate_sample_attention = kwargs.get("calculate_sample_attention", False)
         calculate_feature_attention = kwargs.get("calculate_feature_attention", False)
         layer_idx = kwargs.get("layer_idx", 11)
@@ -1200,8 +1231,8 @@ class EncoderBaseLayer(nn.Module):
         # directly and therefore cannot provide stack position metadata.
         is_capture_layer = kwargs.get("is_last_layer", layer_idx == 11)
 
-        feature_attention=None
-        sample_attention=None
+        feature_attention = None
+        sample_attention = None
         for idx, (sublayer, layer_norm) in enumerate(zip(self.layer_steps, self.layer_norms)):
             if self.pre_norm:
                 residual = x
@@ -1211,7 +1242,7 @@ class EncoderBaseLayer(nn.Module):
                         x, feature_atten_mask, eval_pos, calculate_feature_attention=True
                     )
                 elif idx == self._sequence_capture_idx and calculate_sample_attention and is_capture_layer:
-                    x, _, sample_attention = sublayer(x, feature_atten_mask, eval_pos,calculate_sample_attention=True)
+                    x, _, sample_attention = sublayer(x, feature_atten_mask, eval_pos, calculate_sample_attention=True)
                 else:
                     if isinstance(sublayer, functools.partial):
                         x = sublayer(x, feature_atten_mask, eval_pos)
@@ -1236,7 +1267,7 @@ class EncoderBaseLayer(nn.Module):
                     x, _, sample_attention = sublayer(x, feature_atten_mask, eval_pos, calculate_sample_attention=True)
                     x = x + residual
                 else:
-                    if  isinstance(sublayer, functools.partial):
+                    if isinstance(sublayer, functools.partial):
                         x = sublayer(x, feature_atten_mask, eval_pos)
                         if isinstance(x, tuple):
                             x = x[0]
@@ -1246,14 +1277,16 @@ class EncoderBaseLayer(nn.Module):
                         if isinstance(x, tuple):
                             x = x[0]
                         x = x + residual
-                x=layer_norm(x)
-        return x,feature_attention,sample_attention
-                
+                x = layer_norm(x)
+        return x, feature_attention, sample_attention
+
+
 class LayerStack(nn.Module):
     """
     A flexible container module similar to ``nn.Sequential`` that allows
     keyword arguments to be passed through to each layer.
     """
+
     def __init__(self, layers: list[nn.Module]):
         super().__init__()
         self.layers = nn.ModuleList(layers)
@@ -1263,20 +1296,18 @@ class LayerStack(nn.Module):
         n_layers = len(self.layers)
         feature_attention = None
         sample_attention = None
-        for idx,layer in enumerate(self.layers):
+        for idx, layer in enumerate(self.layers):
             kwargs["layer_idx"] = idx
             kwargs["is_last_layer"] = idx == n_layers - 1
             if self.gradient_checkpointing and self.training:
-                x,layer_feature_attention,layer_sample_attention = checkpoint(
-                    layer, x, use_reentrant=False, **kwargs
-                )
+                x, layer_feature_attention, layer_sample_attention = checkpoint(layer, x, use_reentrant=False, **kwargs)
             else:
-                x,layer_feature_attention,layer_sample_attention = layer(x,**kwargs)
+                x, layer_feature_attention, layer_sample_attention = layer(x, **kwargs)
             if layer_feature_attention is not None:
                 feature_attention = layer_feature_attention
             if layer_sample_attention is not None:
                 sample_attention = layer_sample_attention
-        return x,feature_attention,sample_attention
+        return x, feature_attention, sample_attention
 
     def build_train_cache(self, x_train, **kwargs):
         """Build the per-layer train K/V caches for chunked inference.

--- a/src/synthefy_nori/model/quantile_dist.py
+++ b/src/synthefy_nori/model/quantile_dist.py
@@ -23,17 +23,10 @@ def _enforce_monotone(q: torch.Tensor) -> torch.Tensor:
 def _validate_tau_numpy(tau: np.ndarray, quantile_count: int) -> np.ndarray:
     tau = np.asarray(tau)
     if tau.shape != (quantile_count,):
-        raise ValueError(
-            f"tau must have shape ({quantile_count},), got {tau.shape}"
-        )
+        raise ValueError(f"tau must have shape ({quantile_count},), got {tau.shape}")
     if quantile_count < 1:
         raise ValueError("q must contain at least one quantile")
-    if (
-        not np.isfinite(tau).all()
-        or np.any(tau <= 0.0)
-        or np.any(tau >= 1.0)
-        or np.any(np.diff(tau) <= 0.0)
-    ):
+    if not np.isfinite(tau).all() or np.any(tau <= 0.0) or np.any(tau >= 1.0) or np.any(np.diff(tau) <= 0.0):
         raise ValueError("tau must be finite, strictly increasing values in (0, 1)")
     return tau
 
@@ -45,9 +38,7 @@ def _validate_tau_torch(
     device: torch.device,
 ) -> torch.Tensor:
     if tau.shape != (quantile_count,):
-        raise ValueError(
-            f"tau must have shape ({quantile_count},), got {tuple(tau.shape)}"
-        )
+        raise ValueError(f"tau must have shape ({quantile_count},), got {tuple(tau.shape)}")
     if quantile_count < 1:
         raise ValueError("q must contain at least one quantile")
     if not tau.is_floating_point():
@@ -97,9 +88,7 @@ def quantile_dist_mean_numpy(
 
     left_area = tau[0] * q[..., 0]
     right_area = (1.0 - tau[-1]) * q[..., -1]
-    mid_area = (
-        0.5 * (q[..., :-1] + q[..., 1:]) * np.diff(tau)
-    ).sum(axis=-1)
+    mid_area = (0.5 * (q[..., :-1] + q[..., 1:]) * np.diff(tau)).sum(axis=-1)
     return left_area + mid_area + right_area
 
 

--- a/src/synthefy_nori/model/transformer.py
+++ b/src/synthefy_nori/model/transformer.py
@@ -44,6 +44,7 @@ class ContextCache:
     on nori-6m) for finite, NaN- and Inf-bearing tables alike; it is bit-identical to
     ``forward_cached_regression``, which is literally this build/apply pair.
     """
+
     caches: list
     feature_pos_emb: torch.Tensor | None
     norm_stats: dict | None
@@ -51,45 +52,47 @@ class ContextCache:
     eval_pos: int
     nan_mean: torch.Tensor | None = None
     valid_feature_num: torch.Tensor | None = None
+
+
 from synthefy_nori.model.encoders import get_x_encoder, get_cls_y_encoder, get_reg_y_encoder, preprocesss_4_x
 from torch.amp import autocast
 
 
 class FeaturesTransformer(nn.Module):
     def __init__(
-                self,
-                *,
-                preprocess_config_x:dict[str, Any],
-                encoder_config_x:dict[str, Any],
-                encoder_config_y:dict[str, Any],
-                decoder_config:dict[str, Any],
-                nlayers:int,
-                nhead: int, 
-                embed_dim: int, 
-                hid_dim:int,
-                feature_positional_embedding_type:Literal['none','subortho','learned'] = 'subortho',
-                feature_positional_embedding_num_slots:int = 1000,
-                mask_prediction: bool = False,
-                features_per_group:int = 2,
-                dropout: float=0,
-                pre_norm: bool=False,
-                activation: str='gelu',
-                layer_norm_eps: float=1e-5,
-                device: torch.device|None=None,
-                dtype: torch.dtype|None=None,
-                recompute_attn: bool=False,
-                mlp_use_residual:bool=False,
-                layer_arch: str = 'fmfmsm',
-                norm_type: str = 'layernorm',
-                deepnorm_alpha: float|None = None,
-                use_target_aware_embedding: bool = False,
-                use_column_specific_y_aware: bool = False,
-                use_logn_attention: bool = False,
-                use_learnable_attn_temperature: bool = False,
-                attn_n_ref: float = 1024.0,
-                omit_feature_decoder: bool = False,
-                **layer_kwargs:Any
-                ):
+        self,
+        *,
+        preprocess_config_x: dict[str, Any],
+        encoder_config_x: dict[str, Any],
+        encoder_config_y: dict[str, Any],
+        decoder_config: dict[str, Any],
+        nlayers: int,
+        nhead: int,
+        embed_dim: int,
+        hid_dim: int,
+        feature_positional_embedding_type: Literal["none", "subortho", "learned"] = "subortho",
+        feature_positional_embedding_num_slots: int = 1000,
+        mask_prediction: bool = False,
+        features_per_group: int = 2,
+        dropout: float = 0,
+        pre_norm: bool = False,
+        activation: str = "gelu",
+        layer_norm_eps: float = 1e-5,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        recompute_attn: bool = False,
+        mlp_use_residual: bool = False,
+        layer_arch: str = "fmfmsm",
+        norm_type: str = "layernorm",
+        deepnorm_alpha: float | None = None,
+        use_target_aware_embedding: bool = False,
+        use_column_specific_y_aware: bool = False,
+        use_logn_attention: bool = False,
+        use_learnable_attn_temperature: bool = False,
+        attn_n_ref: float = 1024.0,
+        omit_feature_decoder: bool = False,
+        **layer_kwargs: Any,
+    ):
         super().__init__()
         if mlp_use_residual:
             raise ValueError(
@@ -97,7 +100,7 @@ class FeaturesTransformer(nn.Module):
                 "uses the transformer's outer residual connection. This legacy "
                 "flag was a no-op; leave it false or remove it from the config."
             )
-        
+
         self.preprocess_config_x = preprocess_config_x
         self.encoder_config_x = encoder_config_x
         self.encoder_config_y = encoder_config_y
@@ -123,30 +126,27 @@ class FeaturesTransformer(nn.Module):
         self.norm_type = norm_type
         self.deepnorm_alpha = deepnorm_alpha
         self.omit_feature_decoder = bool(omit_feature_decoder)
-        self.num_reg_quantiles = int(decoder_config.get('num_reg_quantiles', 1))
+        self.num_reg_quantiles = int(decoder_config.get("num_reg_quantiles", 1))
         # Bar-distribution metadata (persisted via decoder_config at training).
         # When regression_loss == 'bar_distribution', the K reg_y_decoder outputs
         # are interpreted as K bin logits over [bar_borders_low, bar_borders_high]
         # at inference time.
-        configured_regression_loss = decoder_config.get('regression_loss')
+        configured_regression_loss = decoder_config.get("regression_loss")
         if configured_regression_loss is None:
             # Legacy configs persisted only the decoder width. Historically a
             # scalar head was the MSE default and wider heads were pinball.
             # A one-level pinball head is inherently indistinguishable here;
             # new checkpoints persist regression_loss and avoid that ambiguity.
-            configured_regression_loss = (
-                'mse' if self.num_reg_quantiles == 1 else 'pinball'
-            )
+            configured_regression_loss = "mse" if self.num_reg_quantiles == 1 else "pinball"
         self.regression_loss = str(configured_regression_loss)
-        configured_quantiles = decoder_config.get('regression_quantiles')
-        if self.regression_loss == 'pinball':
+        configured_quantiles = decoder_config.get("regression_quantiles")
+        if self.regression_loss == "pinball":
             if configured_quantiles is None:
                 # Legacy checkpoints recorded only the decoder width. Those
                 # runs used the historical evenly-spaced grid, so reconstruct
                 # that grid exactly as the old inference path did.
                 self.regression_quantiles = tuple(
-                    (index + 1.0) / (self.num_reg_quantiles + 1.0)
-                    for index in range(self.num_reg_quantiles)
+                    (index + 1.0) / (self.num_reg_quantiles + 1.0) for index in range(self.num_reg_quantiles)
                 )
             else:
                 self.regression_quantiles = tuple(float(q) for q in configured_quantiles)
@@ -156,39 +156,34 @@ class FeaturesTransformer(nn.Module):
                         f"{len(self.regression_quantiles)} does not match "
                         f"num_reg_quantiles={self.num_reg_quantiles}"
                     )
-                if any(
-                    not math.isfinite(q) or q <= 0.0 or q >= 1.0
-                    for q in self.regression_quantiles
-                ) or any(
+                if any(not math.isfinite(q) or q <= 0.0 or q >= 1.0 for q in self.regression_quantiles) or any(
                     left >= right
                     for left, right in zip(
                         self.regression_quantiles,
                         self.regression_quantiles[1:],
                     )
                 ):
-                    raise ValueError(
-                        "decoder_config.regression_quantiles must be strictly "
-                        "increasing values in (0, 1)"
-                    )
+                    raise ValueError("decoder_config.regression_quantiles must be strictly increasing values in (0, 1)")
         else:
             self.regression_quantiles = ()
-        self.num_bars = int(decoder_config.get('num_bars', self.num_reg_quantiles))
-        self.bar_borders_low = float(decoder_config.get('bar_borders_low', -10.0))
-        self.bar_borders_high = float(decoder_config.get('bar_borders_high', 10.0))
+        self.num_bars = int(decoder_config.get("num_bars", self.num_reg_quantiles))
+        self.bar_borders_low = float(decoder_config.get("bar_borders_low", -10.0))
+        self.bar_borders_high = float(decoder_config.get("bar_borders_high", 10.0))
         # Bar-borders mode: 'uniform' (linspace over [low, high]) or
         # 'normal_quantile' (N(0,1) quantile-spaced for equal mass per bin
         # under standard normal). Normal-quantile concentrates ~3-4× more
         # bins near y=0 where context-normalized targets actually live;
         # eliminates wasted tail bins. Borders are persisted as a buffer so
         # inference uses the exact same edges.
-        self.bar_borders_mode = str(decoder_config.get('bar_borders_mode', 'uniform'))
-        if self.regression_loss == 'bar_distribution':
-            if self.bar_borders_mode == 'normal_quantile':
+        self.bar_borders_mode = str(decoder_config.get("bar_borders_mode", "uniform"))
+        if self.regression_loss == "bar_distribution":
+            if self.bar_borders_mode == "normal_quantile":
                 # N(0,1) quantile spacing — bins are equal-mass under standard
                 # normal. Replace ±inf at the edges with finite extreme values
                 # (±8 std covers all real ctx-normalized data).
                 try:
                     from scipy.stats import norm as _norm
+
                     qs = torch.linspace(0.0, 1.0, self.num_bars + 1, dtype=torch.float32)
                     edges_np = _norm.ppf(qs.numpy())
                     edges_np[0] = -8.0
@@ -197,16 +192,20 @@ class FeaturesTransformer(nn.Module):
                 except ImportError:
                     # Fallback: uniform if scipy isn't available.
                     bar_borders = torch.linspace(
-                        self.bar_borders_low, self.bar_borders_high,
-                        self.num_bars + 1, dtype=torch.float32,
+                        self.bar_borders_low,
+                        self.bar_borders_high,
+                        self.num_bars + 1,
+                        dtype=torch.float32,
                     )
             else:
                 bar_borders = torch.linspace(
-                    self.bar_borders_low, self.bar_borders_high,
-                    self.num_bars + 1, dtype=torch.float32,
+                    self.bar_borders_low,
+                    self.bar_borders_high,
+                    self.num_bars + 1,
+                    dtype=torch.float32,
                 )
             # register_buffer makes it part of state_dict and follows .to()
-            self.register_buffer('bar_borders_buffer', bar_borders, persistent=True)
+            self.register_buffer("bar_borders_buffer", bar_borders, persistent=True)
         else:
             self.bar_borders_buffer = None
         self.use_target_aware_embedding = use_target_aware_embedding
@@ -229,9 +228,7 @@ class FeaturesTransformer(nn.Module):
         else:
             self.column_y_aware_alpha = None
         self.target_aware_scale = 1.0
-        self.max_num_classes = int(
-            encoder_config_y.get('max_num_classes', decoder_config.get('num_classes', 10))
-        )
+        self.max_num_classes = int(encoder_config_y.get("max_num_classes", decoder_config.get("num_classes", 10)))
 
         # logN attention scaling + learnable per-layer temperature.
         # Plumbed through EncoderBaseLayer to all per-layer MultiheadAttentions.
@@ -245,22 +242,22 @@ class FeaturesTransformer(nn.Module):
             nhead=self.nhead,
             dropout=self.dropout,
             pre_norm=self.pre_norm,
-            activation=self.activation, # type: ignore
+            activation=self.activation,  # type: ignore
             layer_norm_eps=self.layer_norm_eps,
             device=self.device,
             dtype=self.dtype,
             recompute_attn=self.recompute_attn,
             mlp_use_residual=self.mlp_use_residual,
-            layer_arch=self.layer_arch, # type: ignore
+            layer_arch=self.layer_arch,  # type: ignore
             norm_type=self.norm_type,
             deepnorm_alpha=self.deepnorm_alpha,
             use_logn_attention=self.use_logn_attention,
             use_learnable_attn_temperature=self.use_learnable_attn_temperature,
             attn_n_ref=self.attn_n_ref,
-            **layer_kwargs
+            **layer_kwargs,
         )
 
-        self.encoder_x = get_x_encoder( **encoder_config_x)
+        self.encoder_x = get_x_encoder(**encoder_config_x)
         self.cls_y_encoder = get_cls_y_encoder(**encoder_config_y)
         self.reg_y_encoder = get_reg_y_encoder(**encoder_config_y)
         if self.use_target_aware_embedding:
@@ -285,7 +282,7 @@ class FeaturesTransformer(nn.Module):
 
         self.transformer_encoder = LayerStack([layer_creator() for _ in range(self.nlayers)])
         if pre_norm:
-            if norm_type == 'rmsnorm':
+            if norm_type == "rmsnorm":
                 self.encoder_out_norm = RMSNorm(self.embed_dim, eps=1e-5, elementwise_affine=False)
             else:
                 self.encoder_out_norm = nn.LayerNorm(self.embed_dim, eps=1e-5, elementwise_affine=False)
@@ -293,17 +290,17 @@ class FeaturesTransformer(nn.Module):
             self.encoder_out_norm = nn.Identity()
 
         self.cls_y_decoder = nn.Sequential(
-                                            nn.Linear(self.embed_dim, self.hid_dim),
-                                            nn.GELU(),
-                                            nn.Linear(self.hid_dim, decoder_config['num_classes']),
-                                            )
-        
+            nn.Linear(self.embed_dim, self.hid_dim),
+            nn.GELU(),
+            nn.Linear(self.hid_dim, decoder_config["num_classes"]),
+        )
+
         self.reg_y_decoder = nn.Sequential(
-                                        nn.Linear(self.embed_dim, self.hid_dim),
-                                        nn.LayerNorm(self.hid_dim),
-                                        nn.GELU(),
-                                        nn.Linear(self.hid_dim, self.num_reg_quantiles),
-                                        )
+            nn.Linear(self.embed_dim, self.hid_dim),
+            nn.LayerNorm(self.hid_dim),
+            nn.GELU(),
+            nn.Linear(self.hid_dim, self.num_reg_quantiles),
+        )
         self.feature_decoder = (
             None
             if self.omit_feature_decoder
@@ -314,53 +311,54 @@ class FeaturesTransformer(nn.Module):
                 nn.Linear(self.hid_dim, self.features_per_group),
             )
         )
-        
+
         if feature_positional_embedding_type == "learned":
-            self.feature_positional_embedding = nn.Embedding(
-                feature_positional_embedding_num_slots, self.embed_dim
-            )
+            self.feature_positional_embedding = nn.Embedding(feature_positional_embedding_num_slots, self.embed_dim)
             nn.init.normal_(self.feature_positional_embedding.weight, std=0.02)
             self.feature_positional_embedding_num_slots = feature_positional_embedding_num_slots
         elif feature_positional_embedding_type == "subortho":
             self.feature_positional_embedding = nn.Linear(self.embed_dim // 4, self.embed_dim)
-        
+
         self.x_preprocess = preprocesss_4_x(**preprocess_config_x)
 
-
-    def forward(self, x: torch.Tensor, 
-                y: torch.Tensor, 
-                eval_pos: int, 
-                y_type: torch.Tensor = None,
-                task_type: Literal['reg', 'cls'] = 'cls',
-                calculate_sample_attention: bool = False,
-                calculate_feature_attention: bool = False,
-                return_embeddings: bool = False,
-                **kwargs
-                ) -> torch.Tensor | dict[str, torch.Tensor] | tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
-        '''
-            x: The input x, which includes both train x and test x, Shape: [batch, sequence, feature]
-            y: The input y, which includes both train y and test y, Shape: [batch, label]
-            eval_pos: Train x and train y split point
-            task_type: Type of task, options: cls(classification), reg(regression)
-            return_embeddings: when True, skip the decoder head and return the
-                per-row target-token representation from the final encoder layer
-                (post encoder_out_norm), shape [batch, seq, embed_dim]. Callers
-                slice context (``:eval_pos``) vs query (``eval_pos:``) themselves.
-        '''
+    def forward(
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        eval_pos: int,
+        y_type: torch.Tensor = None,
+        task_type: Literal["reg", "cls"] = "cls",
+        calculate_sample_attention: bool = False,
+        calculate_feature_attention: bool = False,
+        return_embeddings: bool = False,
+        **kwargs,
+    ) -> torch.Tensor | dict[str, torch.Tensor] | tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        """
+        x: The input x, which includes both train x and test x, Shape: [batch, sequence, feature]
+        y: The input y, which includes both train y and test y, Shape: [batch, label]
+        eval_pos: Train x and train y split point
+        task_type: Type of task, options: cls(classification), reg(regression)
+        return_embeddings: when True, skip the decoder head and return the
+            per-row target-token representation from the final encoder layer
+            (post encoder_out_norm), shape [batch, seq, embed_dim]. Callers
+            slice context (``:eval_pos``) vs query (``eval_pos:``) themselves.
+        """
         assert x is not None and y is not None, "x and y must not be none"
         assert eval_pos > 0, "eval_pos must be a positive number"
-        assert len(x.shape)==3, "x must be [Batch, seq, Feature]"
-        assert len(y.shape)==2, "y must be [Batch, label]"
-        assert eval_pos < x.shape[1] and eval_pos <= y.shape[1], "The split point between train x and test x must be less than the feature dimension of x, and less than or equal to the label dimension of y"
-        
+        assert len(x.shape) == 3, "x must be [Batch, seq, Feature]"
+        assert len(y.shape) == 2, "y must be [Batch, label]"
+        assert eval_pos < x.shape[1] and eval_pos <= y.shape[1], (
+            "The split point between train x and test x must be less than the feature dimension of x, and less than or equal to the label dimension of y"
+        )
+
         _, seq_len, _ = x.shape
         x, feature_to_add = self._build_x_preprocess_inputs(x, eval_pos)
-        y = {'data':y}
+        y = {"data": y}
         preprocessed_x = self.x_preprocess(x)
         preprocessed_x = self.process_4_x(preprocessed_x)
         x_encoder_result = self.encoder_x(preprocessed_x)
-        x_emb_result = x_encoder_result['data']
-        
+        x_emb_result = x_encoder_result["data"]
+
         for k in y:
             # Extend the label dimension of y when it is insufficient
             y[k] = y[k].unsqueeze(-1)
@@ -377,25 +375,25 @@ class FeaturesTransformer(nn.Module):
                             dtype=y[k].dtype,
                         ),
                     ),
-                    dim=1
+                    dim=1,
                 )
         target_aware_y = y["data"].squeeze(-1).clone()
         # Mask the test y — functional (no in-place mutation of the input dict)
         seq_positions = torch.arange(y["data"].shape[1], device=y["data"].device)
         y_data_masked = torch.where(
             seq_positions.view(1, -1, 1) >= eval_pos,
-            torch.tensor(float('nan'), device=y["data"].device, dtype=y["data"].dtype),
+            torch.tensor(float("nan"), device=y["data"].device, dtype=y["data"].dtype),
             y["data"],
         )
 
         # Embed y — direct encoder call (avoids mixed_y_embedding graph break).
         # Encoder output may be 4-D [B, S, 1, E] because y has a trailing
         # dim of 1; squeeze it to [B, S, E] to match the old contract.
-        y_enc_input = {'data': y_data_masked, 'eval_pos': eval_pos}
-        if task_type == 'cls':
-            embedded_y = self.cls_y_encoder(y_enc_input)['data'].squeeze(2)
+        y_enc_input = {"data": y_data_masked, "eval_pos": eval_pos}
+        if task_type == "cls":
+            embedded_y = self.cls_y_encoder(y_enc_input)["data"].squeeze(2)
         else:
-            embedded_y = self.reg_y_encoder(y_enc_input)['data'].squeeze(2)
+            embedded_y = self.reg_y_encoder(y_enc_input)["data"].squeeze(2)
 
         embedded_x = self.add_embeddings(x_emb_result)
         embedded_x = self.apply_target_aware_embedding(
@@ -406,9 +404,14 @@ class FeaturesTransformer(nn.Module):
         )
         embedded_all = torch.cat((embedded_x, embedded_y.unsqueeze(2)), dim=2)
         if calculate_sample_attention or calculate_feature_attention:
-            return self.transformer_encoder(embedded_all, feature_atten_mask=None, eval_pos=eval_pos,
-                                            calculate_sample_attention=calculate_sample_attention,
-                                            calculate_feature_attention=calculate_feature_attention, **kwargs)
+            return self.transformer_encoder(
+                embedded_all,
+                feature_atten_mask=None,
+                eval_pos=eval_pos,
+                calculate_sample_attention=calculate_sample_attention,
+                calculate_feature_attention=calculate_feature_attention,
+                **kwargs,
+            )
         else:
             pass
         encoder_out = self.transformer_encoder(embedded_all, feature_atten_mask=None, eval_pos=eval_pos, **kwargs)[0]
@@ -426,22 +429,19 @@ class FeaturesTransformer(nn.Module):
         encoder_out_4_feature = encoder_out[:, :, :-1, :]
         if self.mask_prediction:
             # Direct decoder call (avoids y_decoder graph break)
-            if task_type == 'cls':
+            if task_type == "cls":
                 cls_output = self.cls_y_decoder(test_encoder_out)
                 reg_output = test_encoder_out.new_zeros(
-                    test_encoder_out.shape[0], test_encoder_out.shape[1],
-                    self.num_reg_quantiles)
+                    test_encoder_out.shape[0], test_encoder_out.shape[1], self.num_reg_quantiles
+                )
             else:
                 cls_output = test_encoder_out.new_zeros(
-                    test_encoder_out.shape[0], test_encoder_out.shape[1],
-                    self.cls_y_decoder[-1].out_features)
+                    test_encoder_out.shape[0], test_encoder_out.shape[1], self.cls_y_decoder[-1].out_features
+                )
                 reg_output = self.reg_y_decoder(test_encoder_out)
             feature_pred = (
                 None
-                if (
-                    self.feature_decoder is None
-                    or getattr(self, "_skip_feature_decoder", False)
-                )
+                if (self.feature_decoder is None or getattr(self, "_skip_feature_decoder", False))
                 else self.feature_decoder(encoder_out_4_feature)
             )
             output_decoded = {
@@ -451,36 +451,35 @@ class FeaturesTransformer(nn.Module):
                 "process_config": {
                     "n_x_padding": feature_to_add,
                     "features_per_group": self.features_per_group,
-                    "num_used_features": preprocessed_x.get('_valid_feature_num'),
-                    "mean_for_normalization": preprocessed_x.get('_norm_mean'),
-                    "std_for_normalization": preprocessed_x.get('_norm_std'),
-                }
+                    "num_used_features": preprocessed_x.get("_valid_feature_num"),
+                    "mean_for_normalization": preprocessed_x.get("_norm_mean"),
+                    "std_for_normalization": preprocessed_x.get("_norm_std"),
+                },
             }
         else:
-            if task_type == 'cls':
+            if task_type == "cls":
                 output_decoded = self.cls_y_decoder(test_encoder_out)
             else:
                 output_decoded = self.reg_y_decoder(test_encoder_out)
 
         return output_decoded
 
-    
     def _build_x_preprocess_inputs(
-            self,
-            x: torch.Tensor,
-            eval_pos: int,
+        self,
+        x: torch.Tensor,
+        eval_pos: int,
     ) -> tuple[dict[str, torch.Tensor | int], int]:
         batch_size, seq_len, num_feature = x.shape
         x_dict: dict[str, torch.Tensor | int] = {
-            'data': x,
+            "data": x,
             # The numeric channel treats NaN and both infinities as missing.
             # NanEncoder may retain their kind in a separate indicator channel,
             # but process_4_x must never let an infinity reach the numeric encoder.
-            'mask': (~torch.isfinite(x)).to(torch.int32).to(x.device),
+            "mask": (~torch.isfinite(x)).to(torch.int32).to(x.device),
         }
         feature_to_add = (-num_feature) % self.features_per_group
         if feature_to_add > 0:
-            for k in ('data', 'mask'):
+            for k in ("data", "mask"):
                 value = x_dict[k]
                 assert isinstance(value, torch.Tensor)
                 x_dict[k] = torch.cat(
@@ -496,7 +495,7 @@ class FeaturesTransformer(nn.Module):
                     ),
                     dim=-1,
                 )
-        for k in ('data', 'mask'):
+        for k in ("data", "mask"):
             value = x_dict[k]
             assert isinstance(value, torch.Tensor)
             x_dict[k] = value.reshape(
@@ -505,14 +504,14 @@ class FeaturesTransformer(nn.Module):
                 value.shape[2] // self.features_per_group,
                 self.features_per_group,
             )
-        x_dict['eval_pos'] = eval_pos
+        x_dict["eval_pos"] = eval_pos
         return x_dict, feature_to_add
 
     def _slice_preprocessed_x(
-            self,
-            preprocessed_x: dict[str, torch.Tensor | int],
-            row_slice: slice,
-            total_rows: int,
+        self,
+        preprocessed_x: dict[str, torch.Tensor | int],
+        row_slice: slice,
+        total_rows: int,
     ) -> dict[str, torch.Tensor | int]:
         sliced: dict[str, torch.Tensor | int] = {}
         for k, v in preprocessed_x.items():
@@ -523,11 +522,11 @@ class FeaturesTransformer(nn.Module):
         return sliced
 
     def make_feature_positional_embeddings(
-            self,
-            n_groups: int,
-            *,
-            device: torch.device,
-            dtype: torch.dtype,
+        self,
+        n_groups: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
     ) -> torch.Tensor | None:
         if self.feature_positional_embedding_type == "subortho":
             with autocast(device_type=device.type, enabled=False):
@@ -547,35 +546,35 @@ class FeaturesTransformer(nn.Module):
         raise ValueError(f"Unknown feature_positional_embedding_type={self.feature_positional_embedding_type}")
 
     def apply_feature_positional_embeddings(
-            self,
-            x: torch.Tensor,
-            embs: torch.Tensor | None,
+        self,
+        x: torch.Tensor,
+        embs: torch.Tensor | None,
     ) -> torch.Tensor:
         if embs is None:
             return x
         return x + embs[None, None, :, :]
 
     def _encode_x_rows(
-            self,
-            preprocessed_x: dict[str, torch.Tensor | int],
-            row_slice: slice,
-            *,
-            total_rows: int,
-            feature_pos_emb: torch.Tensor | None,
+        self,
+        preprocessed_x: dict[str, torch.Tensor | int],
+        row_slice: slice,
+        *,
+        total_rows: int,
+        feature_pos_emb: torch.Tensor | None,
     ) -> torch.Tensor:
         x_part = self._slice_preprocessed_x(preprocessed_x, row_slice, total_rows)
-        encoded = self.encoder_x(x_part)['data']
+        encoded = self.encoder_x(x_part)["data"]
         return self.apply_feature_positional_embeddings(encoded, feature_pos_emb)
 
     def _encode_y_full(
-            self,
-            y: torch.Tensor,
-            *,
-            total_rows: int,
-            eval_pos: int,
-            task_type: Literal['reg', 'cls'],
+        self,
+        y: torch.Tensor,
+        *,
+        total_rows: int,
+        eval_pos: int,
+        task_type: Literal["reg", "cls"],
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        y_dict: dict[str, torch.Tensor] = {'data': y}
+        y_dict: dict[str, torch.Tensor] = {"data": y}
         for k in y_dict:
             y_dict[k] = y_dict[k].unsqueeze(-1)
             if y_dict[k].shape[1] < total_rows:
@@ -599,29 +598,29 @@ class FeaturesTransformer(nn.Module):
         seq_positions = torch.arange(total_rows, device=y_dict["data"].device)
         y_data_masked = torch.where(
             seq_positions.view(1, -1, 1) >= eval_pos,
-            torch.tensor(float('nan'), device=y_dict["data"].device, dtype=y_dict["data"].dtype),
+            torch.tensor(float("nan"), device=y_dict["data"].device, dtype=y_dict["data"].dtype),
             y_dict["data"],
         )
-        y_enc_input = {'data': y_data_masked, 'eval_pos': eval_pos}
-        if task_type == 'cls':
-            embedded_y = self.cls_y_encoder(y_enc_input)['data'].squeeze(2)
+        y_enc_input = {"data": y_data_masked, "eval_pos": eval_pos}
+        if task_type == "cls":
+            embedded_y = self.cls_y_encoder(y_enc_input)["data"].squeeze(2)
         else:
-            embedded_y = self.reg_y_encoder(y_enc_input)['data'].squeeze(2)
+            embedded_y = self.reg_y_encoder(y_enc_input)["data"].squeeze(2)
         return target_aware_y, embedded_y
 
     def forward_cached_regression(
-            self,
-            x: torch.Tensor,
-            y: torch.Tensor,
-            eval_pos: int,
-            *,
-            row_chunk_size: int | None = None,
-            cache_dtype: str = "bf16",
-            offload_kv_cache: bool = False,
-            fit_row_chunk: int | None = None,
-            adaptive_query_chunk: bool = True,
-            quantize_kv_cache: bool | None = None,
-            adaptive_oom_chunk: bool | None = None,
+        self,
+        x: torch.Tensor,
+        y: torch.Tensor,
+        eval_pos: int,
+        *,
+        row_chunk_size: int | None = None,
+        cache_dtype: str = "bf16",
+        offload_kv_cache: bool = False,
+        fit_row_chunk: int | None = None,
+        adaptive_query_chunk: bool = True,
+        quantize_kv_cache: bool | None = None,
+        adaptive_oom_chunk: bool | None = None,
     ) -> torch.Tensor:
         """Regression-only cached prediction path for chunked inference.
 
@@ -691,26 +690,28 @@ class FeaturesTransformer(nn.Module):
         # bundle once (build_context_cache) and reuse it across calls
         # (apply_context_cache) instead of rebuilding the O(N_train) cache each time.
         bundle = self.build_context_cache(
-            x[:, :eval_pos], y[:, :eval_pos],
+            x[:, :eval_pos],
+            y[:, :eval_pos],
             cache_dtype=cache_dtype,
             offload_kv_cache=offload_kv_cache,
             fit_row_chunk=fit_row_chunk,
         )
         return self.apply_context_cache(
-            x[:, eval_pos:], bundle,
+            x[:, eval_pos:],
+            bundle,
             row_chunk_size=row_chunk_size,
             adaptive_query_chunk=adaptive_query_chunk,
         )
 
     def build_context_cache(
-            self,
-            x_train: torch.Tensor,
-            y_train: torch.Tensor,
-            *,
-            cache_dtype: str = "bf16",
-            offload_kv_cache: bool = False,
-            fit_row_chunk: int | None = None,
-            quantize_kv_cache: bool | None = None,
+        self,
+        x_train: torch.Tensor,
+        y_train: torch.Tensor,
+        *,
+        cache_dtype: str = "bf16",
+        offload_kv_cache: bool = False,
+        fit_row_chunk: int | None = None,
+        quantize_kv_cache: bool | None = None,
     ) -> ContextCache:
         """Encode a fixed context (train) table once into a reusable ``ContextCache``.
 
@@ -727,17 +728,13 @@ class FeaturesTransformer(nn.Module):
             cache_dtype = "int8" if quantize_kv_cache else "bf16"
         if cache_dtype not in ("bf16", "int8"):
             raise ValueError(
-                "build_context_cache takes a concrete cache_dtype of 'bf16' or "
-                f"'int8', got {cache_dtype!r}."
+                f"build_context_cache takes a concrete cache_dtype of 'bf16' or 'int8', got {cache_dtype!r}."
             )
         if self.mask_prediction:
             raise NotImplementedError("build_context_cache requires mask_prediction=False")
-        if (
-            not bool(self.preprocess_config_x.get("normalize_on_train_only", True))
-            and (
-                bool(self.preprocess_config_x.get("normalize_x", False))
-                or bool(self.preprocess_config_x.get("remove_outliers", False))
-            )
+        if not bool(self.preprocess_config_x.get("normalize_on_train_only", True)) and (
+            bool(self.preprocess_config_x.get("normalize_x", False))
+            or bool(self.preprocess_config_x.get("remove_outliers", False))
         ):
             raise NotImplementedError(
                 "build_context_cache cannot preserve normalize_on_train_only=False: "
@@ -761,21 +758,18 @@ class FeaturesTransformer(nn.Module):
         # Capture the train-derived normalization stats BEFORE process_4_x so they
         # can be re-applied (frozen) to query rows in apply_context_cache. Empty ->
         # None (no normalization is active, so query rows need no train stats).
-        captured = preprocessed_x.get('_norm_stats') or {}
+        captured = preprocessed_x.get("_norm_stats") or {}
         norm_stats = {k: v.detach() for k, v in captured.items()} if captured else None
         # Same for NanEncoder's imputation fill (the train column mean). The key is
         # absent when nan_handling_enabled=False.
-        captured_nan_mean = preprocessed_x.get('_nan_mean')
-        nan_mean = (captured_nan_mean.detach()
-                    if isinstance(captured_nan_mean, torch.Tensor) else None)
-        captured_valid_feature_num = preprocessed_x.get('_valid_feature_num')
+        captured_nan_mean = preprocessed_x.get("_nan_mean")
+        nan_mean = captured_nan_mean.detach() if isinstance(captured_nan_mean, torch.Tensor) else None
+        captured_valid_feature_num = preprocessed_x.get("_valid_feature_num")
         valid_feature_num = (
-            captured_valid_feature_num.detach()
-            if isinstance(captured_valid_feature_num, torch.Tensor)
-            else None
+            captured_valid_feature_num.detach() if isinstance(captured_valid_feature_num, torch.Tensor) else None
         )
         preprocessed_x = self.process_4_x(preprocessed_x)
-        data_tensor = preprocessed_x['data']
+        data_tensor = preprocessed_x["data"]
         assert isinstance(data_tensor, torch.Tensor)
         feature_pos_emb = self.make_feature_positional_embeddings(
             data_tensor.shape[2],
@@ -786,7 +780,7 @@ class FeaturesTransformer(nn.Module):
             y_train[:, :eval_pos],
             total_rows=eval_pos,
             eval_pos=eval_pos,
-            task_type='reg',
+            task_type="reg",
         )
         x_train_enc = self._encode_x_rows(
             preprocessed_x,
@@ -797,7 +791,7 @@ class FeaturesTransformer(nn.Module):
         x_train_enc = self.apply_target_aware_embedding(
             x_train_enc,
             target_aware_y[:, :eval_pos],
-            task_type='reg',
+            task_type="reg",
             eval_pos=eval_pos,
         )
         train_tokens = torch.cat((x_train_enc, embedded_y[:, :eval_pos].unsqueeze(2)), dim=2)
@@ -830,12 +824,12 @@ class FeaturesTransformer(nn.Module):
         )
 
     def apply_context_cache(
-            self,
-            x_test: torch.Tensor,
-            context: ContextCache,
-            *,
-            row_chunk_size: int | None = None,
-            adaptive_query_chunk: bool = True,
+        self,
+        x_test: torch.Tensor,
+        context: ContextCache,
+        *,
+        row_chunk_size: int | None = None,
+        adaptive_query_chunk: bool = True,
     ) -> torch.Tensor:
         """Score query rows against a prebuilt :class:`ContextCache`.
 
@@ -858,11 +852,11 @@ class FeaturesTransformer(nn.Module):
         # eval_pos here only feeds the (overridden) NormalizationEncoder split point.
         x_dict, _feature_to_add = self._build_x_preprocess_inputs(x_test, n_test)
         if context.norm_stats is not None:
-            x_dict['_frozen_norm_stats'] = context.norm_stats
+            x_dict["_frozen_norm_stats"] = context.norm_stats
         if context.nan_mean is not None:
-            x_dict['_frozen_nan_mean'] = context.nan_mean
+            x_dict["_frozen_nan_mean"] = context.nan_mean
         if context.valid_feature_num is not None:
-            x_dict['_frozen_valid_feature_num'] = context.valid_feature_num
+            x_dict["_frozen_valid_feature_num"] = context.valid_feature_num
         preprocessed_x = self.x_preprocess(x_dict)
         preprocessed_x = self.process_4_x(preprocessed_x)
 
@@ -873,7 +867,7 @@ class FeaturesTransformer(nn.Module):
             context.y_train,
             total_rows=eval_pos + n_test,
             eval_pos=eval_pos,
-            task_type='reg',
+            task_type="reg",
         )
         embedded_y_query = embedded_y_full[:, eval_pos:]
 
@@ -882,13 +876,16 @@ class FeaturesTransformer(nn.Module):
 
         def _run_chunk(start: int, end: int) -> torch.Tensor:
             x_q = self._encode_x_rows(
-                preprocessed_x, slice(start, end),
-                total_rows=n_test, feature_pos_emb=context.feature_pos_emb,
+                preprocessed_x,
+                slice(start, end),
+                total_rows=n_test,
+                feature_pos_emb=context.feature_pos_emb,
             )
-            test_tokens = torch.cat(
-                (x_q, embedded_y_query[:, start:end].unsqueeze(2)), dim=2)
+            test_tokens = torch.cat((x_q, embedded_y_query[:, start:end].unsqueeze(2)), dim=2)
             test_out = self.transformer_encoder.forward_test_with_cache(
-                test_tokens, context.caches, feature_atten_mask=None,
+                test_tokens,
+                context.caches,
+                feature_atten_mask=None,
             )
             test_out = self.encoder_out_norm(test_out)
             return self.reg_y_decoder(test_out[:, :, -1])
@@ -917,17 +914,15 @@ class FeaturesTransformer(nn.Module):
         x: torch.Tensor,
         y: torch.Tensor,
         *,
-        task_type: Literal['reg', 'cls'],
+        task_type: Literal["reg", "cls"],
         eval_pos: int,
     ) -> torch.Tensor:
-        scale = float(getattr(self, 'target_aware_scale', 1.0))
-        if (not self.use_target_aware_embedding
-                or eval_pos <= 0
-                or abs(scale) < 1e-8):
+        scale = float(getattr(self, "target_aware_scale", 1.0))
+        if not self.use_target_aware_embedding or eval_pos <= 0 or abs(scale) < 1e-8:
             return x
 
         # Compute bias for context rows, pad query rows with zeros (functional)
-        if task_type == 'cls':
+        if task_type == "cls":
             assert self.cls_target_aware_embedding is not None
             y_ctx = y[:, :eval_pos].to(torch.long)
             y_ctx = torch.clamp(y_ctx, min=0, max=self.max_num_classes - 1)
@@ -948,8 +943,7 @@ class FeaturesTransformer(nn.Module):
         # broadcasts over the n_feature_groups dim of x.
         row_broadcast_bias = target_bias.unsqueeze(2)
 
-        if (self.use_column_specific_y_aware
-                and self.column_y_aware_alpha is not None):
+        if self.use_column_specific_y_aware and self.column_y_aware_alpha is not None:
             # Column-specific gating: each feature group gets a y-bias scaled
             # by its alignment with y_emb. Columns "in the direction of" the
             # y signal get strong y-aware bias; orthogonal columns get less.
@@ -957,10 +951,10 @@ class FeaturesTransformer(nn.Module):
             #
             # col_score[b, t, c] = <x[b, t, c, :], target_bias[b, t, :]>
             # Higher score → column emb is closer to y signal → higher gate.
-            inv_sqrt_d = 1.0 / (self.embed_dim ** 0.5)
+            inv_sqrt_d = 1.0 / (self.embed_dim**0.5)
             col_score = (x * row_broadcast_bias).sum(dim=-1) * inv_sqrt_d  # [B, seq, n_cols]
-            col_gate = torch.sigmoid(col_score).unsqueeze(-1)               # [B, seq, n_cols, 1]
-            col_specific_bias = row_broadcast_bias * col_gate               # [B, seq, n_cols, embed_dim]
+            col_gate = torch.sigmoid(col_score).unsqueeze(-1)  # [B, seq, n_cols, 1]
+            col_specific_bias = row_broadcast_bias * col_gate  # [B, seq, n_cols, embed_dim]
             # Mix old row-broadcast with new column-specific via learned α.
             # alpha=sigmoid(α_param) starts at sigmoid(-5)≈0.007 → ~99.3%
             # original V8old behavior preserved at FT step 0.
@@ -968,15 +962,15 @@ class FeaturesTransformer(nn.Module):
             return x + (1.0 - alpha) * row_broadcast_bias + alpha * col_specific_bias
 
         return x + row_broadcast_bias
-    
-    def process_4_x(self, data:dict):
-        x_input = data['data']
-        mask = data['mask'].to(torch.bool)
-        x_input = torch.where(mask, float('nan'), x_input)
-        data['data'] = x_input
+
+    def process_4_x(self, data: dict):
+        x_input = data["data"]
+        mask = data["mask"].to(torch.bool)
+        x_input = torch.where(mask, float("nan"), x_input)
+        data["data"] = x_input
         return data
-    
-    def add_embeddings(self, x:torch.Tensor):
+
+    def add_embeddings(self, x: torch.Tensor):
         if self.feature_positional_embedding_type == "subortho":
             with autocast(device_type=x.device.type, enabled=False):
                 embs = torch.randn(
@@ -985,7 +979,7 @@ class FeaturesTransformer(nn.Module):
                     dtype=torch.float32,
                 )
                 torch.nn.init.orthogonal_(embs)
-            embs =self.feature_positional_embedding(embs.to(x.dtype))
+            embs = self.feature_positional_embedding(embs.to(x.dtype))
             x += embs[None, None]
         elif self.feature_positional_embedding_type == "learned":
             # Learned positional embeddings (TabPFN-2.6 style).
@@ -1003,4 +997,3 @@ class FeaturesTransformer(nn.Module):
         else:
             raise ValueError(f"Unknown feature_positional_embedding_type={self.feature_positional_embedding_type}")
         return x
-    

--- a/src/synthefy_nori/nori_ts/tsfeatures/auto_features.py
+++ b/src/synthefy_nori/nori_ts/tsfeatures/auto_features.py
@@ -45,9 +45,7 @@ class AutoSeasonalFeature(FeatureGenerator):
 
     def __init__(self, config: Optional[dict] = None):
         # Create default config from Config class
-        default_config = {
-            k: v for k, v in vars(self.Config).items() if not k.startswith("__")
-        }
+        default_config = {k: v for k, v in vars(self.Config).items() if not k.startswith("__")}
 
         # Initialize config with defaults
         self.config = default_config.copy()
@@ -77,9 +75,7 @@ class AutoSeasonalFeature(FeatureGenerator):
             "linear",
             "constant",
         ]:
-            logger.warning(
-                f"Invalid detrend_type: {self.config['detrend_type']}, using 'linear'"
-            )
+            logger.warning(f"Invalid detrend_type: {self.config['detrend_type']}, using 'linear'")
             self.config["detrend_type"] = "linear"
 
     def generate(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -93,9 +89,7 @@ class AutoSeasonalFeature(FeatureGenerator):
         codes, _ = pd.factorize(df.index.get_level_values("item_id"), sort=False)
         n_series = int(codes.max()) + 1 if n else 0
         periods_by_series = np.full((n_series, max_top_k), np.nan)
-        for code, (_item_id, target) in enumerate(
-            df["target"].groupby(level="item_id", sort=False)
-        ):
+        for code, (_item_id, target) in enumerate(df["target"].groupby(level="item_id", sort=False)):
             periods = [p for p, _ in self.find_seasonal_periods(target, **self.config)]
             for i, period in enumerate(periods[:max_top_k]):
                 periods_by_series[code, i] = period
@@ -121,18 +115,14 @@ class AutoSeasonalFeature(FeatureGenerator):
         target_values: pd.Series,
         max_top_k: int = 10,
         do_detrend: bool = True,
-        detrend_type: Literal[
-            "first_diff", "loess", "linear", "constant"
-        ] = "first_diff",
+        detrend_type: Literal["first_diff", "loess", "linear", "constant"] = "first_diff",
         use_peaks_only: bool = True,
         apply_hann_window: bool = True,
         zero_padding_factor: int = 2,
         round_to_closest_integer: bool = True,
         validate_with_acf: bool = False,
         sampling_interval: float = 1.0,
-        magnitude_threshold: Optional[
-            float
-        ] = 0.05,  # Default relative threshold (5% of max)
+        magnitude_threshold: Optional[float] = 0.05,  # Default relative threshold (5% of max)
         relative_threshold: bool = True,  # Interpret threshold as a fraction of max FFT magnitude
         exclude_zero: bool = False,
     ) -> List[Tuple[float, float]]:
@@ -224,16 +214,12 @@ class AutoSeasonalFeature(FeatureGenerator):
                 # Fallback to considering all frequency bins if no peaks are found
                 peak_indices = np.arange(len(fft_magnitudes))
             # Sort the peak indices by magnitude in descending order
-            sorted_peak_indices = peak_indices[
-                np.argsort(fft_magnitudes[peak_indices])[::-1]
-            ]
+            sorted_peak_indices = peak_indices[np.argsort(fft_magnitudes[peak_indices])[::-1]]
             top_indices = sorted_peak_indices[:max_top_k]
         else:
             sorted_indices = np.argsort(fft_magnitudes)[::-1]
             if threshold_value is not None:
-                sorted_indices = [
-                    i for i in sorted_indices if fft_magnitudes[i] >= threshold_value
-                ]
+                sorted_indices = [i for i in sorted_indices if fft_magnitudes[i] >= threshold_value]
             top_indices = sorted_indices[:max_top_k]
 
         # Convert frequencies to periods (avoiding division by zero)
@@ -261,10 +247,7 @@ class AutoSeasonalFeature(FeatureGenerator):
             top_indices = top_indices[unique_period_indices]
 
         # Pair each period with its corresponding magnitude
-        results = [
-            (top_periods[i], fft_magnitudes[top_indices[i]])
-            for i in range(len(top_indices))
-        ]
+        results = [(top_periods[i], fft_magnitudes[top_indices[i]]) for i in range(len(top_indices))]
 
         # Validate with ACF if requested and filter the results accordingly
         if validate_with_acf:
@@ -274,15 +257,11 @@ class AutoSeasonalFeature(FeatureGenerator):
                 nlags=N_original,
                 fft=True,
             )
-            acf_peak_indices, _ = find_peaks(
-                acf_values, height=1.96 / np.sqrt(N_original)
-            )
+            acf_peak_indices, _ = find_peaks(acf_values, height=1.96 / np.sqrt(N_original))
             validated_results = []
             for period, mag in results:
                 period_int = int(round(period))
-                if period_int < len(acf_values) and any(
-                    abs(period_int - peak) <= 1 for peak in acf_peak_indices
-                ):
+                if period_int < len(acf_values) and any(abs(period_int - peak) <= 1 for peak in acf_peak_indices):
                     validated_results.append((period, mag))
             if validated_results:
                 results = validated_results
@@ -293,9 +272,7 @@ class AutoSeasonalFeature(FeatureGenerator):
         return results
 
 
-def detrend(
-    x: np.ndarray, detrend_type: Literal["first_diff", "loess", "linear", "constant"]
-) -> np.ndarray:
+def detrend(x: np.ndarray, detrend_type: Literal["first_diff", "loess", "linear", "constant"]) -> np.ndarray:
     if detrend_type == "first_diff":
         return np.diff(x, prepend=x[0])
 

--- a/src/synthefy_nori/nori_ts/tsfeatures/data_preparation.py
+++ b/src/synthefy_nori/nori_ts/tsfeatures/data_preparation.py
@@ -52,9 +52,7 @@ def generate_test_X(
     for i, last_ts in enumerate(last_timestamps):
         start_ts = last_ts + freq_offset
         timestamps = pd.date_range(start=start_ts, periods=prediction_length, freq=freq)
-        all_timestamps[i * prediction_length : (i + 1) * prediction_length] = (
-            timestamps.values
-        )
+        all_timestamps[i * prediction_length : (i + 1) * prediction_length] = timestamps.values
 
     # Build single DataFrame with vectorized arrays
     test_df = pd.DataFrame(
@@ -233,11 +231,7 @@ offset_alias_to_period_alias = {
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 def to_gluonts_univariate(hf_dataset: datasets.Dataset):
-    series_fields = [
-        col
-        for col in hf_dataset.features
-        if isinstance(hf_dataset.features[col], datasets.Sequence)
-    ]
+    series_fields = [col for col in hf_dataset.features if isinstance(hf_dataset.features[col], datasets.Sequence)]
     series_fields.remove("timestamp")
     dataset_length = hf_dataset.info.splits["train"].num_examples * len(series_fields)
     dataset_freq = pd.infer_freq(hf_dataset[0]["timestamp"])

--- a/src/synthefy_nori/nori_ts/tsfeatures/feature_transformer.py
+++ b/src/synthefy_nori/nori_ts/tsfeatures/feature_transformer.py
@@ -33,9 +33,7 @@ class FeatureTransformer:
 
         self._validate_input(train_tsdf, test_tsdf, target_column)
 
-        static_features = self._merge_static_features(
-            train_tsdf.static_features, test_tsdf.static_features
-        )
+        static_features = self._merge_static_features(train_tsdf.static_features, test_tsdf.static_features)
 
         # Input columns (target + covariates) keep their dtype; only generated columns
         # are downcast to float32 below. The whole featurized frame lives in host RAM
@@ -61,11 +59,7 @@ class FeatureTransformer:
         # The generated features (calendar, seasonal, running index) are bounded and
         # exactly representable in float32, so the downcast is lossless.
         generated_float_cols = [
-            c
-            for c in tsdf.columns
-            if c not in input_columns
-            and c != "_is_train"
-            and tsdf[c].dtype == np.float64
+            c for c in tsdf.columns if c not in input_columns and c != "_is_train" and tsdf[c].dtype == np.float64
         ]
         if generated_float_cols:
             tsdf = tsdf.astype({c: np.float32 for c in generated_float_cols})
@@ -75,16 +69,10 @@ class FeatureTransformer:
         test_slice = tsdf[~tsdf["_is_train"]].drop(columns=["_is_train"])
         del tsdf
 
-        train_tsdf = TimeSeriesDataFrame(
-            pd.DataFrame(train_slice), static_features=static_features
-        )
-        test_tsdf = TimeSeriesDataFrame(
-            pd.DataFrame(test_slice), static_features=static_features
-        )
+        train_tsdf = TimeSeriesDataFrame(pd.DataFrame(train_slice), static_features=static_features)
+        test_tsdf = TimeSeriesDataFrame(pd.DataFrame(test_slice), static_features=static_features)
 
-        assert not train_tsdf[target_column].isna().any(), (
-            "All target values in train_tsdf should be non-NaN"
-        )
+        assert not train_tsdf[target_column].isna().any(), "All target values in train_tsdf should be non-NaN"
         assert test_tsdf[target_column].isna().all()
 
         return train_tsdf, test_tsdf
@@ -111,9 +99,7 @@ class FeatureTransformer:
         target_column: str,
     ):
         if target_column not in train_tsdf.columns:
-            raise ValueError(
-                f"Target column '{target_column}' not found in training data"
-            )
+            raise ValueError(f"Target column '{target_column}' not found in training data")
 
         if not test_tsdf[target_column].isna().all():
             raise ValueError("Test data should not contain target values")

--- a/src/synthefy_nori/nori_ts/tsfeatures/ts_dataframe.py
+++ b/src/synthefy_nori/nori_ts/tsfeatures/ts_dataframe.py
@@ -167,15 +167,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
         elif isinstance(data, Iterable):
             data = self._construct_tsdf_from_iterable_dataset(data, num_cpus=num_cpus)
         else:
-            raise ValueError(
-                f"data must be a pd.DataFrame, Iterable, string or Path (received {type(data)})."
-            )
+            raise ValueError(f"data must be a pd.DataFrame, Iterable, string or Path (received {type(data)}).")
         super().__init__(data=data, *args, **kwargs)  # type: ignore
         self._static_features: Optional[pd.DataFrame] = None
         if static_features is not None:
-            self.static_features = self._construct_static_features(
-                static_features, id_column=id_column
-            )
+            self.static_features = self._construct_static_features(static_features, id_column=id_column)
 
     @property
     def _constructor(self) -> Type[TimeSeriesDataFrame]:
@@ -199,20 +195,14 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if id_column is not None:
             assert id_column in df.columns, f"Column '{id_column}' not found!"
             if id_column != ITEMID and ITEMID in df.columns:
-                logger.warning(
-                    f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions.")
                 df.rename(columns={ITEMID: "__" + ITEMID}, inplace=True)
             df.rename(columns={id_column: ITEMID}, inplace=True)
 
         if timestamp_column is not None:
-            assert timestamp_column in df.columns, (
-                f"Column '{timestamp_column}' not found!"
-            )
+            assert timestamp_column in df.columns, f"Column '{timestamp_column}' not found!"
             if timestamp_column != TIMESTAMP and TIMESTAMP in df.columns:
-                logger.warning(
-                    f"Renaming existing column '{TIMESTAMP}' -> '__{TIMESTAMP}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{TIMESTAMP}' -> '__{TIMESTAMP}' to avoid name collisions.")
                 df.rename(columns={TIMESTAMP: "__" + TIMESTAMP}, inplace=True)
             df.rename(columns={timestamp_column: TIMESTAMP}, inplace=True)
 
@@ -223,27 +213,20 @@ class TimeSeriesDataFrame(pd.DataFrame):
         return df.set_index([ITEMID, TIMESTAMP])
 
     @classmethod
-    def _construct_tsdf_from_iterable_dataset(
-        cls, iterable_dataset: Iterable, num_cpus: int = -1
-    ) -> pd.DataFrame:
+    def _construct_tsdf_from_iterable_dataset(cls, iterable_dataset: Iterable, num_cpus: int = -1) -> pd.DataFrame:
         def load_single_item(item_id: int, ts: dict) -> pd.DataFrame:
             start_timestamp = ts["start"]
             freq = start_timestamp.freq
             if isinstance(start_timestamp, pd.Period):
                 start_timestamp = start_timestamp.to_timestamp(how="S")
             target = ts["target"]
-            datetime_index = tuple(
-                pd.date_range(start_timestamp, periods=len(target), freq=freq)
-            )
-            idx = pd.MultiIndex.from_product(
-                [(item_id,), datetime_index], names=[ITEMID, TIMESTAMP]
-            )
+            datetime_index = tuple(pd.date_range(start_timestamp, periods=len(target), freq=freq))
+            idx = pd.MultiIndex.from_product([(item_id,), datetime_index], names=[ITEMID, TIMESTAMP])
             return pd.Series(target, name="target", index=idx).to_frame()
 
         cls._validate_iterable(iterable_dataset)
         all_ts = Parallel(n_jobs=num_cpus)(
-            delayed(load_single_item)(item_id, ts)
-            for item_id, ts in enumerate(iterable_dataset)
+            delayed(load_single_item)(item_id, ts) for item_id, ts in enumerate(iterable_dataset)
         )
         return pd.concat(all_ts)
 
@@ -256,21 +239,12 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if not isinstance(data.index, pd.MultiIndex):
             raise ValueError(f"data must have pd.MultiIndex, got {type(data.index)}")
         if not pd.api.types.is_datetime64_dtype(data.index.dtypes[TIMESTAMP]):
-            raise ValueError(
-                f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`."
-            )
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`.")
         if not data.index.names == (f"{ITEMID}", f"{TIMESTAMP}"):
-            raise ValueError(
-                f"data must have index names as ('{ITEMID}', '{TIMESTAMP}'), got {data.index.names}"
-            )
+            raise ValueError(f"data must have index names as ('{ITEMID}', '{TIMESTAMP}'), got {data.index.names}")
         item_id_index = data.index.levels[0]
-        if not (
-            pd.api.types.is_integer_dtype(item_id_index)
-            or pd.api.types.is_string_dtype(item_id_index)
-        ):
-            raise ValueError(
-                f"all entries in index `{ITEMID}` must be of integer or string dtype"
-            )
+        if not (pd.api.types.is_integer_dtype(item_id_index) or pd.api.types.is_string_dtype(item_id_index)):
+            raise ValueError(f"all entries in index `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _validate_data_frame(cls, df: pd.DataFrame):
@@ -286,17 +260,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if df[TIMESTAMP].isnull().any():
             raise ValueError(f"`{TIMESTAMP}` column can not have nan")
         if not pd.api.types.is_datetime64_dtype(df[TIMESTAMP]):
-            raise ValueError(
-                f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`."
-            )
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64`.")
         item_id_column = df[ITEMID]
-        if not (
-            pd.api.types.is_integer_dtype(item_id_column)
-            or pd.api.types.is_string_dtype(item_id_column)
-        ):
-            raise ValueError(
-                f"all entries in column `{ITEMID}` must be of integer or string dtype"
-            )
+        if not (pd.api.types.is_integer_dtype(item_id_column) or pd.api.types.is_string_dtype(item_id_column)):
+            raise ValueError(f"all entries in column `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _validate_iterable(cls, data: Iterable):
@@ -309,17 +276,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         for i, ts in enumerate(itertools.chain([first], data)):
             if not isinstance(ts, dict):
-                raise ValueError(
-                    f"{i}'th time-series in data must be a dict, got{type(ts)}"
-                )
+                raise ValueError(f"{i}'th time-series in data must be a dict, got{type(ts)}")
             if not ("target" in ts and "start" in ts):
-                raise ValueError(
-                    f"{i}'th time-series in data must have 'target' and 'start', got{ts.keys()}"
-                )
+                raise ValueError(f"{i}'th time-series in data must have 'target' and 'start', got{ts.keys()}")
             if not isinstance(ts["start"], pd.Period):
-                raise ValueError(
-                    f"{i}'th time-series must have a pandas Period as 'start', got {ts['start']}"
-                )
+                raise ValueError(f"{i}'th time-series must have a pandas Period as 'start', got {ts['start']}")
 
     @classmethod
     def from_data_frame(
@@ -423,9 +384,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         )
 
     @classmethod
-    def from_iterable_dataset(
-        cls, iterable_dataset: Iterable, num_cpus: int = -1
-    ) -> TimeSeriesDataFrame:
+    def from_iterable_dataset(cls, iterable_dataset: Iterable, num_cpus: int = -1) -> TimeSeriesDataFrame:
         """Construct a ``TimeSeriesDataFrame`` from an Iterable of dictionaries each of which
         represent a single time series.
 
@@ -472,13 +431,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
             )
 
         if id_column is not None:
-            assert id_column in static_features.columns, (
-                f"Column '{id_column}' not found in static_features!"
-            )
+            assert id_column in static_features.columns, f"Column '{id_column}' not found in static_features!"
             if id_column != ITEMID and ITEMID in static_features.columns:
-                logger.warning(
-                    f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions."
-                )
+                logger.warning(f"Renaming existing column '{ITEMID}' -> '__{ITEMID}' to avoid name collisions.")
                 static_features.rename(columns={ITEMID: "__" + ITEMID}, inplace=True)
             static_features.rename(columns={id_column: ITEMID}, inplace=True)
         return static_features
@@ -499,9 +454,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             if isinstance(value, pd.Series):
                 value = value.to_frame()
             if not isinstance(value, pd.DataFrame):
-                raise ValueError(
-                    f"static_features must be a pandas DataFrame (received object of type {type(value)})"
-                )
+                raise ValueError(f"static_features must be a pandas DataFrame (received object of type {type(value)})")
             if isinstance(value.index, pd.MultiIndex):
                 raise ValueError("static_features cannot have a MultiIndex")
 
@@ -523,9 +476,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         self._static_features = value
 
-    def infer_frequency(
-        self, num_items: Optional[int] = None, raise_if_irregular: bool = False
-    ) -> str:
+    def infer_frequency(self, num_items: Optional[int] = None, raise_if_irregular: bool = False) -> str:
         """Infer the time series frequency based on the timestamps of the observations.
 
         Parameters
@@ -549,9 +500,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
         ts_df = self
         if num_items is not None and ts_df.num_items > num_items:
-            items_subset = ts_df.item_ids.to_series().sample(
-                n=num_items, random_state=123
-            )
+            items_subset = ts_df.item_ids.to_series().sample(n=num_items, random_state=123)
             ts_df = ts_df.loc[items_subset]
 
         if not ts_df.index.is_monotonic_increasing:
@@ -592,9 +541,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
                         f"Cannot infer frequency. Items with irregular frequency: {reprlib.repr(irregular_items)}"
                     )
                 else:
-                    raise ValueError(
-                        f"Cannot infer frequency. Multiple frequencies detected: {unique_freqs}"
-                    )
+                    raise ValueError(f"Cannot infer frequency. Multiple frequencies detected: {unique_freqs}")
             else:
                 return IRREGULAR_TIME_INDEX_FREQSTR
         else:
@@ -654,9 +601,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             self.static_features = other._static_features
         return self
 
-    def split_by_time(
-        self, cutoff_time: pd.Timestamp
-    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+    def split_by_time(self, cutoff_time: pd.Timestamp) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
         """Split dataframe to two different ``TimeSeriesDataFrame`` s before and after a certain ``cutoff_time``.
 
         Parameters
@@ -771,13 +716,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         """
         if start_index is not None and not isinstance(start_index, int):
-            raise ValueError(
-                f"start_index must be of type int or None (got {type(start_index)})"
-            )
+            raise ValueError(f"start_index must be of type int or None (got {type(start_index)})")
         if end_index is not None and not isinstance(end_index, int):
-            raise ValueError(
-                f"end_index must be of type int or None (got {type(end_index)})"
-            )
+            raise ValueError(f"end_index must be of type int or None (got {type(end_index)})")
 
         if start_index is None and end_index is None:
             # Return a copy to avoid in-place modification.
@@ -802,9 +743,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             slice_end = (
                 lengths.copy()
                 if end_index is None
-                else np.clip(
-                    np.where(end_index >= 0, end_index, lengths + end_index), 0, lengths
-                )
+                else np.clip(np.where(end_index >= 0, end_index, lengths + end_index), 0, lengths)
             )
 
             # Filter out invalid slices where start >= end
@@ -829,15 +768,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
             return self.loc[mask]
         else:
             # Fall back to a slow groupby operation
-            result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(
-                slice(start_index, end_index)
-            )
+            result = self.groupby(level=ITEMID, sort=False, as_index=False).nth(slice(start_index, end_index))
             result.static_features = self.static_features
             return result
 
-    def slice_by_time(
-        self, start_time: pd.Timestamp, end_time: pd.Timestamp
-    ) -> TimeSeriesDataFrame:
+    def slice_by_time(self, start_time: pd.Timestamp, end_time: pd.Timestamp) -> TimeSeriesDataFrame:
         """Select a subsequence from each time series between start (inclusive) and end (exclusive) timestamps.
 
         Parameters
@@ -854,9 +789,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
 
         if end_time < start_time:
-            raise ValueError(
-                f"end_time {end_time} is earlier than start_time {start_time}"
-            )
+            raise ValueError(f"end_time {end_time} is earlier than start_time {start_time}")
 
         nanosecond_before_end_time = end_time - pd.Timedelta(nanoseconds=1)
         return TimeSeriesDataFrame(
@@ -885,9 +818,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         except Exception as err:  # noqa
             raise IOError(f"Could not load pickled data set due to error: {str(err)}")
 
-    def fill_missing_values(
-        self, method: str = "auto", value: float = 0.0
-    ) -> TimeSeriesDataFrame:
+    def fill_missing_values(self, method: str = "auto", value: float = 0.0) -> TimeSeriesDataFrame:
         """Fill missing values represented by NaN.
 
         .. note::
@@ -959,9 +890,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
             filled_df = grouped_df.ffill()
             # If necessary, fill missing values at the start of each time series with bfill
             if filled_df.isna().any(axis=None):
-                filled_df = filled_df.groupby(
-                    level=ITEMID, sort=False, group_keys=False
-                ).bfill()
+                filled_df = filled_df.groupby(level=ITEMID, sort=False, group_keys=False).bfill()
         elif method in ["ffill", "pad"]:
             filled_df = grouped_df.ffill()
         elif method in ["bfill", "backfill"]:
@@ -1065,9 +994,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
         df = self
         if not df.index.is_monotonic_increasing:
-            logger.warning(
-                "Sorting the dataframe index before generating the train/test split."
-            )
+            logger.warning("Sorting the dataframe index before generating the train/test split.")
             df = df.sort_index()
         test_data = df.slice_by_timestep(None, end_index)
         train_data = test_data.slice_by_timestep(None, -prediction_length)
@@ -1192,9 +1119,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         def resample_chunk(chunk: Iterable[Tuple[str, pd.DataFrame]]) -> pd.DataFrame:
             resampled_dfs = []
             for item_id, df in chunk:
-                resampled_df = df.resample(offset, level=TIMESTAMP, **kwargs).agg(
-                    aggregation
-                )
+                resampled_df = df.resample(offset, level=TIMESTAMP, **kwargs).agg(aggregation)
                 resampled_dfs.append(pd.concat({item_id: resampled_df}, names=[ITEMID]))
             return pd.concat(resampled_dfs)
 
@@ -1203,13 +1128,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
         df = pd.DataFrame(self)
         # Make sure that timestamp index has dtype 'datetime64[ns]', otherwise index may contain NaT values.
         # See https://github.com/autogluon/autogluon/issues/4917
-        df.index = df.index.set_levels(
-            df.index.levels[1].astype("datetime64[ns]"), level=TIMESTAMP
-        )
+        df.index = df.index.set_levels(df.index.levels[1].astype("datetime64[ns]"), level=TIMESTAMP)
         chunks = split_into_chunks(df.groupby(level=ITEMID, sort=False), chunk_size)
-        resampled_chunks = Parallel(n_jobs=num_cpus)(
-            delayed(resample_chunk)(chunk) for chunk in chunks
-        )
+        resampled_chunks = Parallel(n_jobs=num_cpus)(delayed(resample_chunk)(chunk) for chunk in chunks)
         resampled_df = TimeSeriesDataFrame(pd.concat(resampled_chunks))
         resampled_df.static_features = self.static_features
         return resampled_df
@@ -1223,9 +1144,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         This method assumes that the TimeSeriesDataFrame is sorted by [item_id, timestamp].
         """
-        return np.concatenate(
-            [[0], np.cumsum(self.num_timesteps_per_item().to_numpy())]
-        ).astype(np.int32)
+        return np.concatenate([[0], np.cumsum(self.num_timesteps_per_item().to_numpy())]).astype(np.int32)
 
     # inline typing stubs for various overridden methods
     if TYPE_CHECKING:
@@ -1237,9 +1156,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         def reindex(*args, **kwargs) -> Self: ...  # type: ignore
 
         @overload
-        def __new__(
-            cls, data: pd.DataFrame, static_features: Optional[pd.DataFrame] = None
-        ) -> Self: ...  # type: ignore
+        def __new__(cls, data: pd.DataFrame, static_features: Optional[pd.DataFrame] = None) -> Self: ...  # type: ignore
 
         @overload
         def __getitem__(self, items: List[str]) -> Self: ...  # type: ignore

--- a/src/synthefy_nori/training/cli.py
+++ b/src/synthefy_nori/training/cli.py
@@ -42,34 +42,30 @@ def load_model_config(source: str | None) -> dict:
     if source.endswith(".json"):
         with open(source, "r", encoding="utf-8") as f:
             return json.load(f)
-    state = torch.load(source, map_location='cpu', weights_only=False)
-    if 'model_config' in state:
-        return state['model_config']
-    return state['config']
+    state = torch.load(source, map_location="cpu", weights_only=False)
+    if "model_config" in state:
+        return state["model_config"]
+    return state["config"]
 
 
 def load_resume_configs(source: str) -> tuple[dict, object | None]:
     """Load only architecture and training metadata needed before resume."""
-    state = torch.load(source, map_location='cpu', weights_only=False)
+    state = torch.load(source, map_location="cpu", weights_only=False)
     try:
-        model_config = copy.deepcopy(
-            state['model_config'] if 'model_config' in state else state['config']
-        )
-        training_config = copy.deepcopy(state.get('config'))
+        model_config = copy.deepcopy(state["model_config"] if "model_config" in state else state["config"])
+        training_config = copy.deepcopy(state.get("config"))
     finally:
         del state
     return model_config, training_config
 
 
 def parse_quantiles(raw: str) -> tuple[float, ...]:
-    vals = [float(part.strip()) for part in raw.split(',') if part.strip()]
+    vals = [float(part.strip()) for part in raw.split(",") if part.strip()]
     if not vals:
         raise argparse.ArgumentTypeError("Expected at least one comma-separated quantile")
     vals = sorted(set(vals))
     if any(not math.isfinite(v) or v <= 0 or v >= 1 for v in vals):
-        raise argparse.ArgumentTypeError(
-            "Quantiles must be finite and satisfy 0 < q < 1"
-        )
+        raise argparse.ArgumentTypeError("Quantiles must be finite and satisfy 0 < q < 1")
     return tuple(vals)
 
 
@@ -107,10 +103,10 @@ def _config_value(config, name: str, default=None):
 
 
 _FEATURE_LOSS_OPTIONS = {
-    '--feature-loss-weight': 'feature_loss_weight',
-    '--feature-loss-weight-end': 'feature_loss_weight_end',
-    '--feature-loss-decay-start-step': 'feature_loss_decay_start_step',
-    '--feature-loss-decay-end-step': 'feature_loss_decay_end_step',
+    "--feature-loss-weight": "feature_loss_weight",
+    "--feature-loss-weight-end": "feature_loss_weight_end",
+    "--feature-loss-decay-start-step": "feature_loss_decay_start_step",
+    "--feature-loss-decay-end-step": "feature_loss_decay_end_step",
 }
 
 
@@ -135,12 +131,12 @@ def configure_feature_loss_schedule(
     """
     explicit = set(explicit_options or ())
     if preserve_existing:
-        decoder_omitted = bool(model_config.get('omit_feature_decoder', False))
+        decoder_omitted = bool(model_config.get("omit_feature_decoder", False))
         missing_fallbacks = {
-            'feature_loss_weight': 0.0 if decoder_omitted else args.feature_loss_weight,
-            'feature_loss_weight_end': None,
-            'feature_loss_decay_start_step': args.feature_loss_decay_start_step,
-            'feature_loss_decay_end_step': args.feature_loss_decay_end_step,
+            "feature_loss_weight": 0.0 if decoder_omitted else args.feature_loss_weight,
+            "feature_loss_weight_end": None,
+            "feature_loss_decay_start_step": args.feature_loss_decay_start_step,
+            "feature_loss_decay_end_step": args.feature_loss_decay_end_step,
         }
         for option, attribute in _FEATURE_LOSS_OPTIONS.items():
             if option in explicit:
@@ -150,34 +146,21 @@ def configure_feature_loss_schedule(
                 attribute,
                 missing_fallbacks[attribute],
             )
-            if inherited is None and attribute != 'feature_loss_weight_end':
+            if inherited is None and attribute != "feature_loss_weight_end":
                 inherited = missing_fallbacks[attribute]
             setattr(args, attribute, inherited)
 
     if args.feature_loss_weight < 0:
         raise ValueError("--feature-loss-weight must be >= 0")
-    if (
-        args.feature_loss_weight_end is not None
-        and args.feature_loss_weight_end < 0
-    ):
+    if args.feature_loss_weight_end is not None and args.feature_loss_weight_end < 0:
         raise ValueError("--feature-loss-weight-end must be >= 0")
-    if (
-        args.feature_loss_decay_start_step < 0
-        or args.feature_loss_decay_end_step < 0
-    ):
-        raise ValueError(
-            "--feature-loss-decay-start-step and "
-            "--feature-loss-decay-end-step must be >= 0"
-        )
+    if args.feature_loss_decay_start_step < 0 or args.feature_loss_decay_end_step < 0:
+        raise ValueError("--feature-loss-decay-start-step and --feature-loss-decay-end-step must be >= 0")
 
-    stays_zero = (
-        args.feature_loss_weight == 0.0
-        and (
-            args.feature_loss_weight_end is None
-            or args.feature_loss_weight_end == 0.0
-        )
+    stays_zero = args.feature_loss_weight == 0.0 and (
+        args.feature_loss_weight_end is None or args.feature_loss_weight_end == 0.0
     )
-    if bool(model_config.get('omit_feature_decoder', False)) and not stays_zero:
+    if bool(model_config.get("omit_feature_decoder", False)) and not stays_zero:
         raise ValueError(
             "This checkpoint omits feature_decoder, so its resolved feature-loss "
             "schedule must remain zero; remove explicit positive feature-loss "
@@ -202,80 +185,75 @@ def configure_regression_head(
     recover metadata first from their serialized ``TrainingConfig`` and
     finally from the decoder width/grid conventions used at the time.
     """
-    decoder = model_config.setdefault('decoder_config', {})
+    decoder = model_config.setdefault("decoder_config", {})
     option_values = {
-        '--regression-loss': args.regression_loss,
-        '--regression-quantiles': args.regression_quantiles,
-        '--num-bars': args.num_bars,
-        '--bar-borders-low': args.bar_borders_low,
-        '--bar-borders-high': args.bar_borders_high,
+        "--regression-loss": args.regression_loss,
+        "--regression-quantiles": args.regression_quantiles,
+        "--num-bars": args.num_bars,
+        "--bar-borders-low": args.bar_borders_low,
+        "--bar-borders-high": args.bar_borders_high,
     }
     if explicit_options is None:
-        explicit = {
-            option for option, value in option_values.items()
-            if value is not None
-        }
+        explicit = {option for option, value in option_values.items() if value is not None}
     else:
         explicit = explicit_options & option_values.keys()
     explicit_head_override = bool(explicit)
 
-    existing_width = int(decoder.get('num_reg_quantiles', 1))
-    if preserve_existing and '--regression-loss' not in explicit:
-        args.regression_loss = decoder.get('regression_loss')
+    existing_width = int(decoder.get("num_reg_quantiles", 1))
+    if preserve_existing and "--regression-loss" not in explicit:
+        args.regression_loss = decoder.get("regression_loss")
         if args.regression_loss is None:
-            legacy_loss = 'mse' if existing_width == 1 else 'pinball'
-            args.regression_loss = _config_value(
-                resume_training_config,
-                'regression_loss',
-                legacy_loss,
-            ) or legacy_loss
+            legacy_loss = "mse" if existing_width == 1 else "pinball"
+            args.regression_loss = (
+                _config_value(
+                    resume_training_config,
+                    "regression_loss",
+                    legacy_loss,
+                )
+                or legacy_loss
+            )
     elif args.regression_loss is None:
-        args.regression_loss = 'mse'
+        args.regression_loss = "mse"
 
-    if preserve_existing and '--regression-quantiles' not in explicit:
+    if preserve_existing and "--regression-quantiles" not in explicit:
         inherited_quantiles = None
-        inherited_quantiles = decoder.get('regression_quantiles')
+        inherited_quantiles = decoder.get("regression_quantiles")
         if inherited_quantiles is None:
             inherited_quantiles = _config_value(
                 resume_training_config,
-                'regression_quantiles',
+                "regression_quantiles",
             )
-        if inherited_quantiles is None and args.regression_loss == 'pinball':
-            inherited_quantiles = tuple(
-                (index + 1.0) / (existing_width + 1.0)
-                for index in range(existing_width)
-            )
-        args.regression_quantiles = tuple(
-            inherited_quantiles or _DEFAULT_REGRESSION_QUANTILES
-        )
+        if inherited_quantiles is None and args.regression_loss == "pinball":
+            inherited_quantiles = tuple((index + 1.0) / (existing_width + 1.0) for index in range(existing_width))
+        args.regression_quantiles = tuple(inherited_quantiles or _DEFAULT_REGRESSION_QUANTILES)
     elif args.regression_quantiles is None:
         args.regression_quantiles = _DEFAULT_REGRESSION_QUANTILES
     else:
         args.regression_quantiles = tuple(args.regression_quantiles)
 
-    if preserve_existing and '--num-bars' not in explicit:
+    if preserve_existing and "--num-bars" not in explicit:
         args.num_bars = int(
             decoder.get(
-                'num_bars',
-                _config_value(resume_training_config, 'num_bars', 5000),
+                "num_bars",
+                _config_value(resume_training_config, "num_bars", 5000),
             )
         )
     elif args.num_bars is None:
         args.num_bars = 5000
-    if preserve_existing and '--bar-borders-low' not in explicit:
+    if preserve_existing and "--bar-borders-low" not in explicit:
         args.bar_borders_low = float(
             decoder.get(
-                'bar_borders_low',
-                _config_value(resume_training_config, 'bar_borders_low', -10.0),
+                "bar_borders_low",
+                _config_value(resume_training_config, "bar_borders_low", -10.0),
             )
         )
     elif args.bar_borders_low is None:
         args.bar_borders_low = -10.0
-    if preserve_existing and '--bar-borders-high' not in explicit:
+    if preserve_existing and "--bar-borders-high" not in explicit:
         args.bar_borders_high = float(
             decoder.get(
-                'bar_borders_high',
-                _config_value(resume_training_config, 'bar_borders_high', 10.0),
+                "bar_borders_high",
+                _config_value(resume_training_config, "bar_borders_high", 10.0),
             )
         )
     elif args.bar_borders_high is None:
@@ -283,31 +261,29 @@ def configure_regression_head(
 
     if preserve_existing and not explicit_head_override:
         head_width = existing_width
-    elif args.regression_loss == 'pinball':
+    elif args.regression_loss == "pinball":
         head_width = len(args.regression_quantiles)
-    elif args.regression_loss == 'bar_distribution':
+    elif args.regression_loss == "bar_distribution":
         head_width = int(args.num_bars)
     else:
         head_width = 1
 
-    decoder['num_reg_quantiles'] = head_width
-    decoder['regression_loss'] = str(args.regression_loss)
-    if args.regression_loss == 'pinball':
+    decoder["num_reg_quantiles"] = head_width
+    decoder["regression_loss"] = str(args.regression_loss)
+    if args.regression_loss == "pinball":
         if len(args.regression_quantiles) != head_width:
             raise ValueError(
                 "Resume checkpoint quantile metadata does not match its decoder "
                 f"width: {len(args.regression_quantiles)} levels for {head_width} outputs"
             )
-        decoder['regression_quantiles'] = [
-            float(q) for q in args.regression_quantiles
-        ]
+        decoder["regression_quantiles"] = [float(q) for q in args.regression_quantiles]
     else:
-        decoder.pop('regression_quantiles', None)
+        decoder.pop("regression_quantiles", None)
 
-    if args.regression_loss == 'bar_distribution':
-        decoder['num_bars'] = int(args.num_bars)
-        decoder['bar_borders_low'] = float(args.bar_borders_low)
-        decoder['bar_borders_high'] = float(args.bar_borders_high)
+    if args.regression_loss == "bar_distribution":
+        decoder["num_bars"] = int(args.num_bars)
+        decoder["bar_borders_low"] = float(args.bar_borders_low)
+        decoder["bar_borders_high"] = float(args.bar_borders_high)
 
 
 def configure_architecture_extras(
@@ -319,17 +295,15 @@ def configure_architecture_extras(
     """Apply one-sided boolean architecture switches without resume drift."""
     if preserve_existing:
         if args.no_qassmax:
-            model_config['use_qassmax'] = False
+            model_config["use_qassmax"] = False
         if args.no_target_aware_embedding:
-            model_config['use_target_aware_embedding'] = False
+            model_config["use_target_aware_embedding"] = False
         if args.column_specific_y_aware:
-            model_config['use_column_specific_y_aware'] = True
+            model_config["use_column_specific_y_aware"] = True
         return
-    model_config['use_qassmax'] = not args.no_qassmax
-    model_config['use_target_aware_embedding'] = not args.no_target_aware_embedding
-    model_config['use_column_specific_y_aware'] = bool(
-        args.column_specific_y_aware
-    )
+    model_config["use_qassmax"] = not args.no_qassmax
+    model_config["use_target_aware_embedding"] = not args.no_target_aware_embedding
+    model_config["use_column_specific_y_aware"] = bool(args.column_specific_y_aware)
 
 
 def configure_feature_decoder_architecture(
@@ -347,15 +321,13 @@ def configure_feature_decoder_architecture(
     """
     if preserve_existing:
         return
-    model_config['omit_feature_decoder'] = bool(
-        args.skip_zero_feature_decoder and feature_loss_stays_zero
-    )
+    model_config["omit_feature_decoder"] = bool(args.skip_zero_feature_decoder and feature_loss_stays_zero)
 
 
 def parse_tags(raw: str | None) -> tuple[str, ...]:
     if raw is None:
         return ()
-    return tuple(part.strip() for part in raw.split(',') if part.strip())
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
 
 
 def parse_shape_palette(raw: str | None) -> tuple[tuple[int, int, float], ...]:
@@ -364,35 +336,27 @@ def parse_shape_palette(raw: str | None) -> tuple[tuple[int, int, float], ...]:
         return ()
     entries = []
     seen = set()
-    for item in raw.split(','):
+    for item in raw.split(","):
         item = item.strip()
         try:
-            dims, weight_raw = item.split(':', maxsplit=1)
-            rows_raw, features_raw = dims.lower().split('x', maxsplit=1)
+            dims, weight_raw = item.split(":", maxsplit=1)
+            rows_raw, features_raw = dims.lower().split("x", maxsplit=1)
             rows = int(rows_raw)
             features = int(features_raw)
             weight = float(weight_raw)
         except ValueError as exc:
-            raise argparse.ArgumentTypeError(
-                "Shape palette entries must be ROWSxFEATURES:WEIGHT"
-            ) from exc
+            raise argparse.ArgumentTypeError("Shape palette entries must be ROWSxFEATURES:WEIGHT") from exc
         if rows <= 1 or features <= 0 or weight <= 0 or not math.isfinite(weight):
             raise argparse.ArgumentTypeError(
-                f"Shape palette values must be finite and positive "
-                f"(with rows > 1), got {item!r}"
+                f"Shape palette values must be finite and positive (with rows > 1), got {item!r}"
             )
         shape = (rows, features)
         if shape in seen:
-            raise argparse.ArgumentTypeError(
-                f"Duplicate shape palette entry: {dims}"
-            )
+            raise argparse.ArgumentTypeError(f"Duplicate shape palette entry: {dims}")
         seen.add(shape)
         entries.append((rows, features, weight))
     total = sum(weight for _, _, weight in entries)
-    return tuple(
-        (rows, features, weight / total)
-        for rows, features, weight in entries
-    )
+    return tuple((rows, features, weight / total) for rows, features, weight in entries)
 
 
 def parse_context_ratio_palette(raw: str | None) -> tuple[float, ...]:
@@ -400,15 +364,10 @@ def parse_context_ratio_palette(raw: str | None) -> tuple[float, ...]:
     if not raw:
         return ()
     try:
-        ratios = tuple(float(part.strip()) for part in raw.split(',') if part.strip())
+        ratios = tuple(float(part.strip()) for part in raw.split(",") if part.strip())
     except ValueError as exc:
-        raise argparse.ArgumentTypeError(
-            "Context ratios must be comma-separated numbers"
-        ) from exc
-    if not ratios or any(
-        not math.isfinite(ratio) or ratio <= 0 or ratio >= 1
-        for ratio in ratios
-    ):
+        raise argparse.ArgumentTypeError("Context ratios must be comma-separated numbers") from exc
+    if not ratios or any(not math.isfinite(ratio) or ratio <= 0 or ratio >= 1 for ratio in ratios):
         raise argparse.ArgumentTypeError("Context ratios must satisfy 0 < ratio < 1")
     if len(set(ratios)) != len(ratios):
         raise argparse.ArgumentTypeError("Context ratio palette contains duplicates")
@@ -416,395 +375,671 @@ def parse_context_ratio_palette(raw: str | None) -> tuple[float, ...]:
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Train Nori from scratch')
-    parser.add_argument('--device', type=str, default='cuda:0')
-    parser.add_argument('--checkpoint', type=str, default=None,
-                        help='Checkpoint (.ckpt/.pt) or JSON file to load model architecture config from. '
-                             'Defaults to the bundled model_base.json.')
-    parser.add_argument('--resume', type=str, default=None,
-                        help='Training checkpoint to resume from')
-    parser.add_argument('--resume-model-only', action='store_true',
-                        help='Load only model weights from --resume and reset optimizer/scheduler/step counters')
-    parser.add_argument('--optimizer', type=str, default='adamw',
-                        choices=['adamw', 'muon'],
-                        help='Optimizer to use (default: adamw)')
-    parser.add_argument('--muon-include-embeddings', action='store_true',
-                        help='Route 2D embedding tables to Muon instead of AdamW. '
-                             'Default behavior excludes embeddings; this flag turns them on.')
-    parser.add_argument('--muon-include-nd', action='store_true',
-                        help='Route higher-rank (3D/4D) attention qkv/out_proj weights to '
-                             'Muon via reshape-to-2D. Switches backend to MuonND (stock '
-                             'torch.optim.Muon rejects ndim != 2). Captures the bulk of '
-                             'attention parameters — the largest weight tensors in the model.')
-    parser.add_argument('--lr', type=float, default=3e-4)
-    parser.add_argument('--batch-size', type=int, default=8)
-    parser.add_argument('--total-steps', type=int, default=200_000)
-    parser.add_argument('--run-steps', type=int, default=None,
-                        help='If set, run only this many optimizer steps in the current invocation while keeping total_steps as the global LR-schedule horizon')
-    parser.add_argument('--warmup-steps', type=int, default=2000)
-    parser.add_argument('--decay-start-step', type=int, default=0,
-                        help='Step to begin cosine decay (0 = right after warmup)')
-    parser.add_argument('--no-wandb', action='store_true')
-    parser.add_argument('--wandb-project', type=str, default=os.environ.get('WANDB_PROJECT', 'synthefy-nori'),
-                        help='Weights & Biases project name')
-    parser.add_argument('--wandb-entity', type=str, default=os.environ.get('WANDB_ENTITY'),
-                        help='Optional Weights & Biases entity/team')
-    parser.add_argument('--wandb-name', type=str, default=os.environ.get('WANDB_NAME'),
-                        help='Optional Weights & Biases run name')
-    parser.add_argument('--wandb-group', type=str, default=os.environ.get('WANDB_RUN_GROUP'),
-                        help='Optional Weights & Biases run group')
-    parser.add_argument('--wandb-job-type', type=str, default=os.environ.get('WANDB_JOB_TYPE'),
-                        help='Optional Weights & Biases job type')
-    parser.add_argument('--wandb-tags', type=parse_tags, default=parse_tags(os.environ.get('WANDB_TAGS')),
-                        help='Comma-separated Weights & Biases tags')
-    parser.add_argument('--checkpoint-dir', type=str, default=None,
-                        help='Checkpoint directory (default: ./checkpoints/<timestamp>)')
-    parser.add_argument('--ema-decay', type=float, default=0.0,
-                        help='EMA decay for validation/checkpoint averaging (0 disables EMA)')
-    parser.add_argument('--ema-foreach', action='store_true',
-                        help='Update EMA tensors with grouped foreach kernels. '
-                             'Experimental and off by default.')
-    parser.add_argument('--gradient-accumulation', type=int, default=1)
-    parser.add_argument('--log-interval', type=int, default=100)
-    parser.add_argument('--save-interval', type=int, default=5000)
-    parser.add_argument('--feature-loss-weight', type=float, default=0.5)
-    parser.add_argument('--feature-loss-weight-end', type=float, default=None,
-                        help='Optional end value for linear feature-loss decay')
-    parser.add_argument('--feature-loss-decay-start-step', type=int, default=0,
-                        help='Optimizer step to begin feature-loss decay')
-    parser.add_argument('--feature-loss-decay-end-step', type=int, default=0,
-                        help='Optimizer step to end feature-loss decay')
-    parser.add_argument('--no-mixed-precision', action='store_true')
-    parser.add_argument('--compile', action='store_true',
-                        help='Use torch.compile for kernel fusion speedup')
-    parser.add_argument('--gradient-checkpointing', action='store_true',
-                        help='Checkpoint inter-layer activations to reduce VRAM')
-    parser.add_argument('--max-budget', type=int, default=None,
-                        help='Max n_samples*n_features per batch (OOM protection)')
-    parser.add_argument('--min-samples', type=int, default=None,
-                        help='Min n_samples per synthetic table (default: 50)')
-    parser.add_argument('--max-samples', type=int, default=None,
-                        help='Max n_samples per synthetic table (default: 2000)')
-    parser.add_argument('--min-features', type=int, default=None,
-                        help='Min n_features per synthetic table (default: 2)')
-    parser.add_argument('--max-features', type=int, default=None,
-                        help='Max n_features per synthetic table (default: 250)')
-    parser.add_argument('--fixed-size', type=str, default=None,
-                        help='Fixed NxF size (e.g. "1024x64"). Overrides random sampling.')
-    parser.add_argument('--context-ratio-min', type=float, default=0.3,
-                        help='Minimum labeled-context fraction (default: 0.3).')
-    parser.add_argument('--context-ratio-max', type=float, default=0.8,
-                        help='Maximum labeled-context fraction (default: 0.8).')
-    parser.add_argument('--no-synth-v2', action='store_true',
-                        help='Disable synth_v2 data augmentations (revert to Run 8 behavior)')
-    parser.add_argument('--no-synth-v3', action='store_true',
-                        help='Disable synth_v3 data augmentations (true categoricals, interactions, skewed targets)')
-    parser.add_argument('--no-rich-reg-targets', action='store_true',
-                        help='Disable rich regression targets (multi-feature deps + interactions in y)')
+    parser = argparse.ArgumentParser(description="Train Nori from scratch")
+    parser.add_argument("--device", type=str, default="cuda:0")
     parser.add_argument(
-        '--no-scale-variation',
-        action='store_true',
-        default=True,
-        help='Deprecated compatibility flag; target scale variation is always '
-             'disabled because context normalization cancels it.',
-    )
-    parser.add_argument('--synth-v4', action='store_true',
-                        help='Enable synth_v4 data augmentations (TabICLv2-inspired diversity)')
-    parser.add_argument('--no-v4-filter', action='store_true',
-                        help='Disable ExtraTrees filtering in synth_v4')
-    parser.add_argument('--learnability-filter', action='store_true',
-                        help='Enable ExtraTrees learnability filter for all synthetic data (independent of synth_v4)')
-    parser.add_argument('--learnability-filter-cls-min-score', type=float, default=0.60,
-                        help='Minimum cls ExtraTrees OOB score to keep a dataset')
-    parser.add_argument('--learnability-filter-cls-margin', type=float, default=0.10,
-                        help='Minimum cls ExtraTrees margin above chance to keep a dataset')
-    parser.add_argument('--learnability-filter-reg-min-score', type=float, default=0.10,
-                        help='Minimum reg ExtraTrees OOB R2 to keep a dataset')
-    parser.add_argument('--icl-filter-model', type=str, default='',
-                        help='GPU model for ICL learnability filtering. Options: '
-                             '"limix" to auto-download LimiX-2M from HuggingFace, '
-                             '"hf" to auto-download the Synthefy checkpoint, '
-                             'path to local checkpoint (.pt/.ckpt), '
-                             'or empty string to disable. '
-                             'Runs on the training GPU after each batch.')
-    parser.add_argument('--icl-filter-cls-min-auc', type=float, default=0.55,
-                        help='Minimum classification accuracy for ICL filter (default: 0.55)')
-    parser.add_argument('--icl-filter-reg-min-r2', type=float, default=0.05,
-                        help='Minimum regression R2 for ICL filter (default: 0.05)')
-    parser.add_argument(
-        '--icl-filter-use-train-context',
-        action='store_true',
-        default=True,
-        help='Deprecated compatibility flag; the ICL filter always uses the '
-             'sampled training split.',
-    )
-    parser.add_argument('--icl-scaling-filter', action='store_true',
-                        help='Enable ICL scaling filter: reject datasets where more context does not help')
-    parser.add_argument('--icl-scaling-min-improvement', type=float, default=0.03,
-                        help='Minimum R2 improvement from small to large context (default: 0.03)')
-    parser.add_argument('--v4-keep-edge-noise', action='store_true',
-                        help='Keep Gaussian edge noise with synth_v4 (default: removed)')
-    parser.add_argument('--task-type', type=str, default='both',
-                        choices=['both', 'cls', 'reg'],
-                        help='Task specialization: both (50/50), cls-only, or reg-only')
-    parser.add_argument('--regression-ratio', type=float, default=0.5,
-                        help='Fraction of steps that are regression when task_type=both (default: 0.5)')
-    parser.add_argument('--regression-loss', type=str, default='mse',
-                        choices=['mse', 'smooth_l1', 'huber', 'pinball', 'bar_distribution'],
-                        help='Regression loss function (default: mse)')
-    parser.add_argument('--regression-loss-beta', type=float, default=1.0,
-                        help='Beta for smooth_l1/huber loss (default: 1.0)')
-    parser.add_argument('--regression-quantiles', type=parse_quantiles,
-                        default=parse_quantiles("0.1,0.25,0.5,0.75,0.9"),
-                        help='Comma-separated quantiles for pinball loss (default: 0.1,0.25,0.5,0.75,0.9)')
-    parser.add_argument('--pinball-tail-weight', type=float, default=0.0,
-                        help='Upweight extreme quantiles in pinball loss. 0.0=uniform, '
-                             '1.0=~2x weight at extremes (τ=0.01, τ=0.99). Targets bounded-'
-                             'skewed regression datasets (sulfur, Goodreads). Default 0.0.')
-    parser.add_argument('--pinball-monotonicity-weight', type=float, default=0.0,
-                        help='Soft penalty for τ-crossing in pinball loss. Adds '
-                             'relu(q[i] - q[i+1])^2 across adjacent τ. Improves smoothness '
-                             'of the τ-mean point estimate (helps houses, space_ga, '
-                             'physiochemical_protein). Try 0.05.')
-    parser.add_argument('--pinball-mse-weight', type=float, default=0.0,
-                        help='Auxiliary MSE on the τ-mean of pinball quantile predictions. '
-                             'Forces unbiased point estimate; targets the QSAR-TID-11 '
-                             '"prediction compression" failure where extreme-target rows '
-                             'are averaged toward the bulk. Try 0.1.')
-    parser.add_argument('--num-bars', type=int, default=5000,
-                        help='Number of bins for --regression-loss bar_distribution. '
-                             'The reg head is sized to output this many logits per row. '
-                             'Default 5000; bin width = (bar_borders_high - bar_borders_low)/num_bars.')
-    parser.add_argument('--bar-borders-low', type=float, default=-10.0,
-                        help='Lower edge of bar_distribution bins on context-normalized y '
-                             '(default -10.0 = 10 std below context mean).')
-    parser.add_argument('--bar-borders-high', type=float, default=10.0,
-                        help='Upper edge of bar_distribution bins on context-normalized y '
-                             '(default +10.0 = 10 std above context mean).')
-    parser.add_argument('--bar-target-sigma', type=float, default=0.0,
-                        help='Soft-CE width for bar_distribution loss, in BIN units. '
-                             '0.0 (default) = hard CE (one-hot target). >0 = Gaussian-smoothed '
-                             'target with sigma=this many bins, giving partial credit to '
-                             'nearby bins and smoothing the categorical cliffs in CE loss '
-                             'landscape. Recommended: 5-20 for 5000 bins.')
-    parser.add_argument('--reg-prior-prob', type=float, default=0.4,
-                        help='Probability of using regression prior generator for reg episodes (default: 0.4)')
-    parser.add_argument('--reg-denoise', action='store_true',
-                        help='Reduce noise for regression episodes (noise features, missingness, Gaussian noise, target transforms)')
-    parser.add_argument('--reg-deterministic-prob', type=float, default=0.20,
-                        help='Probability that a regression-prior episode is zero-noise / deterministic (default: 0.20)')
-    parser.add_argument('--reg-dense', action='store_true',
-                        help='Dense-signal regression: flatter importances, fewer noise features, more parents, and more smooth multivariate priors')
-    parser.add_argument('--probabilistic-labels', action='store_true',
-                        help='Enable probabilistic classification labelers (logistic, tree, Gaussian, threshold)')
-    parser.add_argument('--nominal-categoricals', action='store_true',
-                        help='Enable nominal (non-ordinal) categorical feature generation')
-    parser.add_argument('--enhanced-missingness', action='store_true',
-                        help='Enable enhanced missingness patterns (row-level, block, target-dependent)')
-    parser.add_argument('--clean-lowdim-prob', type=float, default=0.0,
-                        help='Probability of clean low-dim regime episodes (default: 0.0)')
-    parser.add_argument('--tree-prior-prob', type=float, default=0.0,
-                        help='Probability of tree-ensemble prior episodes (default: 0.0)')
-    parser.add_argument('--lookup-prior-prob', type=float, default=0.0,
-                        help='Probability of categorical lookup prior episodes (default: 0.0)')
-    parser.add_argument('--quadratic-surface-prob', type=float, default=0.0,
-                        help='Probability of quadratic response surface episodes (default: 0.0)')
-    parser.add_argument('--sparse-nonlinear-prob', type=float, default=0.0,
-                        help='Probability of sparse nonlinear high-dim episodes (default: 0.0)')
-    parser.add_argument('--gp-prior-prob', type=float, default=0.0,
-                        help='Probability of GP smooth function episodes (default: 0.0)')
-    parser.add_argument('--context-missingness-prob', type=float, default=0.0,
-                        help='Probability of injecting NaN cells in context rows (default: 0.0)')
-    parser.add_argument('--realistic-augmentation-prob', type=float, default=0.0,
-                        help='Probability of applying heavy-tail/correlation/skew transforms (default: 0.0)')
-    parser.add_argument('--y-transform-prob', type=float, default=0.0,
-                        help='Probability of applying realistic y-target transforms per episode. '
-                             'Simulates integer counts, censored values, ordinal ratings, bounded averages, '
-                             'zero-inflated counts. Targets datasets we underperform on '
-                             '(stock_fardamento02, boston, sensory, Goodreads, etc). Default 0.0 (off).')
-    parser.add_argument('--cap-injection-prob', type=float, default=0.0,
-                        help='Probability of injecting upper/lower quantile cap (saturation) per '
-                             'regression episode. Minimal y-distortion — just clips tails to a '
-                             'single value to teach the model that caps exist. Fixes models failure '
-                             'to predict near timeout/cap values (MIP-2016, boston MEDV). Default 0.0.')
-    parser.add_argument('--heavy-tail-prior-prob', type=float, default=0.0,
-                        help='Probability of applying heavy-tail y transforms per regression episode. '
-                             'Continuous transforms only: log-normal (exp), Pareto additive noise, '
-                             'strong outlier injection (5-10%% @ 3-15x scale). No rounding — safe vs '
-                             'failed y_transform experiment. Targets weak spots on skewed data '
-                             '(stock_fardamento02, CPS1988, sulfur, Food_Delivery_Time). Default 0.0.')
-    parser.add_argument('--pareto-importance-prob', type=float, default=0.0,
-                        help='Probability per regression-prior episode of multiplying the per-feature '
-                             'beta/coefficient vector by a Pareto-distributed importance vector so '
-                             'a few features dominate while many are weak distractors. Targets the '
-                             'high-dim "many distractors" failure (QSAR-TID-11, Allstate). Default 0.0.')
-    parser.add_argument('--latent-factor-prob', type=float, default=0.0,
-                        help='Probability per regression-prior episode of using a latent-factor '
-                             'target: y = f(X @ V) where V is a d×k random projection (k ≪ d). '
-                             'Models datasets with shared low-dim latent structure. Default 0.0.')
-    parser.add_argument('--high-cap-prob', type=float, default=0.0,
-                        help='Probability per cap-injected episode of using a higher cap fraction '
-                             '(20-50%% at cap, percentile drawn from [50, 80] instead of [80, 97]). '
-                             'Models timeout/runtime censoring patterns (MIP-2016, SAT11). '
-                             'Composes with --cap-injection-prob (only applies when cap fires). '
-                             'Default 0.0.')
-    parser.add_argument('--low-unique-y-prob', type=float, default=0.0,
-                        help='Probability per regression episode of rounding/binning y to '
-                             '5-15 unique levels. Models discrete-regression datasets (Wine_Quality '
-                             '6 levels, sensory 1-10 ratings). Default 0.0.')
-    parser.add_argument(
-        '--quality-filter-rules',
+        "--checkpoint",
         type=str,
         default=None,
-        help='Path to synthetic quality rules JSON (from eval_synthetic_benchmark.py)',
+        help="Checkpoint (.ckpt/.pt) or JSON file to load model architecture config from. "
+        "Defaults to the bundled model_base.json.",
+    )
+    parser.add_argument("--resume", type=str, default=None, help="Training checkpoint to resume from")
+    parser.add_argument(
+        "--resume-model-only",
+        action="store_true",
+        help="Load only model weights from --resume and reset optimizer/scheduler/step counters",
     )
     parser.add_argument(
-        '--quality-filter-max-retries',
+        "--optimizer", type=str, default="adamw", choices=["adamw", "muon"], help="Optimizer to use (default: adamw)"
+    )
+    parser.add_argument(
+        "--muon-include-embeddings",
+        action="store_true",
+        help="Route 2D embedding tables to Muon instead of AdamW. "
+        "Default behavior excludes embeddings; this flag turns them on.",
+    )
+    parser.add_argument(
+        "--muon-include-nd",
+        action="store_true",
+        help="Route higher-rank (3D/4D) attention qkv/out_proj weights to "
+        "Muon via reshape-to-2D. Switches backend to MuonND (stock "
+        "torch.optim.Muon rejects ndim != 2). Captures the bulk of "
+        "attention parameters — the largest weight tensors in the model.",
+    )
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--total-steps", type=int, default=200_000)
+    parser.add_argument(
+        "--run-steps",
+        type=int,
+        default=None,
+        help="If set, run only this many optimizer steps in the current invocation while keeping total_steps as the global LR-schedule horizon",
+    )
+    parser.add_argument("--warmup-steps", type=int, default=2000)
+    parser.add_argument(
+        "--decay-start-step", type=int, default=0, help="Step to begin cosine decay (0 = right after warmup)"
+    )
+    parser.add_argument("--no-wandb", action="store_true")
+    parser.add_argument(
+        "--wandb-project",
+        type=str,
+        default=os.environ.get("WANDB_PROJECT", "synthefy-nori"),
+        help="Weights & Biases project name",
+    )
+    parser.add_argument(
+        "--wandb-entity", type=str, default=os.environ.get("WANDB_ENTITY"), help="Optional Weights & Biases entity/team"
+    )
+    parser.add_argument(
+        "--wandb-name", type=str, default=os.environ.get("WANDB_NAME"), help="Optional Weights & Biases run name"
+    )
+    parser.add_argument(
+        "--wandb-group", type=str, default=os.environ.get("WANDB_RUN_GROUP"), help="Optional Weights & Biases run group"
+    )
+    parser.add_argument(
+        "--wandb-job-type",
+        type=str,
+        default=os.environ.get("WANDB_JOB_TYPE"),
+        help="Optional Weights & Biases job type",
+    )
+    parser.add_argument(
+        "--wandb-tags",
+        type=parse_tags,
+        default=parse_tags(os.environ.get("WANDB_TAGS")),
+        help="Comma-separated Weights & Biases tags",
+    )
+    parser.add_argument(
+        "--checkpoint-dir", type=str, default=None, help="Checkpoint directory (default: ./checkpoints/<timestamp>)"
+    )
+    parser.add_argument(
+        "--ema-decay", type=float, default=0.0, help="EMA decay for validation/checkpoint averaging (0 disables EMA)"
+    )
+    parser.add_argument(
+        "--ema-foreach",
+        action="store_true",
+        help="Update EMA tensors with grouped foreach kernels. Experimental and off by default.",
+    )
+    parser.add_argument("--gradient-accumulation", type=int, default=1)
+    parser.add_argument("--log-interval", type=int, default=100)
+    parser.add_argument("--save-interval", type=int, default=5000)
+    parser.add_argument("--feature-loss-weight", type=float, default=0.5)
+    parser.add_argument(
+        "--feature-loss-weight-end", type=float, default=None, help="Optional end value for linear feature-loss decay"
+    )
+    parser.add_argument(
+        "--feature-loss-decay-start-step", type=int, default=0, help="Optimizer step to begin feature-loss decay"
+    )
+    parser.add_argument(
+        "--feature-loss-decay-end-step", type=int, default=0, help="Optimizer step to end feature-loss decay"
+    )
+    parser.add_argument("--no-mixed-precision", action="store_true")
+    parser.add_argument("--compile", action="store_true", help="Use torch.compile for kernel fusion speedup")
+    parser.add_argument(
+        "--gradient-checkpointing", action="store_true", help="Checkpoint inter-layer activations to reduce VRAM"
+    )
+    parser.add_argument(
+        "--max-budget", type=int, default=None, help="Max n_samples*n_features per batch (OOM protection)"
+    )
+    parser.add_argument("--min-samples", type=int, default=None, help="Min n_samples per synthetic table (default: 50)")
+    parser.add_argument(
+        "--max-samples", type=int, default=None, help="Max n_samples per synthetic table (default: 2000)"
+    )
+    parser.add_argument(
+        "--min-features", type=int, default=None, help="Min n_features per synthetic table (default: 2)"
+    )
+    parser.add_argument(
+        "--max-features", type=int, default=None, help="Max n_features per synthetic table (default: 250)"
+    )
+    parser.add_argument(
+        "--fixed-size", type=str, default=None, help='Fixed NxF size (e.g. "1024x64"). Overrides random sampling.'
+    )
+    parser.add_argument(
+        "--context-ratio-min", type=float, default=0.3, help="Minimum labeled-context fraction (default: 0.3)."
+    )
+    parser.add_argument(
+        "--context-ratio-max", type=float, default=0.8, help="Maximum labeled-context fraction (default: 0.8)."
+    )
+    parser.add_argument(
+        "--no-synth-v2", action="store_true", help="Disable synth_v2 data augmentations (revert to Run 8 behavior)"
+    )
+    parser.add_argument(
+        "--no-synth-v3",
+        action="store_true",
+        help="Disable synth_v3 data augmentations (true categoricals, interactions, skewed targets)",
+    )
+    parser.add_argument(
+        "--no-rich-reg-targets",
+        action="store_true",
+        help="Disable rich regression targets (multi-feature deps + interactions in y)",
+    )
+    parser.add_argument(
+        "--no-scale-variation",
+        action="store_true",
+        default=True,
+        help="Deprecated compatibility flag; target scale variation is always "
+        "disabled because context normalization cancels it.",
+    )
+    parser.add_argument(
+        "--synth-v4", action="store_true", help="Enable synth_v4 data augmentations (TabICLv2-inspired diversity)"
+    )
+    parser.add_argument("--no-v4-filter", action="store_true", help="Disable ExtraTrees filtering in synth_v4")
+    parser.add_argument(
+        "--learnability-filter",
+        action="store_true",
+        help="Enable ExtraTrees learnability filter for all synthetic data (independent of synth_v4)",
+    )
+    parser.add_argument(
+        "--learnability-filter-cls-min-score",
+        type=float,
+        default=0.60,
+        help="Minimum cls ExtraTrees OOB score to keep a dataset",
+    )
+    parser.add_argument(
+        "--learnability-filter-cls-margin",
+        type=float,
+        default=0.10,
+        help="Minimum cls ExtraTrees margin above chance to keep a dataset",
+    )
+    parser.add_argument(
+        "--learnability-filter-reg-min-score",
+        type=float,
+        default=0.10,
+        help="Minimum reg ExtraTrees OOB R2 to keep a dataset",
+    )
+    parser.add_argument(
+        "--icl-filter-model",
+        type=str,
+        default="",
+        help="GPU model for ICL learnability filtering. Options: "
+        '"limix" to auto-download LimiX-2M from HuggingFace, '
+        '"hf" to auto-download the Synthefy checkpoint, '
+        "path to local checkpoint (.pt/.ckpt), "
+        "or empty string to disable. "
+        "Runs on the training GPU after each batch.",
+    )
+    parser.add_argument(
+        "--icl-filter-cls-min-auc",
+        type=float,
+        default=0.55,
+        help="Minimum classification accuracy for ICL filter (default: 0.55)",
+    )
+    parser.add_argument(
+        "--icl-filter-reg-min-r2", type=float, default=0.05, help="Minimum regression R2 for ICL filter (default: 0.05)"
+    )
+    parser.add_argument(
+        "--icl-filter-use-train-context",
+        action="store_true",
+        default=True,
+        help="Deprecated compatibility flag; the ICL filter always uses the sampled training split.",
+    )
+    parser.add_argument(
+        "--icl-scaling-filter",
+        action="store_true",
+        help="Enable ICL scaling filter: reject datasets where more context does not help",
+    )
+    parser.add_argument(
+        "--icl-scaling-min-improvement",
+        type=float,
+        default=0.03,
+        help="Minimum R2 improvement from small to large context (default: 0.03)",
+    )
+    parser.add_argument(
+        "--v4-keep-edge-noise", action="store_true", help="Keep Gaussian edge noise with synth_v4 (default: removed)"
+    )
+    parser.add_argument(
+        "--task-type",
+        type=str,
+        default="both",
+        choices=["both", "cls", "reg"],
+        help="Task specialization: both (50/50), cls-only, or reg-only",
+    )
+    parser.add_argument(
+        "--regression-ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of steps that are regression when task_type=both (default: 0.5)",
+    )
+    parser.add_argument(
+        "--regression-loss",
+        type=str,
+        default="mse",
+        choices=["mse", "smooth_l1", "huber", "pinball", "bar_distribution"],
+        help="Regression loss function (default: mse)",
+    )
+    parser.add_argument(
+        "--regression-loss-beta", type=float, default=1.0, help="Beta for smooth_l1/huber loss (default: 1.0)"
+    )
+    parser.add_argument(
+        "--regression-quantiles",
+        type=parse_quantiles,
+        default=parse_quantiles("0.1,0.25,0.5,0.75,0.9"),
+        help="Comma-separated quantiles for pinball loss (default: 0.1,0.25,0.5,0.75,0.9)",
+    )
+    parser.add_argument(
+        "--pinball-tail-weight",
+        type=float,
+        default=0.0,
+        help="Upweight extreme quantiles in pinball loss. 0.0=uniform, "
+        "1.0=~2x weight at extremes (τ=0.01, τ=0.99). Targets bounded-"
+        "skewed regression datasets (sulfur, Goodreads). Default 0.0.",
+    )
+    parser.add_argument(
+        "--pinball-monotonicity-weight",
+        type=float,
+        default=0.0,
+        help="Soft penalty for τ-crossing in pinball loss. Adds "
+        "relu(q[i] - q[i+1])^2 across adjacent τ. Improves smoothness "
+        "of the τ-mean point estimate (helps houses, space_ga, "
+        "physiochemical_protein). Try 0.05.",
+    )
+    parser.add_argument(
+        "--pinball-mse-weight",
+        type=float,
+        default=0.0,
+        help="Auxiliary MSE on the τ-mean of pinball quantile predictions. "
+        "Forces unbiased point estimate; targets the QSAR-TID-11 "
+        '"prediction compression" failure where extreme-target rows '
+        "are averaged toward the bulk. Try 0.1.",
+    )
+    parser.add_argument(
+        "--num-bars",
+        type=int,
+        default=5000,
+        help="Number of bins for --regression-loss bar_distribution. "
+        "The reg head is sized to output this many logits per row. "
+        "Default 5000; bin width = (bar_borders_high - bar_borders_low)/num_bars.",
+    )
+    parser.add_argument(
+        "--bar-borders-low",
+        type=float,
+        default=-10.0,
+        help="Lower edge of bar_distribution bins on context-normalized y (default -10.0 = 10 std below context mean).",
+    )
+    parser.add_argument(
+        "--bar-borders-high",
+        type=float,
+        default=10.0,
+        help="Upper edge of bar_distribution bins on context-normalized y (default +10.0 = 10 std above context mean).",
+    )
+    parser.add_argument(
+        "--bar-target-sigma",
+        type=float,
+        default=0.0,
+        help="Soft-CE width for bar_distribution loss, in BIN units. "
+        "0.0 (default) = hard CE (one-hot target). >0 = Gaussian-smoothed "
+        "target with sigma=this many bins, giving partial credit to "
+        "nearby bins and smoothing the categorical cliffs in CE loss "
+        "landscape. Recommended: 5-20 for 5000 bins.",
+    )
+    parser.add_argument(
+        "--reg-prior-prob",
+        type=float,
+        default=0.4,
+        help="Probability of using regression prior generator for reg episodes (default: 0.4)",
+    )
+    parser.add_argument(
+        "--reg-denoise",
+        action="store_true",
+        help="Reduce noise for regression episodes (noise features, missingness, Gaussian noise, target transforms)",
+    )
+    parser.add_argument(
+        "--reg-deterministic-prob",
+        type=float,
+        default=0.20,
+        help="Probability that a regression-prior episode is zero-noise / deterministic (default: 0.20)",
+    )
+    parser.add_argument(
+        "--reg-dense",
+        action="store_true",
+        help="Dense-signal regression: flatter importances, fewer noise features, more parents, and more smooth multivariate priors",
+    )
+    parser.add_argument(
+        "--probabilistic-labels",
+        action="store_true",
+        help="Enable probabilistic classification labelers (logistic, tree, Gaussian, threshold)",
+    )
+    parser.add_argument(
+        "--nominal-categoricals",
+        action="store_true",
+        help="Enable nominal (non-ordinal) categorical feature generation",
+    )
+    parser.add_argument(
+        "--enhanced-missingness",
+        action="store_true",
+        help="Enable enhanced missingness patterns (row-level, block, target-dependent)",
+    )
+    parser.add_argument(
+        "--clean-lowdim-prob",
+        type=float,
+        default=0.0,
+        help="Probability of clean low-dim regime episodes (default: 0.0)",
+    )
+    parser.add_argument(
+        "--tree-prior-prob", type=float, default=0.0, help="Probability of tree-ensemble prior episodes (default: 0.0)"
+    )
+    parser.add_argument(
+        "--lookup-prior-prob",
+        type=float,
+        default=0.0,
+        help="Probability of categorical lookup prior episodes (default: 0.0)",
+    )
+    parser.add_argument(
+        "--quadratic-surface-prob",
+        type=float,
+        default=0.0,
+        help="Probability of quadratic response surface episodes (default: 0.0)",
+    )
+    parser.add_argument(
+        "--sparse-nonlinear-prob",
+        type=float,
+        default=0.0,
+        help="Probability of sparse nonlinear high-dim episodes (default: 0.0)",
+    )
+    parser.add_argument(
+        "--gp-prior-prob", type=float, default=0.0, help="Probability of GP smooth function episodes (default: 0.0)"
+    )
+    parser.add_argument(
+        "--context-missingness-prob",
+        type=float,
+        default=0.0,
+        help="Probability of injecting NaN cells in context rows (default: 0.0)",
+    )
+    parser.add_argument(
+        "--realistic-augmentation-prob",
+        type=float,
+        default=0.0,
+        help="Probability of applying heavy-tail/correlation/skew transforms (default: 0.0)",
+    )
+    parser.add_argument(
+        "--y-transform-prob",
+        type=float,
+        default=0.0,
+        help="Probability of applying realistic y-target transforms per episode. "
+        "Simulates integer counts, censored values, ordinal ratings, bounded averages, "
+        "zero-inflated counts. Targets datasets we underperform on "
+        "(stock_fardamento02, boston, sensory, Goodreads, etc). Default 0.0 (off).",
+    )
+    parser.add_argument(
+        "--cap-injection-prob",
+        type=float,
+        default=0.0,
+        help="Probability of injecting upper/lower quantile cap (saturation) per "
+        "regression episode. Minimal y-distortion — just clips tails to a "
+        "single value to teach the model that caps exist. Fixes models failure "
+        "to predict near timeout/cap values (MIP-2016, boston MEDV). Default 0.0.",
+    )
+    parser.add_argument(
+        "--heavy-tail-prior-prob",
+        type=float,
+        default=0.0,
+        help="Probability of applying heavy-tail y transforms per regression episode. "
+        "Continuous transforms only: log-normal (exp), Pareto additive noise, "
+        "strong outlier injection (5-10%% @ 3-15x scale). No rounding — safe vs "
+        "failed y_transform experiment. Targets weak spots on skewed data "
+        "(stock_fardamento02, CPS1988, sulfur, Food_Delivery_Time). Default 0.0.",
+    )
+    parser.add_argument(
+        "--pareto-importance-prob",
+        type=float,
+        default=0.0,
+        help="Probability per regression-prior episode of multiplying the per-feature "
+        "beta/coefficient vector by a Pareto-distributed importance vector so "
+        "a few features dominate while many are weak distractors. Targets the "
+        'high-dim "many distractors" failure (QSAR-TID-11, Allstate). Default 0.0.',
+    )
+    parser.add_argument(
+        "--latent-factor-prob",
+        type=float,
+        default=0.0,
+        help="Probability per regression-prior episode of using a latent-factor "
+        "target: y = f(X @ V) where V is a d×k random projection (k ≪ d). "
+        "Models datasets with shared low-dim latent structure. Default 0.0.",
+    )
+    parser.add_argument(
+        "--high-cap-prob",
+        type=float,
+        default=0.0,
+        help="Probability per cap-injected episode of using a higher cap fraction "
+        "(20-50%% at cap, percentile drawn from [50, 80] instead of [80, 97]). "
+        "Models timeout/runtime censoring patterns (MIP-2016, SAT11). "
+        "Composes with --cap-injection-prob (only applies when cap fires). "
+        "Default 0.0.",
+    )
+    parser.add_argument(
+        "--low-unique-y-prob",
+        type=float,
+        default=0.0,
+        help="Probability per regression episode of rounding/binning y to "
+        "5-15 unique levels. Models discrete-regression datasets (Wine_Quality "
+        "6 levels, sensory 1-10 ratings). Default 0.0.",
+    )
+    parser.add_argument(
+        "--quality-filter-rules",
+        type=str,
+        default=None,
+        help="Path to synthetic quality rules JSON (from eval_synthetic_benchmark.py)",
+    )
+    parser.add_argument(
+        "--quality-filter-max-retries",
         type=int,
         default=3,
-        help='Max retries when generated data fails quality rules (default: 3)',
+        help="Max retries when generated data fails quality rules (default: 3)",
     )
-    parser.add_argument('--scm-prior', action='store_true',
-                        help='Enable TabICL prior generator (MLP/Tree SCM + Reg2Cls)')
-    parser.add_argument('--scm-prior-prob', type=float, default=0.5,
-                        help='Per-dataset probability of using TabICL prior (default: 0.5)')
-    parser.add_argument('--synth-v5', action='store_true',
-                        help='Enable synth_v5 SCM improvements (informative categoricals, concat aggregation, multi-dim nodes)')
-    parser.add_argument('--synth-v5-mixture', action='store_true',
-                        help='Enable synth_v5 mixture prior (25%% v4, 35%% v5c, 40%% v5a per dataset)')
-    parser.add_argument('--model-v2', action='store_true',
-                        help='v2 arch: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD')
-    parser.add_argument('--model-v2-lite', action='store_true',
-                        help='v2-lite arch: SwiGLU + RMSNorm + pre-norm/DeepNorm, keep RBF (no PBLD)')
-    parser.add_argument('--embed-dim', type=int, default=None,
-                        help='Override embedding dimension (default: from checkpoint)')
-    parser.add_argument('--hid-dim', type=int, default=None,
-                        help='Override MLP hidden dimension (default: from checkpoint)')
-    parser.add_argument('--nhead', type=int, default=None,
-                        help='Override number of attention heads (default: from checkpoint)')
-    parser.add_argument('--nlayers', type=int, default=None,
-                        help='Override number of transformer layers (default: from checkpoint)')
-    parser.add_argument('--features-per-group', type=int, default=None,
-                        help='Override features_per_group (default: from checkpoint, TabPFN uses 3)')
-    parser.add_argument('--feature-positional-embedding-type', type=str, default=None,
-                        choices=['subortho', 'learned', 'none'],
-                        help='Feature positional embedding type. '
-                             'subortho=random orthogonal each fwd (default). '
-                             'learned=nn.Embedding table with permuted slots (TabPFN-2.6 style). '
-                             'none=no feature positional embedding.')
-    parser.add_argument('--feature-positional-embedding-num-slots', type=int, default=1000,
-                        help='Number of learned positional slots when type=learned (default: 1000)')
-    parser.add_argument('--no-qassmax', action='store_true',
-                        help='Disable query-aware scalable softmax in sequence attention')
-    parser.add_argument('--no-target-aware-embedding', action='store_true',
-                        help='Disable target-aware label injection into context feature tokens')
-    parser.add_argument('--column-specific-y-aware', action='store_true',
-                        help='Add column-specific gating to target-aware embedding so each '
-                             'feature column gets a y-derived bias scaled by its alignment '
-                             'with the y embedding direction. Closes the gap with TabICL on '
-                             'high-dim datasets where most features are noise (QSAR-TID-11). '
-                             'Backward-compatible — alpha init makes new path contribute ~0.7%% '
-                             'at FT step 0, so V8old behavior is preserved at start.')
-    parser.add_argument('--freeze-column-y-alpha', action='store_true',
-                        help='With --column-specific-y-aware, freeze column_y_aware_alpha at '
-                             'its init value so it cannot grow during training. Control '
-                             'experiment to isolate whether V10s gains come from the new '
-                             'gating mechanism vs. just continued V8old FT.')
-    parser.add_argument('--regression-only', action='store_true',
-                        help='Regression-only forward path (strips cls branch for cleaner compile)')
-    parser.add_argument('--target-aware-init-scale', type=float, default=1.0,
-                        help='Initial scale for target-aware embedding during warm-up')
-    parser.add_argument('--target-aware-warmup-steps', type=int, default=0,
-                        help='Warm target-aware embedding to full scale over this many optimizer steps')
-    parser.add_argument('--dim-bias-samples', type=float, default=1.5,
-                        help='Exponent to bias n_samples toward larger tables (1.0=uniform, 1.5=40%% > 1000)')
-    parser.add_argument('--dim-bias-features', type=float, default=1.3,
-                        help='Exponent to bias n_features toward larger feature counts (1.0=uniform)')
-    parser.add_argument('--prefetch-workers', type=int, default=4,
-                        help='Number of async data generation workers (0 to disable prefetching)')
-    parser.add_argument('--prefetch-count', type=int, default=4,
-                        help='Number of batches to prefetch ahead')
-    parser.add_argument('--no-prefetch', action='store_true',
-                        help='Disable async data prefetching')
-    parser.add_argument('--seed', type=int, default=42,
-                        help='Random seed for data generation and training. Seeds Python, '
-                             'NumPy, and torch (CPU + CUDA) so same-seed runs are '
-                             'reproducible (default: 42)')
-    parser.add_argument('--debug-dump-dir', type=str, default='',
-                        help='Dump per-step NPZ files (data, gradients, '
-                             'weights, loss) for the first --debug-dump-steps '
-                             'optimizer steps into this directory. Setting this '
-                             'also enables deterministic mode (seeded torch + '
-                             'cudnn.deterministic).')
-    parser.add_argument('--debug-dump-steps', type=int, default=5,
-                        help='Number of optimizer steps to dump (default: 5)')
     parser.add_argument(
-        '--shape-palette',
+        "--scm-prior", action="store_true", help="Enable TabICL prior generator (MLP/Tree SCM + Reg2Cls)"
+    )
+    parser.add_argument(
+        "--scm-prior-prob", type=float, default=0.5, help="Per-dataset probability of using TabICL prior (default: 0.5)"
+    )
+    parser.add_argument(
+        "--synth-v5",
+        action="store_true",
+        help="Enable synth_v5 SCM improvements (informative categoricals, concat aggregation, multi-dim nodes)",
+    )
+    parser.add_argument(
+        "--synth-v5-mixture",
+        action="store_true",
+        help="Enable synth_v5 mixture prior (25%% v4, 35%% v5c, 40%% v5a per dataset)",
+    )
+    parser.add_argument("--model-v2", action="store_true", help="v2 arch: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD")
+    parser.add_argument(
+        "--model-v2-lite",
+        action="store_true",
+        help="v2-lite arch: SwiGLU + RMSNorm + pre-norm/DeepNorm, keep RBF (no PBLD)",
+    )
+    parser.add_argument(
+        "--embed-dim", type=int, default=None, help="Override embedding dimension (default: from checkpoint)"
+    )
+    parser.add_argument(
+        "--hid-dim", type=int, default=None, help="Override MLP hidden dimension (default: from checkpoint)"
+    )
+    parser.add_argument(
+        "--nhead", type=int, default=None, help="Override number of attention heads (default: from checkpoint)"
+    )
+    parser.add_argument(
+        "--nlayers", type=int, default=None, help="Override number of transformer layers (default: from checkpoint)"
+    )
+    parser.add_argument(
+        "--features-per-group",
+        type=int,
+        default=None,
+        help="Override features_per_group (default: from checkpoint, TabPFN uses 3)",
+    )
+    parser.add_argument(
+        "--feature-positional-embedding-type",
+        type=str,
+        default=None,
+        choices=["subortho", "learned", "none"],
+        help="Feature positional embedding type. "
+        "subortho=random orthogonal each fwd (default). "
+        "learned=nn.Embedding table with permuted slots (TabPFN-2.6 style). "
+        "none=no feature positional embedding.",
+    )
+    parser.add_argument(
+        "--feature-positional-embedding-num-slots",
+        type=int,
+        default=1000,
+        help="Number of learned positional slots when type=learned (default: 1000)",
+    )
+    parser.add_argument(
+        "--no-qassmax", action="store_true", help="Disable query-aware scalable softmax in sequence attention"
+    )
+    parser.add_argument(
+        "--no-target-aware-embedding",
+        action="store_true",
+        help="Disable target-aware label injection into context feature tokens",
+    )
+    parser.add_argument(
+        "--column-specific-y-aware",
+        action="store_true",
+        help="Add column-specific gating to target-aware embedding so each "
+        "feature column gets a y-derived bias scaled by its alignment "
+        "with the y embedding direction. Closes the gap with TabICL on "
+        "high-dim datasets where most features are noise (QSAR-TID-11). "
+        "Backward-compatible — alpha init makes new path contribute ~0.7%% "
+        "at FT step 0, so V8old behavior is preserved at start.",
+    )
+    parser.add_argument(
+        "--freeze-column-y-alpha",
+        action="store_true",
+        help="With --column-specific-y-aware, freeze column_y_aware_alpha at "
+        "its init value so it cannot grow during training. Control "
+        "experiment to isolate whether V10s gains come from the new "
+        "gating mechanism vs. just continued V8old FT.",
+    )
+    parser.add_argument(
+        "--regression-only",
+        action="store_true",
+        help="Regression-only forward path (strips cls branch for cleaner compile)",
+    )
+    parser.add_argument(
+        "--target-aware-init-scale",
+        type=float,
+        default=1.0,
+        help="Initial scale for target-aware embedding during warm-up",
+    )
+    parser.add_argument(
+        "--target-aware-warmup-steps",
+        type=int,
+        default=0,
+        help="Warm target-aware embedding to full scale over this many optimizer steps",
+    )
+    parser.add_argument(
+        "--dim-bias-samples",
+        type=float,
+        default=1.5,
+        help="Exponent to bias n_samples toward larger tables (1.0=uniform, 1.5=40%% > 1000)",
+    )
+    parser.add_argument(
+        "--dim-bias-features",
+        type=float,
+        default=1.3,
+        help="Exponent to bias n_features toward larger feature counts (1.0=uniform)",
+    )
+    parser.add_argument(
+        "--prefetch-workers",
+        type=int,
+        default=4,
+        help="Number of async data generation workers (0 to disable prefetching)",
+    )
+    parser.add_argument("--prefetch-count", type=int, default=4, help="Number of batches to prefetch ahead")
+    parser.add_argument("--no-prefetch", action="store_true", help="Disable async data prefetching")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for data generation and training. Seeds Python, "
+        "NumPy, and torch (CPU + CUDA) so same-seed runs are "
+        "reproducible (default: 42)",
+    )
+    parser.add_argument(
+        "--debug-dump-dir",
+        type=str,
+        default="",
+        help="Dump per-step NPZ files (data, gradients, "
+        "weights, loss) for the first --debug-dump-steps "
+        "optimizer steps into this directory. Setting this "
+        "also enables deterministic mode (seeded torch + "
+        "cudnn.deterministic).",
+    )
+    parser.add_argument(
+        "--debug-dump-steps", type=int, default=5, help="Number of optimizer steps to dump (default: 5)"
+    )
+    parser.add_argument(
+        "--shape-palette",
         type=parse_shape_palette,
         default=(),
-        metavar='ROWSxFEATURES:WEIGHT,...',
-        help='Explicit weighted physical-shape palette. Experimental and off '
-             'by default; mutually exclusive with --fixed-size.',
+        metavar="ROWSxFEATURES:WEIGHT,...",
+        help="Explicit weighted physical-shape palette. Experimental and off "
+        "by default; mutually exclusive with --fixed-size.",
     )
     parser.add_argument(
-        '--context-ratio-palette',
+        "--context-ratio-palette",
         type=parse_context_ratio_palette,
         default=(),
-        metavar='RATIO,...',
-        help='Optional discrete context/query ratios. This bounds eval_pos '
-             'compiler signatures but changes the training curriculum.',
+        metavar="RATIO,...",
+        help="Optional discrete context/query ratios. This bounds eval_pos "
+        "compiler signatures but changes the training curriculum.",
     )
     parser.add_argument(
-        '--compile-encoder-layers',
-        choices=['none', 'static', 'dynamic'],
-        default='none',
+        "--compile-encoder-layers",
+        choices=["none", "static", "dynamic"],
+        default="none",
         help='Regionally compile one shared encoder-layer forward. "static" '
-             'compiles exact signatures and requires a bounded shape/ratio '
-             'contract. "dynamic" compiles shape-generic kernels and needs no '
-             'palette, so it leaves the data curriculum untouched. '
-             'Experimental and off by default.',
+        "compiles exact signatures and requires a bounded shape/ratio "
+        'contract. "dynamic" compiles shape-generic kernels and needs no '
+        "palette, so it leaves the data curriculum untouched. "
+        "Experimental and off by default.",
     )
     parser.add_argument(
-        '--compile-pinball-loss',
+        "--compile-pinball-loss",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help='Regionally compile the large-quantile pinball objective. '
-             'Enabled by default; use --no-compile-pinball-loss for eager execution.',
+        help="Regionally compile the large-quantile pinball objective. "
+        "Enabled by default; use --no-compile-pinball-loss for eager execution.",
     )
     parser.add_argument(
-        '--compile-mode',
-        choices=['default', 'reduce-overhead', 'max-autotune-no-cudagraphs'],
-        default='default',
-        help='torch.compile mode used by --compile-encoder-layers.',
+        "--compile-mode",
+        choices=["default", "reduce-overhead", "max-autotune-no-cudagraphs"],
+        default="default",
+        help="torch.compile mode used by --compile-encoder-layers.",
     )
     parser.add_argument(
-        '--compile-cache-limit',
+        "--compile-cache-limit",
         type=int,
         default=1024,
-        help='Maximum live Dynamo variants for static encoder compilation.',
+        help="Maximum live Dynamo variants for static encoder compilation.",
     )
     parser.add_argument(
-        '--compile-disable-ddp-optimizer',
-        action='store_true',
-        help='Disable Dynamo DDPOptimizer graph splitting. This is faster and '
-             'disk-cacheable for regional layer compilation on the tested model.',
+        "--compile-disable-ddp-optimizer",
+        action="store_true",
+        help="Disable Dynamo DDPOptimizer graph splitting. This is faster and "
+        "disk-cacheable for regional layer compilation on the tested model.",
     )
-    parser.add_argument('--freeze-unused-heads', action='store_true', default=True,
-                        help='Freeze the feature decoder when feature loss remains zero.')
-    parser.add_argument('--no-freeze-unused-heads', dest='freeze_unused_heads',
-                        action='store_false',
-                        help='Keep the feature decoder trainable.')
-    parser.add_argument('--skip-zero-feature-decoder', action='store_true',
-                        help='Skip feature-decoder execution when feature loss stays '
-                             'zero. Requires unused-head freezing; off by default.')
-    parser.add_argument('--native-rms-norm', action='store_true',
-                        help='Use PyTorch native RMSNorm kernels during this run. '
-                             'Experimental and off by default.')
-    raw_cli_options = {
-        token.split('=', 1)[0]
-        for token in sys.argv[1:]
-        if token.startswith('--')
-    }
+    parser.add_argument(
+        "--freeze-unused-heads",
+        action="store_true",
+        default=True,
+        help="Freeze the feature decoder when feature loss remains zero.",
+    )
+    parser.add_argument(
+        "--no-freeze-unused-heads",
+        dest="freeze_unused_heads",
+        action="store_false",
+        help="Keep the feature decoder trainable.",
+    )
+    parser.add_argument(
+        "--skip-zero-feature-decoder",
+        action="store_true",
+        help="Skip feature-decoder execution when feature loss stays "
+        "zero. Requires unused-head freezing; off by default.",
+    )
+    parser.add_argument(
+        "--native-rms-norm",
+        action="store_true",
+        help="Use PyTorch native RMSNorm kernels during this run. Experimental and off by default.",
+    )
+    raw_cli_options = {token.split("=", 1)[0] for token in sys.argv[1:] if token.startswith("--")}
     args = parser.parse_args()
 
     # Seed Python/NumPy/torch from --seed so same-seed runs are reproducible.
@@ -813,6 +1048,7 @@ def main():
     # debug-dump mode. Seeding here is cheap and does not affect training speed.
     import random as _random
     import numpy as _np_seed
+
     _random.seed(args.seed)
     _np_seed.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -823,13 +1059,12 @@ def main():
         # is reserved for byte-exact debug dumps, not normal training.
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-        print(f"[debug-dump] deterministic mode ON: seed={args.seed}, "
-              f"cudnn.deterministic=True")
+        print(f"[debug-dump] deterministic mode ON: seed={args.seed}, cudnn.deterministic=True")
 
     # Auto-generate checkpoint directory with timestamp
     if args.checkpoint_dir is None:
-        timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
-        args.checkpoint_dir = f'./checkpoints/{timestamp}'
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        args.checkpoint_dir = f"./checkpoints/{timestamp}"
 
     if args.run_steps is not None and args.run_steps <= 0:
         parser.error("--run-steps must be a positive integer")
@@ -838,30 +1073,18 @@ def main():
     if not 0.0 <= args.target_aware_init_scale <= 1.0:
         parser.error("--target-aware-init-scale must be in [0, 1]")
     if not 0 < args.context_ratio_min <= args.context_ratio_max < 1:
-        parser.error(
-            "--context-ratio-min/--context-ratio-max must satisfy "
-            "0 < min <= max < 1"
-        )
+        parser.error("--context-ratio-min/--context-ratio-max must satisfy 0 < min <= max < 1")
     if args.shape_palette and args.fixed_size:
         parser.error("--shape-palette and --fixed-size are mutually exclusive")
     if args.compile_cache_limit <= 0:
         parser.error("--compile-cache-limit must be positive")
-    if args.compile_encoder_layers == 'static':
+    if args.compile_encoder_layers == "static":
         if not args.shape_palette and not args.fixed_size:
-            parser.error(
-                "--compile-encoder-layers static requires --shape-palette "
-                "or --fixed-size"
-            )
+            parser.error("--compile-encoder-layers static requires --shape-palette or --fixed-size")
         if not args.context_ratio_palette:
-            parser.error(
-                "--compile-encoder-layers static requires "
-                "--context-ratio-palette"
-            )
-    if (args.compile_disable_ddp_optimizer
-            and args.compile_encoder_layers == 'none'):
-        parser.error(
-            "--compile-disable-ddp-optimizer requires --compile-encoder-layers"
-        )
+            parser.error("--compile-encoder-layers static requires --context-ratio-palette")
+    if args.compile_disable_ddp_optimizer and args.compile_encoder_layers == "none":
+        parser.error("--compile-disable-ddp-optimizer requires --compile-encoder-layers")
     # A resume checkpoint owns the architecture of the tensors it restores.
     # Building from the bundled config here used to rely on strict=False later,
     # which could silently leave a partly fresh, mismatched model.
@@ -891,15 +1114,11 @@ def main():
     except ValueError as exc:
         parser.error(str(exc))
     if args.skip_zero_feature_decoder and not feature_loss_stays_zero:
-        parser.error(
-            "--skip-zero-feature-decoder requires feature loss to remain zero"
-        )
+        parser.error("--skip-zero-feature-decoder requires feature loss to remain zero")
     if args.skip_zero_feature_decoder and not args.freeze_unused_heads:
-        parser.error(
-            "--skip-zero-feature-decoder requires --freeze-unused-heads"
-        )
+        parser.error("--skip-zero-feature-decoder requires --freeze-unused-heads")
     # Enable mask prediction for training
-    model_config['mask_prediction'] = True
+    model_config["mask_prediction"] = True
     try:
         configure_regression_head(
             model_config,
@@ -926,36 +1145,39 @@ def main():
         preserve_existing=bool(args.resume),
     )
     if args.regression_only:
-        model_config['regression_only'] = True
+        model_config["regression_only"] = True
 
     # --- Distributed setup ---
-    local_rank = int(os.environ.get('LOCAL_RANK', 0))
-    world_size = int(os.environ.get('WORLD_SIZE', 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
     distributed = world_size > 1
 
     if distributed:
         # Per-layer compile can take >10min per new shape on 14 layers.
         # Default 600s NCCL timeout causes rank desync during compilation.
         import datetime as _dt
-        nccl_timeout = int(os.environ.get('NCCL_TIMEOUT', '3600'))
-        torch.distributed.init_process_group(
-            backend='nccl',
-            timeout=_dt.timedelta(seconds=nccl_timeout))
-        device = f'cuda:{local_rank}'
+
+        nccl_timeout = int(os.environ.get("NCCL_TIMEOUT", "3600"))
+        torch.distributed.init_process_group(backend="nccl", timeout=_dt.timedelta(seconds=nccl_timeout))
+        device = f"cuda:{local_rank}"
         torch.cuda.set_device(device)
         effective_lr = args.lr * world_size  # Linear scaling rule
     else:
         device = args.device
         # Set default CUDA device so that torch.compile, empty_cache(), etc.
         # target the correct GPU instead of defaulting to cuda:0.
-        if device.startswith('cuda'):
+        if device.startswith("cuda"):
             torch.cuda.set_device(device)
         effective_lr = args.lr
 
     # Apply dimension overrides (before v2 arch changes since deepnorm_alpha depends on nlayers)
-    for key, arg_val in [('embed_dim', args.embed_dim), ('hid_dim', args.hid_dim),
-                         ('nhead', args.nhead), ('nlayers', args.nlayers),
-                         ('features_per_group', args.features_per_group)]:
+    for key, arg_val in [
+        ("embed_dim", args.embed_dim),
+        ("hid_dim", args.hid_dim),
+        ("nhead", args.nhead),
+        ("nlayers", args.nlayers),
+        ("features_per_group", args.features_per_group),
+    ]:
         if arg_val is not None:
             old_val = model_config.get(key)
             model_config[key] = arg_val
@@ -964,9 +1186,9 @@ def main():
 
     # Feature positional embedding type / slots
     if args.feature_positional_embedding_type is not None:
-        old_val = model_config.get('feature_positional_embedding_type', 'subortho')
-        model_config['feature_positional_embedding_type'] = args.feature_positional_embedding_type
-        model_config['feature_positional_embedding_num_slots'] = args.feature_positional_embedding_num_slots
+        old_val = model_config.get("feature_positional_embedding_type", "subortho")
+        model_config["feature_positional_embedding_type"] = args.feature_positional_embedding_type
+        model_config["feature_positional_embedding_num_slots"] = args.feature_positional_embedding_num_slots
         if local_rank == 0:
             print(
                 f"Model override: feature_positional_embedding_type {old_val} -> "
@@ -978,9 +1200,9 @@ def main():
     # dimensions match the transformer backbone.
     if args.embed_dim is not None:
         new_dim = args.embed_dim
-        for sub_key in ('encoder_config_x', 'encoder_config_y'):
+        for sub_key in ("encoder_config_x", "encoder_config_y"):
             sub = model_config.get(sub_key, {})
-            for field in ('embedding_size', 'mask_embedding_size'):
+            for field in ("embedding_size", "mask_embedding_size"):
                 if field in sub:
                     sub[field] = new_dim
 
@@ -988,28 +1210,28 @@ def main():
     # ValidFeatureEncoder pads input groups to this size, so it must match.
     if args.features_per_group is not None:
         fpg = args.features_per_group
-        if 'preprocess_config_x' in model_config and 'num_features' in model_config['preprocess_config_x']:
-            model_config['preprocess_config_x']['num_features'] = fpg
-        if 'encoder_config_x' in model_config and 'num_features' in model_config['encoder_config_x']:
-            model_config['encoder_config_x']['num_features'] = fpg
+        if "preprocess_config_x" in model_config and "num_features" in model_config["preprocess_config_x"]:
+            model_config["preprocess_config_x"]["num_features"] = fpg
+        if "encoder_config_x" in model_config and "num_features" in model_config["encoder_config_x"]:
+            model_config["encoder_config_x"]["num_features"] = fpg
         if local_rank == 0:
             print(f"Propagated features_per_group={fpg} to preprocess_config_x and encoder_config_x")
 
     # Apply v2 architecture overrides
     if args.model_v2:
-        model_config['activation'] = 'swiglu'
-        model_config['norm_type'] = 'rmsnorm'
-        model_config['pre_norm'] = True
-        model_config['deepnorm_alpha'] = model_config['nlayers'] ** (-0.5)
-        model_config['encoder_config_x']['numeric_embed_type'] = 'PBLD'
-        model_config['encoder_config_x']['PBLD_config'] = {'n_frequencies': 48}
+        model_config["activation"] = "swiglu"
+        model_config["norm_type"] = "rmsnorm"
+        model_config["pre_norm"] = True
+        model_config["deepnorm_alpha"] = model_config["nlayers"] ** (-0.5)
+        model_config["encoder_config_x"]["numeric_embed_type"] = "PBLD"
+        model_config["encoder_config_x"]["PBLD_config"] = {"n_frequencies": 48}
         if local_rank == 0:
             print("Model v2 enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm + PBLD")
     elif args.model_v2_lite:
-        model_config['activation'] = 'swiglu'
-        model_config['norm_type'] = 'rmsnorm'
-        model_config['pre_norm'] = True
-        model_config['deepnorm_alpha'] = model_config['nlayers'] ** (-0.5)
+        model_config["activation"] = "swiglu"
+        model_config["norm_type"] = "rmsnorm"
+        model_config["pre_norm"] = True
+        model_config["deepnorm_alpha"] = model_config["nlayers"] ** (-0.5)
         # Keep RBF numeric embedding (no PBLD) for speed
         if local_rank == 0:
             print("Model v2-lite enabled: SwiGLU + RMSNorm + pre-norm/DeepNorm (RBF kept)")
@@ -1023,7 +1245,7 @@ def main():
     # been applied. model_config is the only architecture record the checkpoint
     # carries, so a flag left unwritten here is a flag a later load has to guess.
     finalize_arch_config(model_config)
-    if local_rank == 0 and 'qass_mode' in model_config:
+    if local_rank == 0 and "qass_mode" in model_config:
         print(f"QASS mode: {model_config['qass_mode']} (pinned into model_config)")
 
     # Build model from scratch (random init)
@@ -1053,11 +1275,12 @@ def main():
             print(f"  [freeze] feature_decoder {action} (feature loss is 0)")
 
     # Freeze column_y_aware_alpha if requested (V10c control experiment).
-    if args.freeze_column_y_alpha and getattr(model, 'column_y_aware_alpha', None) is not None:
+    if args.freeze_column_y_alpha and getattr(model, "column_y_aware_alpha", None) is not None:
         model.column_y_aware_alpha.requires_grad_(False)
         if local_rank == 0:
-            print(f"  [freeze] column_y_aware_alpha grad disabled "
-                  f"(value held at {model.column_y_aware_alpha.item():.4f})")
+            print(
+                f"  [freeze] column_y_aware_alpha grad disabled (value held at {model.column_y_aware_alpha.item():.4f})"
+            )
 
     if local_rank == 0:
         n_params = sum(p.numel() for p in model.parameters())
@@ -1066,7 +1289,7 @@ def main():
 
     model.to(device)
 
-    if args.compile_encoder_layers != 'none':
+    if args.compile_encoder_layers != "none":
         cache_limit = max(8, int(args.compile_cache_limit))
         torch._dynamo.config.cache_size_limit = cache_limit
         torch._dynamo.config.recompile_limit = cache_limit
@@ -1074,9 +1297,9 @@ def main():
         torch._dynamo.config.accumulated_recompile_limit = cache_limit
         if args.compile_disable_ddp_optimizer:
             torch._dynamo.config.optimize_ddp = False
-        compile_mode = None if args.compile_mode == 'default' else args.compile_mode
+        compile_mode = None if args.compile_mode == "default" else args.compile_mode
         layers = model.transformer_encoder.layers
-        use_dynamic = args.compile_encoder_layers == 'dynamic'
+        use_dynamic = args.compile_encoder_layers == "dynamic"
         compiled_forward = torch.compile(
             type(layers[0]).forward,
             dynamic=use_dynamic,
@@ -1087,11 +1310,11 @@ def main():
             layer.forward = types.MethodType(compiled_forward, layer)
         if local_rank == 0:
             print(
-                f'{args.compile_encoder_layers.capitalize()} regional '
-                'compilation enabled: '
-                f'{len(layers)} encoder layers, mode={args.compile_mode}, '
-                f'cache_limit={cache_limit}, '
-                f'ddp_optimizer={not args.compile_disable_ddp_optimizer}'
+                f"{args.compile_encoder_layers.capitalize()} regional "
+                "compilation enabled: "
+                f"{len(layers)} encoder layers, mode={args.compile_mode}, "
+                f"cache_limit={cache_limit}, "
+                f"ddp_optimizer={not args.compile_disable_ddp_optimizer}"
             )
 
     if args.gradient_checkpointing:
@@ -1107,7 +1330,7 @@ def main():
     # use --fixed-size to avoid recompilation overhead.
     if args.compile:
         # Disable FX graph cache to avoid pickle errors with DDP + pybind11 objects
-        os.environ['TORCHINDUCTOR_FX_GRAPH_CACHE'] = '0'
+        os.environ["TORCHINDUCTOR_FX_GRAPH_CACHE"] = "0"
         import torch._inductor.config as _inductor_cfg
         import torch._dynamo.config as _dynamo_cfg
 
@@ -1135,15 +1358,17 @@ def main():
         _set_cfg(_dynamo_cfg, "automatic_dynamic_shapes", False)
 
         if local_rank == 0:
-            print("Compiling model with torch.compile (FX cache disabled, DDP optimize off, "
-                  "cache_size=512, static shapes)...")
+            print(
+                "Compiling model with torch.compile (FX cache disabled, DDP optimize off, "
+                "cache_size=512, static shapes)..."
+            )
         model = torch.compile(model, dynamic=False)
 
     # DDP wrapping (after compile)
     if distributed:
         from torch.nn.parallel import DistributedDataParallel as DDP
-        model = DDP(model, device_ids=[local_rank], find_unused_parameters=False,
-                    gradient_as_bucket_view=True)
+
+        model = DDP(model, device_ids=[local_rank], find_unused_parameters=False, gradient_as_bucket_view=True)
         if local_rank == 0:
             print(f"DDP enabled: {world_size} GPUs, effective LR={effective_lr:.2e}")
 
@@ -1159,17 +1384,17 @@ def main():
     fixed_n_samples = None
     fixed_n_features = None
     if args.fixed_size:
-        parts = args.fixed_size.lower().split('x')
+        parts = args.fixed_size.lower().split("x")
         if len(parts) != 2:
             parser.error(f"--fixed-size must be NxF (e.g. '1024x64'), got '{args.fixed_size}'")
         fixed_n_samples, fixed_n_features = int(parts[0]), int(parts[1])
-        features_per_group = model_config.get('features_per_group', 2)
+        features_per_group = model_config.get("features_per_group", 2)
         if fixed_n_features % features_per_group != 0:
             fixed_n_features += features_per_group - (fixed_n_features % features_per_group)
         if local_rank == 0:
             print(f"Fixed size: {fixed_n_samples} samples x {fixed_n_features} features")
 
-    feature_multiple = int(model_config.get('features_per_group', 2))
+    feature_multiple = int(model_config.get("features_per_group", 2))
     for rows, features, _weight in args.shape_palette:
         if features % feature_multiple:
             parser.error(
@@ -1177,24 +1402,17 @@ def main():
                 f"model features_per_group={feature_multiple}"
             )
         if rows * features > max_budget:
-            parser.error(
-                f"Explicit palette shape {rows}x{features} exceeds "
-                f"--max-budget={max_budget}"
-            )
+            parser.error(f"Explicit palette shape {rows}x{features} exceeds --max-budget={max_budget}")
     if local_rank == 0 and (args.shape_palette or args.context_ratio_palette):
-        physical_shapes = len(args.shape_palette) if args.shape_palette else 'sampled'
+        physical_shapes = len(args.shape_palette) if args.shape_palette else "sampled"
         context_shapes = (
             len(args.context_ratio_palette)
             if args.context_ratio_palette
             else sum(
-                args.context_ratio_min <= ratio <= args.context_ratio_max
-                for ratio in NoriTrainer.CONTEXT_RATIO_BUCKETS
+                args.context_ratio_min <= ratio <= args.context_ratio_max for ratio in NoriTrainer.CONTEXT_RATIO_BUCKETS
             )
         )
-        print(
-            f"Static sampling contract: {physical_shapes} physical shapes x "
-            f"{context_shapes} context ratios"
-        )
+        print(f"Static sampling contract: {physical_shapes} physical shapes x {context_shapes} context ratios")
 
     # Training config
     train_config = TrainingConfig(
@@ -1227,7 +1445,7 @@ def main():
         feature_loss_decay_end_step=args.feature_loss_decay_end_step,
         mixed_precision=not args.no_mixed_precision,
         checkpoint_path=args.checkpoint or "",
-        features_per_group=model_config.get('features_per_group', 2),
+        features_per_group=model_config.get("features_per_group", 2),
         target_aware_init_scale=args.target_aware_init_scale,
         target_aware_warmup_steps=args.target_aware_warmup_steps,
         compile=args.compile,
@@ -1334,5 +1552,5 @@ def main():
         torch.distributed.destroy_process_group()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/synthefy_nori/training/config.py
+++ b/src/synthefy_nori/training/config.py
@@ -130,17 +130,17 @@ class TrainingConfig:
     scale_variation: bool = False
 
     # TabICL prior generator (alternative data source from TabICL's prior system)
-    scm_prior: bool = False   # Enable TabICL MLP/Tree SCM prior
+    scm_prior: bool = False  # Enable TabICL MLP/Tree SCM prior
     scm_prior_prob: float = 0.5  # Per-dataset probability of using TabICL prior
 
     # Synthetic data v4 augmentations (TabICLv2-inspired diversity improvements)
     synth_v4: bool = False
-    v4_filter: bool = True         # ExtraTrees filtering (reject unlearnable data)
+    v4_filter: bool = True  # ExtraTrees filtering (reject unlearnable data)
     learnability_filter: bool = False  # Standalone ExtraTrees filter (independent of synth_v4)
     learnability_filter_cls_min_score: float = 0.60
     learnability_filter_cls_margin: float = 0.10
     learnability_filter_reg_min_score: float = 0.10
-    icl_filter_model: str = ''       # Path to frozen LimiX checkpoint for ICL-based filtering
+    icl_filter_model: str = ""  # Path to frozen LimiX checkpoint for ICL-based filtering
     icl_filter_cls_min_auc: float = 0.55
     icl_filter_reg_min_r2: float = 0.05
     # Compatibility field for older manifests. The sampled training split is
@@ -161,11 +161,11 @@ class TrainingConfig:
     synth_v5_mixture: bool = False  # mixture prior: 25% v4, 35% v5c, 40% v5a per dataset
 
     # Task-type specialization: 'both' (default 50/50), 'cls', or 'reg'
-    task_type: str = 'both'
+    task_type: str = "both"
 
     # Regression training improvements
     regression_ratio: float = 0.5  # fraction of 'both' steps that are regression
-    regression_loss: str = 'mse'  # 'mse', 'smooth_l1', 'huber', 'pinball', 'bar_distribution'
+    regression_loss: str = "mse"  # 'mse', 'smooth_l1', 'huber', 'pinball', 'bar_distribution'
     regression_loss_beta: float = 1.0  # beta for smooth_l1/huber (ignored for mse)
     regression_quantiles: tuple[float, ...] = (0.1, 0.25, 0.5, 0.75, 0.9)
     # Tail-weighted pinball: upweight extreme quantiles to fix right/left-tail
@@ -206,7 +206,7 @@ class TrainingConfig:
     bar_target_sigma_y: float = 0.0
     # Bar borders mode: 'uniform' (linspace [low, high]) or 'normal_quantile'
     # (N(0,1) quantile-spaced — ~3-4× more bins concentrated near y=0).
-    bar_borders_mode: str = 'uniform'
+    bar_borders_mode: str = "uniform"
     # Auxiliary MSE weight on bar head's expected-value point estimate.
     # Forces softmax(logits)·bin_centers to be calibrated against true y,
     # fixing the "compression" failure mode where bar CE is satisfied but
@@ -216,7 +216,7 @@ class TrainingConfig:
     reg_denoise: bool = False  # reduce noise for regression episodes
     reg_deterministic_prob: float = 0.20  # probability a regression-prior episode is zero-noise
     reg_dense: bool = False  # dense-signal regression mode: flat importances,
-                             # fewer noise features, more parents, higher R²
+    # fewer noise features, more parents, higher R²
 
     # Probabilistic classification labelers (non-percentile class boundaries)
     # When True, ~50% of cls episodes use logistic/tree/Gaussian/threshold labelers
@@ -391,4 +391,4 @@ class TrainingConfig:
 
     # Async data prefetching
     prefetch_workers: int = 4  # number of background data generation processes (0 = disabled)
-    prefetch_count: int = 4    # number of batches to prefetch ahead
+    prefetch_count: int = 4  # number of batches to prefetch ahead

--- a/src/synthefy_nori/training/data_generator.py
+++ b/src/synthefy_nori/training/data_generator.py
@@ -26,6 +26,7 @@ import numpy as np
 # Edge function factories
 # ---------------------------------------------------------------------------
 
+
 def _get_activations(expanded=False):
     """Return list of activation functions for MLP edge functions.
 
@@ -34,13 +35,13 @@ def _get_activations(expanded=False):
                   if False, return original 8 activations.
     """
     base = [
-        lambda x: x,                          # identity
-        np.tanh,                               # tanh
+        lambda x: x,  # identity
+        np.tanh,  # tanh
         lambda x: 1 / (1 + np.exp(-np.clip(x, -20, 20))),  # sigmoid
-        lambda x: np.log1p(np.abs(x)),         # log(1+|x|)
-        np.abs,                                # abs
-        np.sin,                                # sin
-        lambda x: x ** 2,                      # x^2
+        lambda x: np.log1p(np.abs(x)),  # log(1+|x|)
+        np.abs,  # abs
+        np.sin,  # sin
+        lambda x: x**2,  # x^2
         lambda x: x * (1 / (1 + np.exp(-1.702 * np.clip(x, -20, 20)))),  # approx gelu
     ]
     if not expanded:
@@ -52,19 +53,19 @@ def _get_activations(expanded=False):
         lambda x: 1.0507 * np.where(x > 0, x, 1.6733 * (np.exp(np.clip(x, -20, 20)) - 1)),  # SELU
         lambda x: x / (1 + np.exp(-np.clip(x, -20, 20))),  # SiLU / Swish
         lambda x: np.maximum(0, np.minimum(x, 6)),  # ReLU6
-        lambda x: np.clip(x, -1, 1),          # HardTanh
-        lambda x: np.sign(x),                  # signum
-        lambda x: (x > 0).astype(float),       # Heaviside
-        lambda x: np.exp(-x ** 2),             # Gaussian
+        lambda x: np.clip(x, -1, 1),  # HardTanh
+        lambda x: np.sign(x),  # signum
+        lambda x: (x > 0).astype(float),  # Heaviside
+        lambda x: np.exp(-(x**2)),  # Gaussian
         lambda x: np.log1p(np.exp(np.clip(x, -20, 20))),  # softplus
-        lambda x: np.maximum(x, 0),            # ReLU (explicit)
+        lambda x: np.maximum(x, 0),  # ReLU (explicit)
         # Non-standard / diverse
-        lambda x: np.cos(x),                   # cosine
+        lambda x: np.cos(x),  # cosine
         lambda x: np.sign(x) * np.sqrt(np.abs(x)),  # sqrt with sign
-        lambda x: np.clip(x, 0, 1),            # clamp 0-1
+        lambda x: np.clip(x, 0, 1),  # clamp 0-1
         lambda x: np.round(np.clip(x, -10, 10)),  # round
-        lambda x: np.mod(x, 1.0),              # modulo 1
-        lambda x: x ** 3,                      # cube
+        lambda x: np.mod(x, 1.0),  # modulo 1
+        lambda x: x**3,  # cube
         lambda x: np.sign(x) * (np.abs(x) ** 0.5),  # power 0.5
         lambda x: np.sign(x) * (np.abs(x) ** 1.5),  # power 1.5
         lambda x: np.where(x > 0, x, -0.5 * x),  # Leaky ReLU (0.5)
@@ -115,17 +116,17 @@ def _make_random_tree(rng, depth, max_depth):
     if depth >= max_depth or rng.random() < 0.3:
         # Leaf node
         value = rng.uniform(-2, 2)
-        return ('leaf', value)
+        return ("leaf", value)
     threshold = rng.uniform(-4, 4)
     left = _make_random_tree(rng, depth + 1, max_depth)
     right = _make_random_tree(rng, depth + 1, max_depth)
-    return ('split', threshold, left, right)
+    return ("split", threshold, left, right)
 
 
 def _eval_random_tree(tree, x):
     """Evaluate a random tree on scalar input x (vectorized)."""
     kind = tree[0]
-    if kind == 'leaf':
+    if kind == "leaf":
         return np.full(x.shape, tree[1])
     # split node
     _, threshold, left, right = tree
@@ -240,7 +241,7 @@ def _make_rbf_fn(rng):
 
     def rbf_fn(x):
         v = x.ravel()
-        return amplitude * np.exp(-((v - center) ** 2) / (2 * sigma ** 2))
+        return amplitude * np.exp(-((v - center) ** 2) / (2 * sigma**2))
 
     return rbf_fn
 
@@ -251,11 +252,13 @@ def _make_logexp_fn(rng):
     a = rng.uniform(0.5, 2.0)
 
     if use_log:
+
         def logexp_fn(x):
             v = x.ravel()
             return a * np.log1p(np.abs(v)) * np.sign(v)
     else:
         b = rng.uniform(0.3, 1.5)
+
         def logexp_fn(x):
             v = np.clip(x.ravel(), -5, 5)
             return a * (np.exp(b * v) - 1)
@@ -280,11 +283,13 @@ def _make_quadratic_fn(rng, in_dim=1):
     b = rng.uniform(-0.5, 0.5)
 
     if in_dim == 1:
+
         def quadratic_fn(x):
             v = np.clip(x.ravel(), -5, 5)
-            out = M[0, 0] * v ** 2 + w[0] * v + b
+            out = M[0, 0] * v**2 + w[0] * v + b
             return 50.0 * np.tanh(out / 50.0)
     else:
+
         def quadratic_fn(x):
             # x: [n_samples, in_dim]
             x_clipped = np.clip(x, -5, 5)
@@ -303,8 +308,14 @@ def _make_product_fn(rng, in_dim):
     interactions between two different random functions.
     """
     # Use simpler functions for the two factors (avoid recursion/slowness)
-    simple_makers = [_make_piecewise_fn, _make_poly_fn, _make_periodic_fn,
-                     _make_rbf_fn, _make_logexp_fn, _make_quadratic_fn]
+    simple_makers = [
+        _make_piecewise_fn,
+        _make_poly_fn,
+        _make_periodic_fn,
+        _make_rbf_fn,
+        _make_logexp_fn,
+        _make_quadratic_fn,
+    ]
     fn1 = simple_makers[int(rng.integers(0, len(simple_makers)))](rng)
     fn2 = simple_makers[int(rng.integers(0, len(simple_makers)))](rng)
 
@@ -321,7 +332,7 @@ def _make_multidim_scalar_fn(in_dim, rng, expanded=False):
     then applies a scalar edge function. Returns [n_samples].
     """
     proj = rng.standard_normal(in_dim)
-    proj /= (np.linalg.norm(proj) + 1e-8)
+    proj /= np.linalg.norm(proj) + 1e-8
     scalar_fn = _make_edge_fn(1, rng, expanded=expanded)
 
     def multidim_fn(x):
@@ -378,6 +389,7 @@ def _make_edge_fn(in_dim, rng, expanded=False):
 # Root node distribution sampling
 # ---------------------------------------------------------------------------
 
+
 def _sample_root(n_samples, rng):
     """Sample root node values from a random distribution."""
     choice = rng.integers(0, 7)
@@ -416,6 +428,7 @@ def _sample_root(n_samples, rng):
 # ---------------------------------------------------------------------------
 # Aggregation functions
 # ---------------------------------------------------------------------------
+
 
 def _aggregate(parent_values, rng, expanded=False):
     """Aggregate values from multiple parents.
@@ -467,12 +480,21 @@ def _aggregate(parent_values, rng, expanded=False):
 # Local Causal Structure (LCS)
 # ---------------------------------------------------------------------------
 
+
 class LocalCausalStructure:
     """A small causal graph with 3-8 nodes, topologically ordered."""
 
-    def __init__(self, n_nodes, external_parent_indices, rng, expanded=False,
-                 synth_v5=False, external_d_nodes=None, synth_v5_declone=True,
-                 max_parents=4):
+    def __init__(
+        self,
+        n_nodes,
+        external_parent_indices,
+        rng,
+        expanded=False,
+        synth_v5=False,
+        external_d_nodes=None,
+        synth_v5_declone=True,
+        max_parents=4,
+    ):
         """
         n_nodes: number of nodes in this LCS
         external_parent_indices: list of global indices of nodes from
@@ -518,8 +540,9 @@ class LocalCausalStructure:
 
             # Possible parents: internal nodes with idx < i, plus external nodes
             internal_candidates = list(range(i))
-            all_candidates = [(True, idx) for idx in internal_candidates] + \
-                             [(False, idx) for idx in external_parent_indices]
+            all_candidates = [(True, idx) for idx in internal_candidates] + [
+                (False, idx) for idx in external_parent_indices
+            ]
 
             if len(all_candidates) == 0:
                 # Root node
@@ -529,7 +552,7 @@ class LocalCausalStructure:
 
             # Randomly select 1..max_parents parents.  ``Generator.integers``
             # excludes its upper bound, so include it explicitly.
-            max_p = getattr(self, '_max_parents', 4)
+            max_p = getattr(self, "_max_parents", 4)
             n_parents = min(rng.integers(1, max_p + 1), len(all_candidates))
             chosen = rng.choice(len(all_candidates), size=n_parents, replace=False)
             parents = [all_candidates[c] for c in chosen]
@@ -542,18 +565,13 @@ class LocalCausalStructure:
                 return external_d_nodes.get(idx, 1)
 
             # Concat-then-transform mode: synth_v5, 2+ parents, 40% probability
-            use_concat = (synth_v5 and len(parents) >= 2
-                          and rng.random() < 0.4)
+            use_concat = synth_v5 and len(parents) >= 2 and rng.random() < 0.4
             self.concat_mode[i] = use_concat
 
             if use_concat:
                 # Single multivariate function for all parents concatenated
-                total_in_dim = sum(
-                    _parent_dim(is_internal, idx)
-                    for is_internal, idx in parents
-                )
-                self.edge_fns[i] = [_make_concat_edge_fn(
-                    total_in_dim, rng, expanded=expanded)]
+                total_in_dim = sum(_parent_dim(is_internal, idx) for is_internal, idx in parents)
+                self.edge_fns[i] = [_make_concat_edge_fn(total_in_dim, rng, expanded=expanded)]
             else:
                 # Per-parent edge functions (original behavior)
                 fns = []
@@ -561,8 +579,7 @@ class LocalCausalStructure:
                     parent_d = _parent_dim(is_internal, idx)
                     if synth_v5 and parent_d > 1:
                         # Multi-dim parent: project d->1 then scalar fn
-                        fns.append(_make_multidim_scalar_fn(parent_d, rng,
-                                                            expanded=expanded))
+                        fns.append(_make_multidim_scalar_fn(parent_d, rng, expanded=expanded))
                     else:
                         fns.append(_make_edge_fn(1, rng, expanded=expanded))
                 self.edge_fns[i] = fns
@@ -612,8 +629,7 @@ class LocalCausalStructure:
             base = result.reshape(-1, 1)
             # Clip scales to [0.3, 1.7] to prevent sign flips and
             # extreme amplification that caused cascading overflow
-            scales = np.clip(
-                self.rng.normal(loc=1.0, scale=0.35, size=d), 0.3, 1.7)
+            scales = np.clip(self.rng.normal(loc=1.0, scale=0.35, size=d), 0.3, 1.7)
             base = base * scales[None, :]
             sig = max(float(np.std(result)), 1e-6)
             noise_rel = sig * self.rng.uniform(0.20, 0.80)
@@ -682,13 +698,11 @@ class LocalCausalStructure:
                     if parent_val.ndim == 1:
                         parent_val = parent_val.reshape(-1, 1)
                     parent_contributions.append(fn(parent_val))
-                agg_result = _aggregate(parent_contributions, self.rng,
-                                        expanded=self.expanded)
+                agg_result = _aggregate(parent_contributions, self.rng, expanded=self.expanded)
                 # Standardize after aggregation
                 agg_result = self._robust_standardize(agg_result)
                 if d > 1:
-                    agg_result = self._expand_to_multidim(
-                        agg_result, d, n_samples)
+                    agg_result = self._expand_to_multidim(agg_result, d, n_samples)
                 values.append(agg_result)
         return values
 
@@ -697,8 +711,8 @@ class LocalCausalStructure:
 # Hierarchical SCM
 # ---------------------------------------------------------------------------
 
-def _build_hierarchical_scm(n_features, rng, expanded=False, synth_v5=False,
-                            synth_v5_declone=True, max_parents=4):
+
+def _build_hierarchical_scm(n_features, rng, expanded=False, synth_v5=False, synth_v5_declone=True, max_parents=4):
     """Build a hierarchical SCM with multiple LCS.
 
     Returns:
@@ -723,11 +737,16 @@ def _build_hierarchical_scm(n_features, rng, expanded=False, synth_v5=False,
         # External parents from previous LCS nodes
         external_parents = list(range(node_offset))
 
-        lcs = LocalCausalStructure(n_nodes, external_parents, rng,
-                                   expanded=expanded, synth_v5=synth_v5,
-                                   external_d_nodes=global_d_nodes,
-                                   synth_v5_declone=synth_v5_declone,
-                                   max_parents=max_parents)
+        lcs = LocalCausalStructure(
+            n_nodes,
+            external_parents,
+            rng,
+            expanded=expanded,
+            synth_v5=synth_v5,
+            external_d_nodes=global_d_nodes,
+            synth_v5_declone=synth_v5_declone,
+            max_parents=max_parents,
+        )
         lcs_list.append((lcs, node_offset))
         for j in range(n_nodes):
             global_idx = node_offset + j
@@ -758,9 +777,11 @@ def _finite_mean_std(values):
     scaled = finite_values / scale
     return float(np.mean(scaled) * scale), float(np.std(scaled) * scale)
 
+
 def _finite_std(values):
     """Return a warning-free finite-only standard deviation."""
     return _finite_mean_std(values)[1]
+
 
 def _finite_column_variation(values, tolerance=1e-8):
     """Identify columns with finite variation without all-NaN warnings."""
@@ -793,13 +814,12 @@ def _finite_column_variation(values, tolerance=1e-8):
     absolute_std = np.sqrt(variances) * scales
     return (counts >= 2) & (absolute_std > float(tolerance))
 
+
 def _finite_column_means(values):
     """Return finite-only column means, using zero for empty columns."""
     values = np.asarray(values, dtype=np.float64)
-    return np.asarray([
-        _finite_mean_std(values[:, col])[0]
-        for col in range(values.shape[1])
-    ], dtype=np.float64)
+    return np.asarray([_finite_mean_std(values[:, col])[0] for col in range(values.shape[1])], dtype=np.float64)
+
 
 def _finite_percentile(values, percentile):
     """Return a finite-only percentile, or None when no fit data exists."""
@@ -809,8 +829,8 @@ def _finite_percentile(values, percentile):
         return None
     return float(np.percentile(finite_values, percentile))
 
-def _calibrate_noise_to_target_r2(
-        signal, raw_noise, target_r2, context_rows=None):
+
+def _calibrate_noise_to_target_r2(signal, raw_noise, target_r2, context_rows=None):
     """Scale the complete sampled noise vector to an empirical target R².
 
     The noise shape (heteroskedasticity and sparse outliers) is sampled first.
@@ -844,22 +864,17 @@ def _calibrate_noise_to_target_r2(
     cross = float(np.dot(signal_centered, noise_reference))
     r2 = max(float(target_r2), 1e-8)
     residual_fraction = 1.0 - r2
-    discriminant = (
-        residual_fraction ** 2 * cross ** 2
-        + r2 * noise_ss * residual_fraction * signal_ss
-    )
-    scale = (
-        residual_fraction * cross + np.sqrt(max(discriminant, 0.0))
-    ) / (r2 * noise_ss)
+    discriminant = residual_fraction**2 * cross**2 + r2 * noise_ss * residual_fraction * signal_ss
+    scale = (residual_fraction * cross + np.sqrt(max(discriminant, 0.0))) / (r2 * noise_ss)
     noise *= max(float(scale), 0.0)
     noisy_reference = signal_reference + noise[:labeled_rows]
     noisy_centered = noisy_reference - np.mean(noisy_reference)
     total_ss = float(np.dot(noisy_centered, noisy_centered))
     realized_r2 = (
-        1.0 - float(np.dot(noise[:labeled_rows], noise[:labeled_rows])) / total_ss
-        if total_ss > 1e-12 else 1.0
+        1.0 - float(np.dot(noise[:labeled_rows], noise[:labeled_rows])) / total_ss if total_ss > 1e-12 else 1.0
     )
     return noise, float(np.clip(realized_r2, 0.0, 1.0))
+
 
 def _normalize_target_pair(y, y_clean, context_rows=None):
     """Normalize noisy/clean targets with one labeled-context affine map."""
@@ -872,8 +887,8 @@ def _normalize_target_pair(y, y_clean, context_rows=None):
         return (y - mu) / std, (y_clean - mu) / std, mu, std
     return y - mu, y_clean - mu, mu, std
 
-def _add_entity_lookup_signal(y_raw, entity_lookup_signal, rng, meta,
-                              context_rows=None):
+
+def _add_entity_lookup_signal(y_raw, entity_lookup_signal, rng, meta, context_rows=None):
     """Add categorical/group-relative signal at a controlled variance ratio."""
     labeled_rows = _resolve_context_rows(len(y_raw), context_rows)
     entity_std = np.std(entity_lookup_signal[:labeled_rows])
@@ -884,14 +899,12 @@ def _add_entity_lookup_signal(y_raw, entity_lookup_signal, rng, meta,
     if y_std_orig < 1e-8:
         y_std_orig = 1.0
     target_ratio = rng.uniform(0.25, 0.55)
-    entity_scale = (
-        np.sqrt(target_ratio / max(1 - target_ratio, 1e-6))
-        * y_std_orig / entity_std
-    )
+    entity_scale = np.sqrt(target_ratio / max(1 - target_ratio, 1e-6)) * y_std_orig / entity_std
     y_with_effect = y_raw + entity_lookup_signal * entity_scale
-    meta['entity_lookup_signal_std'] = float(entity_std)
-    meta['entity_lookup_target_ratio'] = float(target_ratio)
+    meta["entity_lookup_signal_std"] = float(entity_std)
+    meta["entity_lookup_target_ratio"] = float(target_ratio)
     return np.where(np.isfinite(y_with_effect), y_with_effect, 0.0)
+
 
 def _scale_rich_target_component(extra, y_raw, rng, context_rows=None):
     """Scale a rich-target component using labeled-context variance only."""
@@ -901,11 +914,9 @@ def _scale_rich_target_component(extra, y_raw, rng, context_rows=None):
     if extra_std <= 1e-8 or y_std_orig <= 1e-8:
         return extra
     target_ratio = float(rng.uniform(0.3, 0.7))
-    extra_scale = (
-        np.sqrt(target_ratio / (1.0 - target_ratio))
-        * y_std_orig / extra_std
-    )
+    extra_scale = np.sqrt(target_ratio / (1.0 - target_ratio)) * y_std_orig / extra_std
     return extra * extra_scale
+
 
 def _apply_feature_dependent_tail_missingness(X, rng, context_rows=None):
     """Mask feature columns from an observed covariate's context-fitted tail."""
@@ -940,6 +951,7 @@ def _apply_feature_dependent_tail_missingness(X, rng, context_rows=None):
     # control flow, even though they may still be masked row-locally above.
     return bool(np.any(tail_rows[:labeled_rows]))
 
+
 def _resolve_context_rows(n_samples, context_rows):
     """Return the labeled-row budget used to calibrate synth-v6 complexity."""
     if context_rows is None:
@@ -948,8 +960,8 @@ def _resolve_context_rows(n_samples, context_rows):
         raise ValueError("context_rows must be at least 1")
     return max(1, min(int(context_rows), int(n_samples)))
 
-def _sample_context_safe_duplicate_indices(
-        n_samples, n_duplicates, rng, context_rows=None):
+
+def _sample_context_safe_duplicate_indices(n_samples, n_duplicates, rng, context_rows=None):
     """Sample duplicates without ever copying a query row into context.
 
     Context-to-query copies remain possible because repeated measurements can
@@ -962,13 +974,12 @@ def _sample_context_safe_duplicate_indices(
     # Preserve the released draw order and exact no-split behavior. Only
     # redraw pairs whose original direction would copy query into context.
     src_idx = rng.choice(n_samples, size=size, replace=True)
-    dst_idx = rng.choice(
-        n_samples, size=size, replace=False)
+    dst_idx = rng.choice(n_samples, size=size, replace=False)
     unsafe = (src_idx >= labeled_rows) & (dst_idx < labeled_rows)
     if np.any(unsafe):
-        src_idx[unsafe] = rng.integers(
-            0, labeled_rows, size=int(np.sum(unsafe)))
+        src_idx[unsafe] = rng.integers(0, labeled_rows, size=int(np.sum(unsafe)))
     return src_idx, dst_idx
+
 
 def _context_prefix(values, context_rows):
     """Return the labeled prefix used to fit episode-level transforms."""
@@ -976,10 +987,12 @@ def _context_prefix(values, context_rows):
     labeled_rows = _resolve_context_rows(len(values), context_rows)
     return values[:labeled_rows]
 
+
 def _context_mean_std(values, context_rows):
     """Fit location and scale without inspecting query targets."""
     reference = _context_prefix(values, context_rows)
     return _finite_mean_std(reference)
+
 
 def _signed_expm1_with_linear_tails(values, scale, limit=20.0):
     """Apply signed expm1 without allowing query-only tails to overflow."""
@@ -992,6 +1005,7 @@ def _signed_expm1_with_linear_tails(values, scale, limit=20.0):
         warped[above] += np.exp(limit) * (magnitude[above] - limit)
     return np.sign(values) * warped
 
+
 def _signed_power_with_linear_tails(values, power, limit=20.0):
     """Apply a signed power centrally and linearize extreme query tails."""
     values = np.asarray(values, dtype=np.float64)
@@ -1003,6 +1017,7 @@ def _signed_power_with_linear_tails(values, power, limit=20.0):
         slope = float(power) * float(limit) ** (float(power) - 1.0)
         warped[above] += slope * (magnitude[above] - limit)
     return np.sign(values) * warped
+
 
 def _exp_with_linear_tails(values, limit=20.0):
     """Exponentiate centrally while keeping extreme tails injective."""
@@ -1019,6 +1034,7 @@ def _exp_with_linear_tails(values, limit=20.0):
     warped[above] = upper_value * (1.0 + z[above] - limit)
     result[finite] = warped
     return result
+
 
 def _sigmoid_with_linear_tails(values, limit=8.0):
     """Apply a sigmoid centrally with monotone non-saturating tails."""
@@ -1039,8 +1055,8 @@ def _sigmoid_with_linear_tails(values, limit=8.0):
     result[finite] = warped
     return result
 
-def _apply_invertible_feature_correlation(
-        X, cols, rng, rho, context_rows=None):
+
+def _apply_invertible_feature_correlation(X, cols, rng, rho, context_rows=None):
     """Correlate columns with a full-rank coordinate transform.
 
     Unlike adding an unobserved random shared factor after y is generated, this
@@ -1059,30 +1075,24 @@ def _apply_invertible_feature_correlation(
     labeled_rows = _resolve_context_rows(len(group), context_rows)
     reference = group[:labeled_rows]
     missing = ~np.isfinite(group)
-    means = np.asarray([
-        np.mean(column[np.isfinite(column)])
-        if np.isfinite(column).any() else 0.0
-        for column in reference.T
-    ])
+    means = np.asarray(
+        [np.mean(column[np.isfinite(column)]) if np.isfinite(column).any() else 0.0 for column in reference.T]
+    )
     filled = np.where(missing, means[None, :], group)
-    scales = np.asarray([
-        np.std(column[np.isfinite(column)])
-        if np.isfinite(column).any() else 0.0
-        for column in reference.T
-    ])
+    scales = np.asarray(
+        [np.std(column[np.isfinite(column)]) if np.isfinite(column).any() else 0.0 for column in reference.T]
+    )
     scales = np.where(scales > 1e-8, scales, 1.0)
     standardized = (filled - means[None, :]) / scales[None, :]
 
     signs = rng.choice(np.asarray([-1.0, 1.0]), size=len(cols))
-    covariance = (
-        (1.0 - rho) * np.eye(len(cols), dtype=np.float64)
-        + rho * np.outer(signs, signs)
-    )
+    covariance = (1.0 - rho) * np.eye(len(cols), dtype=np.float64) + rho * np.outer(signs, signs)
     transform = np.linalg.cholesky(covariance)
     mixed = standardized @ transform.T
     mixed[missing] = np.nan
     X[:, cols] = mixed
     return transform, means, scales
+
 
 def _affine_stabilize_feature_column(values, context_rows=None):
     """Return a finite-range affine reparameterization, preserving NaNs.
@@ -1107,8 +1117,8 @@ def _affine_stabilize_feature_column(values, context_rows=None):
         result[finite] = values[finite] - mean
     return result
 
-def _finalize_feature_batch(
-        X_batch, max_abs=1e4, context_rows=None):
+
+def _finalize_feature_batch(X_batch, max_abs=1e4, context_rows=None):
     """Apply context-stable numeric safety to every generated family.
 
     Context-wide affine corrections fit only the labeled prefix. Remaining
@@ -1122,8 +1132,7 @@ def _finalize_feature_batch(
     X_out = np.asarray(X_batch, dtype=np.float64).copy()
     labeled_rows = _resolve_context_rows(X_out.shape[1], context_rows)
     if np.isinf(X_out[:, :labeled_rows]).any():
-        raise SyntheticDataFilterError(
-            'final synthetic context contains infinity')
+        raise SyntheticDataFilterError("final synthetic context contains infinity")
     affine_changes = []
     bounded_changes = []
     for batch_idx in range(X_out.shape[0]):
@@ -1132,18 +1141,12 @@ def _finalize_feature_batch(
             reference = col[:labeled_rows]
             finite_reference = reference[np.isfinite(reference)]
             affine_changed = False
-            if (
-                len(finite_reference)
-                and float(np.max(np.abs(finite_reference))) > max_abs
-            ):
-                col = _affine_stabilize_feature_column(
-                    col, context_rows=labeled_rows)
+            if len(finite_reference) and float(np.max(np.abs(finite_reference))) > max_abs:
+                col = _affine_stabilize_feature_column(col, context_rows=labeled_rows)
                 finite_reference = col[:labeled_rows]
-                finite_reference = finite_reference[
-                    np.isfinite(finite_reference)]
+                finite_reference = finite_reference[np.isfinite(finite_reference)]
                 if len(finite_reference):
-                    remaining_max = float(
-                        np.max(np.abs(finite_reference)))
+                    remaining_max = float(np.max(np.abs(finite_reference)))
                     if remaining_max > max_abs:
                         col *= max_abs / remaining_max
                 affine_changed = True
@@ -1153,12 +1156,10 @@ def _finalize_feature_batch(
             # target oracle is not treated as exact.
             bounded = col.copy()
             finite = np.isfinite(col)
-            bounded[finite] = np.clip(
-                col[finite], -max_abs, max_abs)
+            bounded[finite] = np.clip(col[finite], -max_abs, max_abs)
             bounded[np.isposinf(col)] = max_abs
             bounded[np.isneginf(col)] = -max_abs
-            bounded_changed = not np.array_equal(
-                col, bounded, equal_nan=True)
+            bounded_changed = not np.array_equal(col, bounded, equal_nan=True)
             if bounded_changed:
                 col = bounded
             if affine_changed or bounded_changed:
@@ -1181,23 +1182,25 @@ def _is_numerical_scoreability_error(error):
     recognize the narrow messages emitted for non-finite or numerically
     overflowing data; callers must propagate every other exception.
     """
-    if isinstance(error, (FloatingPointError, OverflowError,
-                          np.linalg.LinAlgError)):
+    if isinstance(error, (FloatingPointError, OverflowError, np.linalg.LinAlgError)):
         return True
     if not isinstance(error, ValueError):
         return False
     message = str(error).lower()
-    return re.search(
-        r'\b(?:nan|nans|inf|infs|infinite|infinity|overflow|numerical)\b'
-        r'|\bnon[-_ ]?finite\b|\bnot finite\b|\bvalue too large\b',
-        message,
-    ) is not None
+    return (
+        re.search(
+            r"\b(?:nan|nans|inf|infs|infinite|infinity|overflow|numerical)\b"
+            r"|\bnon[-_ ]?finite\b|\bnot finite\b|\bvalue too large\b",
+            message,
+        )
+        is not None
+    )
 
 
 def _check_learnability(
     X,
     y,
-    task_type='reg',
+    task_type="reg",
     *,
     cls_min_score=0.60,
     cls_margin=0.10,
@@ -1219,15 +1222,14 @@ def _check_learnability(
     n, f = X.shape
     if n < 20:
         return False
-    if (not np.isfinite(y).all() or np.isinf(X).any()
-            or (context_rows is None and _finite_std(y) <= 1e-8)):
+    if not np.isfinite(y).all() or np.isinf(X).any() or (context_rows is None and _finite_std(y) <= 1e-8):
         return False
 
     # Subsample large tables to keep ExtraTrees fast in prefetch workers.
     # 1000 rows is enough for a reliable OOB signal; fitting on 4096×384
     # is ~16x slower and causes CPU starvation with multiple DDP workers.
     max_rows = 1000
-    split_mode = task_type == 'reg' and context_rows is not None
+    split_mode = task_type == "reg" and context_rows is not None
     if split_mode:
         labeled_rows = _resolve_context_rows(n, context_rows)
         query_rows = n - labeled_rows
@@ -1235,10 +1237,8 @@ def _check_learnability(
             return False
         context_count = min(labeled_rows, max_rows)
         query_count = min(query_rows, max_rows)
-        context_idx = np.linspace(
-            0, labeled_rows - 1, context_count).round().astype(np.int64)
-        query_idx = labeled_rows + np.linspace(
-            0, query_rows - 1, query_count).round().astype(np.int64)
+        context_idx = np.linspace(0, labeled_rows - 1, context_count).round().astype(np.int64)
+        query_idx = labeled_rows + np.linspace(0, query_rows - 1, query_count).round().astype(np.int64)
         X_fit, y_fit = X[context_idx], y[context_idx]
         X_test, y_test = X[query_idx], y[query_idx]
         if _finite_std(y_fit) <= 1e-8 or _finite_std(y_test) <= 1e-8:
@@ -1251,18 +1251,14 @@ def _check_learnability(
 
     # Use a fast model with limited depth
     model_kwargs = {
-        'n_estimators': 15,
-        'max_depth': 6,
-        'random_state': 0,
-        'n_jobs': 1,
+        "n_estimators": 15,
+        "max_depth": 6,
+        "random_state": 0,
+        "n_jobs": 1,
     }
     if not split_mode:
         model_kwargs.update(bootstrap=True, oob_score=True)
-    model = (
-        ExtraTreesClassifier(**model_kwargs)
-        if task_type == 'cls'
-        else ExtraTreesRegressor(**model_kwargs)
-    )
+    model = ExtraTreesClassifier(**model_kwargs) if task_type == "cls" else ExtraTreesRegressor(**model_kwargs)
 
     # Replace NaN with 0 for sklearn
     X_clean = np.nan_to_num(X_fit, nan=0.0)
@@ -1272,10 +1268,7 @@ def _check_learnability(
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             model.fit(X_clean, y_fit_clean)
-            score = (
-                model.score(np.nan_to_num(X_test, nan=0.0), y_test)
-                if split_mode else float(model.oob_score_)
-            )
+            score = model.score(np.nan_to_num(X_test, nan=0.0), y_test) if split_mode else float(model.oob_score_)
     except Exception as error:
         if _is_numerical_scoreability_error(error):
             return False
@@ -1283,7 +1276,7 @@ def _check_learnability(
     score = float(score)
     if not np.isfinite(score):
         return False
-    if task_type == 'cls':
+    if task_type == "cls":
         n_classes = len(np.unique(y_fit_clean))
         return score > max(1.0 / max(n_classes, 1) + cls_margin, cls_min_score)
     return score > reg_min_score
@@ -1292,7 +1285,7 @@ def _check_learnability(
 def _check_icl_scaling(
     X,
     y,
-    task_type='reg',
+    task_type="reg",
     *,
     reg_min_score=0.10,
     min_improvement=0.03,
@@ -1310,13 +1303,12 @@ def _check_icl_scaling(
     n, f = X.shape
     if n < 60:
         return False
-    if (not np.isfinite(y).all() or np.isinf(X).any()
-            or (context_rows is None and _finite_std(y) <= 1e-8)):
+    if not np.isfinite(y).all() or np.isinf(X).any() or (context_rows is None and _finite_std(y) <= 1e-8):
         return False
 
     max_rows = 1000
     rng = np.random.default_rng(1)
-    split_mode = task_type == 'reg' and context_rows is not None
+    split_mode = task_type == "reg" and context_rows is not None
     if split_mode:
         labeled_rows = _resolve_context_rows(n, context_rows)
         query_rows = n - labeled_rows
@@ -1328,11 +1320,13 @@ def _check_icl_scaling(
             query_count = min(query_rows, 20)
         context_idx = (
             rng.choice(labeled_rows, size=context_count, replace=False)
-            if labeled_rows > context_count else np.arange(labeled_rows)
+            if labeled_rows > context_count
+            else np.arange(labeled_rows)
         )
         query_idx = labeled_rows + (
             rng.choice(query_rows, size=query_count, replace=False)
-            if query_rows > query_count else np.arange(query_rows)
+            if query_rows > query_count
+            else np.arange(query_rows)
         )
         X_pool = np.nan_to_num(X[context_idx], nan=0.0)
         y_pool = y[context_idx]
@@ -1365,8 +1359,7 @@ def _check_icl_scaling(
     max_ctx = n_pool
     if max_ctx <= min_ctx:
         return False
-    context_sizes = np.unique(
-        np.geomspace(min_ctx, max_ctx, n_context_sizes).astype(int))
+    context_sizes = np.unique(np.geomspace(min_ctx, max_ctx, n_context_sizes).astype(int))
     if len(context_sizes) < 2:
         return False
 
@@ -1378,13 +1371,8 @@ def _check_icl_scaling(
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                model_cls = (
-                    ExtraTreesClassifier
-                    if task_type == 'cls' else ExtraTreesRegressor
-                )
-                model = model_cls(
-                    n_estimators=10, max_depth=5,
-                    random_state=0, n_jobs=1)
+                model_cls = ExtraTreesClassifier if task_type == "cls" else ExtraTreesRegressor
+                model = model_cls(n_estimators=10, max_depth=5, random_state=0, n_jobs=1)
                 model.fit(X_train, y_train)
                 score = model.score(X_test, y_test)
         except Exception as error:
@@ -1398,7 +1386,7 @@ def _check_icl_scaling(
         return False
     final_score = scores[-1]
     improvement = scores[-1] - scores[0]
-    if task_type == 'cls':
+    if task_type == "cls":
         chance = 1.0 / max(len(np.unique(y)), 2)
         return final_score > chance + 0.05 and improvement > min_improvement
     return final_score > reg_min_score and improvement > min_improvement
@@ -1420,10 +1408,12 @@ def _get_icl_filter_model(model_path):
         return _icl_filter_model
 
     import torch
+
     torch.set_num_threads(2)
     torch.set_num_interop_threads(1)
 
     from synthefy_nori.utils.loading import load_model
+
     model = load_model(model_path, mask_prediction=True)
     model.eval()
     for p in model.parameters():
@@ -1454,7 +1444,7 @@ def _check_learnability_icl(
     # task_type contract.
     if model_path is None:
         model_path = task_type
-        task_type = 'reg'
+        task_type = "reg"
 
     X = np.asarray(X)
     y = np.asarray(y)
@@ -1463,8 +1453,7 @@ def _check_learnability_icl(
     n, f = X.shape
     if n < 20:
         return False
-    if (not np.isfinite(y).all() or np.isinf(X).any()
-            or (context_rows is None and _finite_std(y) <= 1e-8)):
+    if not np.isfinite(y).all() or np.isinf(X).any() or (context_rows is None and _finite_std(y) <= 1e-8):
         return False
 
     model = _get_icl_filter_model(model_path)
@@ -1473,7 +1462,7 @@ def _check_learnability_icl(
         feat_idx = rng.choice(f, size=max_features, replace=False)
         X = X[:, feat_idx]
 
-    split_mode = task_type == 'reg' and context_rows is not None
+    split_mode = task_type == "reg" and context_rows is not None
     if split_mode:
         labeled_rows = _resolve_context_rows(n, context_rows)
         query_rows = n - labeled_rows
@@ -1482,20 +1471,15 @@ def _check_learnability_icl(
         n_ctx = min(max_context, labeled_rows)
         n_qry = min(max_query, query_rows)
         context_idx = (
-            rng.choice(labeled_rows, size=n_ctx, replace=False)
-            if labeled_rows > n_ctx else np.arange(labeled_rows)
+            rng.choice(labeled_rows, size=n_ctx, replace=False) if labeled_rows > n_ctx else np.arange(labeled_rows)
         )
         query_idx = labeled_rows + (
-            rng.choice(query_rows, size=n_qry, replace=False)
-            if query_rows > n_qry else np.arange(query_rows)
+            rng.choice(query_rows, size=n_qry, replace=False) if query_rows > n_qry else np.arange(query_rows)
         )
         idx = np.concatenate([context_idx, query_idx])
     else:
         total = min(n, max_context + max_query)
-        idx = (
-            rng.choice(n, size=total, replace=False)
-            if n > total else np.arange(n)
-        )
+        idx = rng.choice(n, size=total, replace=False) if n > total else np.arange(n)
         n_ctx = min(max_context, total - 10)
         n_qry = total - n_ctx
 
@@ -1503,20 +1487,18 @@ def _check_learnability_icl(
     y_sub = y[idx].copy()
     X_sub = np.nan_to_num(X_sub, nan=0.0).astype(np.float32)
 
-    if task_type == 'cls':
+    if task_type == "cls":
         classes = np.unique(y_sub[np.isfinite(y_sub)])
         n_classes = len(classes)
         if n_classes < 2:
             return False
         label_map = {c: i for i, c in enumerate(classes)}
-        y_sub = np.array(
-            [label_map.get(v, 0) for v in y_sub], dtype=np.float32)
+        y_sub = np.array([label_map.get(v, 0) for v in y_sub], dtype=np.float32)
         n_classes = min(n_classes, 10)
     else:
         y_sub = y_sub.astype(np.float32)
         ctx_mean, ctx_std = _finite_mean_std(y_sub[:n_ctx])
-        if (not np.isfinite(ctx_mean) or not np.isfinite(ctx_std)
-                or ctx_std < 1e-8):
+        if not np.isfinite(ctx_mean) or not np.isfinite(ctx_std) or ctx_std < 1e-8:
             return False
         y_sub = (y_sub - ctx_mean) / ctx_std
         n_classes = None
@@ -1525,20 +1507,23 @@ def _check_learnability_icl(
     y_t = torch.from_numpy(y_sub).unsqueeze(0)
     with torch.no_grad():
         out = model(
-            x_t, y_t, eval_pos=n_ctx, task_type=task_type,
-            y_type='cls' if task_type == 'cls' else 'reg',
+            x_t,
+            y_t,
+            eval_pos=n_ctx,
+            task_type=task_type,
+            y_type="cls" if task_type == "cls" else "reg",
         )
 
-    if task_type == 'cls':
-        logits = out['cls_output'][:, :n_qry, :n_classes]
+    if task_type == "cls":
+        logits = out["cls_output"][:, :n_qry, :n_classes]
         preds = logits.argmax(dim=-1).squeeze(0).numpy()
-        true = y_sub[n_ctx:n_ctx + n_qry]
+        true = y_sub[n_ctx : n_ctx + n_qry]
         acc = np.mean(preds == true)
         chance = 1.0 / n_classes
         return np.isfinite(acc) and acc > chance + (cls_min_auc - 0.5)
 
-    preds = out['reg_output'][:, :n_qry, 0].squeeze(0).numpy()
-    true = y_sub[n_ctx:n_ctx + n_qry]
+    preds = out["reg_output"][:, :n_qry, 0].squeeze(0).numpy()
+    true = y_sub[n_ctx : n_ctx + n_qry]
     if not np.isfinite(preds).all() or not np.isfinite(true).all():
         return False
     ss_res = np.sum((true - preds) ** 2)
@@ -1557,22 +1542,18 @@ def _extract_quality_task_rules(quality_rules, task_type):
     """
     if not quality_rules or not isinstance(quality_rules, dict):
         return None
-    task_map = quality_rules.get('task_rules', quality_rules)
-    if task_type == 'cls':
-        return task_map.get('classification') or task_map.get('cls')
-    return task_map.get('regression') or task_map.get('reg')
+    task_map = quality_rules.get("task_rules", quality_rules)
+    if task_type == "cls":
+        return task_map.get("classification") or task_map.get("cls")
+    return task_map.get("regression") or task_map.get("reg")
 
 
-def _compute_health_stats_fast(
-        X, y, task_type='reg', context_rows=None):
+def _compute_health_stats_fast(X, y, task_type="reg", context_rows=None):
     """Compute fast, training-time dataset health stats for filtering."""
     X = np.asarray(X)
     y = np.asarray(y)
     n_samples, n_features = X.shape
-    labeled_rows = (
-        _resolve_context_rows(n_samples, context_rows)
-        if task_type == 'reg' else n_samples
-    )
+    labeled_rows = _resolve_context_rows(n_samples, context_rows) if task_type == "reg" else n_samples
     X_reference = X[:labeled_rows]
     y_reference = y[:labeled_rows]
 
@@ -1586,58 +1567,56 @@ def _compute_health_stats_fast(
         const_frac = float(1.0 - (nonconst / max(n_features, 1)))
 
     stats = {
-        'nan_frac': nan_frac,
-        'const_feature_frac': const_frac,
-        'nonconstant_features': nonconst,
-        'n_samples': int(n_samples),
-        'n_features': int(n_features),
+        "nan_frac": nan_frac,
+        "const_feature_frac": const_frac,
+        "nonconstant_features": nonconst,
+        "n_samples": int(n_samples),
+        "n_features": int(n_features),
     }
 
-    if task_type == 'cls':
+    if task_type == "cls":
         y_int = y_reference.astype(np.int64, copy=False)
         vals, counts = np.unique(y_int, return_counts=True)
-        stats['y_unique'] = int(len(vals))
-        stats['minority_frac'] = float(counts.min() / max(len(y_int), 1)) if len(counts) > 0 else 0.0
+        stats["y_unique"] = int(len(vals))
+        stats["minority_frac"] = float(counts.min() / max(len(y_int), 1)) if len(counts) > 0 else 0.0
     else:
         y_f = y_reference.astype(np.float64, copy=False)
         y_f = np.nan_to_num(y_f, nan=0.0, posinf=0.0, neginf=0.0)
-        stats['y_std'] = _finite_std(y_f)
+        stats["y_std"] = _finite_std(y_f)
 
     return stats
 
 
-def _passes_quality_rules(
-        X, y, task_type, quality_rules, context_rows=None):
+def _passes_quality_rules(X, y, task_type, quality_rules, context_rows=None):
     """Return True if dataset passes mined quality rules."""
     task_rules = _extract_quality_task_rules(quality_rules, task_type)
     if task_rules is None:
         return True
 
-    stats = _compute_health_stats_fast(
-        X, y, task_type, context_rows=context_rows)
+    stats = _compute_health_stats_fast(X, y, task_type, context_rows=context_rows)
 
-    max_nan_frac = task_rules.get('max_nan_frac')
-    if max_nan_frac is not None and stats['nan_frac'] > float(max_nan_frac):
+    max_nan_frac = task_rules.get("max_nan_frac")
+    if max_nan_frac is not None and stats["nan_frac"] > float(max_nan_frac):
         return False
 
-    max_const_feature_frac = task_rules.get('max_const_feature_frac')
-    if max_const_feature_frac is not None and stats['const_feature_frac'] > float(max_const_feature_frac):
+    max_const_feature_frac = task_rules.get("max_const_feature_frac")
+    if max_const_feature_frac is not None and stats["const_feature_frac"] > float(max_const_feature_frac):
         return False
 
-    min_nonconstant_features = task_rules.get('min_nonconstant_features')
-    if min_nonconstant_features is not None and stats['nonconstant_features'] < int(min_nonconstant_features):
+    min_nonconstant_features = task_rules.get("min_nonconstant_features")
+    if min_nonconstant_features is not None and stats["nonconstant_features"] < int(min_nonconstant_features):
         return False
 
-    if task_type == 'cls':
-        min_y_unique = task_rules.get('min_y_unique')
-        if min_y_unique is not None and stats['y_unique'] < int(min_y_unique):
+    if task_type == "cls":
+        min_y_unique = task_rules.get("min_y_unique")
+        if min_y_unique is not None and stats["y_unique"] < int(min_y_unique):
             return False
-        min_minority_frac = task_rules.get('min_minority_frac')
-        if min_minority_frac is not None and stats['minority_frac'] < float(min_minority_frac):
+        min_minority_frac = task_rules.get("min_minority_frac")
+        if min_minority_frac is not None and stats["minority_frac"] < float(min_minority_frac):
             return False
     else:
-        min_y_std = task_rules.get('min_y_std')
-        if min_y_std is not None and stats['y_std'] < float(min_y_std):
+        min_y_std = task_rules.get("min_y_std")
+        if min_y_std is not None and stats["y_std"] < float(min_y_std):
             return False
 
     return True
@@ -1647,8 +1626,7 @@ class SyntheticDataFilterError(RuntimeError):
     """Raised when no valid episode is produced within the retry budget."""
 
 
-def _passes_basic_episode_health(
-        X, y, task_type='reg', context_rows=None):
+def _passes_basic_episode_health(X, y, task_type="reg", context_rows=None):
     """Family-independent invariants required for any training episode."""
     X = np.asarray(X)
     y = np.asarray(y)
@@ -1661,53 +1639,57 @@ def _passes_basic_episode_health(
     # NaN is a supported missing-value representation; infinity is not.
     if np.isinf(X).any():
         return False
-    labeled_rows = (
-        _resolve_context_rows(X.shape[0], context_rows)
-        if task_type == 'reg' else X.shape[0]
-    )
+    labeled_rows = _resolve_context_rows(X.shape[0], context_rows) if task_type == "reg" else X.shape[0]
     X_reference = X[:labeled_rows]
     y_reference = y[:labeled_rows]
     if labeled_rows == 1:
         return bool(np.isfinite(X_reference).any())
-    if task_type == 'reg' and _finite_std(y_reference) <= 1e-8:
+    if task_type == "reg" and _finite_std(y_reference) <= 1e-8:
         return False
-    if task_type == 'cls' and len(np.unique(y_reference)) < 2:
+    if task_type == "cls" and len(np.unique(y_reference)) < 2:
         return False
     return bool(np.any(_finite_column_variation(X_reference)))
 
 
 def _passes_requested_dataset_filters(
-        data, *, task_type='reg', quality_rules=None, learnability_filter=False,
-        learnability_filter_reg_min_score=0.10, icl_filter_model=None,
-        icl_filter_reg_min_r2=0.05, icl_scaling_filter=False,
-        icl_scaling_min_improvement=0.03, context_rows=None):
+    data,
+    *,
+    task_type="reg",
+    quality_rules=None,
+    learnability_filter=False,
+    learnability_filter_reg_min_score=0.10,
+    icl_filter_model=None,
+    icl_filter_reg_min_r2=0.05,
+    icl_scaling_filter=False,
+    icl_scaling_min_improvement=0.03,
+    context_rows=None,
+):
     """Apply health, quality, and optional learnability gates to final X/y."""
-    X, y = data['X'], data['y']
-    effective_context_rows = context_rows if task_type == 'reg' else None
-    if not _passes_basic_episode_health(
-            X, y, task_type, context_rows=effective_context_rows):
+    X, y = data["X"], data["y"]
+    effective_context_rows = context_rows if task_type == "reg" else None
+    if not _passes_basic_episode_health(X, y, task_type, context_rows=effective_context_rows):
         return False
     if quality_rules is not None and not _passes_quality_rules(
-            X, y, task_type, quality_rules,
-            context_rows=effective_context_rows):
+        X, y, task_type, quality_rules, context_rows=effective_context_rows
+    ):
         return False
 
     if icl_filter_model is not None:
         passed = _check_learnability_icl(
-            X, y, task_type, icl_filter_model,
-            reg_min_r2=icl_filter_reg_min_r2,
-            context_rows=effective_context_rows)
+            X, y, task_type, icl_filter_model, reg_min_r2=icl_filter_reg_min_r2, context_rows=effective_context_rows
+        )
     elif learnability_filter:
         passed = _check_learnability(
-            X, y, task_type,
-            reg_min_score=learnability_filter_reg_min_score,
-            context_rows=effective_context_rows)
+            X, y, task_type, reg_min_score=learnability_filter_reg_min_score, context_rows=effective_context_rows
+        )
     else:
         passed = True
 
     if passed and icl_scaling_filter:
         passed = _check_icl_scaling(
-            X, y, task_type,
+            X,
+            y,
+            task_type,
             reg_min_score=learnability_filter_reg_min_score,
             min_improvement=icl_scaling_min_improvement,
             context_rows=effective_context_rows,
@@ -1716,32 +1698,38 @@ def _passes_requested_dataset_filters(
 
 
 def _generate_filtered_episode(
-        generate_once, *, max_retries=3, quality_rules=None,
-        task_type='reg',
-        learnability_filter=False, learnability_filter_reg_min_score=0.10,
-        icl_filter_model=None, icl_filter_reg_min_r2=0.05,
-        icl_scaling_filter=False, icl_scaling_min_improvement=0.03,
-        context_rows=None):
+    generate_once,
+    *,
+    max_retries=3,
+    quality_rules=None,
+    task_type="reg",
+    learnability_filter=False,
+    learnability_filter_reg_min_score=0.10,
+    icl_filter_model=None,
+    icl_filter_reg_min_r2=0.05,
+    icl_scaling_filter=False,
+    icl_scaling_min_improvement=0.03,
+    context_rows=None,
+):
     """Regenerate until the actual episode passes every requested gate."""
     attempts = max(0, int(max_retries)) + 1
     for _attempt in range(attempts):
         data = generate_once()
         if _passes_requested_dataset_filters(
-                data,
-                task_type=task_type,
-                quality_rules=quality_rules,
-                learnability_filter=learnability_filter,
-                learnability_filter_reg_min_score=(
-                    learnability_filter_reg_min_score),
-                icl_filter_model=icl_filter_model,
-                icl_filter_reg_min_r2=icl_filter_reg_min_r2,
-                icl_scaling_filter=icl_scaling_filter,
-                icl_scaling_min_improvement=icl_scaling_min_improvement,
-                context_rows=context_rows):
-            data['filtered'] = False
+            data,
+            task_type=task_type,
+            quality_rules=quality_rules,
+            learnability_filter=learnability_filter,
+            learnability_filter_reg_min_score=(learnability_filter_reg_min_score),
+            icl_filter_model=icl_filter_model,
+            icl_filter_reg_min_r2=icl_filter_reg_min_r2,
+            icl_scaling_filter=icl_scaling_filter,
+            icl_scaling_min_improvement=icl_scaling_min_improvement,
+            context_rows=context_rows,
+        ):
+            data["filtered"] = False
             return data
-    raise SyntheticDataFilterError(
-        f"synthetic episode failed all filters after {attempts} attempts")
+    raise SyntheticDataFilterError(f"synthetic episode failed all filters after {attempts} attempts")
 
 
 def _apply_feature_importances(X, rng, mild=False):
@@ -1770,7 +1758,7 @@ def _apply_feature_importances(X, rng, mild=False):
     weights = np.abs(weights)
     # Floor: no feature gets fully zeroed (prevents constant-feature artifacts)
     weights = np.maximum(weights, 0.05 * weights.max())
-    weights /= (weights.sum() + 1e-8)
+    weights /= weights.sum() + 1e-8
     weights *= n_features  # normalize so mean weight = 1
 
     # Shuffle so importance isn't correlated with column order
@@ -1873,12 +1861,9 @@ def _create_repeated_entity_categorical(X, col, rng):
     n_groups = max(2, min(32, int(np.sqrt(cardinality))))
     entity_group = rng.integers(0, n_groups, size=cardinality)
     group_effect = rng.standard_normal(n_groups)
-    entity_effect = (
-        0.75 * group_effect[entity_group]
-        + 0.35 * rng.standard_normal(cardinality)
-    )
+    entity_effect = 0.75 * group_effect[entity_group] + 0.35 * rng.standard_normal(cardinality)
     entity_effect = entity_effect - entity_effect.mean()
-    entity_effect /= (np.std(entity_effect) + 1e-8)
+    entity_effect /= np.std(entity_effect) + 1e-8
     row_effect = entity_effect[entity_ids]
     counts = np.bincount(entity_ids, minlength=cardinality)
     observed = counts[counts > 0]
@@ -1892,21 +1877,18 @@ def _create_repeated_entity_categorical(X, col, rng):
 
     X[:, col] = entity_ids.astype(np.float64)
     entity_meta = {
-        'cardinality': int(cardinality),
-        'observed_entities': int(len(observed)),
-        'repeated_entity_fraction': float(
-            np.mean(observed >= 2) if len(observed) > 0 else 0.0
-        ),
-        'max_entity_fraction': float(counts.max() / max(n, 1)),
-        'mean_count_per_observed_entity': float(
-            observed.mean() if len(observed) > 0 else 0.0
-        ),
+        "cardinality": int(cardinality),
+        "observed_entities": int(len(observed)),
+        "repeated_entity_fraction": float(np.mean(observed >= 2) if len(observed) > 0 else 0.0),
+        "max_entity_fraction": float(counts.max() / max(n, 1)),
+        "mean_count_per_observed_entity": float(observed.mean() if len(observed) > 0 else 0.0),
     }
     return row_effect.astype(np.float64), entity_meta
 
 
-def _create_nominal_categorical(X, col, n_samples, rng, cardinality,
-                                task_type, n_features, discrete_cols, cat_cols_iter):
+def _create_nominal_categorical(
+    X, col, n_samples, rng, cardinality, task_type, n_features, discrete_cols, cat_cols_iter
+):
     """Create nominal (non-ordinal) categorical features with random effects.
 
     Two types:
@@ -1942,7 +1924,7 @@ def _create_nominal_categorical(X, col, n_samples, rng, cardinality,
     # from ordinal categoricals derived from continuous values)
     cat_effects = rng.standard_normal(cardinality)
     cat_effects -= cat_effects.mean()
-    cat_effects /= (np.std(cat_effects) + 1e-8)
+    cat_effects /= np.std(cat_effects) + 1e-8
     row_effect = cat_effects[cat_ids].astype(np.float64)
 
     X[:, col] = cat_ids.astype(np.float64)
@@ -1950,8 +1932,7 @@ def _create_nominal_categorical(X, col, n_samples, rng, cardinality,
     if use_crossed:
         # --- Crossed nominal: two columns interact ---
         # Find a second column that's not already categorified
-        available = [c for c in range(n_features)
-                     if c != col and c not in discrete_cols and c not in cat_cols_iter]
+        available = [c for c in range(n_features) if c != col and c not in discrete_cols and c not in cat_cols_iter]
         if not available:
             return row_effect, 1
 
@@ -1966,7 +1947,7 @@ def _create_nominal_categorical(X, col, n_samples, rng, cardinality,
         # Second column's main effect
         cat_effects2 = rng.standard_normal(K2)
         cat_effects2 -= cat_effects2.mean()
-        cat_effects2 /= (np.std(cat_effects2) + 1e-8)
+        cat_effects2 /= np.std(cat_effects2) + 1e-8
 
         # Sparse interaction: only ~30% of (K1 × K2) cells are nonzero
         interaction = np.zeros((cardinality, K2))
@@ -2003,7 +1984,7 @@ def _apply_kumaraswamy_warping(X, col, rng):
     v_scaled = (v - vmin) / (vmax - vmin)
     v_scaled = np.clip(v_scaled, 1e-8, 1 - 1e-8)
 
-    X[:, col] = 1 - (1 - v_scaled ** a) ** b
+    X[:, col] = 1 - (1 - v_scaled**a) ** b
 
 
 def _inject_heavy_tails(X, rng, causal_cols=None, exclude_cols=None):
@@ -2033,20 +2014,20 @@ def _inject_heavy_tails(X, rng, causal_cols=None, exclude_cols=None):
         causal_set = set(causal_cols)
         non_causal = [c for c in eligible_features if c not in causal_set]
         causal_elig = [c for c in eligible_features if c in causal_set]
-        n_from_non_causal = min(len(non_causal),
-                                max(1, int(n_cols_affected * 0.8)))
-        n_from_causal = min(len(causal_elig),
-                            n_cols_affected - n_from_non_causal)
-        affected_cols = np.concatenate([
-            rng.choice(non_causal, size=n_from_non_causal, replace=False)
-            if non_causal else np.array([], dtype=int),
-            rng.choice(causal_elig, size=n_from_causal, replace=False)
-            if causal_elig and n_from_causal > 0 else np.array([], dtype=int),
-        ]).astype(int)
+        n_from_non_causal = min(len(non_causal), max(1, int(n_cols_affected * 0.8)))
+        n_from_causal = min(len(causal_elig), n_cols_affected - n_from_non_causal)
+        affected_cols = np.concatenate(
+            [
+                rng.choice(non_causal, size=n_from_non_causal, replace=False)
+                if non_causal
+                else np.array([], dtype=int),
+                rng.choice(causal_elig, size=n_from_causal, replace=False)
+                if causal_elig and n_from_causal > 0
+                else np.array([], dtype=int),
+            ]
+        ).astype(int)
     else:
-        affected_cols = rng.choice(eligible_features,
-                                   size=min(n_cols_affected, len(eligible_features)),
-                                   replace=False)
+        affected_cols = rng.choice(eligible_features, size=min(n_cols_affected, len(eligible_features)), replace=False)
     for col in affected_cols:
         col_std = np.std(X[:, col])
         if col_std < 1e-8:
@@ -2056,18 +2037,17 @@ def _inject_heavy_tails(X, rng, causal_cols=None, exclude_cols=None):
         if rng.random() < 0.5:
             # Spike+slab mixture: produces realistic high kurtosis
             # Real kurtosis ~82 often comes from zero-inflation + rare extremes
-            p_zero = rng.uniform(0.6, 0.95)   # big spike at mode
-            p_out = rng.uniform(0.005, 0.03)   # rare extreme outliers
+            p_zero = rng.uniform(0.6, 0.95)  # big spike at mode
+            p_out = rng.uniform(0.005, 0.03)  # rare extreme outliers
 
             mask_zero = rng.random(n_samples) < p_zero
             X[mask_zero, col] = 0.0
 
             mask_out = (~mask_zero) & (rng.random(n_samples) < p_out)
             if np.any(mask_out):
-                df = rng.uniform(1.5, 3.0)     # heavier tails than original
-                amp = rng.uniform(8.0, 30.0)   # bigger amplification
-                X[mask_out, col] = mu + amp * col_std * rng.standard_t(
-                    df, size=int(mask_out.sum()))
+                df = rng.uniform(1.5, 3.0)  # heavier tails than original
+                amp = rng.uniform(8.0, 30.0)  # bigger amplification
+                X[mask_out, col] = mu + amp * col_std * rng.standard_t(df, size=int(mask_out.sum()))
         else:
             # Original: Student-t outlier injection
             outlier_frac = rng.uniform(0.01, 0.05)
@@ -2086,9 +2066,7 @@ def _inject_heavy_tails(X, rng, causal_cols=None, exclude_cols=None):
         # Only corrupt eligible (continuous) columns
         corrupt_pool = eligible_features if eligible_features else list(range(n_features))
         n_cols_corrupt = max(1, int(len(corrupt_pool) * rng.uniform(0.2, 0.6)))
-        corrupt_cols = rng.choice(corrupt_pool,
-                                  size=min(n_cols_corrupt, len(corrupt_pool)),
-                                  replace=False)
+        corrupt_cols = rng.choice(corrupt_pool, size=min(n_cols_corrupt, len(corrupt_pool)), replace=False)
         for col in corrupt_cols:
             col_std = np.std(X[:, col])
             if col_std < 1e-8:
@@ -2099,9 +2077,7 @@ def _inject_heavy_tails(X, rng, causal_cols=None, exclude_cols=None):
     return X
 
 
-def _add_latent_bayes_error(
-        X, y_raw, n_features, rng, task_type='reg', *,
-        protected_cols=None, metadata=None):
+def _add_latent_bayes_error(X, y_raw, n_features, rng, task_type="reg", *, protected_cols=None, metadata=None):
     """Add latent dimensions and hard negatives to create realistic Bayes error.
 
     Three mechanisms:
@@ -2111,9 +2087,7 @@ def _add_latent_bayes_error(
     """
     del task_type
     n_samples = X.shape[0]
-    protected_cols = set() if protected_cols is None else {
-        int(col) for col in protected_cols
-    }
+    protected_cols = set() if protected_cols is None else {int(col) for col in protected_cols}
 
     # 1. Latent influence: generate hidden features that affect y but aren't in X
     n_latent = max(1, int(n_features * rng.uniform(0.05, 0.2)))
@@ -2129,24 +2103,14 @@ def _add_latent_bayes_error(
         # Prefer causal sources: a hard negative should resemble signal, while
         # its destination must never destroy a column that the target uses.
         source_pool = sorted(protected_cols) or list(range(n_features))
-        source_pool = [
-            col for col in source_pool
-            if 0 <= col < n_features and np.isfinite(X[:, col]).sum() >= 2
-        ]
+        source_pool = [col for col in source_pool if 0 <= col < n_features and np.isfinite(X[:, col]).sum() >= 2]
         n_sources = min(n_hard, len(source_pool))
         src_cols = (
-            rng.choice(source_pool, size=n_sources, replace=False)
-            if n_sources else np.asarray([], dtype=np.int64)
+            rng.choice(source_pool, size=n_sources, replace=False) if n_sources else np.asarray([], dtype=np.int64)
         )
-        available = [
-            col for col in range(n_features)
-            if col not in protected_cols and col not in src_cols
-        ]
+        available = [col for col in range(n_features) if col not in protected_cols and col not in src_cols]
         n_pairs = min(len(src_cols), len(available))
-        tgt_cols = (
-            rng.choice(available, size=n_pairs, replace=False)
-            if n_pairs else np.asarray([], dtype=np.int64)
-        )
+        tgt_cols = rng.choice(available, size=n_pairs, replace=False) if n_pairs else np.asarray([], dtype=np.int64)
         modified = []
         modified_sources = []
         for src, tgt in zip(src_cols, tgt_cols):
@@ -2163,16 +2127,14 @@ def _add_latent_bayes_error(
                 continue
             source_filled = np.where(finite, src_values, src_median)
             noise_level = rng.uniform(0.5, 2.0)
-            hard_negative = source_filled + rng.normal(
-                0.0, col_std * noise_level, n_samples)
+            hard_negative = source_filled + rng.normal(0.0, col_std * noise_level, n_samples)
             missing_target = np.isnan(X[:, tgt])
             X[:, tgt] = np.where(missing_target, np.nan, hard_negative)
             modified.append(int(tgt))
             modified_sources.append(int(src))
         if metadata is not None and modified:
-            metadata.setdefault('hard_negative_cols', []).extend(modified)
-            metadata.setdefault('hard_negative_source_cols', []).extend(
-                modified_sources)
+            metadata.setdefault("hard_negative_cols", []).extend(modified)
+            metadata.setdefault("hard_negative_source_cols", []).extend(modified_sources)
 
     return X, y_raw
 
@@ -2227,8 +2189,7 @@ def _probabilistic_label(y_raw, X, n_classes, rng):
         exp_logits = np.exp(logits)
         probs = exp_logits / (exp_logits.sum(axis=1, keepdims=True) + 1e-8)
         # Sample from distribution
-        y = np.array([rng.choice(n_classes, p=p) for p in probs],
-                     dtype=np.float32)
+        y = np.array([rng.choice(n_classes, p=p) for p in probs], dtype=np.float32)
 
     elif strategy == 1:
         # --- Random tree labeler ---
@@ -2237,7 +2198,7 @@ def _probabilistic_label(y_raw, X, n_classes, rng):
         split_cols = rng.choice(n_features, size=n_split_feats, replace=False)
         depth = int(rng.integers(2, 5))
         # Build random splits: at each level, pick a feature and threshold
-        n_leaves = 2 ** depth
+        n_leaves = 2**depth
         leaf_labels = rng.integers(0, n_classes, size=n_leaves).astype(np.float32)
         # Assign each sample to a leaf via recursive splitting
         leaf_idx = np.zeros(n_samples, dtype=np.int64)
@@ -2270,8 +2231,7 @@ def _probabilistic_label(y_raw, X, n_classes, rng):
         # Random class centers
         centers = rng.standard_normal((n_classes, n_dims)) * 1.5
         # Compute distances and assign
-        dists = np.sum((X_sub[:, None, :] - centers[None, :, :]) ** 2,
-                       axis=2)  # [n_samples, n_classes]
+        dists = np.sum((X_sub[:, None, :] - centers[None, :, :]) ** 2, axis=2)  # [n_samples, n_classes]
         y = dists.argmin(axis=1).astype(np.float32)
 
     else:
@@ -2287,8 +2247,7 @@ def _probabilistic_label(y_raw, X, n_classes, rng):
             if vmax - vmin < 1e-8:
                 y = rng.integers(0, n_classes, size=n_samples).astype(np.float32)
             else:
-                thresholds = np.sort(rng.uniform(vmin, vmax,
-                                                 size=n_classes - 1))
+                thresholds = np.sort(rng.uniform(vmin, vmax, size=n_classes - 1))
                 region = np.digitize(col_vals, thresholds)
                 # Random permutation of region-to-class mapping
                 perm = rng.permutation(n_classes)
@@ -2352,13 +2311,20 @@ def _apply_heteroskedastic_label_noise(y, X, n_classes, rng):
     return y
 
 
-def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
-                               reg_dense=False, reg_deterministic_prob=0.20,
-                               pareto_importance_prob=0.0,
-                               latent_factor_prob=0.0,
-                               X_scm=None, X_scm_target=None,
-                               preserve_target_features=False,
-                               context_rows=None):
+def _generate_regression_prior(
+    n_samples,
+    n_features,
+    rng,
+    reg_denoise=False,
+    reg_dense=False,
+    reg_deterministic_prob=0.20,
+    pareto_importance_prob=0.0,
+    latent_factor_prob=0.0,
+    X_scm=None,
+    X_scm_target=None,
+    preserve_target_features=False,
+    context_rows=None,
+):
     """Generate regression dataset matching common real-world patterns.
 
     Covers regimes the SCM generator under-represents: real regression is
@@ -2385,9 +2351,9 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
     use_scm_features = X_scm is not None
     labeled_rows = _resolve_context_rows(n_samples, context_rows)
     prior_meta = {
-        'generator_family': 'regression_prior',
-        'use_scm_features': bool(use_scm_features),
-        'context_rows': labeled_rows,
+        "generator_family": "regression_prior",
+        "use_scm_features": bool(use_scm_features),
+        "context_rows": labeled_rows,
     }
     if use_scm_features:
         # Hybrid mode: use SCM-generated features with regression prior targets.
@@ -2458,17 +2424,21 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
     # multivariate priors for spatial, kinematic, and process-style targets.
     if reg_dense:
         # Dense mode favors target types where many features matter jointly.
-        reg_type = int(rng.choice(
-            [0, 2, 3, 4, 6, 7, 8, 9],
-            p=[0.06, 0.08, 0.10, 0.16, 0.22, 0.15, 0.13, 0.10],
-        ))
+        reg_type = int(
+            rng.choice(
+                [0, 2, 3, 4, 6, 7, 8, 9],
+                p=[0.06, 0.08, 0.10, 0.16, 0.22, 0.15, 0.13, 0.10],
+            )
+        )
     else:
         # Upweight smooth multivariate priors (RBF, Fourier, chained trig,
         # polynomial surface) to address spatial/kinematic/process gaps.
-        reg_type = int(rng.choice(
-            10,
-            p=[0.08, 0.07, 0.10, 0.08, 0.10, 0.05, 0.18, 0.15, 0.11, 0.08],
-        ))
+        reg_type = int(
+            rng.choice(
+                10,
+                p=[0.08, 0.07, 0.10, 0.08, 0.10, 0.05, 0.18, 0.15, 0.11, 0.08],
+            )
+        )
     # Latent-factor override: shared low-dim structure across many features.
     # Replaces the chosen reg_type with reg_type=10 so the branches below
     # remain unchanged.
@@ -2476,21 +2446,21 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         reg_type = 10
     smooth_joint_prior = reg_type in (6, 7, 8, 9)
     reg_type_names = {
-        0: 'dense_linear',
-        1: 'sparse_linear',
-        2: 'gam',
-        3: 'additive_pairwise',
-        4: 'random_mlp',
-        5: 'random_tree',
-        6: 'radial_distance',
-        7: 'fourier_features',
-        8: 'chained_trig',
-        9: 'polynomial_surface',
-        10: 'latent_factor',
+        0: "dense_linear",
+        1: "sparse_linear",
+        2: "gam",
+        3: "additive_pairwise",
+        4: "random_mlp",
+        5: "random_tree",
+        6: "radial_distance",
+        7: "fourier_features",
+        8: "chained_trig",
+        9: "polynomial_surface",
+        10: "latent_factor",
     }
-    prior_meta['reg_type_id'] = int(reg_type)
-    prior_meta['reg_type_name'] = reg_type_names[int(reg_type)]
-    prior_meta['smooth_joint_prior'] = bool(smooth_joint_prior)
+    prior_meta["reg_type_id"] = int(reg_type)
+    prior_meta["reg_type_name"] = reg_type_names[int(reg_type)]
+    prior_meta["smooth_joint_prior"] = bool(smooth_joint_prior)
 
     # Pareto feature-importance gate. Build a per-feature multiplier that
     # concentrates total importance on a few features (a few × 10–100 the
@@ -2506,8 +2476,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         raw = rng.pareto(alpha_pareto, size=n_features) + 1.0
         # Normalize so the average importance is 1.0 (preserves overall y scale).
         pareto_w = raw / raw.mean()
-        prior_meta['pareto_importance'] = True
-        prior_meta['pareto_alpha'] = alpha_pareto
+        prior_meta["pareto_importance"] = True
+        prior_meta["pareto_alpha"] = alpha_pareto
 
     if reg_type == 0:
         # Dense linear: many small effects (ridge-like)
@@ -2516,7 +2486,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         if pareto_w is not None:
             beta = beta * pareto_w
         y = X @ beta
-        prior_meta['active_dims'] = int(n_features)
+        prior_meta["active_dims"] = int(n_features)
 
     elif reg_type == 1:
         # Sparse linear: few strong effects
@@ -2529,7 +2499,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             # is even more skewed (1 dominates among the active).
             beta = beta * pareto_w
         y = X @ beta
-        prior_meta['active_dims'] = int(k)
+        prior_meta["active_dims"] = int(k)
 
     elif reg_type == 2:
         # GAM: sum of smooth univariate functions
@@ -2545,9 +2515,9 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             if fn_type == 0:
                 y += weight * x_col
             elif fn_type == 1:
-                y += weight * (x_col ** 2 - 1)
+                y += weight * (x_col**2 - 1)
             elif fn_type == 2:
-                y += weight * np.clip(x_col ** 3, -50, 50) * 0.1
+                y += weight * np.clip(x_col**3, -50, 50) * 0.1
             elif fn_type == 3:
                 y += weight * np.sign(x_col) * np.log1p(np.abs(x_col))
             elif fn_type == 4:
@@ -2562,8 +2532,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
                 y += weight * np.cos(freq * x_col)
             else:
                 # exp decay: exponential proximity patterns
-                y += weight * np.exp(-0.5 * x_col ** 2)
-        prior_meta['active_dims'] = int(n_active)
+                y += weight * np.exp(-0.5 * x_col**2)
+        prior_meta["active_dims"] = int(n_active)
 
     elif reg_type == 3:
         # Additive + pairwise interactions
@@ -2579,8 +2549,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             i, j = rng.choice(n_features, size=2, replace=False)
             weight = rng.standard_normal() * 0.3 / max(np.sqrt(n_interactions), 1)
             y += weight * X[:, i] * X[:, j]
-        prior_meta['active_dims'] = int(n_features)
-        prior_meta['interaction_terms'] = int(n_interactions)
+        prior_meta["active_dims"] = int(n_features)
+        prior_meta["interaction_terms"] = int(n_interactions)
 
     elif reg_type == 4:
         # Random MLP: smooth nonlinear target (forward kinematics, spatial, etc.)
@@ -2598,7 +2568,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         # Smooth activations dominate (GELU/SiLU/tanh/softplus >> ReLU)
         act_roll = rng.random()
         if act_roll < 0.30:
-            act_fn = lambda h: np.tanh(h)       # smooth, bounded
+            act_fn = lambda h: np.tanh(h)  # smooth, bounded
         elif act_roll < 0.55:
             # GELU approximation: x * sigmoid(1.702 * x)
             act_fn = lambda h: h * (1.0 / (1.0 + np.exp(-1.702 * h)))
@@ -2623,9 +2593,9 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         # Final projection
         W_out = rng.standard_normal((in_dim, 1)) / np.sqrt(in_dim)
         y = (h @ W_out).ravel()
-        prior_meta['active_dims'] = int(n_active)
-        prior_meta['hidden_width'] = int(hid)
-        prior_meta['n_mlp_layers'] = int(n_layers)
+        prior_meta["active_dims"] = int(n_active)
+        prior_meta["hidden_width"] = int(hid)
+        prior_meta["n_mlp_layers"] = int(n_layers)
 
     elif reg_type == 6:
         # Radial / distance prior: smoother and more structured than a plain
@@ -2642,8 +2612,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         Z = Z / np.where(Z_std > 1e-8, Z_std, 1.0)
         n_basis = int(rng.integers(3, min(12, max(4, n_samples // 8 + 1)) + 1))
         if labeled_rows >= n_basis:
-            center_idx = rng.choice(
-                labeled_rows, size=n_basis, replace=False)
+            center_idx = rng.choice(labeled_rows, size=n_basis, replace=False)
             centers = Z[center_idx]
         else:
             centers = rng.standard_normal((n_basis, metric_dim))
@@ -2652,21 +2621,21 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             amp = rng.standard_normal() / np.sqrt(n_basis)
             lengthscales = rng.uniform(0.6, 2.2, size=metric_dim)
             diff = (Z - centers[j]) / lengthscales[np.newaxis, :]
-            dist = np.sqrt(np.sum(diff ** 2, axis=1) + 1e-6)
+            dist = np.sqrt(np.sum(diff**2, axis=1) + 1e-6)
             kernel_roll = rng.random()
             if kernel_roll < 0.55:
-                basis = np.exp(-0.5 * dist ** 2)
+                basis = np.exp(-0.5 * dist**2)
             elif kernel_roll < 0.85:
-                basis = 1.0 / (1.0 + dist ** 2)
+                basis = 1.0 / (1.0 + dist**2)
             else:
                 basis = -np.log(dist + 0.15)
             y += amp * basis
         if rng.random() < 0.5:
             linear = rng.standard_normal(metric_dim) / np.sqrt(metric_dim)
             y += 0.2 * (Z @ linear)
-        prior_meta['active_dims'] = int(n_active)
-        prior_meta['latent_dim'] = int(metric_dim)
-        prior_meta['basis_count'] = int(n_basis)
+        prior_meta["active_dims"] = int(n_active)
+        prior_meta["latent_dim"] = int(metric_dim)
+        prior_meta["basis_count"] = int(n_basis)
 
     elif reg_type == 7:
         # Fourier features: low-dimensional smooth periodic structure with
@@ -2684,7 +2653,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         y = np.zeros(n_samples)
         for _ in range(n_terms):
             omega = rng.standard_normal(latent_dim)
-            omega /= (np.linalg.norm(omega) + 1e-8)
+            omega /= np.linalg.norm(omega) + 1e-8
             omega *= rng.uniform(0.25, 2.0)
             harmonic = int(rng.integers(1, 4))
             phase = rng.uniform(-np.pi, np.pi)
@@ -2692,9 +2661,9 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             a = rng.standard_normal() / np.sqrt(n_terms)
             b = rng.standard_normal() / np.sqrt(n_terms)
             y += a * np.cos(proj) + b * np.sin(proj)
-        prior_meta['active_dims'] = int(n_active)
-        prior_meta['latent_dim'] = int(latent_dim)
-        prior_meta['term_count'] = int(n_terms)
+        prior_meta["active_dims"] = int(n_active)
+        prior_meta["latent_dim"] = int(latent_dim)
+        prior_meta["term_count"] = int(n_terms)
 
     elif reg_type == 8:
         # Kinematics-like chained trigonometric system. Unlike the original
@@ -2719,22 +2688,15 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             freq = rng.uniform(0.6, 2.0)
             phase = rng.uniform(-np.pi, np.pi)
             coupling = rng.uniform(0.05, 0.30)
-            theta = theta + freq * joint_inputs[:, i] + phase + coupling * np.sin(
-                theta + 0.5 * joint_inputs[:, i]
-            )
+            theta = theta + freq * joint_inputs[:, i] + phase + coupling * np.sin(theta + 0.5 * joint_inputs[:, i])
             link = rng.uniform(0.6, 1.6) / np.sqrt(n_joints)
             x_pos += link * np.cos(theta)
             y_pos += link * np.sin(theta)
             aux += link * np.sin(rng.uniform(0.5, 1.5) * theta + phase)
         coeffs = rng.standard_normal(4)
-        y = (
-            coeffs[0] * x_pos
-            + coeffs[1] * y_pos
-            + coeffs[2] * aux
-            + coeffs[3] * np.sin(theta)
-        )
-        prior_meta['active_dims'] = int(n_active)
-        prior_meta['joint_count'] = int(n_joints)
+        y = coeffs[0] * x_pos + coeffs[1] * y_pos + coeffs[2] * aux + coeffs[3] * np.sin(theta)
+        prior_meta["active_dims"] = int(n_active)
+        prior_meta["joint_count"] = int(n_joints)
 
     elif reg_type == 9:
         # Full polynomial surface: smooth quadratic response over many features,
@@ -2750,9 +2712,9 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         y = quad + X_active @ w + b
         if rng.random() < 0.5:
             u = rng.standard_normal(n_active)
-            u /= (np.linalg.norm(u) + 1e-8)
+            u /= np.linalg.norm(u) + 1e-8
             y += 0.15 * np.clip(X_active @ u, -4, 4) ** 3
-        prior_meta['active_dims'] = int(n_active)
+        prior_meta["active_dims"] = int(n_active)
 
     elif reg_type == 10:
         # Latent-factor target: y = sum_j h_j(X @ V_j) where V is d×k random
@@ -2778,14 +2740,14 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             elif fn_type == 1:
                 y += wj * np.tanh(z)
             elif fn_type == 2:
-                y += wj * (z ** 2 - 1)
+                y += wj * (z**2 - 1)
             elif fn_type == 3:
                 freq = rng.uniform(0.5, 2.0)
                 y += wj * np.sin(freq * z)
             else:
                 y += wj * np.sign(z) * np.log1p(np.abs(z))
-        prior_meta['active_dims'] = int(n_features)
-        prior_meta['latent_dim'] = int(k)
+        prior_meta["active_dims"] = int(n_features)
+        prior_meta["latent_dim"] = int(k)
 
     else:
         # Random tree-like: piecewise-constant target (insurance, pricing, etc.)
@@ -2798,8 +2760,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
             threshold = rng.standard_normal()
             weight = rng.standard_normal() / np.sqrt(n_rules)
             y += weight * (X[:, col] > threshold).astype(np.float64)
-        prior_meta['active_dims'] = int(n_active)
-        prior_meta['rule_count'] = int(n_rules)
+        prior_meta["active_dims"] = int(n_active)
+        prior_meta["rule_count"] = int(n_rules)
 
     # --- Smooth clipping for extreme y values (before adding noise) ---
     # Use tanh soft-clip instead of hard clip to avoid gradient cliffs
@@ -2829,8 +2791,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         # synthetic regression. Keep them moderately high-SNR without making
         # them fully deterministic.
         target_r2 = min(0.985, target_r2 + rng.uniform(0.04, 0.10))
-    prior_meta['target_r2'] = float(target_r2)
-    prior_meta['deterministic'] = bool(target_r2 >= 1.0)
+    prior_meta["target_r2"] = float(target_r2)
+    prior_meta["deterministic"] = bool(target_r2 >= 1.0)
 
     if target_r2 < 1.0:
         # Sample every noise component first.  Calibrating only the initial
@@ -2845,7 +2807,7 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         if n_features >= 2 and rng.random() < _het_prob:
             driver_col = int(rng.choice(n_features))
             het_scale = np.abs(X[:, driver_col])
-            het_scale /= (np.mean(het_scale[:labeled_rows]) + 1e-8)
+            het_scale /= np.mean(het_scale[:labeled_rows]) + 1e-8
             total_noise += rng.standard_normal(n_samples) * het_scale * 0.3
 
         # --- Occasional y outliers ---
@@ -2855,16 +2817,16 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         if rng.random() < _outlier_prob:
             n_outliers = max(1, int(n_samples * rng.uniform(0.01, 0.05)))
             outlier_idx = rng.choice(n_samples, size=n_outliers, replace=False)
-            total_noise[outlier_idx] += (
-                rng.standard_normal(n_outliers) * rng.uniform(3, 8))
+            total_noise[outlier_idx] += rng.standard_normal(n_outliers) * rng.uniform(3, 8)
 
         calibrated_noise, realized_target_r2 = _calibrate_noise_to_target_r2(
-            y_clean, total_noise, target_r2, context_rows=context_rows)
+            y_clean, total_noise, target_r2, context_rows=context_rows
+        )
         y = y_clean + calibrated_noise
     else:
         realized_target_r2 = 1.0
-    prior_meta['realized_target_r2'] = float(realized_target_r2)
-    prior_meta['context_realized_target_r2'] = float(realized_target_r2)
+    prior_meta["realized_target_r2"] = float(realized_target_r2)
+    prior_meta["context_realized_target_r2"] = float(realized_target_r2)
 
     # --- Discretize some features (30%) ---
     _disc_prob = 0.15 if smooth_joint_prior else 0.3
@@ -2872,14 +2834,13 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         n_disc = max(1, int(rng.integers(1, max(2, n_features // 3 + 1))))
         disc_cols = (
             np.asarray([], dtype=np.int64)
-            if preserve_target_features else
-            rng.choice(n_features, size=n_disc, replace=False)
+            if preserve_target_features
+            else rng.choice(n_features, size=n_disc, replace=False)
         )
         for col in disc_cols:
             n_bins = int(rng.integers(3, 15))
             col_vals = X[:, col]
-            edges = np.quantile(
-                col_vals[:labeled_rows], np.linspace(0, 1, n_bins + 1))
+            edges = np.quantile(col_vals[:labeled_rows], np.linspace(0, 1, n_bins + 1))
             X[:, col] = np.digitize(col_vals, edges[1:-1]).astype(np.float64)
 
     # --- Replace some features with noise ---
@@ -2891,8 +2852,8 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
         n_noise = max(1, int(rng.integers(1, max(2, n_features // 4 + 1))))
         noise_cols = (
             np.asarray([], dtype=np.int64)
-            if preserve_target_features else
-            rng.choice(n_features, size=n_noise, replace=False)
+            if preserve_target_features
+            else rng.choice(n_features, size=n_noise, replace=False)
         )
         for col in noise_cols:
             X[:, col] = rng.standard_normal(n_samples)
@@ -2932,29 +2893,37 @@ def _generate_regression_prior(n_samples, n_features, rng, reg_denoise=False,
     # Fit target normalization on labeled context only.
     if not np.all(np.isfinite(y)):
         y = np.where(np.isfinite(y), y, 0.0)
-    y, y_clean_out, _y_mean, _y_std = _normalize_target_pair(
-        y, y_clean, context_rows=context_rows)
+    y, y_clean_out, _y_mean, _y_std = _normalize_target_pair(y, y_clean, context_rows=context_rows)
     y = y.astype(np.float32)
     y_clean_out = y_clean_out.astype(np.float32)
 
-    prior_meta['oracle_exact'] = bool(preserve_target_features)
-    prior_meta['r2_oracle_bound'] = 0.0
+    prior_meta["oracle_exact"] = bool(preserve_target_features)
+    prior_meta["r2_oracle_bound"] = 0.0
 
     return {
-        'X': X_out,
-        'y': y,
-        'y_clean': y_clean_out,
-        'task_type': 'reg',
-        'n_classes': None,
-        'filtered': False,
-        'meta': prior_meta,
+        "X": X_out,
+        "y": y,
+        "y_clean": y_clean_out,
+        "task_type": "reg",
+        "n_classes": None,
+        "filtered": False,
+        "meta": prior_meta,
     }
 
 
-def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
-                                     n_features, discrete_cols, cat_cols_iter,
-                                     signal_cols=None, context_rows=None,
-                                     excluded_cols=None):
+def _create_groupby_relative_numeric(
+    X,
+    cat_col,
+    n_samples,
+    rng,
+    cardinality,
+    n_features,
+    discrete_cols,
+    cat_cols_iter,
+    signal_cols=None,
+    context_rows=None,
+    excluded_cols=None,
+):
     """B-3 relative-GroupBy prior: target depends on a numeric feature's value
     RELATIVE to its category group (x - E[x|c], x/E[x|c], or within-group rank).
     Teaches the GroupBy / relative-aggregation ICL circuit (TabPrep Pattern B-3).
@@ -2967,7 +2936,8 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
     # 1. Zipf categorical into cat_col
     alpha = rng.uniform(0.6, 1.4)
     ranks = np.arange(1, cardinality + 1, dtype=np.float64)
-    probs = ranks ** (-alpha); probs /= probs.sum()
+    probs = ranks ** (-alpha)
+    probs /= probs.sum()
     cat_ids = rng.choice(cardinality, size=n_samples, replace=True, p=probs)
     X[:, cat_col] = cat_ids.astype(np.float64, copy=False)
     if signal_cols is not None:
@@ -2976,13 +2946,14 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
     # 2. pick a continuous numeric column (not already discrete/categorical)
     excluded_cols = set() if excluded_cols is None else set(excluded_cols)
     available = [
-        c for c in range(n_features)
-        if c != cat_col and c not in discrete_cols
-        and c not in cat_cols_iter and c not in excluded_cols
+        c
+        for c in range(n_features)
+        if c != cat_col and c not in discrete_cols and c not in cat_cols_iter and c not in excluded_cols
     ]
     if not available:
         eff = rng.standard_normal(cardinality)
-        eff -= eff.mean(); eff /= (eff.std() + 1e-8)
+        eff -= eff.mean()
+        eff /= eff.std() + 1e-8
         return eff[cat_ids].astype(np.float64, copy=False), 1
     num_col = int(rng.choice(available))
     if signal_cols is not None:
@@ -2996,10 +2967,8 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
     context_ids = cat_ids[:labeled_rows]
     context_x = x[:labeled_rows]
     global_mean = float(np.mean(context_x)) if len(context_x) else 0.0
-    grp_sum = np.bincount(
-        context_ids, weights=context_x, minlength=cardinality)
-    grp_cnt = np.bincount(
-        context_ids, minlength=cardinality).astype(np.float64)
+    grp_sum = np.bincount(context_ids, weights=context_x, minlength=cardinality)
+    grp_cnt = np.bincount(context_ids, minlength=cardinality).astype(np.float64)
     group_means = np.full(cardinality, global_mean, dtype=np.float64)
     seen_groups = grp_cnt > 0
     group_means[seen_groups] = grp_sum[seen_groups] / grp_cnt[seen_groups]
@@ -3007,14 +2976,14 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
 
     # 4. relative op
     op = int(rng.integers(0, 3))
-    if op == 0:                       # x - E[x|c]
+    if op == 0:  # x - E[x|c]
         rel = x - grp_mean
-    elif op == 1:                     # x / E[x|c], denominator-guarded (repro lesson)
+    elif op == 1:  # x / E[x|c], denominator-guarded (repro lesson)
         denom = grp_mean.copy()
         small = np.abs(denom) < 1e-3
         denom[small] = np.where(denom[small] >= 0, 1e-3, -1e-3)
         rel = np.clip(x / denom, -10.0, 10.0)
-    else:                             # within-group empirical CDF in [0,1]
+    else:  # within-group empirical CDF in [0,1]
         rel = np.full(n_samples, 0.5, dtype=np.float64)
         global_sorted = np.sort(context_x)
         for g in np.unique(cat_ids):
@@ -3024,8 +2993,8 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
                 reference = global_sorted
             if len(reference) > 1:
                 # Mid-rank ECDF evaluated against context values only.
-                left = np.searchsorted(reference, x[row_mask], side='left')
-                right = np.searchsorted(reference, x[row_mask], side='right')
+                left = np.searchsorted(reference, x[row_mask], side="left")
+                right = np.searchsorted(reference, x[row_mask], side="right")
                 rel[row_mask] = (left + right) / (2.0 * len(reference))
 
     # 5. standardize -> target effect with random sign/scale
@@ -3038,15 +3007,30 @@ def _create_groupby_relative_numeric(X, cat_col, n_samples, rng, cardinality,
     return row_effect.astype(np.float64, copy=False), 1
 
 
-def generate_dataset(n_samples, n_features, task_type, n_classes=None,
-                     rng=None, augment=False, augment_v3=False,
-                     rich_reg_targets=True, scale_variation=True,
-                     augment_v4=False, v4_filter=True, v4_no_edge_noise=True,
-                     synth_v5=False, synth_v5_denoise=True,
-                     synth_v5_declone=True, synth_v5_mixture=False,
-                     reg_denoise=False, reg_dense=False,
-                     probabilistic_labels=False, nominal_categoricals=False,
-                     enhanced_missingness=False, context_rows=None):
+def generate_dataset(
+    n_samples,
+    n_features,
+    task_type,
+    n_classes=None,
+    rng=None,
+    augment=False,
+    augment_v3=False,
+    rich_reg_targets=True,
+    scale_variation=True,
+    augment_v4=False,
+    v4_filter=True,
+    v4_no_edge_noise=True,
+    synth_v5=False,
+    synth_v5_denoise=True,
+    synth_v5_declone=True,
+    synth_v5_mixture=False,
+    reg_denoise=False,
+    reg_dense=False,
+    probabilistic_labels=False,
+    nominal_categoricals=False,
+    enhanced_missingness=False,
+    context_rows=None,
+):
     """Generate a synthetic dataset using hierarchical SCM.
 
     Args:
@@ -3094,12 +3078,12 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     if rng is None:
         rng = np.random.default_rng()
     meta = {
-        'generator_family': 'scm',
-        'task_type': task_type,
-        'repeated_entity_cols': [],
-        'repeated_entity_stats': [],
-        'entity_lookup_signal_std': 0.0,
-        'entity_lookup_target_ratio': 0.0,
+        "generator_family": "scm",
+        "task_type": task_type,
+        "repeated_entity_cols": [],
+        "repeated_entity_stats": [],
+        "entity_lookup_signal_std": 0.0,
+        "entity_lookup_target_ratio": 0.0,
     }
 
     # Mixture prior: randomly select v4/v5a/v5c-like mode per dataset
@@ -3122,10 +3106,15 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             synth_v5_declone = False
 
     # Build SCM (expanded edge fns/aggregation if synth_v4)
-    _max_parents = 7 if (reg_dense and task_type == 'reg') else 4
+    _max_parents = 7 if (reg_dense and task_type == "reg") else 4
     lcs_list, global_nodes, global_parents = _build_hierarchical_scm(
-        n_features, rng, expanded=augment_v4, synth_v5=synth_v5,
-        synth_v5_declone=synth_v5_declone, max_parents=_max_parents)
+        n_features,
+        rng,
+        expanded=augment_v4,
+        synth_v5=synth_v5,
+        synth_v5_declone=synth_v5_declone,
+        max_parents=_max_parents,
+    )
 
     # Track causal column indices (synth_v5: protected from noise overwrite)
     _causal_col_indices = []
@@ -3169,13 +3158,10 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
         # then remaining non-ancestor nodes
         direct_parents = set(global_parents.get(target_idx, []))
         other_ancestors = ancestors - direct_parents
-        non_ancestors = [i for i in all_indices
-                         if i != target_idx and i not in ancestors]
+        non_ancestors = [i for i in all_indices if i != target_idx and i not in ancestors]
         rng.shuffle(non_ancestors)
 
-        priority_order = (sorted(direct_parents)
-                          + sorted(other_ancestors)
-                          + list(non_ancestors))
+        priority_order = sorted(direct_parents) + sorted(other_ancestors) + list(non_ancestors)
 
         # Extract feature columns, respecting priority
         feature_cols = []
@@ -3210,8 +3196,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                         _causal_col_indices.append(n_cols_so_far + k)
                 n_cols_so_far += n_observe
 
-        X = np.column_stack(feature_cols) if feature_cols else \
-            rng.standard_normal((n_samples, 1))
+        X = np.column_stack(feature_cols) if feature_cols else rng.standard_normal((n_samples, 1))
 
         # Trim or pad to exactly n_features
         if X.shape[1] > n_features:
@@ -3223,16 +3208,12 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             keep = sorted(causal_set)[:n_keep]
             remaining_budget = n_keep - len(keep)
             if remaining_budget > 0 and other_cols:
-                keep.extend(rng.choice(
-                    other_cols,
-                    size=min(remaining_budget, len(other_cols)),
-                    replace=False).tolist())
+                keep.extend(rng.choice(other_cols, size=min(remaining_budget, len(other_cols)), replace=False).tolist())
             keep = sorted(keep)[:n_features]
             X = X[:, keep]
             # Remap causal indices
             keep_set = set(keep)
-            _causal_col_indices = [i for i, k in enumerate(keep)
-                                   if k in causal_set]
+            _causal_col_indices = [i for i, k in enumerate(keep) if k in causal_set]
         elif X.shape[1] < n_features:
             extra = n_features - X.shape[1]
             X = np.column_stack([X, rng.standard_normal((n_samples, extra))])
@@ -3241,7 +3222,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
         target_val = all_values[target_idx]
         if target_val.ndim > 1:
             w = rng.standard_normal(target_val.shape[1])
-            w /= (np.linalg.norm(w) + 1e-8)
+            w /= np.linalg.norm(w) + 1e-8
             y_raw = target_val @ w
         else:
             y_raw = target_val
@@ -3268,7 +3249,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     # Safety: ensure y_raw is 1D
     if y_raw.ndim > 1:
         w = rng.standard_normal(y_raw.shape[1])
-        w /= (np.linalg.norm(w) + 1e-8)
+        w /= np.linalg.norm(w) + 1e-8
         y_raw = y_raw @ w
     y_raw = y_raw.ravel()
     entity_lookup_signal = np.zeros(n_samples, dtype=np.float64)
@@ -3284,15 +3265,15 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     # CLS v4 gets more noise features to dilute MI (real CLS MI median=0.021)
     # synth_v5+denoise: reduced range — multi-dim hidden columns already suppress learnability
     if augment and n_features >= 2:
-        if augment_v4 and task_type == 'cls':
+        if augment_v4 and task_type == "cls":
             if synth_v5 and synth_v5_denoise:
                 noise_frac = rng.uniform(0.05, 0.25)
             else:
                 noise_frac = rng.uniform(0.15, 0.55)
         else:
-            if reg_dense and task_type == 'reg':
+            if reg_dense and task_type == "reg":
                 noise_frac = rng.uniform(0, 0.15)
-            elif reg_denoise and task_type == 'reg':
+            elif reg_denoise and task_type == "reg":
                 noise_frac = rng.uniform(0, 0.2)
             else:
                 noise_frac = rng.uniform(0, 0.5)
@@ -3365,16 +3346,16 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     # --- 3.7 Feature importances [synth_v4] ---
     # CLS uses milder importances to avoid MI overshoot (real CLS MI median=0.021)
     # reg_dense: skip power-law importances 60% of the time (flat importance profile)
-    _imp_prob = 0.35 if (reg_dense and task_type == 'reg') else 0.85
+    _imp_prob = 0.35 if (reg_dense and task_type == "reg") else 0.85
     if augment_v4 and n_features >= 2 and rng.random() < _imp_prob:
-        X = _apply_feature_importances(X, rng, mild=(task_type == 'cls'))
+        X = _apply_feature_importances(X, rng, mild=(task_type == "cls"))
 
     # --- 4. Add Gaussian noise to features (existing) ---
     # synth_v4: reduced noise (TabICLv2 found no benefit from full noise,
     # but removing it entirely makes MI too high vs real data)
     # CLS gets more noise since real CLS has very low MI (median 0.021)
     if augment_v4 and v4_no_edge_noise:
-        if task_type == 'cls':
+        if task_type == "cls":
             # synth_v5+denoise: less noise needed (multi-dim hidden dims already suppress MI)
             if synth_v5 and synth_v5_denoise:
                 noise_scale = rng.uniform(0.05, 0.25)
@@ -3386,9 +3367,9 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             else:
                 noise_scale = rng.uniform(0.02, 0.15)
     else:
-        if reg_dense and task_type == 'reg':
+        if reg_dense and task_type == "reg":
             noise_scale = rng.uniform(0.005, 0.08)
-        elif reg_denoise and task_type == 'reg':
+        elif reg_denoise and task_type == "reg":
             noise_scale = rng.uniform(0.01, 0.15)
         else:
             noise_scale = rng.uniform(0.01, 0.3)
@@ -3415,7 +3396,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
         elif augment_v4:
             disc_frac = rng.uniform(0.4, 0.98)
         else:
-            if reg_denoise and task_type == 'reg':
+            if reg_denoise and task_type == "reg":
                 disc_frac = rng.uniform(0, 0.4)
             else:
                 disc_frac = rng.uniform(0, 0.8)
@@ -3440,8 +3421,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     thresholds = np.nanpercentile(X[:, col], percentiles)
                     # Remove duplicate thresholds
                     thresholds = np.unique(thresholds)
-                    X[:, col] = np.digitize(X[:, col], thresholds).astype(
-                        np.float64)
+                    X[:, col] = np.digitize(X[:, col], thresholds).astype(np.float64)
                 else:
                     # Round to 0-2 decimal places, then rank to integer
                     decimals = int(rng.integers(0, 3))
@@ -3449,12 +3429,10 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     # Map unique values to integer ranks
                     unique_vals = np.unique(rounded)
                     rank_map = {v: i for i, v in enumerate(unique_vals)}
-                    X[:, col] = np.array(
-                        [rank_map[v] for v in rounded], dtype=np.float64)
+                    X[:, col] = np.array([rank_map[v] for v in rounded], dtype=np.float64)
                 discrete_cols.add(int(col))
             if len(causal_disc_cols):
-                meta['coarsened_signal_cols'] = sorted(
-                    int(col) for col in causal_disc_cols)
+                meta["coarsened_signal_cols"] = sorted(int(col) for col in causal_disc_cols)
 
     # --- 5.5 True categorical features [synth_v3] ---
     # Unlike discretization (which bins continuous values preserving order),
@@ -3474,32 +3452,26 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             if nominal_categoricals and rng.random() < 0.4:
                 cardinality = int(rng.integers(3, min(31, max(4, n_samples // 8))))
                 row_effect, n_used = _create_nominal_categorical(
-                    X, col, n_samples, rng, cardinality,
-                    task_type, n_features, discrete_cols, cat_cols_set)
+                    X, col, n_samples, rng, cardinality, task_type, n_features, discrete_cols, cat_cols_set
+                )
                 entity_lookup_signal += row_effect
                 discrete_cols.add(int(col))
                 cat_cardinality[int(col)] = cardinality
                 if n_used == 2:
                     # Crossed nominal consumed a second column
-                    meta.setdefault('nominal_crossed_cols', []).append(int(col))
+                    meta.setdefault("nominal_crossed_cols", []).append(int(col))
                 else:
-                    meta.setdefault('nominal_independent_cols', []).append(int(col))
+                    meta.setdefault("nominal_independent_cols", []).append(int(col))
                 continue
 
             entity_prob = 0.55 if (n_samples >= 1024 and n_features <= 64) else 0.35
-            use_repeated_entity = (
-                task_type == 'cls'
-                and n_samples >= 64
-                and rng.random() < entity_prob
-            )
+            use_repeated_entity = task_type == "cls" and n_samples >= 64 and rng.random() < entity_prob
             if use_repeated_entity:
-                row_effect, entity_meta = _create_repeated_entity_categorical(
-                    X, col, rng
-                )
+                row_effect, entity_meta = _create_repeated_entity_categorical(X, col, rng)
                 entity_lookup_signal += row_effect
-                cardinality = int(entity_meta['cardinality'])
-                meta['repeated_entity_cols'].append(int(col))
-                meta['repeated_entity_stats'].append(entity_meta)
+                cardinality = int(entity_meta["cardinality"])
+                meta["repeated_entity_cols"].append(int(col))
+                meta["repeated_entity_stats"].append(entity_meta)
             else:
                 cardinality = int(rng.integers(2, 31))
                 if synth_v5 and rng.random() < 0.7:
@@ -3507,8 +3479,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     _create_informative_categorical(X, col, rng, cardinality)
                 else:
                     # Random noise categorical (original behavior)
-                    X[:, col] = rng.integers(0, cardinality,
-                                             size=n_samples).astype(np.float64)
+                    X[:, col] = rng.integers(0, cardinality, size=n_samples).astype(np.float64)
             discrete_cols.add(int(col))
             cat_cardinality[int(col)] = cardinality
 
@@ -3519,8 +3490,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
         if continuous_cols:
             warp_frac = rng.uniform(0.05, 0.3)
             n_warp = max(1, int(len(continuous_cols) * warp_frac))
-            warp_cols = rng.choice(continuous_cols, size=min(n_warp, len(continuous_cols)),
-                                   replace=False)
+            warp_cols = rng.choice(continuous_cols, size=min(n_warp, len(continuous_cols)), replace=False)
             for col in warp_cols:
                 if not np.any(np.isnan(X[:, col])):
                     _apply_kumaraswamy_warping(X, col, rng)
@@ -3541,15 +3511,14 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     # Only inject into continuous columns — discrete cols get kurtosis from spike distributions
     if augment_v4 and n_features >= 2 and rng.random() < 0.6:
         _ht_causal = _causal_col_indices if synth_v5 else None
-        X = _inject_heavy_tails(X, rng, causal_cols=_ht_causal,
-                                exclude_cols=discrete_cols)
+        X = _inject_heavy_tails(X, rng, causal_cols=_ht_causal, exclude_cols=discrete_cols)
 
     # Regression targets should be generated from the clean feature values
     # before structural missingness is applied to the observed table.
-    X_target = X.copy() if task_type == 'reg' else None
+    X_target = X.copy() if task_type == "reg" else None
 
     # --- 6. Structural missingness (Change 5) ---
-    _miss_prob = 0.15 if (reg_denoise and task_type == 'reg') else 0.3
+    _miss_prob = 0.15 if (reg_denoise and task_type == "reg") else 0.3
     if augment and n_features >= 2 and rng.random() < _miss_prob:
         # Enhanced missingness: row-level and block patterns applied first
         # (these affect multiple columns at once, not per-column)
@@ -3564,8 +3533,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                 n_drop_cols = max(1, int(n_features * col_frac))
                 drop_rows = rng.choice(n_samples, size=n_drop_rows, replace=False)
                 for row in drop_rows:
-                    drop_cols_r = rng.choice(n_features, size=n_drop_cols,
-                                             replace=False)
+                    drop_cols_r = rng.choice(n_features, size=n_drop_cols, replace=False)
                     X[row, drop_cols_r] = np.nan
                 _did_enhanced = True
             elif _enh_type == 1:
@@ -3582,14 +3550,12 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                 # Covariate-dependent tail censoring. The historical variant
                 # read realized y for every row, exposing query labels through
                 # the missingness mask.
-                _did_enhanced = _apply_feature_dependent_tail_missingness(
-                    X, rng, context_rows=context_rows)
+                _did_enhanced = _apply_feature_dependent_tail_missingness(X, rng, context_rows=context_rows)
             elif _enh_type == 3 and discrete_cols:
                 # Categorical missing-as-category: replace NaN with new level
                 # for discrete columns. The model learns that "missing" is a
                 # meaningful category, not just absence of data.
-                mac_cols = [c for c in discrete_cols
-                            if c in cat_cardinality]
+                mac_cols = [c for c in discrete_cols if c in cat_cardinality]
                 if mac_cols:
                     n_mac = min(len(mac_cols), int(rng.integers(1, 4)))
                     mac_selected = rng.choice(mac_cols, size=n_mac, replace=False)
@@ -3636,14 +3602,14 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     # too hard (oob_auc/oob_r2 far below real data).
     if augment_v4 and not synth_v5 and n_features >= 4 and rng.random() < 0.4:
         X, y_raw = _add_latent_bayes_error(
-            X, y_raw, n_features, rng, task_type,
-            protected_cols=_causal_col_indices, metadata=meta)
+            X, y_raw, n_features, rng, task_type, protected_cols=_causal_col_indices, metadata=meta
+        )
 
     # --- 7. Create target y ---
     y_raw = _add_entity_lookup_signal(
-        y_raw, entity_lookup_signal, rng, meta,
-        context_rows=context_rows if task_type == 'reg' else None)
-    if task_type == 'cls':
+        y_raw, entity_lookup_signal, rng, meta, context_rows=context_rows if task_type == "reg" else None
+    )
+    if task_type == "cls":
         if n_classes is None:
             n_classes = int(rng.integers(2, 11))
 
@@ -3659,8 +3625,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     alpha = rng.uniform(0.5, 3.0)
                     proportions = rng.dirichlet(np.full(n_classes, alpha))
                     cumulative = np.cumsum(proportions)
-                    percentiles = np.concatenate(
-                        [[0.0], cumulative[:-1] * 100, [100.0]])
+                    percentiles = np.concatenate([[0.0], cumulative[:-1] * 100, [100.0]])
                 else:
                     # Extreme: one dominant class at 80-95% (toned down)
                     dominant = int(rng.integers(0, n_classes))
@@ -3669,8 +3634,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     proportions = np.full(n_classes, remaining / max(n_classes - 1, 1))
                     proportions[dominant] = dominant_pct
                     cumulative = np.cumsum(proportions)
-                    percentiles = np.concatenate(
-                        [[0.0], cumulative[:-1] * 100, [100.0]])
+                    percentiles = np.concatenate([[0.0], cumulative[:-1] * 100, [100.0]])
             else:
                 # 30% balanced, 30% moderate Dirichlet, 40% extreme imbalance
                 if imbalance_roll < 0.3:
@@ -3680,8 +3644,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     alpha = rng.uniform(0.3, 1.0)
                     proportions = rng.dirichlet(np.full(n_classes, alpha))
                     cumulative = np.cumsum(proportions)
-                    percentiles = np.concatenate(
-                        [[0.0], cumulative[:-1] * 100, [100.0]])
+                    percentiles = np.concatenate([[0.0], cumulative[:-1] * 100, [100.0]])
                 else:
                     # Extreme: one dominant class at 85-99%
                     dominant = int(rng.integers(0, n_classes))
@@ -3690,8 +3653,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                     proportions = np.full(n_classes, remaining / max(n_classes - 1, 1))
                     proportions[dominant] = dominant_pct
                     cumulative = np.cumsum(proportions)
-                    percentiles = np.concatenate(
-                        [[0.0], cumulative[:-1] * 100, [100.0]])
+                    percentiles = np.concatenate([[0.0], cumulative[:-1] * 100, [100.0]])
         else:
             # Original: 50% balanced, 50% moderate Dirichlet
             if rng.random() < 0.5:
@@ -3700,8 +3662,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                 alpha = rng.uniform(0.3, 1.0)
                 proportions = rng.dirichlet(np.full(n_classes, alpha))
                 cumulative = np.cumsum(proportions)
-                percentiles = np.concatenate(
-                    [[0.0], cumulative[:-1] * 100, [100.0]])
+                percentiles = np.concatenate([[0.0], cumulative[:-1] * 100, [100.0]])
 
         # --- Probabilistic labelers: non-percentile classification targets ---
         # When enabled, ~50% of episodes use a feature-based labeler instead
@@ -3726,8 +3687,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
                 n_flip = int(n_samples * flip_rate)
                 if n_flip > 0:
                     flip_idx = rng.choice(n_samples, size=n_flip, replace=False)
-                    y[flip_idx] = rng.integers(0, n_classes, size=n_flip).astype(
-                        np.float32)
+                    y[flip_idx] = rng.integers(0, n_classes, size=n_flip).astype(np.float32)
 
     else:
         # --- Rich regression target [synth_v3]: more feature dependencies ---
@@ -3744,7 +3704,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             for col in dep_cols:
                 edge_fn = _make_edge_fn(1, rng)
                 weight = rng.normal(0, 1.0)
-                extra = extra + weight * edge_fn(target_features[:, col:col+1]).ravel()
+                extra = extra + weight * edge_fn(target_features[:, col : col + 1]).ravel()
 
             # Add feature interaction terms to target (x_i * x_j, ratios, etc.)
             if rng.random() < 0.5:
@@ -3763,8 +3723,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             # Scale extra terms to contribute 30-70% of total y variance.
             # Without this, n_extra terms with weight~N(0,1) can have
             # variance ~50x the original SCM target, drowning it out.
-            extra = _scale_rich_target_component(
-                extra, y_raw, rng, context_rows=context_rows)
+            extra = _scale_rich_target_component(extra, y_raw, rng, context_rows=context_rows)
             y_raw = y_raw + extra
 
             # Safety clip after adding dependencies
@@ -3881,21 +3840,22 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
             dup_frac = min(rng.exponential(0.20), 0.50)
         n_dup = max(1, int(n_samples * dup_frac))
         # Sample rows to duplicate (with replacement — same row can appear 3+x)
-        src_idx, dst_idx = _sample_context_safe_duplicate_indices(
-            n_samples, n_dup, rng, context_rows=context_rows)
+        src_idx, dst_idx = _sample_context_safe_duplicate_indices(n_samples, n_dup, rng, context_rows=context_rows)
         X[dst_idx] = X[src_idx]
         y[dst_idx] = y[src_idx]
         if X_target is not None:
             X_target[dst_idx] = X_target[src_idx]
 
     return {
-        'X': X,
-        'y': y,
-        'task_type': task_type,
-        'n_classes': n_classes if task_type == 'cls' else None,
-        'filtered': False,
-        'meta': meta,
-        'X_target': None if X_target is None else np.where(
+        "X": X,
+        "y": y,
+        "task_type": task_type,
+        "n_classes": n_classes if task_type == "cls" else None,
+        "filtered": False,
+        "meta": meta,
+        "X_target": None
+        if X_target is None
+        else np.where(
             np.isfinite(X_target),
             X_target,
             0.0,
@@ -3903,9 +3863,7 @@ def generate_dataset(n_samples, n_features, task_type, n_classes=None,
     }
 
 
-def _random_decision_tree_predict(
-        X, feature_cols, rng, depth=4, n_classes_leaf=0,
-        context_rows=None):
+def _random_decision_tree_predict(X, feature_cols, rng, depth=4, n_classes_leaf=0, context_rows=None):
     """Generate predictions from a random (unfitted) decision tree.
 
     Procedurally generates random axis-aligned splits and random leaf values.
@@ -3923,7 +3881,7 @@ def _random_decision_tree_predict(
         predictions: [n_samples] (float)
     """
     n_samples = X.shape[0]
-    n_leaves = 2 ** depth
+    n_leaves = 2**depth
     if n_classes_leaf > 0:
         leaf_values = rng.integers(0, n_classes_leaf, size=n_leaves).astype(np.float64)
     else:
@@ -3949,10 +3907,9 @@ def _random_decision_tree_predict(
     return leaf_values[leaf_idx]
 
 
-def _generate_tree_prior_episode(n_samples, n_features, task_type,
-                                 n_classes, rng,
-                                 probabilistic_labels=False,
-                                 context_rows=None):
+def _generate_tree_prior_episode(
+    n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=False, context_rows=None
+):
     """Generate a dataset with tree-ensemble targets.
 
     Produces piecewise-constant targets from random decision tree ensembles.
@@ -3997,22 +3954,19 @@ def _generate_tree_prior_episode(n_samples, n_features, task_type,
     for _ in range(n_trees):
         # Each tree uses a random feature subset
         tree_feats = rng.choice(n_features, size=n_active, replace=False)
-        y += _random_decision_tree_predict(
-            X, tree_feats, rng, depth=tree_depth,
-            context_rows=context_rows)
+        y += _random_decision_tree_predict(X, tree_feats, rng, depth=tree_depth, context_rows=context_rows)
 
     y /= n_trees  # Average
 
     # --- Add noise + create final target ---
-    if task_type == 'reg':
+    if task_type == "reg":
         y_clean = y.copy()
         target_r2 = rng.uniform(0.4, 0.95)
         noise, realized_r2 = _calibrate_noise_to_target_r2(
-            y_clean, rng.standard_normal(n_samples), target_r2,
-            context_rows=context_rows)
+            y_clean, rng.standard_normal(n_samples), target_r2, context_rows=context_rows
+        )
         y = y_clean + noise
-        y, y_clean_out, _mu, _std = _normalize_target_pair(
-            y, y_clean, context_rows=context_rows)
+        y, y_clean_out, _mu, _std = _normalize_target_pair(y, y_clean, context_rows=context_rows)
         y = y.astype(np.float32)
         actual_n_classes = None
     else:
@@ -4036,27 +3990,25 @@ def _generate_tree_prior_episode(n_samples, n_features, task_type,
             X[:, col] = rng.standard_normal(n_samples)
 
     return {
-        'X': X,
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'y_clean': y_clean_out.astype(np.float32) if task_type == 'reg' else None,
-        'meta': {
-            'tree_prior': True,
-            'generator_family': 'tree_prior',
-            'n_trees': n_trees,
-            'tree_depth': tree_depth,
-            'realized_target_r2': float(realized_r2) if task_type == 'reg' else None,
+        "X": X,
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "y_clean": y_clean_out.astype(np.float32) if task_type == "reg" else None,
+        "meta": {
+            "tree_prior": True,
+            "generator_family": "tree_prior",
+            "n_trees": n_trees,
+            "tree_depth": tree_depth,
+            "realized_target_r2": float(realized_r2) if task_type == "reg" else None,
         },
     }
 
 
-def _generate_gp_prior_episode(n_samples, n_features, task_type,
-                               n_classes, rng,
-                               reg_denoise=False,
-                               probabilistic_labels=False,
-                               context_rows=None):
+def _generate_gp_prior_episode(
+    n_samples, n_features, task_type, n_classes, rng, reg_denoise=False, probabilistic_labels=False, context_rows=None
+):
     """Generate a dataset with a Gaussian Process smooth function target.
 
     Uses Random Fourier Features (RFF) to approximate GP samples:
@@ -4070,9 +4022,8 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
     Directly produces smooth joint multivariate functions — the data shape
     of sulfur, debutanizer, space_ga, kin8nm, houses, physiochemical_protein.
     """
-    regression_context_rows = context_rows if task_type == 'reg' else None
-    labeled_rows = _resolve_context_rows(
-        n_samples, regression_context_rows)
+    regression_context_rows = context_rows if task_type == "reg" else None
+    labeled_rows = _resolve_context_rows(n_samples, regression_context_rows)
     # --- Generate features ---
     X = np.zeros((n_samples, n_features), dtype=np.float64)
 
@@ -4139,7 +4090,7 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
         X[:, active] = X_active
 
     # --- GP kernel parameters ---
-    kernel_type = rng.choice(['rbf', 'matern32', 'matern52', 'rbf', 'matern52'])
+    kernel_type = rng.choice(["rbf", "matern32", "matern52", "rbf", "matern52"])
 
     # Per-feature lengthscales — use LONGER lengthscales for smoother functions
     # Real gap datasets (sulfur, debutanizer) have very smooth targets.
@@ -4160,16 +4111,13 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
     else:
         max_rff = max(4, min(64, labeled_rows // 4))
         min_rff = min(32, max_rff)
-        n_rff = (
-            min_rff if min_rff == max_rff
-            else int(rng.integers(min_rff, max_rff + 1))
-        )
+        n_rff = min_rff if min_rff == max_rff else int(rng.integers(min_rff, max_rff + 1))
 
     # --- Sample spectral frequencies from kernel's spectral density ---
-    if kernel_type == 'rbf':
+    if kernel_type == "rbf":
         # RBF kernel: spectral density is Gaussian
         omega = rng.standard_normal((n_rff, n_active)) / lengthscales
-    elif kernel_type == 'matern32':
+    elif kernel_type == "matern32":
         # Matern-3/2: spectral density is Student-t(df=2*nu) = Student-t(3)
         omega = rng.standard_t(3, size=(n_rff, n_active)) / lengthscales
     else:  # matern52
@@ -4198,16 +4146,14 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
     remaining = n_features - n_active
     if remaining >= 2 and rng.random() < 0.5:
         n_corr = min(int(rng.integers(2, min(8, remaining) + 1)), remaining)
-        corr_targets = rng.choice(
-            [i for i in range(n_features) if i not in active],
-            size=n_corr, replace=False)
+        corr_targets = rng.choice([i for i in range(n_features) if i not in active], size=n_corr, replace=False)
         for ct in corr_targets:
             src = rng.choice(active)
             rho = rng.uniform(0.3, 0.8)
             X[:, ct] = rho * X[:, src] + np.sqrt(1 - rho**2) * rng.standard_normal(n_samples)
 
     # --- Noise + normalization ---
-    if task_type == 'reg':
+    if task_type == "reg":
         y_clean = y.copy()
         y_std = float(np.std(y[:labeled_rows]))
         target_r2 = 1.0
@@ -4224,15 +4170,14 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
             raw_noise += rng.standard_normal(n_samples) * het_scale * 0.1
         if target_r2 < 1.0:
             calibrated_noise, realized_target_r2 = _calibrate_noise_to_target_r2(
-                y_clean, raw_noise, target_r2,
-                context_rows=regression_context_rows)
+                y_clean, raw_noise, target_r2, context_rows=regression_context_rows
+            )
             y = y_clean + calibrated_noise
         else:
             calibrated_noise = np.zeros_like(y_clean)
             realized_target_r2 = 1.0
             y = y_clean.copy()
-        y, y_clean, _mu, _std = _normalize_target_pair(
-            y, y_clean, context_rows=regression_context_rows)
+        y, y_clean, _mu, _std = _normalize_target_pair(y, y_clean, context_rows=regression_context_rows)
         y = y.astype(np.float32)
         y_clean = y_clean.astype(np.float32)
         actual_n_classes = None
@@ -4259,49 +4204,48 @@ def _generate_gp_prior_episode(n_samples, n_features, task_type,
                 X[:, col] = rng.standard_normal(n_samples)
 
     meta = {
-        'gp_prior': True,
-        'generator_family': 'gp_prior',
-        'kernel': kernel_type,
-        'n_active': n_active,
-        'n_rff': n_rff,
+        "gp_prior": True,
+        "generator_family": "gp_prior",
+        "kernel": kernel_type,
+        "n_active": n_active,
+        "n_rff": n_rff,
     }
-    if task_type == 'reg':
-        meta.update({
-            'context_rows': labeled_rows,
-            'target_r2': float(target_r2),
-            'context_realized_target_r2': float(realized_target_r2),
-            'noise_std': float(np.std(calibrated_noise[:labeled_rows])),
-            'oracle_exact': True,
-            'r2_oracle_bound': 0.0,
-        })
+    if task_type == "reg":
+        meta.update(
+            {
+                "context_rows": labeled_rows,
+                "target_r2": float(target_r2),
+                "context_realized_target_r2": float(realized_target_r2),
+                "noise_std": float(np.std(calibrated_noise[:labeled_rows])),
+                "oracle_exact": True,
+                "r2_oracle_bound": 0.0,
+            }
+        )
 
     out = {
-        'X': X,
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': meta,
+        "X": X,
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": meta,
     }
-    if task_type == 'reg':
-        out['y_clean'] = y_clean
+    if task_type == "reg":
+        out["y_clean"] = y_clean
     return out
 
 
-def _generate_quadratic_surface_episode(n_samples, n_features, task_type,
-                                        n_classes, rng,
-                                        reg_denoise=False,
-                                        probabilistic_labels=False,
-                                        context_rows=None):
+def _generate_quadratic_surface_episode(
+    n_samples, n_features, task_type, n_classes, rng, reg_denoise=False, probabilistic_labels=False, context_rows=None
+):
     """Generate a dataset with a quadratic response surface target.
 
     y = x^T M x + w^T x + b over a random subset of 4-20 features.
     Covers smooth coupled multivariate interactions (industrial process
     control, kinematics, response surfaces).
     """
-    regression_context_rows = context_rows if task_type == 'reg' else None
-    labeled_rows = _resolve_context_rows(
-        n_samples, regression_context_rows)
+    regression_context_rows = context_rows if task_type == "reg" else None
+    labeled_rows = _resolve_context_rows(n_samples, regression_context_rows)
     X = np.zeros((n_samples, n_features), dtype=np.float64)
     for j in range(n_features):
         dist = int(rng.integers(0, 4))
@@ -4328,9 +4272,7 @@ def _generate_quadratic_surface_episode(n_samples, n_features, task_type,
         min_active = min(4, n_features)
     else:
         max_quadratic_terms = max(1, labeled_rows // 5)
-        context_active_cap = int(
-            np.floor((np.sqrt(1.0 + 8.0 * max_quadratic_terms) - 1.0) / 2.0)
-        )
+        context_active_cap = int(np.floor((np.sqrt(1.0 + 8.0 * max_quadratic_terms) - 1.0) / 2.0))
         max_active = min(20, n_features, max(1, context_active_cap))
         min_active = min(2, max_active)
     n_active = int(rng.integers(min_active, max_active + 1))
@@ -4363,15 +4305,13 @@ def _generate_quadratic_surface_episode(n_samples, n_features, task_type,
     if rng.random() < 0.5 and remaining >= 2:
         n_corr = min(int(rng.integers(2, min(6, remaining) + 1)), remaining)
         if n_corr > 0:
-            corr_targets = rng.choice(
-                [i for i in range(n_features) if i not in active],
-                size=n_corr, replace=False)
+            corr_targets = rng.choice([i for i in range(n_features) if i not in active], size=n_corr, replace=False)
             for ct in corr_targets:
                 src = rng.choice(active)
                 rho = rng.uniform(0.5, 0.95)
                 X[:, ct] = rho * X[:, src] + np.sqrt(1 - rho**2) * rng.standard_normal(n_samples)
 
-    if task_type == 'reg':
+    if task_type == "reg":
         y_clean = y.copy()
         y_std = float(np.std(y[:labeled_rows]))
         target_r2 = 1.0
@@ -4386,15 +4326,14 @@ def _generate_quadratic_surface_episode(n_samples, n_features, task_type,
             raw_noise += rng.standard_normal(n_samples) * het_scale * 0.1
         if target_r2 < 1.0:
             calibrated_noise, realized_target_r2 = _calibrate_noise_to_target_r2(
-                y_clean, raw_noise, target_r2,
-                context_rows=regression_context_rows)
+                y_clean, raw_noise, target_r2, context_rows=regression_context_rows
+            )
             y = y_clean + calibrated_noise
         else:
             calibrated_noise = np.zeros_like(y_clean)
             realized_target_r2 = 1.0
             y = y_clean.copy()
-        y, y_clean, _mu, _std = _normalize_target_pair(
-            y, y_clean, context_rows=regression_context_rows)
+        y, y_clean, _mu, _std = _normalize_target_pair(y, y_clean, context_rows=regression_context_rows)
         y = y.astype(np.float32)
         y_clean = y_clean.astype(np.float32)
         actual_n_classes = None
@@ -4414,45 +4353,45 @@ def _generate_quadratic_surface_episode(n_samples, n_features, task_type,
     n_noise = int(n_features * noise_frac)
     if n_noise > 0:
         noise_cols = rng.choice(
-            [i for i in range(n_features) if i not in active],
-            size=min(n_noise, n_features - n_active), replace=False)
+            [i for i in range(n_features) if i not in active], size=min(n_noise, n_features - n_active), replace=False
+        )
         for col in noise_cols:
             X[:, col] = rng.standard_normal(n_samples)
 
     meta = {
-        'quadratic_surface': True,
-        'generator_family': 'quadratic_surface',
-        'n_active': n_active,
-        'quadratic_terms': n_active * (n_active + 1) // 2,
+        "quadratic_surface": True,
+        "generator_family": "quadratic_surface",
+        "n_active": n_active,
+        "quadratic_terms": n_active * (n_active + 1) // 2,
     }
-    if task_type == 'reg':
-        meta.update({
-            'context_rows': labeled_rows,
-            'target_r2': float(target_r2),
-            'context_realized_target_r2': float(realized_target_r2),
-            'noise_std': float(np.std(calibrated_noise[:labeled_rows])),
-            'oracle_exact': True,
-            'r2_oracle_bound': 0.0,
-        })
+    if task_type == "reg":
+        meta.update(
+            {
+                "context_rows": labeled_rows,
+                "target_r2": float(target_r2),
+                "context_realized_target_r2": float(realized_target_r2),
+                "noise_std": float(np.std(calibrated_noise[:labeled_rows])),
+                "oracle_exact": True,
+                "r2_oracle_bound": 0.0,
+            }
+        )
 
     out = {
-        'X': X,
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': meta,
+        "X": X,
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": meta,
     }
-    if task_type == 'reg':
-        out['y_clean'] = y_clean
+    if task_type == "reg":
+        out["y_clean"] = y_clean
     return out
 
 
-def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
-                                       n_classes, rng,
-                                       reg_denoise=False,
-                                       probabilistic_labels=False,
-                                       context_rows=None):
+def _generate_sparse_nonlinear_episode(
+    n_samples, n_features, task_type, n_classes, rng, reg_denoise=False, probabilistic_labels=False, context_rows=None
+):
     """QSAR/MIP-inspired high-dim sparse nonlinear with realistic correlation structure.
 
     Real chemistry/genomics datasets have:
@@ -4471,9 +4410,8 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
     - Remaining features are redundant proxies (correlated via blocks) or distractors
     - 30% of episodes add a threshold effect; 50% use heteroskedastic noise
     """
-    regression_context_rows = context_rows if task_type == 'reg' else None
-    labeled_rows = _resolve_context_rows(
-        n_samples, regression_context_rows)
+    regression_context_rows = context_rows if task_type == "reg" else None
+    labeled_rows = _resolve_context_rows(n_samples, regression_context_rows)
 
     # === 1. Feature blocks with multicollinearity ===
     # n_blocks: roughly n_features / avg_block_size, clipped to [max(1, n/10), min(80, n/2)]
@@ -4576,11 +4514,11 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         else:
             h = np.sin(h)
         y = h @ W2
-        fn_name = 'mlp'
+        fn_name = "mlp"
     elif fn_type == 1:
         fn_bank = [
             lambda x, r=rng: x,
-            lambda x, r=rng: x ** 2,
+            lambda x, r=rng: x**2,
             lambda x, r=rng: np.log1p(np.abs(x)) * np.sign(x),
             lambda x, r=rng: np.tanh(x * r.uniform(0.5, 2.0)),
             lambda x, r=rng: np.sin(x * r.uniform(1.0, 4.0)),
@@ -4592,7 +4530,7 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         for k in range(n_strong):
             fn = fn_bank[int(rng.integers(0, len(fn_bank)))]
             y += coefs[k] * fn(X_strong[:, k])
-        fn_name = 'gam'
+        fn_name = "gam"
     elif fn_type == 2:
         A = rng.standard_normal((n_strong, n_strong))
         M = (A + A.T) / 2.0
@@ -4602,7 +4540,7 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         M = (eigvecs * eigvals[None, :]) @ eigvecs.T
         w = rng.standard_normal(n_strong) * 0.5
         y = np.sum((X_strong @ M) * X_strong, axis=1) + X_strong @ w
-        fn_name = 'quadratic'
+        fn_name = "quadratic"
     elif fn_type == 3:
         n_centers = int(rng.integers(3, min(12, n_samples // 10 + 1)))
         centers = rng.standard_normal((n_centers, n_strong))
@@ -4611,9 +4549,9 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         y = np.zeros(n_samples, dtype=np.float64)
         for c_idx in range(n_centers):
             diffs = X_strong - centers[c_idx]
-            dists_sq = np.sum(diffs ** 2, axis=1)
+            dists_sq = np.sum(diffs**2, axis=1)
             y += weights[c_idx] * np.exp(-dists_sq / (2 * sigmas[c_idx] ** 2))
-        fn_name = 'rbf'
+        fn_name = "rbf"
     else:
         w = rng.standard_normal(n_strong)
         y = X_strong @ w
@@ -4623,7 +4561,7 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
             i, j = rng.choice(n_strong, size=2, replace=False)
             coef = rng.standard_normal() * 0.5
             y += coef * X_strong[:, i] * X_strong[:, j]
-        fn_name = 'interactions'
+        fn_name = "interactions"
 
     # Smooth cap on strong signal
     y = 50.0 * np.tanh(y / 50.0)
@@ -4635,21 +4573,19 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         X_weak = X[:, weak_indices]
         weak_coefs = rng.standard_normal(n_weak)
         y_weak_raw = X_weak @ weak_coefs
-        y_weak_std = max(
-            float(np.std(y_weak_raw[:labeled_rows])), 1e-8)
+        y_weak_std = max(float(np.std(y_weak_raw[:labeled_rows])), 1e-8)
         y = y + y_weak_raw * (weak_scale_frac * y_strong_std / y_weak_std)
 
     # === 5. Occasional threshold effect (30%) ===
     if rng.random() < 0.30 and n_strong > 0:
         idx = int(rng.integers(0, n_strong))
         threshold = rng.uniform(-1.0, 1.0)
-        effect_scale = max(
-            float(np.std(y[:labeled_rows])), 1e-8) * rng.uniform(0.2, 0.6)
+        effect_scale = max(float(np.std(y[:labeled_rows])), 1e-8) * rng.uniform(0.2, 0.6)
         above = (X_strong[:, idx] > threshold).astype(np.float64) * 2.0 - 1.0
         y = y + above * effect_scale
 
     # === 6. Noise (heteroskedastic 50% / homoscedastic 50%) ===
-    if task_type == 'reg':
+    if task_type == "reg":
         y_clean = y.copy()
         y_std = float(np.std(y[:labeled_rows]))
         target_r2 = 1.0
@@ -4658,32 +4594,26 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
             if regression_context_rows is not None:
                 target_r2 = rng.uniform(0.65, 0.95)
             else:
-                target_r2 = (
-                    rng.uniform(0.5, 0.95)
-                    if reg_denoise else rng.uniform(0.3, 0.90)
-                )
+                target_r2 = rng.uniform(0.5, 0.95) if reg_denoise else rng.uniform(0.3, 0.90)
             base_noise_std = y_std * np.sqrt((1.0 - target_r2) / max(target_r2, 1e-6))
 
             if rng.random() < 0.5 and n_strong > 0:
                 driver_idx = int(rng.integers(0, n_strong))
                 driver = X_strong[:, driver_idx]
                 noise_scale = np.abs(driver) + 0.5
-                noise_scale = noise_scale / max(
-                    float(np.mean(noise_scale[:labeled_rows])), 1e-8)
-                raw_noise = (
-                    rng.standard_normal(n_samples) * base_noise_std * noise_scale)
+                noise_scale = noise_scale / max(float(np.mean(noise_scale[:labeled_rows])), 1e-8)
+                raw_noise = rng.standard_normal(n_samples) * base_noise_std * noise_scale
             else:
                 raw_noise = rng.standard_normal(n_samples) * base_noise_std
             calibrated_noise, realized_target_r2 = _calibrate_noise_to_target_r2(
-                y_clean, raw_noise, target_r2,
-                context_rows=regression_context_rows)
+                y_clean, raw_noise, target_r2, context_rows=regression_context_rows
+            )
             y = y_clean + calibrated_noise
         else:
             realized_target_r2 = 1.0
             y = y_clean.copy()
 
-        y, y_clean, _mu, _std = _normalize_target_pair(
-            y, y_clean, context_rows=regression_context_rows)
+        y, y_clean, _mu, _std = _normalize_target_pair(y, y_clean, context_rows=regression_context_rows)
         y = y.astype(np.float32)
         y_clean = y_clean.astype(np.float32)
         actual_n_classes = None
@@ -4700,40 +4630,41 @@ def _generate_sparse_nonlinear_episode(n_samples, n_features, task_type,
         actual_n_classes = n_classes
 
     meta = {
-        'sparse_nonlinear_v2': True,
-        'generator_family': 'sparse_nonlinear',
-        'n_strong': n_strong,
-        'n_weak': n_weak,
-        'n_blocks': n_blocks,
-        'fn_type': fn_name,
+        "sparse_nonlinear_v2": True,
+        "generator_family": "sparse_nonlinear",
+        "n_strong": n_strong,
+        "n_weak": n_weak,
+        "n_blocks": n_blocks,
+        "fn_type": fn_name,
     }
-    if task_type == 'reg':
-        meta.update({
-            'context_rows': labeled_rows,
-            'target_r2': float(target_r2),
-            'context_realized_target_r2': float(realized_target_r2),
-            'noise_std': float(np.std(calibrated_noise[:labeled_rows])),
-            'oracle_exact': True,
-            'r2_oracle_bound': 0.0,
-        })
+    if task_type == "reg":
+        meta.update(
+            {
+                "context_rows": labeled_rows,
+                "target_r2": float(target_r2),
+                "context_realized_target_r2": float(realized_target_r2),
+                "noise_std": float(np.std(calibrated_noise[:labeled_rows])),
+                "oracle_exact": True,
+                "r2_oracle_bound": 0.0,
+            }
+        )
 
     out = {
-        'X': X.astype(np.float32),
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': meta,
+        "X": X.astype(np.float32),
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": meta,
     }
-    if task_type == 'reg':
-        out['y_clean'] = y_clean
+    if task_type == "reg":
+        out["y_clean"] = y_clean
     return out
 
 
-def _generate_lookup_prior_episode(n_samples, n_features, task_type,
-                                   n_classes, rng,
-                                   probabilistic_labels=False,
-                                   context_rows=None):
+def _generate_lookup_prior_episode(
+    n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=False, context_rows=None
+):
     """Generate a dataset with categorical lookup targets.
 
     Produces data where y = f(entity_ids) + continuous_signal + noise.
@@ -4744,23 +4675,20 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
     Target depends primarily on entity-specific effects.
     """
     X = np.zeros((n_samples, n_features), dtype=np.float64)
-    regression_context_rows = context_rows if task_type == 'reg' else None
-    labeled_rows = _resolve_context_rows(
-        n_samples, regression_context_rows)
+    regression_context_rows = context_rows if task_type == "reg" else None
+    labeled_rows = _resolve_context_rows(n_samples, regression_context_rows)
 
     # --- Categorical ID columns (1-3) ---
-    if task_type == 'reg':
+    if task_type == "reg":
         # Retain an ID column even for explicit one- and two-feature episodes.
         if n_features <= 1:
             n_id_cols, n_cont = 1, 0
         else:
-            n_id_cols = min(
-                int(rng.integers(1, 4)), max(1, n_features - 1))
+            n_id_cols = min(int(rng.integers(1, 4)), max(1, n_features - 1))
             n_cont = n_features - n_id_cols
     else:
         # Preserve the released classification geometry.
-        n_id_cols = min(
-            int(rng.integers(1, 4)), max(1, n_features // 3))
+        n_id_cols = min(int(rng.integers(1, 4)), max(1, n_features // 3))
         n_cont = max(2, n_features - n_id_cols)
         n_id_cols = n_features - n_cont
 
@@ -4780,23 +4708,17 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
             min_K = 3 if has_query and labeled_rows >= 2 else 2
             max_K = max(min_K, min(200, max(1, labeled_rows // 8)))
             min_K = min(10, max_K)
-            K = (
-                max_K if min_K == max_K
-                else int(np.exp(rng.uniform(
-                    np.log(float(min_K)), np.log(float(max_K)))))
-            )
+            K = max_K if min_K == max_K else int(np.exp(rng.uniform(np.log(float(min_K)), np.log(float(max_K)))))
             K = int(np.clip(K, min_K, max_K))
         elif rng.random() < 0.40:
             # High-cardinality (near-unique IDs): K close to n_samples
             max_K = int(min(300, max(20, n_samples // 2)))
-            K = int(np.exp(rng.uniform(
-                np.log(10.0), np.log(float(max_K)))))
+            K = int(np.exp(rng.uniform(np.log(10.0), np.log(float(max_K)))))
             K = int(np.clip(K, 10, max_K))
         else:
             # Moderate cardinality (counts more useful)
             max_K = int(min(200, max(10, n_samples // 4)))
-            K = int(np.exp(rng.uniform(
-                np.log(10.0), np.log(float(max_K)))))
+            K = int(np.exp(rng.uniform(np.log(10.0), np.log(float(max_K)))))
             K = int(np.clip(K, 10, max_K))
 
         # Zipf-like frequency. Stronger long-tail (alpha 1.0-3.0 vs old
@@ -4812,8 +4734,7 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
             n_query = n_samples - labeled_rows
             min_seen = min(2, labeled_rows)
             if n_query > 0 and K > min_seen:
-                desired_unseen = max(
-                    1, int(np.ceil(K * rng.uniform(0.10, 0.25))))
+                desired_unseen = max(1, int(np.ceil(K * rng.uniform(0.10, 0.25))))
                 n_unseen = min(desired_unseen, K - min_seen)
             else:
                 n_unseen = 0
@@ -4822,52 +4743,41 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
             seen_ids = id_order[n_unseen:]
             seen_probs = probs[seen_ids]
             seen_probs /= seen_probs.sum()
-            cat_ids[:labeled_rows] = rng.choice(
-                seen_ids, size=labeled_rows, replace=True, p=seen_probs)
+            cat_ids[:labeled_rows] = rng.choice(seen_ids, size=labeled_rows, replace=True, p=seen_probs)
             coverage_size = min(len(seen_ids), labeled_rows)
-            coverage_positions = rng.choice(
-                labeled_rows, size=coverage_size, replace=False)
-            cat_ids[coverage_positions] = rng.permutation(
-                seen_ids)[:coverage_size]
+            coverage_positions = rng.choice(labeled_rows, size=coverage_size, replace=False)
+            cat_ids[coverage_positions] = rng.permutation(seen_ids)[:coverage_size]
             if n_query > 0:
-                cat_ids[labeled_rows:] = rng.choice(
-                    seen_ids, size=n_query, replace=True, p=seen_probs)
+                cat_ids[labeled_rows:] = rng.choice(seen_ids, size=n_query, replace=True, p=seen_probs)
                 if n_unseen:
                     cold_fraction = rng.uniform(0.05, 0.20)
                     n_cold = max(1, int(round(n_query * cold_fraction)))
-                    cold_positions = labeled_rows + rng.choice(
-                        n_query, size=min(n_cold, n_query), replace=False)
+                    cold_positions = labeled_rows + rng.choice(n_query, size=min(n_cold, n_query), replace=False)
                     unseen_probs = probs[unseen_ids]
                     unseen_probs /= unseen_probs.sum()
                     cat_ids[cold_positions] = rng.choice(
-                        unseen_ids, size=len(cold_positions), replace=True,
-                        p=unseen_probs)
-            context_counts = np.bincount(
-                cat_ids[:labeled_rows], minlength=K)
+                        unseen_ids, size=len(cold_positions), replace=True, p=unseen_probs
+                    )
+            context_counts = np.bincount(cat_ids[:labeled_rows], minlength=K)
             query_ids = cat_ids[labeled_rows:]
             unseen = (
-                ~np.isin(query_ids, np.flatnonzero(context_counts))
-                if len(query_ids) else np.asarray([], dtype=bool)
+                ~np.isin(query_ids, np.flatnonzero(context_counts)) if len(query_ids) else np.asarray([], dtype=bool)
             )
-            minimum_context_counts.append(
-                int(context_counts[seen_ids].min()) if len(seen_ids) else 0)
-            query_unseen_fractions.append(
-                float(unseen.mean()) if len(unseen) else 0.0)
+            minimum_context_counts.append(int(context_counts[seen_ids].min()) if len(seen_ids) else 0)
+            query_unseen_fractions.append(float(unseen.mean()) if len(unseen) else 0.0)
             unseen_cardinalities.append(int(n_unseen))
         cardinalities.append(K)
 
         # Force some IDs to appear EXACTLY ONCE (rare singleton pattern).
         # Real high-card datasets have ~5-25% singleton rate. Pick random
         # rows to overwrite with rare-IDs (drawn from the tail of K).
-        if (regression_context_rows is None
-                and rng.random() < 0.50 and K > 30):
+        if regression_context_rows is None and rng.random() < 0.50 and K > 30:
             singleton_frac = rng.uniform(0.05, 0.25)
             n_singletons = max(1, int(n_samples * singleton_frac))
             # IDs in the tail (less common already) — promote to singletons
             tail_start = max(K - n_singletons, K // 2)
             singleton_ids = rng.choice(
-                np.arange(tail_start, K), size=n_singletons,
-                replace=(K - tail_start < n_singletons)
+                np.arange(tail_start, K), size=n_singletons, replace=(K - tail_start < n_singletons)
             )
             singleton_rows = rng.choice(n_samples, size=n_singletons, replace=False)
             cat_ids[singleton_rows] = singleton_ids
@@ -4876,12 +4786,9 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
         n_groups = max(2, min(20, int(np.sqrt(K))))
         entity_group = rng.integers(0, n_groups, size=K)
         group_effect = rng.standard_normal(n_groups) * 1.5
-        entity_effect = (
-            0.7 * group_effect[entity_group]
-            + 0.4 * rng.standard_normal(K)
-        )
+        entity_effect = 0.7 * group_effect[entity_group] + 0.4 * rng.standard_normal(K)
         entity_effect -= entity_effect.mean()
-        entity_effect /= (np.std(entity_effect) + 1e-8)
+        entity_effect /= np.std(entity_effect) + 1e-8
 
         # Weight decreases for secondary ID columns
         weight = 1.0 if j == 0 else rng.uniform(0.3, 0.7)
@@ -4903,22 +4810,19 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
     # Weak continuous signal (1-3 features)
     n_active_cont = min(int(rng.integers(1, 4)), n_cont) if n_cont else 0
     active_cols = (
-        rng.choice(range(n_id_cols, n_features),
-                   size=n_active_cont, replace=False)
-        if n_active_cont else np.asarray([], dtype=np.int64)
+        rng.choice(range(n_id_cols, n_features), size=n_active_cont, replace=False)
+        if n_active_cont
+        else np.asarray([], dtype=np.int64)
     )
     beta = rng.standard_normal(n_active_cont) * 0.5
-    cont_signal = (
-        X[:, active_cols] @ beta
-        if n_active_cont else np.zeros(n_samples, dtype=np.float64)
-    )
+    cont_signal = X[:, active_cols] @ beta if n_active_cont else np.zeros(n_samples, dtype=np.float64)
 
     # Combined signal: entity dominant, continuous secondary
     entity_weight = rng.uniform(0.6, 0.9)
     y_raw = entity_weight * entity_signal + (1 - entity_weight) * cont_signal
 
     # --- Create final target ---
-    if task_type == 'reg':
+    if task_type == "reg":
         y_clean = y_raw.copy()
         y_std = float(np.std(y_raw[:labeled_rows]))
         target_r2 = 1.0
@@ -4926,13 +4830,12 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
         if y_std > 1e-8:
             target_r2 = rng.uniform(0.4, 0.90)
             calibrated_noise, realized_target_r2 = _calibrate_noise_to_target_r2(
-                y_clean, rng.standard_normal(n_samples), target_r2,
-                context_rows=regression_context_rows)
+                y_clean, rng.standard_normal(n_samples), target_r2, context_rows=regression_context_rows
+            )
             y_raw = y_clean + calibrated_noise
         else:
             realized_target_r2 = 1.0
-        y_raw, y_clean, _mu, _std = _normalize_target_pair(
-            y_raw, y_clean, context_rows=regression_context_rows)
+        y_raw, y_clean, _mu, _std = _normalize_target_pair(y_raw, y_clean, context_rows=regression_context_rows)
         y = y_raw.astype(np.float32, copy=False)
         y_clean = y_clean.astype(np.float32)
         actual_n_classes = None
@@ -4953,42 +4856,49 @@ def _generate_lookup_prior_episode(n_samples, n_features, task_type,
             X[:, j] = rng.standard_normal(n_samples)
 
     meta = {
-        'lookup_prior': True,
-        'generator_family': 'lookup_prior',
-        'n_id_cols': n_id_cols,
+        "lookup_prior": True,
+        "generator_family": "lookup_prior",
+        "n_id_cols": n_id_cols,
     }
-    if task_type == 'reg':
-        meta.update({
-            'cardinalities': cardinalities,
-            'minimum_context_counts': minimum_context_counts,
-            'query_unseen_fractions': query_unseen_fractions,
-            'unseen_cardinalities': unseen_cardinalities,
-            'context_rows': labeled_rows,
-            'target_r2': float(target_r2),
-            'context_realized_target_r2': float(realized_target_r2),
-            'noise_std': float(np.std(calibrated_noise[:labeled_rows])),
-            'oracle_exact': True,
-            'r2_oracle_bound': 0.0,
-        })
+    if task_type == "reg":
+        meta.update(
+            {
+                "cardinalities": cardinalities,
+                "minimum_context_counts": minimum_context_counts,
+                "query_unseen_fractions": query_unseen_fractions,
+                "unseen_cardinalities": unseen_cardinalities,
+                "context_rows": labeled_rows,
+                "target_r2": float(target_r2),
+                "context_realized_target_r2": float(realized_target_r2),
+                "noise_std": float(np.std(calibrated_noise[:labeled_rows])),
+                "oracle_exact": True,
+                "r2_oracle_bound": 0.0,
+            }
+        )
 
     out = {
-        'X': X,
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': meta,
+        "X": X,
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": meta,
     }
-    if task_type == 'reg':
-        out['y_clean'] = y_clean
+    if task_type == "reg":
+        out["y_clean"] = y_clean
     return out
 
 
-def _generate_clean_lowdim_episode(n_samples, n_features_batch, task_type,
-                                   n_classes, rng,
-                                   probabilistic_labels=False,
-                                   nominal_categoricals=False,
-                                   context_rows=None):
+def _generate_clean_lowdim_episode(
+    n_samples,
+    n_features_batch,
+    task_type,
+    n_classes,
+    rng,
+    probabilistic_labels=False,
+    nominal_categoricals=False,
+    context_rows=None,
+):
     """Generate a clean, low-dimensional episode with high categorical fraction.
 
     Covers real-world tabular datasets with 5-30 features, mostly categorical,
@@ -5038,7 +4948,7 @@ def _generate_clean_lowdim_episode(n_samples, n_features_batch, task_type,
             # Nominal: random effects per category
             effects = rng.standard_normal(cardinality)
             effects -= effects.mean()
-            effects /= (np.std(effects) + 1e-8)
+            effects /= np.std(effects) + 1e-8
             cat_effects_list.append(effects[cat_ids])
         else:
             # Ordinal: category ID is the value (preserves ordering)
@@ -5047,7 +4957,7 @@ def _generate_clean_lowdim_episode(n_samples, n_features_batch, task_type,
         X[:, j] = cat_ids.astype(np.float64)
 
     # --- Generate target y ---
-    if task_type == 'reg':
+    if task_type == "reg":
         # Simple target: sparse linear on continuous + categorical effects
         y = np.zeros(n_samples, dtype=np.float64)
         n_active = min(int(rng.integers(1, 6)), n_features)
@@ -5120,18 +5030,16 @@ def _generate_clean_lowdim_episode(n_samples, n_features_batch, task_type,
                 X[finite, col] = np.clip(col_vals[finite], lo, hi)
 
     return {
-        'X': X.astype(np.float64),
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': {'clean_lowdim': True, 'actual_n_features': n_features},
+        "X": X.astype(np.float64),
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": {"clean_lowdim": True, "actual_n_features": n_features},
     }
 
 
-def _generate_cat_dominant_episode(n_samples, n_features, task_type,
-                                    n_classes, rng,
-                                    probabilistic_labels=False):
+def _generate_cat_dominant_episode(n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=False):
     """Generate a categorical-dominant regression dataset.
 
     Fills the gap between SCM (mostly continuous, only 1-3 cat cols via
@@ -5242,15 +5150,14 @@ def _generate_cat_dominant_episode(n_samples, n_features, task_type,
     # Small continuous-feature signal (cat dominant)
     if n_cont > 0:
         n_active_cont = min(n_cont, int(rng.integers(1, max(2, n_cont // 2 + 1))))
-        active_cont_cols = rng.choice(range(n_cat, n_features),
-                                        size=n_active_cont, replace=False)
+        active_cont_cols = rng.choice(range(n_cat, n_features), size=n_active_cont, replace=False)
         beta = rng.standard_normal(n_active_cont) * 0.4
         cont_signal = X[:, active_cont_cols] @ beta
         if np.std(y_raw) > 1e-8 and np.std(cont_signal) > 1e-8:
             y_raw = (y_raw / np.std(y_raw)) + 0.3 * (cont_signal / np.std(cont_signal))
 
     # Calibrated noise + standardize
-    if task_type == 'reg':
+    if task_type == "reg":
         y_std = float(np.std(y_raw))
         if y_std > 1e-8:
             target_r2 = float(rng.uniform(0.45, 0.92))
@@ -5282,24 +5189,19 @@ def _generate_cat_dominant_episode(n_samples, n_features, task_type,
             median = sorted_vals[n_fin // 2]
             mad = np.median(np.abs(sorted_vals - median))
             if mad > 1e-12:
-                X[finite, col] = np.clip(col_vals[finite],
-                                           median - 6 * mad,
-                                           median + 6 * mad)
+                X[finite, col] = np.clip(col_vals[finite], median - 6 * mad, median + 6 * mad)
 
     return {
-        'X': X.astype(np.float64),
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': {'cat_dominant': True, 'n_cat': n_cat,
-                 'cat_frac': float(n_cat) / max(n_features, 1)},
+        "X": X.astype(np.float64),
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": {"cat_dominant": True, "n_cat": n_cat, "cat_frac": float(n_cat) / max(n_features, 1)},
     }
 
 
-def _generate_binary_fingerprint_episode(n_samples, n_features, task_type,
-                                          n_classes, rng,
-                                          probabilistic_labels=False):
+def _generate_binary_fingerprint_episode(n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=False):
     """Generate a binary-fingerprint regression episode.
 
     Targets the QSAR-TID-11 archetype: a high-dimensional binary feature
@@ -5325,12 +5227,10 @@ def _generate_binary_fingerprint_episode(n_samples, n_features, task_type,
     for j in range(n_features):
         s = int(X[:, j].sum())
         if s == 0:
-            flip_idx = rng.choice(n_samples, size=max(1, n_samples // 100),
-                                    replace=False)
+            flip_idx = rng.choice(n_samples, size=max(1, n_samples // 100), replace=False)
             X[flip_idx, j] = 1.0
         elif s == n_samples:
-            flip_idx = rng.choice(n_samples, size=max(1, n_samples // 100),
-                                    replace=False)
+            flip_idx = rng.choice(n_samples, size=max(1, n_samples // 100), replace=False)
             X[flip_idx, j] = 0.0
 
     # --- Active subset (signal-bearing bits) ---
@@ -5392,7 +5292,7 @@ def _generate_binary_fingerprint_episode(n_samples, n_features, task_type,
     # Smooth clip before noise
     y_raw = 50.0 * np.tanh(y_raw / 50.0)
 
-    if task_type == 'reg':
+    if task_type == "reg":
         y_std = float(np.std(y_raw))
         if y_std > 1e-8:
             target_r2 = float(rng.uniform(0.40, 0.90))
@@ -5415,19 +5315,16 @@ def _generate_binary_fingerprint_episode(n_samples, n_features, task_type,
         actual_n_classes = n_classes
 
     return {
-        'X': X.astype(np.float64),
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': {'binary_fingerprint': True, 'n_active': n_active,
-                 'mean_on_rate': float(on_rates.mean())},
+        "X": X.astype(np.float64),
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": {"binary_fingerprint": True, "n_active": n_active, "mean_on_rate": float(on_rates.mean())},
     }
 
 
-def _generate_temporal_prior_episode(n_samples, n_features, task_type,
-                                      n_classes, rng,
-                                      probabilistic_labels=False):
+def _generate_temporal_prior_episode(n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=False):
     """Generate a temporally-structured regression episode.
 
     The generated rows are in TEMPORAL ORDER. Since the trainer's eval_pos
@@ -5468,7 +5365,7 @@ def _generate_temporal_prior_episode(n_samples, n_features, task_type,
         rho = rng.uniform(0.3, 0.95, size=n_features)
         X = np.zeros((n_samples, n_features), dtype=np.float64)
         X[0] = rng.standard_normal(n_features)
-        noise_scale = np.sqrt(1.0 - rho ** 2)
+        noise_scale = np.sqrt(1.0 - rho**2)
         for ti in range(1, n_samples):
             X[ti] = rho * X[ti - 1] + noise_scale * rng.standard_normal(n_features)
     elif mode == 1:
@@ -5577,7 +5474,7 @@ def _generate_temporal_prior_episode(n_samples, n_features, task_type,
     y_raw = 50.0 * np.tanh(y_raw / 50.0)
 
     # Calibrated noise + standardize
-    if task_type == 'reg':
+    if task_type == "reg":
         y_std = float(np.std(y_raw))
         if y_std > 1e-8:
             target_r2 = float(rng.uniform(0.45, 0.92))
@@ -5611,44 +5508,37 @@ def _generate_temporal_prior_episode(n_samples, n_features, task_type,
             median = sorted_vals[n_fin // 2]
             mad = np.median(np.abs(sorted_vals - median))
             if mad > 1e-12:
-                X[finite, col] = np.clip(col_vals[finite],
-                                          median - 8 * mad,
-                                          median + 8 * mad)
+                X[finite, col] = np.clip(col_vals[finite], median - 8 * mad, median + 8 * mad)
 
     return {
-        'X': X.astype(np.float64),
-        'y': y.astype(np.float32),
-        'task_type': task_type,
-        'n_classes': actual_n_classes,
-        'filtered': False,
-        'meta': {'temporal_prior': True, 'mode': int(mode)},
+        "X": X.astype(np.float64),
+        "y": y.astype(np.float32),
+        "task_type": task_type,
+        "n_classes": actual_n_classes,
+        "filtered": False,
+        "meta": {"temporal_prior": True, "mode": int(mode)},
     }
 
 
-def generate_dataset_filtered(n_samples, n_features, task_type, n_classes=None,
-                              rng=None, max_retries=3, quality_rules=None, **kwargs):
+def generate_dataset_filtered(
+    n_samples, n_features, task_type, n_classes=None, rng=None, max_retries=3, quality_rules=None, **kwargs
+):
     """Generate until the actual public episode passes requested filters."""
-    v4_filter = kwargs.get('augment_v4', False) and kwargs.get(
-        'v4_filter', True)
-    learnability_filter = (
-        kwargs.pop('learnability_filter', False) or v4_filter)
-    learnability_filter_reg_min_score = kwargs.pop(
-        'learnability_filter_reg_min_score', 0.10)
+    v4_filter = kwargs.get("augment_v4", False) and kwargs.get("v4_filter", True)
+    learnability_filter = kwargs.pop("learnability_filter", False) or v4_filter
+    learnability_filter_reg_min_score = kwargs.pop("learnability_filter_reg_min_score", 0.10)
     # Keep public classification knobs accepted even though the shared helper
     # dispatches them through staging's task-aware filter implementation.
-    kwargs.pop('learnability_filter_cls_min_score', 0.60)
-    kwargs.pop('learnability_filter_cls_margin', 0.10)
-    icl_filter_model = kwargs.pop('icl_filter_model', None)
-    kwargs.pop('icl_filter_cls_min_auc', 0.55)
-    icl_filter_reg_min_r2 = kwargs.pop('icl_filter_reg_min_r2', 0.05)
-    icl_scaling_filter = kwargs.pop('icl_scaling_filter', False)
-    icl_scaling_min_improvement = kwargs.pop(
-        'icl_scaling_min_improvement', 0.03)
-    context_rows = kwargs.get('context_rows')
+    kwargs.pop("learnability_filter_cls_min_score", 0.60)
+    kwargs.pop("learnability_filter_cls_margin", 0.10)
+    icl_filter_model = kwargs.pop("icl_filter_model", None)
+    kwargs.pop("icl_filter_cls_min_auc", 0.55)
+    icl_filter_reg_min_r2 = kwargs.pop("icl_filter_reg_min_r2", 0.05)
+    icl_scaling_filter = kwargs.pop("icl_scaling_filter", False)
+    icl_scaling_min_improvement = kwargs.pop("icl_scaling_min_improvement", 0.03)
+    context_rows = kwargs.get("context_rows")
     return _generate_filtered_episode(
-        lambda: generate_dataset(
-            n_samples, n_features, task_type,
-            n_classes=n_classes, rng=rng, **kwargs),
+        lambda: generate_dataset(n_samples, n_features, task_type, n_classes=n_classes, rng=rng, **kwargs),
         max_retries=max_retries,
         task_type=task_type,
         quality_rules=quality_rules,
@@ -5662,8 +5552,7 @@ def generate_dataset_filtered(n_samples, n_features, task_type, n_classes=None,
     )
 
 
-def _apply_train_feature_augmentation(X_batch, rng, p_episode=0.6,
-                                       p_col=0.40):
+def _apply_train_feature_augmentation(X_batch, rng, p_episode=0.6, p_col=0.40):
     """Train-time per-column feature distribution augmentation.
 
     Closes the synth/real distribution-shape gap. The literature consensus
@@ -5719,8 +5608,7 @@ def _apply_train_feature_augmentation(X_batch, rng, p_episode=0.6,
             if unique_count < cat_threshold_unique:
                 continue
             # Also skip if col looks integer-encoded
-            if np.allclose(col[finite], np.round(col[finite]), atol=1e-6) \
-                    and unique_count < N // 4:
+            if np.allclose(col[finite], np.round(col[finite]), atol=1e-6) and unique_count < N // 4:
                 continue
 
             if rng.random() >= p_col:
@@ -5776,8 +5664,7 @@ def _apply_train_feature_augmentation(X_batch, rng, p_episode=0.6,
                     continue
 
                 # Sanity: replace bad values
-                new_col = np.nan_to_num(new_col, nan=0.0,
-                                         posinf=0.0, neginf=0.0)
+                new_col = np.nan_to_num(new_col, nan=0.0, posinf=0.0, neginf=0.0)
 
                 # CRITICAL: re-standardize per-col after transform. YJ + log +
                 # exp produce wildly-different scales; encoder assumes z-scored
@@ -5798,47 +5685,67 @@ def _apply_train_feature_augmentation(X_batch, rng, p_episode=0.6,
     return X_aug
 
 
-def generate_batch(batch_size, n_samples, n_features, task_type,
-                   n_classes=None, rng=None, augment=False, augment_v3=False,
-                   rich_reg_targets=True, scale_variation=True,
-                   augment_v4=False, v4_filter=True, v4_no_edge_noise=True,
-                   synth_v5=False, synth_v5_denoise=True,
-                   synth_v5_declone=True, synth_v5_mixture=False,
-                   reg_prior_prob=0.0, reg_denoise=False,
-                   reg_deterministic_prob=0.20,
-                   reg_dense=False,
-                   scm_prior=False, scm_prior_prob=0.5,
-                   probabilistic_labels=False, nominal_categoricals=False,
-                   enhanced_missingness=False,
-                   clean_lowdim_prob=0.0,
-                   tree_prior_prob=0.0, lookup_prior_prob=0.0,
-                   quadratic_surface_prob=0.0, sparse_nonlinear_prob=0.0,
-                   gp_prior_prob=0.0,
-                   cat_dominant_prob=0.0,
-                   binary_fingerprint_prob=0.0,
-                   temporal_prior_prob=0.0,
-                   train_feature_augment_prob=0.0,
-                   context_missingness_prob=0.0,
-                   realistic_augmentation_prob=0.0,
-                   y_transform_prob=0.0,
-                   cap_injection_prob=0.0,
-                   heavy_tail_prior_prob=0.0,
-                   pareto_importance_prob=0.0,
-                   latent_factor_prob=0.0,
-                   high_cap_prob=0.0,
-                   low_unique_y_prob=0.0,
-                   learnability_filter=False,
-                   learnability_filter_cls_min_score=0.60,
-                   learnability_filter_cls_margin=0.10,
-                   learnability_filter_reg_min_score=0.10,
-                   icl_filter_model=None,
-                   icl_filter_cls_min_auc=0.55,
-                   icl_filter_reg_min_r2=0.05,
-                   icl_scaling_filter=False,
-                   icl_scaling_min_improvement=0.03,
-                   quality_rules=None, filter_max_retries=3,
-                   context_rows=None, oracle_sink=None,
-                   cap_high_fraction_prob=0.0):
+def generate_batch(
+    batch_size,
+    n_samples,
+    n_features,
+    task_type,
+    n_classes=None,
+    rng=None,
+    augment=False,
+    augment_v3=False,
+    rich_reg_targets=True,
+    scale_variation=True,
+    augment_v4=False,
+    v4_filter=True,
+    v4_no_edge_noise=True,
+    synth_v5=False,
+    synth_v5_denoise=True,
+    synth_v5_declone=True,
+    synth_v5_mixture=False,
+    reg_prior_prob=0.0,
+    reg_denoise=False,
+    reg_deterministic_prob=0.20,
+    reg_dense=False,
+    scm_prior=False,
+    scm_prior_prob=0.5,
+    probabilistic_labels=False,
+    nominal_categoricals=False,
+    enhanced_missingness=False,
+    clean_lowdim_prob=0.0,
+    tree_prior_prob=0.0,
+    lookup_prior_prob=0.0,
+    quadratic_surface_prob=0.0,
+    sparse_nonlinear_prob=0.0,
+    gp_prior_prob=0.0,
+    cat_dominant_prob=0.0,
+    binary_fingerprint_prob=0.0,
+    temporal_prior_prob=0.0,
+    train_feature_augment_prob=0.0,
+    context_missingness_prob=0.0,
+    realistic_augmentation_prob=0.0,
+    y_transform_prob=0.0,
+    cap_injection_prob=0.0,
+    heavy_tail_prior_prob=0.0,
+    pareto_importance_prob=0.0,
+    latent_factor_prob=0.0,
+    high_cap_prob=0.0,
+    low_unique_y_prob=0.0,
+    learnability_filter=False,
+    learnability_filter_cls_min_score=0.60,
+    learnability_filter_cls_margin=0.10,
+    learnability_filter_reg_min_score=0.10,
+    icl_filter_model=None,
+    icl_filter_cls_min_auc=0.55,
+    icl_filter_reg_min_r2=0.05,
+    icl_scaling_filter=False,
+    icl_scaling_min_improvement=0.03,
+    quality_rules=None,
+    filter_max_retries=3,
+    context_rows=None,
+    oracle_sink=None,
+    cap_high_fraction_prob=0.0,
+):
     """Generate a batch of synthetic datasets with the same dimensions.
 
     Args:
@@ -5883,7 +5790,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     """
     if rng is None:
         rng = np.random.default_rng()
-    v6_context_rows = context_rows if task_type == 'reg' else None
+    v6_context_rows = context_rows if task_type == "reg" else None
     if cap_high_fraction_prob > 0:
         high_cap_prob = cap_high_fraction_prob
 
@@ -5893,70 +5800,100 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     actual_n_classes = n_classes
 
     for _ in range(batch_size):
-        selected_family = 'other'
+        selected_family = "other"
         # --- Clean low-dim regime ---
         # Simple 5-30 feature datasets with high categorical fraction,
         # low noise. Covers Amazon-like tabular tasks.
         if clean_lowdim_prob > 0 and rng.random() < clean_lowdim_prob:
             data = _generate_clean_lowdim_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 probabilistic_labels=probabilistic_labels,
                 nominal_categoricals=nominal_categoricals,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- Tree-ensemble prior ---
         # Piecewise-constant targets from random decision tree ensembles.
         elif tree_prior_prob > 0 and rng.random() < tree_prior_prob:
-            selected_family = 'tree_prior'
+            selected_family = "tree_prior"
             data = _generate_tree_prior_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 probabilistic_labels=probabilistic_labels,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- Categorical lookup prior ---
         # Entity-lookup data: y = f(entity_id) + noise.
         elif lookup_prior_prob > 0 and rng.random() < lookup_prior_prob:
             data = _generate_lookup_prior_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 probabilistic_labels=probabilistic_labels,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- Quadratic response surface prior ---
         elif quadratic_surface_prob > 0 and rng.random() < quadratic_surface_prob:
             data = _generate_quadratic_surface_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 reg_denoise=reg_denoise,
                 probabilistic_labels=probabilistic_labels,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- Sparse nonlinear high-dim prior ---
         elif sparse_nonlinear_prob > 0 and rng.random() < sparse_nonlinear_prob:
             data = _generate_sparse_nonlinear_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 reg_denoise=reg_denoise,
                 probabilistic_labels=probabilistic_labels,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- GP smooth function prior ---
         # y sampled from Gaussian Process with RBF/Matern kernels.
         # Produces smooth joint multivariate functions (sulfur, debutanizer,
         # space_ga, kin8nm, houses, physiochemical_protein patterns).
         elif gp_prior_prob > 0 and rng.random() < gp_prior_prob:
             data = _generate_gp_prior_episode(
-                n_samples, n_features, task_type, n_classes, rng,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes,
+                rng,
                 reg_denoise=reg_denoise,
                 probabilistic_labels=probabilistic_labels,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         # --- Categorical-dominant prior ---
         # 60-95% of cols are categorical (cardinalities 2-50, biased small).
         # Targets cat-heavy benchmarks (Ailerons, Buzzinsocialmedia,
         # Food_Delivery_Time, MIP-2016) where SCM under-generates.
         elif cat_dominant_prob > 0 and rng.random() < cat_dominant_prob:
             data = _generate_cat_dominant_episode(
-                n_samples, n_features, task_type, n_classes, rng,
-                probabilistic_labels=probabilistic_labels)
+                n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=probabilistic_labels
+            )
         # --- Binary fingerprint prior ---
         # All-binary high-dim data with sparse signal. Targets QSAR-TID-11
         # archetype (chemical fingerprints, drug-binding affinity).
         elif binary_fingerprint_prob > 0 and rng.random() < binary_fingerprint_prob:
             data = _generate_binary_fingerprint_episode(
-                n_samples, n_features, task_type, n_classes, rng,
-                probabilistic_labels=probabilistic_labels)
+                n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=probabilistic_labels
+            )
         # --- Temporal prior ---
         # Rows generated in temporal order with one of 5 patterns:
         # AR(1) autocorrelated features, lagged-y, concept drift, trend+seasonal,
@@ -5965,29 +5902,32 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
         # (Food_Delivery_Time, NASA_PHM, Allstate, dataset_sales, etc.).
         elif temporal_prior_prob > 0 and rng.random() < temporal_prior_prob:
             data = _generate_temporal_prior_episode(
-                n_samples, n_features, task_type, n_classes, rng,
-                probabilistic_labels=probabilistic_labels)
+                n_samples, n_features, task_type, n_classes, rng, probabilistic_labels=probabilistic_labels
+            )
         # TabICL prior: MLP/Tree SCM with rich activations and meta-distribution
         # HP sampling. For cls, applies Reg2Cls to convert continuous targets to
         # class labels. For reg, uses raw SCM output (standardized continuous y).
-        elif (scm_prior and rng.random() < scm_prior_prob):
+        elif scm_prior and rng.random() < scm_prior_prob:
             from synthefy_nori.training.scm_prior_generator import generate_scm_prior_dataset
+
             data = generate_scm_prior_dataset(
-                n_samples, n_features, task_type,
-                n_classes=n_classes, rng=rng,
-                context_rows=v6_context_rows)
+                n_samples, n_features, task_type, n_classes=n_classes, rng=rng, context_rows=v6_context_rows
+            )
         # For regression, use the regression-specific prior with probability
         # reg_prior_prob. These cover real-world regimes (dense linear, GAM,
         # interactions) that the SCM generator under-represents.
-        elif (task_type == 'reg' and reg_prior_prob > 0
-                and rng.random() < reg_prior_prob):
+        elif task_type == "reg" and reg_prior_prob > 0 and rng.random() < reg_prior_prob:
             # 50/50 split: rich SCM X vs pure Gaussian X.
             # SCM X teaches: messy features can have clean additive targets.
             # Gaussian X teaches: clean PCA'd data needs simple Ridge/Lasso/GAM.
             if rng.random() < 0.5:
                 base_data = generate_dataset_filtered(
-                    n_samples, n_features, task_type,
-                    n_classes=n_classes, rng=rng, max_retries=filter_max_retries,
+                    n_samples,
+                    n_features,
+                    task_type,
+                    n_classes=n_classes,
+                    rng=rng,
+                    max_retries=filter_max_retries,
                     quality_rules=quality_rules,
                     learnability_filter=learnability_filter,
                     learnability_filter_cls_min_score=learnability_filter_cls_min_score,
@@ -6002,7 +5942,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                     augment_v3=augment_v3,
                     rich_reg_targets=False,
                     scale_variation=False,
-                    augment_v4=augment_v4, v4_filter=v4_filter,
+                    augment_v4=augment_v4,
+                    v4_filter=v4_filter,
                     v4_no_edge_noise=v4_no_edge_noise,
                     synth_v5=synth_v5,
                     synth_v5_denoise=synth_v5_denoise,
@@ -6012,31 +5953,43 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                     reg_dense=reg_dense,
                     nominal_categoricals=nominal_categoricals,
                     enhanced_missingness=enhanced_missingness,
-                    context_rows=v6_context_rows)
+                    context_rows=v6_context_rows,
+                )
                 data = _generate_regression_prior(
-                    n_samples, n_features, rng,
+                    n_samples,
+                    n_features,
+                    rng,
                     reg_denoise=reg_denoise,
                     reg_deterministic_prob=reg_deterministic_prob,
                     reg_dense=reg_dense,
                     pareto_importance_prob=pareto_importance_prob,
                     latent_factor_prob=latent_factor_prob,
-                    X_scm=base_data['X'],
-                    X_scm_target=base_data.get('X_target'),
+                    X_scm=base_data["X"],
+                    X_scm_target=base_data.get("X_target"),
                     preserve_target_features=True,
-                    context_rows=v6_context_rows)
+                    context_rows=v6_context_rows,
+                )
             else:
-                data = _generate_regression_prior(n_samples, n_features, rng,
-                                                  reg_denoise=reg_denoise,
-                                                  reg_deterministic_prob=reg_deterministic_prob,
-                                                  reg_dense=reg_dense,
-                                                  pareto_importance_prob=pareto_importance_prob,
-                                                  latent_factor_prob=latent_factor_prob,
-                                                  preserve_target_features=True,
-                                                  context_rows=v6_context_rows)
+                data = _generate_regression_prior(
+                    n_samples,
+                    n_features,
+                    rng,
+                    reg_denoise=reg_denoise,
+                    reg_deterministic_prob=reg_deterministic_prob,
+                    reg_dense=reg_dense,
+                    pareto_importance_prob=pareto_importance_prob,
+                    latent_factor_prob=latent_factor_prob,
+                    preserve_target_features=True,
+                    context_rows=v6_context_rows,
+                )
         else:
             data = generate_dataset_filtered(
-                n_samples, n_features, task_type,
-                n_classes=n_classes, rng=rng, max_retries=filter_max_retries,
+                n_samples,
+                n_features,
+                task_type,
+                n_classes=n_classes,
+                rng=rng,
+                max_retries=filter_max_retries,
                 quality_rules=quality_rules,
                 learnability_filter=learnability_filter,
                 learnability_filter_cls_min_score=learnability_filter_cls_min_score,
@@ -6051,7 +6004,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 augment_v3=augment_v3,
                 rich_reg_targets=rich_reg_targets,
                 scale_variation=scale_variation,
-                augment_v4=augment_v4, v4_filter=v4_filter,
+                augment_v4=augment_v4,
+                v4_filter=v4_filter,
                 v4_no_edge_noise=v4_no_edge_noise,
                 synth_v5=synth_v5,
                 synth_v5_denoise=synth_v5_denoise,
@@ -6062,40 +6016,45 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 probabilistic_labels=probabilistic_labels,
                 nominal_categoricals=nominal_categoricals,
                 enhanced_missingness=enhanced_missingness,
-                context_rows=v6_context_rows)
+                context_rows=v6_context_rows,
+            )
         filter_attempt = 0
         while not _passes_requested_dataset_filters(
-                data,
-                task_type=task_type,
-                quality_rules=quality_rules,
-                learnability_filter=learnability_filter,
-                learnability_filter_reg_min_score=(
-                    learnability_filter_reg_min_score),
-                icl_filter_model=icl_filter_model,
-                icl_filter_reg_min_r2=icl_filter_reg_min_r2,
-                icl_scaling_filter=icl_scaling_filter,
-                icl_scaling_min_improvement=icl_scaling_min_improvement,
-                context_rows=v6_context_rows):
+            data,
+            task_type=task_type,
+            quality_rules=quality_rules,
+            learnability_filter=learnability_filter,
+            learnability_filter_reg_min_score=(learnability_filter_reg_min_score),
+            icl_filter_model=icl_filter_model,
+            icl_filter_reg_min_r2=icl_filter_reg_min_r2,
+            icl_scaling_filter=icl_scaling_filter,
+            icl_scaling_min_improvement=icl_scaling_min_improvement,
+            context_rows=v6_context_rows,
+        ):
             if filter_attempt >= max(0, int(filter_max_retries)):
                 raise SyntheticDataFilterError(
-                    "synthetic episode failed all filters after "
-                    f"{filter_attempt + 1} attempts")
+                    f"synthetic episode failed all filters after {filter_attempt + 1} attempts"
+                )
             filter_attempt += 1
-            if selected_family == 'tree_prior':
+            if selected_family == "tree_prior":
                 data = _generate_tree_prior_episode(
-                    n_samples, n_features, task_type, n_classes, rng,
+                    n_samples,
+                    n_features,
+                    task_type,
+                    n_classes,
+                    rng,
                     probabilistic_labels=probabilistic_labels,
-                    context_rows=v6_context_rows)
+                    context_rows=v6_context_rows,
+                )
                 continue
             # The general SCM path already exhausted its own retry budget.
-            raise SyntheticDataFilterError(
-                "synthetic episode failed health after regeneration")
+            raise SyntheticDataFilterError("synthetic episode failed health after regeneration")
 
-        X_list.append(data['X'])
-        y_list.append(data['y'])
+        X_list.append(data["X"])
+        y_list.append(data["y"])
         episode_data.append(data)
-        if actual_n_classes is None and task_type == 'cls':
-            actual_n_classes = data['n_classes']
+        if actual_n_classes is None and task_type == "cls":
+            actual_n_classes = data["n_classes"]
 
     # Debug: detect shape mismatch before np.stack fails
     shapes = [x.shape for x in X_list]
@@ -6104,7 +6063,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
         raise ValueError(
             f"X shape mismatch in batch: {shapes}, y shapes: {y_shapes}, "
             f"n_samples={n_samples}, n_features={n_features}, "
-            f"task_type={task_type}, meta={[d.get('meta',{}) for d in [data]]}")
+            f"task_type={task_type}, meta={[d.get('meta', {}) for d in [data]]}"
+        )
 
     X_batch = np.stack(X_list, axis=0)
     y_batch = np.stack(y_list, axis=0)
@@ -6117,8 +6077,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     # Skips integer-valued / low-unique cols (cat protection) — same heuristic
     # used by inference cat detection.
     if train_feature_augment_prob > 0.0:
-        X_batch = _apply_train_feature_augmentation(
-            X_batch, rng, p_episode=train_feature_augment_prob)
+        X_batch = _apply_train_feature_augmentation(X_batch, rng, p_episode=train_feature_augment_prob)
 
     # Context missingness augmentation: inject 1-8% random NaN cells across
     # the full feature matrix. Real benchmark datasets have NaN in both
@@ -6135,6 +6094,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     # Suppress numpy warnings from realistic augmentation (nanstd on
     # columns with ≤1 non-NaN value, exp overflow before clipping).
     import warnings as _warnings
+
     _warning_filters_before = list(_warnings.filters)
     # Realistic augmentation: applies to all priors post-generation.
     # Addresses three gaps vs real data identified in benchmark analysis:
@@ -6143,7 +6103,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     #   3. Skewed feature distributions (real features are often log-normal)
     if realistic_augmentation_prob > 0:
         B, N, F = X_batch.shape
-        _warnings.filterwarnings('ignore', category=RuntimeWarning)
+        _warnings.filterwarnings("ignore", category=RuntimeWarning)
         for b in range(B):
             if rng.random() >= realistic_augmentation_prob:
                 continue
@@ -6165,15 +6125,13 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                     y = _signed_power_with_linear_tails(y, power)
                 elif transform == 2:
                     # Log-normal: y → exp(y) (always positive)
-                    y = _exp_with_linear_tails(
-                        y * rng.uniform(0.5, 1.5))
+                    y = _exp_with_linear_tails(y * rng.uniform(0.5, 1.5))
                 else:
                     # Asymmetric clip: heavy right tail
                     clip_lo = rng.uniform(-3, -1)
                     y = np.clip(y, clip_lo, None)
-                    context_median = float(np.median(
-                        _context_prefix(y, v6_context_rows)))
-                    y = y ** 2 * np.sign(y - context_median)
+                    context_median = float(np.median(_context_prefix(y, v6_context_rows)))
+                    y = y**2 * np.sign(y - context_median)
 
                 # Soft clip extreme values, re-standardize
                 y = 50.0 * np.tanh(y / 50.0)
@@ -6196,8 +6154,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                         continue
                     rho = rng.uniform(0.2, 0.7)
                     _apply_invertible_feature_correlation(
-                        X, np.arange(start, end), rng, rho,
-                        context_rows=v6_context_rows)
+                        X, np.arange(start, end), rng, rho, context_rows=v6_context_rows
+                    )
 
             # --- Skewed feature distributions (30% of augmented episodes) ---
             # Real features are often log-normal, power-law, or bounded.
@@ -6213,31 +6171,24 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                         continue
                     ft = int(rng.integers(0, 3))
                     finite_col = context_col[np.isfinite(context_col)]
-                    max_abs = (
-                        float(np.max(np.abs(finite_col)))
-                        if len(finite_col) else 0.0
-                    )
+                    max_abs = float(np.max(np.abs(finite_col))) if len(finite_col) else 0.0
                     if ft == 0:
                         # Positive and skewed centrally, with linear tails so
                         # extreme query values cannot underflow together.
                         raw_scale = rng.uniform(0.3, 0.8)
-                        scale = min(
-                            raw_scale, 20.0 / max(max_abs, 1e-8))
+                        scale = min(raw_scale, 20.0 / max(max_abs, 1e-8))
                         transformed = _exp_with_linear_tails(col * scale)
                     elif ft == 1:
                         # Signed square is heavy-tailed and exactly invertible.
                         col64 = col.astype(np.float64, copy=False)
-                        transformed = np.sign(col64) * col64 ** 2
+                        transformed = np.sign(col64) * col64**2
                     else:
                         # Sigmoid-shaped centrally, with linear tails instead
                         # of floating-point saturation at zero or one.
                         raw_scale = rng.uniform(0.5, 2.0)
-                        scale = min(
-                            raw_scale, 8.0 / max(max_abs, 1e-8))
-                        transformed = _sigmoid_with_linear_tails(
-                            col * scale)
-                    X[:, col_idx] = _affine_stabilize_feature_column(
-                        transformed, context_rows=v6_context_rows)
+                        scale = min(raw_scale, 8.0 / max(max_abs, 1e-8))
+                        transformed = _sigmoid_with_linear_tails(col * scale)
+                    X[:, col_idx] = _affine_stabilize_feature_column(transformed, context_rows=v6_context_rows)
 
     # --- Realistic y-target transforms ---
     # Real-world regression targets often have distributions our smooth SCM /
@@ -6247,8 +6198,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     # 11 unique values, half-integer spacing), bounded rating averages
     # (Goodreads 0-5 with quarter-step), and zero-inflated counts (socmob).
     # Each transform is followed by re-standardization (mean=0, std=1).
-    if y_transform_prob > 0 and task_type == 'reg':
-        _warnings.filterwarnings('ignore', category=RuntimeWarning)
+    if y_transform_prob > 0 and task_type == "reg":
+        _warnings.filterwarnings("ignore", category=RuntimeWarning)
         B = y_batch.shape[0]
         for b in range(B):
             if rng.random() >= y_transform_prob:
@@ -6273,13 +6224,11 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 # MIP-2016 solve-time timeout at 72000). No rounding, just
                 # percentile-based clipping.
                 cap_pct = float(rng.uniform(80.0, 97.0))
-                cap_val = float(np.percentile(
-                    _context_prefix(y, v6_context_rows), cap_pct))
+                cap_val = float(np.percentile(_context_prefix(y, v6_context_rows), cap_pct))
                 y = np.minimum(y, cap_val)
                 if rng.random() < 0.4:
                     floor_pct = float(rng.uniform(3.0, 15.0))
-                    floor_val = float(np.percentile(
-                        _context_prefix(y, v6_context_rows), floor_pct))
+                    floor_val = float(np.percentile(_context_prefix(y, v6_context_rows), floor_pct))
                     y = np.maximum(y, floor_val)
 
             elif t < 0.60:
@@ -6288,10 +6237,8 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 # resolution like 0-100 scores or multi-panel averaged ratings.
                 n_levels = int(rng.integers(15, 41))
                 reference = _context_prefix(y, v6_context_rows)
-                edges = np.quantile(
-                    reference, np.linspace(0.0, 1.0, n_levels + 1))
-                y = np.searchsorted(
-                    edges[1:-1], y, side='right').astype(np.float64)
+                edges = np.quantile(reference, np.linspace(0.0, 1.0, n_levels + 1))
+                y = np.searchsorted(edges[1:-1], y, side="right").astype(np.float64)
                 step = float(rng.choice([0.1, 0.25, 0.5, 1.0]))
                 offset = rng.uniform(-5.0, 15.0)
                 y = y * step + offset
@@ -6352,7 +6299,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     # targets (Wine_Quality: 6 levels, sensory: 1-10 ratings, ordinal scales).
     # Runs BEFORE cap_injection so cap patterns can stack on top of a discrete
     # target distribution if both fire. Re-standardizes for episode sanity.
-    if low_unique_y_prob > 0 and task_type == 'reg':
+    if low_unique_y_prob > 0 and task_type == "reg":
         B = y_batch.shape[0]
         for b in range(B):
             if rng.random() >= low_unique_y_prob:
@@ -6361,12 +6308,10 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
             n_levels = int(rng.integers(5, 16))
             # Quantile-bucket so each level has roughly equal mass; preserves
             # the original target ordering and rough scale.
-            edges = np.quantile(
-                _context_prefix(y, v6_context_rows),
-                np.linspace(0, 1, n_levels + 1))
+            edges = np.quantile(_context_prefix(y, v6_context_rows), np.linspace(0, 1, n_levels + 1))
             edges[0] -= 1e-6  # ensure inclusive lower bound
             edges[-1] += 1e-6
-            level_idx = np.clip(np.searchsorted(edges, y, side='right') - 1, 0, n_levels - 1)
+            level_idx = np.clip(np.searchsorted(edges, y, side="right") - 1, 0, n_levels - 1)
             # Use bucket midpoints as the level value.
             mids = 0.5 * (edges[:-1] + edges[1:])
             y = mids[level_idx]
@@ -6375,7 +6320,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 y = (y - mu) / sd
             y_batch[b] = y.astype(np.float32)
 
-    if cap_injection_prob > 0 and task_type == 'reg':
+    if cap_injection_prob > 0 and task_type == "reg":
         B = y_batch.shape[0]
         for b in range(B):
             if rng.random() >= cap_injection_prob:
@@ -6385,15 +6330,14 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
             # cap, SAT11 algo cutoff). When triggered, the cap percentile is
             # drawn from [50, 80] so 20-50% of values sit at the cap, vs
             # the default [80, 97] saturation pattern.
-            use_high_cap = (high_cap_prob > 0 and rng.random() < high_cap_prob)
+            use_high_cap = high_cap_prob > 0 and rng.random() < high_cap_prob
             # Upper cap (more common: boston, MIP-2016, Goodreads)
             if rng.random() < 0.75:
                 if use_high_cap:
                     cap_pct = float(rng.uniform(50.0, 80.0))
                 else:
                     cap_pct = float(rng.uniform(80.0, 97.0))
-                cap_val = float(np.percentile(
-                    _context_prefix(y, v6_context_rows), cap_pct))
+                cap_val = float(np.percentile(_context_prefix(y, v6_context_rows), cap_pct))
                 y = np.minimum(y, cap_val)
             # Lower floor (less common)
             if rng.random() < 0.30:
@@ -6401,8 +6345,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                     floor_pct = float(rng.uniform(20.0, 50.0))
                 else:
                     floor_pct = float(rng.uniform(3.0, 20.0))
-                floor_val = float(np.percentile(
-                    _context_prefix(y, v6_context_rows), floor_pct))
+                floor_val = float(np.percentile(_context_prefix(y, v6_context_rows), floor_pct))
                 y = np.maximum(y, floor_val)
             # Re-standardize (context-only re-norm happens in trainer, but
             # ensure episode-level sanity)
@@ -6424,7 +6367,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
     #   3. Stronger outlier injection: 5-10% at 3-15x scale (vs default 1-5% at 3-8x)
     #
     # Re-standardized after transform to keep trainer's context-norm sane.
-    if heavy_tail_prior_prob > 0 and task_type == 'reg':
+    if heavy_tail_prior_prob > 0 and task_type == "reg":
         B = y_batch.shape[0]
         for b in range(B):
             if rng.random() >= heavy_tail_prior_prob:
@@ -6445,8 +6388,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 # on top of existing signal. Targets sulfur/debutanizer style
                 # heavy-right-tail distributions.
                 alpha = rng.uniform(1.5, 4.0)  # lower alpha = heavier tail
-                _mean, context_std = _context_mean_std(
-                    y, v6_context_rows)
+                _mean, context_std = _context_mean_std(y, v6_context_rows)
                 y_std = max(context_std, 1e-8)
                 tail_noise = rng.pareto(alpha, size=len(y)) * y_std
                 # Apply to positive side only, randomly
@@ -6456,8 +6398,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
             elif t < 0.80:
                 # Stronger outlier injection: larger fraction, larger magnitude
                 # Represents rare extreme events (measurement errors, tail events)
-                _mean, context_std = _context_mean_std(
-                    y, v6_context_rows)
+                _mean, context_std = _context_mean_std(y, v6_context_rows)
                 y_std = max(context_std, 1e-8)
                 n_out = max(1, int(len(y) * rng.uniform(0.05, 0.10)))
                 out_idx = rng.choice(len(y), size=n_out, replace=False)
@@ -6473,8 +6414,7 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 # real failure mode (Job_Profitability has ~0.2% of rows at
                 # ~1500× the bulk std). One-sided to mimic real data where
                 # the catastrophic tail is usually directional.
-                _mean, context_std = _context_mean_std(
-                    y, v6_context_rows)
+                _mean, context_std = _context_mean_std(y, v6_context_rows)
                 y_std = max(context_std, 1e-8)
                 n_out = max(1, int(len(y) * rng.uniform(0.005, 0.02)))
                 out_idx = rng.choice(len(y), size=n_out, replace=False)
@@ -6489,24 +6429,25 @@ def generate_batch(batch_size, n_samples, n_features, task_type,
                 y = (y - mu) / sd
             y_batch[b] = y.astype(np.float32)
 
-    X_batch, _affine_changes, bounded_changes = _finalize_feature_batch(
-        X_batch, context_rows=v6_context_rows)
+    X_batch, _affine_changes, bounded_changes = _finalize_feature_batch(X_batch, context_rows=v6_context_rows)
     if oracle_sink is not None:
         bounded_episodes = {batch_idx for batch_idx, _col in bounded_changes}
         for batch_idx, data in enumerate(episode_data):
-            meta = dict(data.get('meta') or {})
-            lineage = list(meta.get('transformation_lineage') or [])
-            y_clean = data.get('y_clean')
-            oracle_exact = meta.get('oracle_exact')
+            meta = dict(data.get("meta") or {})
+            lineage = list(meta.get("transformation_lineage") or [])
+            y_clean = data.get("y_clean")
+            oracle_exact = meta.get("oracle_exact")
             if batch_idx in bounded_episodes:
-                lineage.append('final_feature_bound')
+                lineage.append("final_feature_bound")
                 y_clean = None
                 oracle_exact = None
-            oracle_sink.append({
-                **meta,
-                'oracle_exact': oracle_exact,
-                'y_clean': y_clean,
-                'transformation_lineage': lineage,
-            })
+            oracle_sink.append(
+                {
+                    **meta,
+                    "oracle_exact": oracle_exact,
+                    "y_clean": y_clean,
+                    "transformation_lineage": lineage,
+                }
+            )
     _warnings.filters[:] = _warning_filters_before
     return X_batch, y_batch, actual_n_classes

--- a/src/synthefy_nori/training/loss.py
+++ b/src/synthefy_nori/training/loss.py
@@ -42,8 +42,9 @@ _UNSAFE_ACCELERATOR_RUNTIME_MARKERS = (
 )
 
 
-def _pinball_loss(pred: torch.Tensor, target: torch.Tensor, quantiles: torch.Tensor,
-                   tail_weight: float = 0.0) -> torch.Tensor:
+def _pinball_loss(
+    pred: torch.Tensor, target: torch.Tensor, quantiles: torch.Tensor, tail_weight: float = 0.0
+) -> torch.Tensor:
     """Pinball loss for predicted quantiles.
 
     Args:
@@ -235,10 +236,7 @@ def _apply_pinball_objective(
         monotonicity_weight,
         mse_weight,
     )
-    if (
-        not _compiled_pinball_requested(pred, compile_pinball_loss)
-        or _pinball_compile_failed
-    ):
+    if not _compiled_pinball_requested(pred, compile_pinball_loss) or _pinball_compile_failed:
         return _pinball_objective_per_episode(*args)
 
     with _pinball_compile_lock:
@@ -279,8 +277,7 @@ def _apply_pinball_objective(
         return _pinball_objective_per_episode(*args)
 
 
-def _bar_distribution_loss(logits: torch.Tensor, target: torch.Tensor,
-                            borders: torch.Tensor) -> torch.Tensor:
+def _bar_distribution_loss(logits: torch.Tensor, target: torch.Tensor, borders: torch.Tensor) -> torch.Tensor:
     """Cross-entropy loss over arbitrary (possibly non-uniform) bin borders.
 
     The model head outputs [..., num_bars] logits. Targets (already
@@ -307,13 +304,13 @@ def _bar_distribution_loss(logits: torch.Tensor, target: torch.Tensor,
     return F.cross_entropy(
         logits.reshape(-1, logits.shape[-1]).float(),
         idx.reshape(-1),
-        reduction='none',
+        reduction="none",
     ).reshape(target.shape)
 
 
-def _bar_distribution_soft_loss(logits: torch.Tensor, target: torch.Tensor,
-                                 borders: torch.Tensor, sigma_y: float
-                                 ) -> torch.Tensor:
+def _bar_distribution_soft_loss(
+    logits: torch.Tensor, target: torch.Tensor, borders: torch.Tensor, sigma_y: float
+) -> torch.Tensor:
     """Soft cross-entropy with Gaussian-smoothed bin targets in y-space.
 
     Hard CE has K categorical cliffs in the loss landscape — predicting
@@ -339,15 +336,14 @@ def _bar_distribution_soft_loss(logits: torch.Tensor, target: torch.Tensor,
     """
     bin_centers = 0.5 * (borders[:-1] + borders[1:])  # [num_bars]
     diff = target.float().unsqueeze(-1) - bin_centers
-    log_target = -(diff ** 2) / (2.0 * float(sigma_y) ** 2 + 1e-12)
+    log_target = -(diff**2) / (2.0 * float(sigma_y) ** 2 + 1e-12)
     target_dist = torch.softmax(log_target, dim=-1)
     log_pred = torch.log_softmax(logits.float(), dim=-1)
     loss = -(target_dist * log_pred).sum(dim=-1)
     return loss
 
 
-def _bar_aux_mse_loss(logits: torch.Tensor, target: torch.Tensor,
-                      borders: torch.Tensor) -> torch.Tensor:
+def _bar_aux_mse_loss(logits: torch.Tensor, target: torch.Tensor, borders: torch.Tensor) -> torch.Tensor:
     """Auxiliary MSE on the bar head's expected-value point estimate.
 
     Bar CE is satisfied as long as the right BIN gets high mass — but the
@@ -364,20 +360,29 @@ def _bar_aux_mse_loss(logits: torch.Tensor, target: torch.Tensor,
     return (expected - target.float()) ** 2
 
 
-def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
-                      task_type, n_classes=None, feature_loss_weight=0.5,
-                      regression_loss='mse', regression_loss_beta=1.0,
-                      regression_quantiles=None, pinball_tail_weight=0.0,
-                      pinball_monotonicity_weight: float = 0.0,
-                      pinball_mse_weight: float = 0.0,
-                      num_bars: int = 5000,
-                      bar_borders_low: float = -10.0,
-                      bar_borders_high: float = 10.0,
-                      bar_target_sigma: float = 0.0,
-                      bar_borders: torch.Tensor | None = None,
-                      bar_target_sigma_y: float = 0.0,
-                      bar_aux_mse_weight: float = 0.0,
-                      compile_pinball_loss: bool = True):
+def compute_ccmm_loss(
+    model_output,
+    y_true,
+    x_original,
+    feature_mask,
+    task_type,
+    n_classes=None,
+    feature_loss_weight=0.5,
+    regression_loss="mse",
+    regression_loss_beta=1.0,
+    regression_quantiles=None,
+    pinball_tail_weight=0.0,
+    pinball_monotonicity_weight: float = 0.0,
+    pinball_mse_weight: float = 0.0,
+    num_bars: int = 5000,
+    bar_borders_low: float = -10.0,
+    bar_borders_high: float = 10.0,
+    bar_target_sigma: float = 0.0,
+    bar_borders: torch.Tensor | None = None,
+    bar_target_sigma_y: float = 0.0,
+    bar_aux_mse_weight: float = 0.0,
+    compile_pinball_loss: bool = True,
+):
     """Compute the unified CCMM loss.
 
     Args:
@@ -400,24 +405,24 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
         total_loss: scalar
         loss_dict: dict with individual loss components for logging
     """
-    process_config = model_output['process_config']
-    n_x_padding = process_config['n_x_padding']
+    process_config = model_output["process_config"]
+    n_x_padding = process_config["n_x_padding"]
     # num_used_features: [B, n_groups, 1]
-    num_used_features = process_config['num_used_features']
+    num_used_features = process_config["num_used_features"]
     if num_used_features is not None:
         num_used_features = num_used_features.detach()
     # mean_norm: [B, n_groups, fpg], std_norm: [B, n_groups, fpg]
-    mean_norm = process_config['mean_for_normalization']
+    mean_norm = process_config["mean_for_normalization"]
     if mean_norm is not None:
         mean_norm = mean_norm.detach()
-    std_norm = process_config['std_for_normalization']
+    std_norm = process_config["std_for_normalization"]
     if std_norm is not None:
         std_norm = std_norm.detach()
     # features_per_group: actual ValidFeatureEncoder num_features (a scalar-like tensor).
     # By construction (cli.py propagates features_per_group into the encoder's
     # num_features), this equals the model's reshape grouping dimension, so we
     # derive the grouping size `fpg` from it rather than hardcoding 2.
-    model_fpg = process_config['features_per_group']
+    model_fpg = process_config["features_per_group"]
     fpg = int(model_fpg.item()) if isinstance(model_fpg, torch.Tensor) else int(model_fpg)
 
     batch_size = y_true.shape[0]
@@ -428,8 +433,8 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
     y_loss = torch.tensor(0.0, device=y_true.device)
     n_y_cells = 0
 
-    if task_type == 'cls':
-        cls_output = model_output['cls_output']  # [B, n_query, max_classes]
+    if task_type == "cls":
+        cls_output = model_output["cls_output"]  # [B, n_query, max_classes]
         if cls_output.shape[0] > 0:
             max_classes = cls_output.shape[-1]
             if n_classes is not None:
@@ -437,44 +442,42 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
                 cls_output = cls_output[..., :max_classes]
             y_true_long = y_true.long().clamp(0, max_classes - 1)
             y_loss = F.cross_entropy(
-                cls_output.float().reshape(-1, cls_output.shape[-1]),
-                y_true_long.reshape(-1),
-                reduction='sum'
+                cls_output.float().reshape(-1, cls_output.shape[-1]), y_true_long.reshape(-1), reduction="sum"
             )
             n_y_cells = batch_size * n_query
     else:
-        reg_output = model_output['reg_output']  # [B, n_query, 1]
+        reg_output = model_output["reg_output"]  # [B, n_query, 1]
         if reg_output.shape[0] > 0:
-            pred = reg_output.float()             # [B, n_query, Q]
-            target = y_true.float()               # [B, n_query]
+            pred = reg_output.float()  # [B, n_query, Q]
+            target = y_true.float()  # [B, n_query]
             # Normalize per-episode losses so all regression datasets contribute
             # comparably even when query-target scale varies across episodes.
             per_ep_var = target.var(dim=1, unbiased=False).clamp(min=0.01)  # [B]
-            if regression_loss == 'mse':
+            if regression_loss == "mse":
                 pred = pred.squeeze(-1)
                 per_ep_loss = ((pred - target) ** 2).mean(dim=1)
                 per_ep_loss = per_ep_loss / per_ep_var
-            elif regression_loss == 'smooth_l1':
+            elif regression_loss == "smooth_l1":
                 pred = pred.squeeze(-1)
                 beta = max(float(regression_loss_beta), 1e-6)
                 per_ep_loss = F.smooth_l1_loss(
                     pred,
                     target,
-                    reduction='none',
+                    reduction="none",
                     beta=beta,
                 ).mean(dim=1)
                 per_ep_loss = per_ep_loss / torch.sqrt(per_ep_var)
-            elif regression_loss == 'huber':
+            elif regression_loss == "huber":
                 pred = pred.squeeze(-1)
                 delta = max(float(regression_loss_beta), 1e-6)
                 per_ep_loss = F.huber_loss(
                     pred,
                     target,
-                    reduction='none',
+                    reduction="none",
                     delta=delta,
                 ).mean(dim=1)
                 per_ep_loss = per_ep_loss / torch.sqrt(per_ep_var)
-            elif regression_loss == 'pinball':
+            elif regression_loss == "pinball":
                 if regression_quantiles is None:
                     regression_quantiles = (0.1, 0.25, 0.5, 0.75, 0.9)
                 quantiles = torch.as_tensor(
@@ -500,7 +503,7 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
                     pinball_mse_weight,
                     compile_pinball_loss,
                 )
-            elif regression_loss == 'bar_distribution':
+            elif regression_loss == "bar_distribution":
                 # pred: [B, n_query, num_bars] logits (no squeeze)
                 if pred.shape[-1] != num_bars:
                     raise ValueError(
@@ -514,8 +517,11 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
                     borders_t = bar_borders.to(pred.device)
                 else:
                     borders_t = torch.linspace(
-                        bar_borders_low, bar_borders_high, num_bars + 1,
-                        device=pred.device, dtype=torch.float32,
+                        bar_borders_low,
+                        bar_borders_high,
+                        num_bars + 1,
+                        device=pred.device,
+                        dtype=torch.float32,
                     )
                 # Resolve sigma_y: prefer explicit y-space sigma; else convert
                 # legacy sigma_bins to sigma_y via mean bin width (only well-
@@ -531,11 +537,16 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
                 # Soft CE when sigma_y>0; hard CE otherwise.
                 if sigma_y > 0:
                     per_ex_loss = _bar_distribution_soft_loss(
-                        pred, target, borders_t, sigma_y=sigma_y,
+                        pred,
+                        target,
+                        borders_t,
+                        sigma_y=sigma_y,
                     )
                 else:
                     per_ex_loss = _bar_distribution_loss(
-                        pred, target, borders_t,
+                        pred,
+                        target,
+                        borders_t,
                     )  # [B, n_query]
                 per_ep_loss = per_ex_loss.mean(dim=1)
                 # bar_distribution loss is CE in log-space: not episode-variance
@@ -556,7 +567,7 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
             else:
                 raise ValueError(f"Unsupported regression_loss: {regression_loss}")
 
-            if regression_loss not in ('pinball', 'bar_distribution'):
+            if regression_loss not in ("pinball", "bar_distribution"):
                 # If the model is dramatically worse than predicting the mean, the
                 # gradient is usually dominated by noise rather than useful signal.
                 # Not applied to pinball (raw quantile loss) or bar_distribution
@@ -568,19 +579,17 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
     if feature_loss_weight <= 0:
         y_loss_avg = y_loss / max(n_y_cells, 1)
         loss_dict = {
-            'total_loss': y_loss_avg.item(),
-            'y_loss': y_loss_avg.item(),
-            'feat_loss': 0.0,
-            'n_y_cells': n_y_cells,
-            'n_feat_cells': 0,
+            "total_loss": y_loss_avg.item(),
+            "y_loss": y_loss_avg.item(),
+            "feat_loss": 0.0,
+            "n_y_cells": n_y_cells,
+            "n_feat_cells": 0,
         }
         return y_loss_avg, loss_dict
 
-    feature_pred = model_output.get('feature_pred')
+    feature_pred = model_output.get("feature_pred")
     if feature_pred is None:
-        raise ValueError(
-            "feature_pred is required when feature_loss_weight is positive"
-        )
+        raise ValueError("feature_pred is required when feature_loss_weight is positive")
 
     # ------------------------------------------------------------------
     # 2. Feature reconstruction loss (masked cells only)
@@ -598,16 +607,24 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
     # Pad x_original and feature_mask to be divisible by fpg
     pad_amount = n_x_padding
     if pad_amount > 0:
-        x_padded = torch.cat([
-            x_original,
-            torch.zeros(batch_size, x_original.shape[1], pad_amount,
-                        device=x_original.device, dtype=x_original.dtype)
-        ], dim=-1)
-        mask_padded = torch.cat([
-            feature_mask,
-            torch.zeros(batch_size, feature_mask.shape[1], pad_amount,
-                        device=feature_mask.device, dtype=feature_mask.dtype).bool()
-        ], dim=-1)
+        x_padded = torch.cat(
+            [
+                x_original,
+                torch.zeros(
+                    batch_size, x_original.shape[1], pad_amount, device=x_original.device, dtype=x_original.dtype
+                ),
+            ],
+            dim=-1,
+        )
+        mask_padded = torch.cat(
+            [
+                feature_mask,
+                torch.zeros(
+                    batch_size, feature_mask.shape[1], pad_amount, device=feature_mask.device, dtype=feature_mask.dtype
+                ).bool(),
+            ],
+            dim=-1,
+        )
     else:
         x_padded = x_original
         mask_padded = feature_mask
@@ -652,7 +669,7 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
         valid = ~torch.isnan(masked_true)
         n_valid = valid.sum()
         if n_valid > 0:
-            feat_loss = F.mse_loss(masked_pred[valid], masked_true[valid], reduction='sum')
+            feat_loss = F.mse_loss(masked_pred[valid], masked_true[valid], reduction="sum")
             n_feat_cells = n_valid.item()
 
     # ------------------------------------------------------------------
@@ -663,11 +680,11 @@ def compute_ccmm_loss(model_output, y_true, x_original, feature_mask,
     total_loss = y_loss_avg + feature_loss_weight * feat_loss_avg
 
     loss_dict = {
-        'total_loss': total_loss.item(),
-        'y_loss': y_loss_avg.item(),
-        'feat_loss': feat_loss_avg.item(),
-        'n_y_cells': n_y_cells,
-        'n_feat_cells': n_feat_cells,
+        "total_loss": total_loss.item(),
+        "y_loss": y_loss_avg.item(),
+        "feat_loss": feat_loss_avg.item(),
+        "n_y_cells": n_y_cells,
+        "n_feat_cells": n_feat_cells,
     }
 
     return total_loss, loss_dict

--- a/src/synthefy_nori/training/masking.py
+++ b/src/synthefy_nori/training/masking.py
@@ -27,11 +27,11 @@ def create_masks(n_query, n_features, mask_ratio, mask_type, rng=None):
     if rng is None:
         rng = np.random.default_rng()
 
-    if mask_type == 'cell':
+    if mask_type == "cell":
         return _cell_mask(n_query, n_features, mask_ratio, rng)
-    elif mask_type == 'column':
+    elif mask_type == "column":
         return _column_mask(n_query, n_features, mask_ratio, rng)
-    elif mask_type == 'block':
+    elif mask_type == "block":
         return _block_mask(n_query, n_features, mask_ratio, rng)
     else:
         raise ValueError(f"Unknown mask_type: {mask_type}")
@@ -75,7 +75,7 @@ def _block_mask(n_query, n_features, mask_ratio, rng):
         row_start = rng.integers(0, max(1, n_query - block_rows + 1))
         col_start = rng.integers(0, max(1, n_features - block_cols + 1))
 
-        mask[row_start:row_start + block_rows, col_start:col_start + block_cols] = True
+        mask[row_start : row_start + block_rows, col_start : col_start + block_cols] = True
         cells_masked = mask.sum()
 
     return mask
@@ -85,7 +85,7 @@ def random_mask_type(rng=None):
     """Randomly select a mask type."""
     if rng is None:
         rng = np.random.default_rng()
-    return rng.choice(['cell', 'column', 'block'])
+    return rng.choice(["cell", "column", "block"])
 
 
 def random_mask_ratio(min_ratio=0.1, max_ratio=0.4, rng=None):

--- a/src/synthefy_nori/training/optim.py
+++ b/src/synthefy_nori/training/optim.py
@@ -111,8 +111,11 @@ class MuonND(torch.optim.Optimizer):
         ns_steps: int = 5,
     ) -> None:
         defaults = dict(
-            lr=lr, momentum=momentum, nesterov=nesterov,
-            weight_decay=weight_decay, ns_steps=ns_steps,
+            lr=lr,
+            momentum=momentum,
+            nesterov=nesterov,
+            weight_decay=weight_decay,
+            ns_steps=ns_steps,
         )
         super().__init__(params, defaults)
 
@@ -124,13 +127,13 @@ class MuonND(torch.optim.Optimizer):
                 loss = closure()
 
         for group in self.param_groups:
-            lr = group['lr']
-            momentum = group['momentum']
-            nesterov = group['nesterov']
-            wd = group['weight_decay']
-            ns_steps = group['ns_steps']
+            lr = group["lr"]
+            momentum = group["momentum"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            ns_steps = group["ns_steps"]
 
-            for p in group['params']:
+            for p in group["params"]:
                 if p.grad is None or p.ndim < 2:
                     continue
 
@@ -142,10 +145,10 @@ class MuonND(torch.optim.Optimizer):
                     grad2d = p.grad.reshape(-1, orig_shape[-1])
 
                 state = self.state[p]
-                if 'momentum_buffer' not in state:
-                    state['momentum_buffer'] = torch.zeros_like(grad2d)
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(grad2d)
 
-                buf = state['momentum_buffer']
+                buf = state["momentum_buffer"]
                 buf.mul_(momentum).add_(grad2d)
                 if nesterov:
                     g_eff = grad2d.add(buf, alpha=momentum)
@@ -228,22 +231,26 @@ class HybridMuonAdamW(torch.optim.Optimizer):
                 two_d = [(n, p) for n, p in muon_named_params if p.ndim == 2]
                 nd = [(n, p) for n, p in muon_named_params if p.ndim > 2]
                 if two_d:
-                    self._sub_optimizers.append(torch.optim.Muon(
-                        two_d,
-                        lr=lr,
-                        weight_decay=weight_decay,
-                        momentum=muon_momentum,
-                        nesterov=muon_nesterov,
-                        adjust_lr_fn=muon_adjust_lr_fn,
-                    ))
+                    self._sub_optimizers.append(
+                        torch.optim.Muon(
+                            two_d,
+                            lr=lr,
+                            weight_decay=weight_decay,
+                            momentum=muon_momentum,
+                            nesterov=muon_nesterov,
+                            adjust_lr_fn=muon_adjust_lr_fn,
+                        )
+                    )
                 if nd:
-                    self._sub_optimizers.append(MuonND(
-                        nd,
-                        lr=lr,
-                        momentum=muon_momentum,
-                        nesterov=muon_nesterov,
-                        weight_decay=weight_decay,
-                    ))
+                    self._sub_optimizers.append(
+                        MuonND(
+                            nd,
+                            lr=lr,
+                            momentum=muon_momentum,
+                            nesterov=muon_nesterov,
+                            weight_decay=weight_decay,
+                        )
+                    )
             else:
                 raise ValueError(f"Unknown muon_backend: {muon_backend!r}")
         # Keep the historic .muon attribute for state_dict compatibility,

--- a/src/synthefy_nori/training/prefetch.py
+++ b/src/synthefy_nori/training/prefetch.py
@@ -75,7 +75,7 @@ class DataPrefetcher:
 
     def start(self):
         """Spawn worker processes. Must be called before submit/get."""
-        ctx = mp.get_context('spawn')
+        ctx = mp.get_context("spawn")
         self._task_queue = ctx.Queue(maxsize=self.prefetch_count + self.num_workers)
         self._result_queue = ctx.Queue(maxsize=self.prefetch_count + self.num_workers)
         self._workers = []
@@ -133,8 +133,7 @@ class DataPrefetcher:
                     return _ErrorSentinel(err_type, err_msg, tb)
                 else:
                     # Cache the error for when that task_id is requested
-                    self._results_cache[task_id] = _ErrorSentinel(
-                        err_type, err_msg, tb)
+                    self._results_cache[task_id] = _ErrorSentinel(err_type, err_msg, tb)
                     continue
 
             if task_id == target_id:
@@ -173,6 +172,7 @@ class DataPrefetcher:
 
 class _ErrorSentinel:
     """Placeholder for worker errors cached out of order."""
+
     def __init__(self, err_type, err_msg, tb):
         self.err_type = err_type
         self.err_msg = err_msg

--- a/src/synthefy_nori/training/scm_prior_generator.py
+++ b/src/synthefy_nori/training/scm_prior_generator.py
@@ -28,12 +28,14 @@ import torch.nn as nn
 try:
     from sklearn.tree import DecisionTreeRegressor
     from sklearn.ensemble import ExtraTreesRegressor
+
     HAS_SKLEARN = True
 except ImportError:
     HAS_SKLEARN = False
 
 try:
     from xgboost import XGBRegressor
+
     HAS_XGB = True
 except ImportError:
     HAS_XGB = False
@@ -52,33 +54,41 @@ def _resolve_context_rows(n_samples, context_rows):
 # Activation functions  (matches TabICL activations.py exactly)
 # ============================================================================
 
+
 class SignActivation(nn.Module):
     def forward(self, x):
         return 2 * (x >= 0.0).float() - 1.0
 
+
 class RBFActivation(nn.Module):
     def forward(self, x):
-        return torch.exp(-(x ** 2))
+        return torch.exp(-(x**2))
+
 
 class ExpActivation(nn.Module):
     def forward(self, x):
         return torch.exp(x)
 
+
 class SqrtAbsActivation(nn.Module):
     def forward(self, x):
         return torch.sqrt(torch.abs(x))
+
 
 class UnitIntervalIndicator(nn.Module):
     def forward(self, x):
         return (torch.abs(x) <= 1.0).float()
 
+
 class SineActivation(nn.Module):
     def forward(self, x):
         return torch.sin(x)
 
+
 class SquareActivation(nn.Module):
     def forward(self, x):
-        return x ** 2
+        return x**2
+
 
 class AbsActivation(nn.Module):
     def forward(self, x):
@@ -103,11 +113,7 @@ class StdScaleLayer(nn.Module):
             fit_rows = _resolve_context_rows(x.shape[0], self.context_rows)
             reference = x[:fit_rows]
             self.mean = reference.mean(dim=0, keepdim=True)
-            self.std = (
-                reference.std(dim=0, keepdim=True)
-                if fit_rows > 1
-                else torch.zeros_like(self.mean)
-            ) + 1e-6
+            self.std = (reference.std(dim=0, keepdim=True) if fit_rows > 1 else torch.zeros_like(self.mean)) + 1e-6
         return (x - self.mean) / self.std
 
 
@@ -121,8 +127,7 @@ class RandomScaleLayer(nn.Module):
     def forward(self, x):
         if not self.initialized:
             self.scale = torch.exp(
-                torch.log(torch.tensor(1.0, device=x.device))
-                + 2 * torch.randn(1, 1, device=x.device)
+                torch.log(torch.tensor(1.0, device=x.device)) + 2 * torch.randn(1, 1, device=x.device)
             )
             self.bias = torch.randn(1, 1, device=x.device)
             self.initialized = True
@@ -138,24 +143,16 @@ class RandomFunctionActivation(nn.Module):
 
     def __init__(self, n_frequencies=256):
         super().__init__()
-        self.freqs = nn.Parameter(
-            n_frequencies * torch.rand(n_frequencies), requires_grad=False
-        )
-        self.bias = nn.Parameter(
-            2 * math.pi * torch.rand(n_frequencies), requires_grad=False
-        )
+        self.freqs = nn.Parameter(n_frequencies * torch.rand(n_frequencies), requires_grad=False)
+        self.bias = nn.Parameter(2 * math.pi * torch.rand(n_frequencies), requires_grad=False)
         self.stdscaler = StdScaleLayer()
 
-        decay_exponent = -math.exp(
-            pyrandom.uniform(math.log(0.7), math.log(3.0))
-        )
+        decay_exponent = -math.exp(pyrandom.uniform(math.log(0.7), math.log(3.0)))
         with torch.no_grad():
             safe_freqs = self.freqs.clamp_min(torch.finfo(self.freqs.dtype).eps)
-            freq_factors = safe_freqs ** decay_exponent
-            freq_factors = freq_factors / (freq_factors ** 2).sum().sqrt()
-        self.l2_weights = nn.Parameter(
-            freq_factors * torch.randn(n_frequencies), requires_grad=False
-        )
+            freq_factors = safe_freqs**decay_exponent
+            freq_factors = freq_factors / (freq_factors**2).sum().sqrt()
+        self.l2_weights = nn.Parameter(freq_factors * torch.randn(n_frequencies), requires_grad=False)
 
     def forward(self, x):
         x = self.stdscaler(x)
@@ -242,11 +239,11 @@ def get_activations():
 # XSampler — root distribution sampling  (matches TabICL utils.py)
 # ============================================================================
 
+
 class XSampler:
     """Sample root cause variables for the SCM."""
 
-    def __init__(self, n_samples, n_features, sampling="mixed",
-                 pre_sample_stats=False, device="cpu"):
+    def __init__(self, n_samples, n_features, sampling="mixed", pre_sample_stats=False, device="cpu"):
         self.n_samples = n_samples
         self.n_features = n_features
         self.sampling = sampling
@@ -297,11 +294,7 @@ class XSampler:
                     probs = torch.rand(n_cats, device=device)
                     x = torch.multinomial(probs, n, replacement=True).float()
                     reference = x[:fit_rows]
-                    reference_std = (
-                        reference.std()
-                        if fit_rows > 1
-                        else torch.zeros((), device=x.device, dtype=x.dtype)
-                    )
+                    reference_std = reference.std() if fit_rows > 1 else torch.zeros((), device=x.device, dtype=x.dtype)
                     x = (x - reference.mean()) / reference_std.clamp(min=1e-6)
                 elif pyrandom.random() > zipf_p:
                     # Zipf
@@ -320,6 +313,7 @@ class XSampler:
 # ============================================================================
 # GaussianNoise  (supports per-dim std tensors like TabICL)
 # ============================================================================
+
 
 class GaussianNoise(nn.Module):
     def __init__(self, std):
@@ -342,8 +336,8 @@ class GaussianNoise(nn.Module):
 # Block-wise dropout initialization  (matches TabICL mlp_scm.py)
 # ============================================================================
 
-def _block_wise_dropout_init(weight, init_std, dropout_prob,
-                              scale_by_dropout=True):
+
+def _block_wise_dropout_init(weight, init_std, dropout_prob, scale_by_dropout=True):
     """Initialize balanced diagonal blocks with real element dropout.
 
     Every input and output belongs to exactly one diagonal block, including
@@ -404,6 +398,7 @@ def _block_wise_dropout_init(weight, init_std, dropout_prob,
 # MLPSCM — MLP-based Structural Causal Model  (matches TabICL mlp_scm.py)
 # ============================================================================
 
+
 class MLPSCM(nn.Module):
     """MLP-based SCM.
 
@@ -416,17 +411,30 @@ class MLPSCM(nn.Module):
     Then outputs = outputs[2:]  (skip causes and first linear projection).
     """
 
-    def __init__(self, n_samples, n_features, n_outputs=1,
-                 is_causal=True, num_causes=10, y_is_effect=True,
-                 in_clique=False, sort_features=True,
-                 num_layers=10, hidden_dim=20,
-                 activation_factory=None,
-                 init_std=1.0,
-                 block_wise_dropout=True, dropout_prob=0.1,
-                 scale_init_std_by_dropout=True,
-                 sampling="normal", pre_sample_cause_stats=False,
-                 noise_std=0.01, pre_sample_noise_std=False,
-                 device="cpu", context_rows=None):
+    def __init__(
+        self,
+        n_samples,
+        n_features,
+        n_outputs=1,
+        is_causal=True,
+        num_causes=10,
+        y_is_effect=True,
+        in_clique=False,
+        sort_features=True,
+        num_layers=10,
+        hidden_dim=20,
+        activation_factory=None,
+        init_std=1.0,
+        block_wise_dropout=True,
+        dropout_prob=0.1,
+        scale_init_std_by_dropout=True,
+        sampling="normal",
+        pre_sample_cause_stats=False,
+        noise_std=0.01,
+        pre_sample_noise_std=False,
+        device="cpu",
+        context_rows=None,
+    ):
         super().__init__()
         self.device = device
         self.n_samples = n_samples
@@ -456,50 +464,59 @@ class MLPSCM(nn.Module):
         # Build layers as TabICL does: [Linear, Sequential(Act,Linear,Noise), ...]
         layers = [nn.Linear(self.num_causes, hidden_dim)]
         for _ in range(num_layers - 1):
-            layers.append(self._make_layer_module(
-                hidden_dim, hidden_dim, activation_factory,
-                noise_std, pre_sample_noise_std, device,
-            ))
+            layers.append(
+                self._make_layer_module(
+                    hidden_dim,
+                    hidden_dim,
+                    activation_factory,
+                    noise_std,
+                    pre_sample_noise_std,
+                    device,
+                )
+            )
         if not is_causal:
-            layers.append(self._make_layer_module(
-                hidden_dim, n_outputs, activation_factory,
-                noise_std, pre_sample_noise_std, device,
-                is_output=True,
-            ))
+            layers.append(
+                self._make_layer_module(
+                    hidden_dim,
+                    n_outputs,
+                    activation_factory,
+                    noise_std,
+                    pre_sample_noise_std,
+                    device,
+                    is_output=True,
+                )
+            )
         self.layers = nn.Sequential(*layers).to(device)
         for module in self.layers.modules():
             if isinstance(module, StdScaleLayer):
                 module.context_rows = context_rows
 
         # Initialize all parameters
-        self._initialize_parameters(
-            init_std, block_wise_dropout, dropout_prob, scale_init_std_by_dropout
-        )
+        self._initialize_parameters(init_std, block_wise_dropout, dropout_prob, scale_init_std_by_dropout)
 
         # X sampler
         self.x_sampler = XSampler(
-            n_samples, self.num_causes, sampling=sampling,
-            pre_sample_stats=pre_sample_cause_stats, device=device,
+            n_samples,
+            self.num_causes,
+            sampling=sampling,
+            pre_sample_stats=pre_sample_cause_stats,
+            device=device,
         )
 
-    def _make_layer_module(self, in_dim, out_dim, activation_factory,
-                            noise_std, pre_sample_noise_std, device,
-                            is_output=False):
+    def _make_layer_module(
+        self, in_dim, out_dim, activation_factory, noise_std, pre_sample_noise_std, device, is_output=False
+    ):
         activation = activation_factory()
         linear = nn.Linear(in_dim, out_dim)
         if pre_sample_noise_std:
-            ns = torch.abs(
-                torch.normal(torch.zeros(1, out_dim, device=device),
-                             float(noise_std))
-            )
+            ns = torch.abs(torch.normal(torch.zeros(1, out_dim, device=device), float(noise_std)))
             if noise_std > 0:
                 ns.clamp_(min=torch.finfo(ns.dtype).eps)
         else:
             ns = noise_std
         return nn.Sequential(activation, linear, GaussianNoise(ns))
 
-    def _initialize_parameters(self, init_std, block_wise_dropout,
-                                dropout_prob, scale_by_dropout):
+    def _initialize_parameters(self, init_std, block_wise_dropout, dropout_prob, scale_by_dropout):
         # Activation modules can own one-dimensional parameters (notably the
         # Fourier frequencies, phases and weights in RandomFunctionActivation).
         # Initialize Linear modules explicitly rather than treating every
@@ -508,8 +525,7 @@ class MLPSCM(nn.Module):
             if not isinstance(module, nn.Linear):
                 continue
             if block_wise_dropout:
-                _block_wise_dropout_init(module.weight, init_std, dropout_prob,
-                                         scale_by_dropout)
+                _block_wise_dropout_init(module.weight, init_std, dropout_prob, scale_by_dropout)
             else:
                 nn.init.normal_(module.weight, std=init_std)
             if module.bias is not None:
@@ -547,22 +563,16 @@ class MLPSCM(nn.Module):
             total_dim = outputs_flat.shape[-1]
 
             if self.in_clique:
-                start = pyrandom.randint(
-                    0, max(0, total_dim - self.n_outputs - self.n_features)
-                )
-                random_perm = start + torch.randperm(
-                    self.n_outputs + self.n_features, device=self.device
-                )
+                start = pyrandom.randint(0, max(0, total_dim - self.n_outputs - self.n_features))
+                random_perm = start + torch.randperm(self.n_outputs + self.n_features, device=self.device)
             else:
-                random_perm = torch.randperm(
-                    max(total_dim - 1, 1), device=self.device
-                )
+                random_perm = torch.randperm(max(total_dim - 1, 1), device=self.device)
 
-            indices_X = random_perm[self.n_outputs:self.n_outputs + self.n_features]
+            indices_X = random_perm[self.n_outputs : self.n_outputs + self.n_features]
             if self.y_is_effect:
                 indices_y = list(range(-self.n_outputs, 0))
             else:
-                indices_y = random_perm[:self.n_outputs]
+                indices_y = random_perm[: self.n_outputs]
 
             if self.sort_features:
                 indices_X, _ = torch.sort(indices_X)
@@ -588,6 +598,7 @@ class MLPSCM(nn.Module):
 # TreeSCM — Tree-based Structural Causal Model  (matches TabICL tree_scm.py)
 # ============================================================================
 
+
 class TreeLayer:
     """A single tree-based transformation layer."""
 
@@ -611,11 +622,15 @@ class TreeLayer:
                     random_state=int(rng.integers(0, 2**31)),
                 )
             else:
-                model = DecisionTreeRegressor(
-                    max_depth=max_depth,
-                    splitter="random",
-                    random_state=int(rng.integers(0, 2**31)),
-                ) if HAS_SKLEARN else None
+                model = (
+                    DecisionTreeRegressor(
+                        max_depth=max_depth,
+                        splitter="random",
+                        random_state=int(rng.integers(0, 2**31)),
+                    )
+                    if HAS_SKLEARN
+                    else None
+                )
                 if model is None:
                     raise ImportError("sklearn is required for TreeSCM")
             self.models.append(model)
@@ -635,8 +650,7 @@ class TreeLayer:
                 lo = float(np.min(reference))
                 hi = float(np.max(reference))
                 query_col = query[:, col]
-                query[:, col] = np.nan_to_num(
-                    query_col, nan=median, posinf=hi, neginf=lo)
+                query[:, col] = np.nan_to_num(query_col, nan=median, posinf=hi, neginf=lo)
         out = np.zeros((n, self.out_dim), dtype=np.float32)
         for i, model in enumerate(self.models):
             y_fake = rng.standard_normal(n).astype(np.float32)
@@ -650,12 +664,23 @@ class TreeLayer:
 class TreeSCM:
     """Tree-based SCM (always non-causal, shallow layers for speed)."""
 
-    def __init__(self, n_samples, n_features, n_outputs=1,
-                 num_causes=10, tree_model="xgboost",
-                 max_depth_lambda=0.5, n_estimators_lambda=0.5,
-                 sampling="normal", pre_sample_cause_stats=False,
-                 noise_std=0.01, pre_sample_noise_std=False,
-                 rng=None, device="cpu", context_rows=None):
+    def __init__(
+        self,
+        n_samples,
+        n_features,
+        n_outputs=1,
+        num_causes=10,
+        tree_model="xgboost",
+        max_depth_lambda=0.5,
+        n_estimators_lambda=0.5,
+        sampling="normal",
+        pre_sample_cause_stats=False,
+        noise_std=0.01,
+        pre_sample_noise_std=False,
+        rng=None,
+        device="cpu",
+        context_rows=None,
+    ):
         self.n_samples = n_samples
         self.n_features = n_features
         self.n_outputs = n_outputs
@@ -680,38 +705,42 @@ class TreeSCM:
         self.n_estimators_lambda = n_estimators_lambda
 
         self.x_sampler = XSampler(
-            n_samples, self.num_causes, sampling=sampling,
-            pre_sample_stats=pre_sample_cause_stats, device=device,
+            n_samples,
+            self.num_causes,
+            sampling=sampling,
+            pre_sample_stats=pre_sample_cause_stats,
+            device=device,
         )
 
     def generate(self):
         rng = self.rng
-        causes = self.x_sampler.sample(
-            context_rows=self.context_rows,
-        ).cpu().numpy()
+        causes = (
+            self.x_sampler.sample(
+                context_rows=self.context_rows,
+            )
+            .cpu()
+            .numpy()
+        )
 
         h = causes
         for layer_idx in range(self.num_layers):
-            max_depth = 2 + int(np.random.exponential(
-                1.0 / max(self.max_depth_lambda, 0.01)))
+            max_depth = 2 + int(np.random.exponential(1.0 / max(self.max_depth_lambda, 0.01)))
             max_depth = min(max_depth, 4)
-            n_estimators = 1 + int(np.random.exponential(
-                1.0 / max(self.n_estimators_lambda, 0.01)))
+            n_estimators = 1 + int(np.random.exponential(1.0 / max(self.n_estimators_lambda, 0.01)))
             n_estimators = min(n_estimators, 4)
 
             out_dim = self.hidden_dim if layer_idx < self.num_layers - 1 else self.n_outputs
 
-            tree_layer = TreeLayer(
-                self.tree_model, max_depth, n_estimators, out_dim, rng)
+            tree_layer = TreeLayer(self.tree_model, max_depth, n_estimators, out_dim, rng)
             h = tree_layer.fit_transform(
-                h, rng, context_rows=self.context_rows,
+                h,
+                rng,
+                context_rows=self.context_rows,
             )
 
             if self.noise_std > 0:
                 if self.pre_sample_noise_std:
-                    noise_scale = np.abs(
-                        rng.normal(0.0, self.noise_std, size=(1, out_dim))
-                    ).astype(np.float32)
+                    noise_scale = np.abs(rng.normal(0.0, self.noise_std, size=(1, out_dim))).astype(np.float32)
                     noise_scale = np.maximum(noise_scale, np.finfo(np.float32).eps)
                 else:
                     noise_scale = self.noise_std
@@ -729,6 +758,7 @@ class TreeSCM:
 # ============================================================================
 # Reg2Cls — Convert regression targets to classification
 # ============================================================================
+
 
 def _outlier_remove(X, threshold=4.0):
     """Two-pass outlier clamping (matches TabICL reg2cls.py)."""
@@ -803,8 +833,7 @@ def _num2cat(X, cat_prob=0.2, max_categories=float("inf"), rng=None):
 
     for j in range(n_features):
         if pyrandom.random() < col_prob:
-            n_cats = min(max(round(pyrandom.gammavariate(1, 10)), 2),
-                         int(min(max_categories, 100)))
+            n_cats = min(max(round(pyrandom.gammavariate(1, 10)), 2), int(min(max_categories, 100)))
             # Rank-based discretization using MulticlassAssigner logic
             col = X[:, j]
             ranks = np.argsort(np.argsort(col))
@@ -871,11 +900,10 @@ def reg2cls(X, y, n_classes, rng=None):
 # Meta-distribution hyperparameter sampling
 # ============================================================================
 
-def meta_trunc_norm_log_scaled(rng, min_mean=0.01, max_mean=10.0,
-                                round_val=False, lower_bound=0.0):
+
+def meta_trunc_norm_log_scaled(rng, min_mean=0.01, max_mean=10.0, round_val=False, lower_bound=0.0):
     """Log-scaled truncated normal (TabICL meta_trunc_norm_log_scaled)."""
-    log_mean = rng.uniform(
-        math.log(max(min_mean, 1e-8)), math.log(max(max_mean, 1e-7)))
+    log_mean = rng.uniform(math.log(max(min_mean, 1e-8)), math.log(max(max_mean, 1e-7)))
     mu = math.exp(log_mean)
     log_std = rng.uniform(math.log(0.01), math.log(1.0))
     sigma = mu * math.exp(log_std)
@@ -947,7 +975,10 @@ def _robust_stabilize_features(X, clip_value=50.0, context_rows=None):
     """
     if isinstance(X, torch.Tensor):
         X = torch.nan_to_num(
-            X.float(), nan=0.0, posinf=1e6, neginf=-1e6,
+            X.float(),
+            nan=0.0,
+            posinf=1e6,
+            neginf=-1e6,
         ).clamp(-1e6, 1e6)
         fit_rows = _resolve_context_rows(X.shape[0], context_rows)
         reference = X[:fit_rows]
@@ -955,15 +986,15 @@ def _robust_stabilize_features(X, clip_value=50.0, context_rows=None):
         centered = X - med
         reference_centered = reference - med
         mad = reference_centered.abs().median(dim=0).values.unsqueeze(0)
-        bound_scale = (
-            reference_centered.abs().amax(dim=0, keepdim=True) / clip_value
-        )
+        bound_scale = reference_centered.abs().amax(dim=0, keepdim=True) / clip_value
         scale = torch.where(mad < 1e-6, bound_scale, mad).clamp(min=1e-6)
         return (centered / scale).clamp(-clip_value, clip_value)
 
     X = np.nan_to_num(
         np.asarray(X, dtype=np.float32),
-        nan=0.0, posinf=1e6, neginf=-1e6,
+        nan=0.0,
+        posinf=1e6,
+        neginf=-1e6,
     )
     X = np.clip(X, -1e6, 1e6)
     fit_rows = _resolve_context_rows(X.shape[0], context_rows)
@@ -972,15 +1003,12 @@ def _robust_stabilize_features(X, clip_value=50.0, context_rows=None):
     centered = X - med
     reference_centered = reference - med
     mad = np.median(np.abs(reference_centered), axis=0, keepdims=True)
-    bound_scale = (
-        np.max(np.abs(reference_centered), axis=0, keepdims=True) / clip_value
-    )
+    bound_scale = np.max(np.abs(reference_centered), axis=0, keepdims=True) / clip_value
     scale = np.maximum(np.where(mad < 1e-6, bound_scale, mad), 1e-6)
     return np.clip(centered / scale, -clip_value, clip_value)
 
 
-def _validate_generated_data(
-        X, y, n_samples, n_features, context_rows=None):
+def _validate_generated_data(X, y, n_samples, n_features, context_rows=None):
     """Return whether an SCM draw is finite and has usable X/y variation."""
     if tuple(X.shape) != (n_samples, n_features):
         return False, f"X shape {tuple(X.shape)}"
@@ -990,10 +1018,7 @@ def _validate_generated_data(
         if y_flat.numel() != n_samples:
             return False, f"y shape {tuple(y.shape)}"
         fit_rows = _resolve_context_rows(n_samples, context_rows)
-        if (
-            not bool(torch.isfinite(X[:fit_rows]).all())
-            or not bool(torch.isfinite(y_flat[:fit_rows]).all())
-        ):
+        if not bool(torch.isfinite(X[:fit_rows]).all()) or not bool(torch.isfinite(y_flat[:fit_rows]).all()):
             return False, "nonfinite context output"
         if fit_rows > 1:
             if not bool((X[:fit_rows].float().std(dim=0, unbiased=False) > 1e-8).any()):
@@ -1006,10 +1031,7 @@ def _validate_generated_data(
     if y_flat.size != n_samples:
         return False, f"y shape {tuple(np.asarray(y).shape)}"
     fit_rows = _resolve_context_rows(n_samples, context_rows)
-    if (
-        not np.isfinite(X[:fit_rows]).all()
-        or not np.isfinite(y_flat[:fit_rows]).all()
-    ):
+    if not np.isfinite(X[:fit_rows]).all() or not np.isfinite(y_flat[:fit_rows]).all():
         return False, "nonfinite context output"
     if fit_rows > 1:
         if not np.any(np.std(X[:fit_rows], axis=0) > 1e-8):
@@ -1054,10 +1076,7 @@ def _retryable_generation_exception(exc):
         r"|\bnon[-_ ]?finite\b",
         message,
     )
-    return (
-        isinstance(exc, (RuntimeError, ValueError))
-        and numerical_failure is not None
-    )
+    return isinstance(exc, (RuntimeError, ValueError)) and numerical_failure is not None
 
 
 def sample_hyperparams(rng, n_features, device="cpu"):
@@ -1069,19 +1088,14 @@ def sample_hyperparams(rng, n_features, device="cpu"):
 
     # Shared SCM parameters
     hp["is_causal"] = meta_choice(rng, [True, False])()
-    hp["num_causes"] = meta_trunc_norm_log_scaled(
-        rng, max_mean=12, min_mean=1, round_val=True, lower_bound=1)()
+    hp["num_causes"] = meta_trunc_norm_log_scaled(rng, max_mean=12, min_mean=1, round_val=True, lower_bound=1)()
     hp["y_is_effect"] = meta_choice(rng, [True, False])()
     hp["in_clique"] = meta_choice(rng, [True, False])()
     hp["sort_features"] = meta_choice(rng, [True, False])()
-    hp["num_layers"] = meta_trunc_norm_log_scaled(
-        rng, max_mean=6, min_mean=1, round_val=True, lower_bound=2)()
-    hp["hidden_dim"] = meta_trunc_norm_log_scaled(
-        rng, max_mean=130, min_mean=5, round_val=True, lower_bound=4)()
-    hp["init_std"] = meta_trunc_norm_log_scaled(
-        rng, max_mean=10.0, min_mean=0.01, lower_bound=0.0)()
-    hp["noise_std"] = meta_trunc_norm_log_scaled(
-        rng, max_mean=0.3, min_mean=0.0001, lower_bound=0.0)()
+    hp["num_layers"] = meta_trunc_norm_log_scaled(rng, max_mean=6, min_mean=1, round_val=True, lower_bound=2)()
+    hp["hidden_dim"] = meta_trunc_norm_log_scaled(rng, max_mean=130, min_mean=5, round_val=True, lower_bound=4)()
+    hp["init_std"] = meta_trunc_norm_log_scaled(rng, max_mean=10.0, min_mean=0.01, lower_bound=0.0)()
+    hp["noise_std"] = meta_trunc_norm_log_scaled(rng, max_mean=0.3, min_mean=0.0001, lower_bound=0.0)()
     hp["sampling"] = meta_choice(rng, ["normal", "mixed", "uniform"])()
     hp["pre_sample_cause_stats"] = meta_choice(rng, [True, False])()
     hp["pre_sample_noise_std"] = meta_choice(rng, [True, False])()
@@ -1101,6 +1115,7 @@ def sample_hyperparams(rng, n_features, device="cpu"):
 # ============================================================================
 # Top-level generation function
 # ============================================================================
+
 
 @contextlib.contextmanager
 def _seeded_global_rngs(rng, device):
@@ -1125,8 +1140,8 @@ def _seeded_global_rngs(rng, device):
 
 
 def generate_scm_prior_dataset(
-        n_samples, n_features, task_type, n_classes=None,
-        rng=None, device="cpu", context_rows=None):
+    n_samples, n_features, task_type, n_classes=None, rng=None, device="cpu", context_rows=None
+):
     """Generate a single dataset using TabICL's prior system.
 
     Returns dict(X=[n_samples, n_features], y=[n_samples], n_classes=int|None).
@@ -1138,18 +1153,21 @@ def generate_scm_prior_dataset(
     effective_context_rows = context_rows if task_type == "reg" else None
     with _seeded_global_rngs(rng, device):
         return _generate_scm_prior_dataset(
-            n_samples, n_features, task_type, n_classes, rng, device,
+            n_samples,
+            n_features,
+            task_type,
+            n_classes,
+            rng,
+            device,
             context_rows=effective_context_rows,
         )
 
 
-def _generate_scm_prior_dataset(
-        n_samples, n_features, task_type, n_classes, rng, device,
-        context_rows=None):
+def _generate_scm_prior_dataset(n_samples, n_features, task_type, n_classes, rng, device, context_rows=None):
     labeled_rows = _resolve_context_rows(n_samples, context_rows)
 
     # Sample n_classes (TabICL: 50% binary, 50% uniform 2-10)
-    if task_type == 'cls' and n_classes is None:
+    if task_type == "cls" and n_classes is None:
         if rng.random() > 0.5:
             n_classes = int(rng.integers(2, 11))
         else:
@@ -1159,12 +1177,20 @@ def _generate_scm_prior_dataset(
 
     if hp["scm_type"] == "mlp":
         X, y, generation_meta = _generate_mlp(
-            n_samples, n_features, hp, rng, device,
+            n_samples,
+            n_features,
+            hp,
+            rng,
+            device,
             context_rows=labeled_rows,
         )
     else:
         X, y, generation_meta = _generate_tree(
-            n_samples, n_features, hp, rng, device,
+            n_samples,
+            n_features,
+            hp,
+            rng,
+            device,
             context_rows=labeled_rows,
         )
 
@@ -1200,10 +1226,10 @@ def _generate_scm_prior_dataset(
         if keep_mask.sum() < n_features:
             X[:, ~keep_mask] = 0.0
 
-    if task_type == 'cls':
+    if task_type == "cls":
         X, y, n_classes = reg2cls(X, y, n_classes, rng=rng)
 
-    if task_type == 'reg':
+    if task_type == "reg":
         y_reference = y[:labeled_rows]
         y_mean = np.mean(y_reference)
         y_std = np.std(y_reference)
@@ -1216,27 +1242,26 @@ def _generate_scm_prior_dataset(
     X = np.nan_to_num(X, nan=0.0, posinf=50.0, neginf=-50.0, copy=False)
 
     meta = {
-        'generator_family': 'scm_prior',
-        'scm_type': hp['scm_type'],
-        'active_dims': int(hp['num_causes']),
-        'noise_std': float(hp['noise_std']),
-        'context_rows': labeled_rows,
+        "generator_family": "scm_prior",
+        "scm_type": hp["scm_type"],
+        "active_dims": int(hp["num_causes"]),
+        "noise_std": float(hp["noise_std"]),
+        "context_rows": labeled_rows,
         **generation_meta,
     }
-    if hp['scm_type'] == 'mlp':
-        meta['n_mlp_layers'] = int(hp['num_layers'])
-        meta['hidden_width'] = int(hp['hidden_dim'])
+    if hp["scm_type"] == "mlp":
+        meta["n_mlp_layers"] = int(hp["num_layers"])
+        meta["hidden_width"] = int(hp["hidden_dim"])
 
     return {
-        'X': X,
-        'y': y,
-        'n_classes': n_classes if task_type == 'cls' else None,
-        'meta': meta,
+        "X": X,
+        "y": y,
+        "n_classes": n_classes if task_type == "cls" else None,
+        "meta": meta,
     }
 
 
-def _generate_mlp(
-        n_samples, n_features, hp, rng, device, context_rows=None):
+def _generate_mlp(n_samples, n_features, hp, rng, device, context_rows=None):
     """Generate data using MLP SCM."""
     failure_reason = "unknown generation failure"
     for attempt in range(1, 4):
@@ -1267,13 +1292,21 @@ def _generate_mlp(
             scm.to(device)
             X, y = scm()
             healthy, failure_reason = _validate_generated_data(
-                X, y, n_samples, n_features, context_rows=context_rows,
+                X,
+                y,
+                n_samples,
+                n_features,
+                context_rows=context_rows,
             )
             if healthy:
-                return X, y, {
-                    "generation_attempts": attempt,
-                    "fallback_used": False,
-                }
+                return (
+                    X,
+                    y,
+                    {
+                        "generation_attempts": attempt,
+                        "fallback_used": False,
+                    },
+                )
         except (RuntimeError, ValueError, FloatingPointError, OverflowError) as exc:
             # Sampled numerical pathologies are retryable; programming and
             # dependency errors remain visible to callers.
@@ -1282,23 +1315,30 @@ def _generate_mlp(
             failure_reason = f"{type(exc).__name__}: {exc}"[:240]
 
     X, y = _known_learnable_fallback(n_samples, n_features, rng)
-    return X, y, {
-        "generation_attempts": 3,
-        "fallback_used": True,
-        "fallback_reason": failure_reason,
-    }
+    return (
+        X,
+        y,
+        {
+            "generation_attempts": 3,
+            "fallback_used": True,
+            "fallback_reason": failure_reason,
+        },
+    )
 
 
-def _generate_tree(
-        n_samples, n_features, hp, rng, device, context_rows=None):
+def _generate_tree(n_samples, n_features, hp, rng, device, context_rows=None):
     """Generate data using Tree SCM."""
     if _resolve_context_rows(n_samples, context_rows) == 1:
         X, y = _known_learnable_fallback(n_samples, n_features, rng)
-        return X, y, {
-            "generation_attempts": 0,
-            "fallback_used": True,
-            "fallback_reason": "tree prior requires at least 2 context rows",
-        }
+        return (
+            X,
+            y,
+            {
+                "generation_attempts": 0,
+                "fallback_used": True,
+                "fallback_reason": "tree prior requires at least 2 context rows",
+            },
+        )
     failure_reason = "unknown generation failure"
     for attempt in range(1, 4):
         try:
@@ -1320,21 +1360,33 @@ def _generate_tree(
             )
             X, y = scm.generate()
             healthy, failure_reason = _validate_generated_data(
-                X, y, n_samples, n_features, context_rows=context_rows,
+                X,
+                y,
+                n_samples,
+                n_features,
+                context_rows=context_rows,
             )
             if healthy:
-                return X, y, {
-                    "generation_attempts": attempt,
-                    "fallback_used": False,
-                }
+                return (
+                    X,
+                    y,
+                    {
+                        "generation_attempts": attempt,
+                        "fallback_used": False,
+                    },
+                )
         except (RuntimeError, ValueError, FloatingPointError, OverflowError) as exc:
             if not _retryable_generation_exception(exc):
                 raise
             failure_reason = f"{type(exc).__name__}: {exc}"[:240]
 
     X, y = _known_learnable_fallback(n_samples, n_features, rng)
-    return X, y, {
-        "generation_attempts": 3,
-        "fallback_used": True,
-        "fallback_reason": failure_reason,
-    }
+    return (
+        X,
+        y,
+        {
+            "generation_attempts": 3,
+            "fallback_used": True,
+            "fallback_reason": failure_reason,
+        },
+    )

--- a/src/synthefy_nori/training/trainer.py
+++ b/src/synthefy_nori/training/trainer.py
@@ -30,9 +30,9 @@ class ICLFilterExhaustedError(RuntimeError):
 
 
 def _foreach_ema_update(
-        ema_state: dict[str, torch.Tensor],
-        current_state: dict[str, torch.Tensor],
-        decay: float,
+    ema_state: dict[str, torch.Tensor],
+    current_state: dict[str, torch.Tensor],
+    decay: float,
 ) -> None:
     # Update EMA tensors in device/dtype groups instead of scalar kernels.
     floating_groups: dict[
@@ -44,9 +44,7 @@ def _foreach_ema_update(
     for name, tensor in current_state.items():
         ema_tensor = ema_state[name]
         if torch.is_floating_point(tensor):
-            ema_tensors, current_tensors = floating_groups[
-                (tensor.device, tensor.dtype)
-            ]
+            ema_tensors, current_tensors = floating_groups[(tensor.device, tensor.dtype)]
             ema_tensors.append(ema_tensor)
             current_tensors.append(tensor.detach())
         else:
@@ -75,15 +73,15 @@ def get_wcd_schedule(optimizer, warmup_steps, decay_start_step, total_steps, lr_
             return 1.0
         progress = (step - effective_decay_start) / max(total_steps - effective_decay_start, 1)
         cosine_decay = 0.5 * (1 + math.cos(math.pi * progress))
-        return max(lr_min / optimizer.defaults['lr'], cosine_decay)
+        return max(lr_min / optimizer.defaults["lr"], cosine_decay)
+
     return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 class NoriTrainer:
     """Training loop for Nori with CCMM objective."""
 
-    def __init__(self, model, config: TrainingConfig, model_config: dict = None,
-                 on_checkpoint_saved=None):
+    def __init__(self, model, config: TrainingConfig, model_config: dict = None, on_checkpoint_saved=None):
         self.model = model
         self.config = config
         self.model_config = model_config
@@ -147,7 +145,7 @@ class NoriTrainer:
         # fp16 max is 65504; the MLP normal_(std=1) init + post-norm cause
         # gradient overflow in fp16.  bf16 has the same exponent range as fp32.
         # GradScaler is unnecessary for bf16 (no overflow/underflow risk).
-        self.scaler = GradScaler('cuda', enabled=False)
+        self.scaler = GradScaler("cuda", enabled=False)
 
         # RNG — shared RNG for data shape/task/eval_pos (identical across ranks
         # so all GPUs get the same n_samples, n_features, task_type, n_classes,
@@ -161,7 +159,7 @@ class NoriTrainer:
         self.global_step = 0
         self.optimizer_step = 0
         self.accumulated_micro_steps = 0
-        self.best_loss = float('inf')
+        self.best_loss = float("inf")
 
         # Loss spike detection (EMA-based)
         self._loss_ema = None
@@ -171,8 +169,7 @@ class NoriTrainer:
         self.ema_state_dict = None
         if 0.0 < self.ema_decay < 1.0:
             self.ema_state_dict = {
-                name: tensor.detach().clone()
-                for name, tensor in self._get_bare_model().state_dict().items()
+                name: tensor.detach().clone() for name, tensor in self._get_bare_model().state_dict().items()
             }
             if self.is_main:
                 print(f"EMA enabled: decay={self.ema_decay}")
@@ -187,10 +184,7 @@ class NoriTrainer:
                     print(f"Loaded quality filter rules: {config.quality_filter_rules_path}")
             except Exception as e:
                 if self.is_main:
-                    print(
-                        f"Warning: failed to load quality filter rules "
-                        f"({config.quality_filter_rules_path}): {e}"
-                    )
+                    print(f"Warning: failed to load quality filter rules ({config.quality_filter_rules_path}): {e}")
                 self.quality_rules = None
 
         # Async data prefetching
@@ -227,7 +221,25 @@ class NoriTrainer:
 
     # Shape buckets for torch.compile. These keep recompiles bounded while still
     # allowing larger late-curriculum tables.
-    SAMPLE_BUCKETS = [64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 24576, 32768, 49152]
+    SAMPLE_BUCKETS = [
+        64,
+        128,
+        256,
+        512,
+        768,
+        1024,
+        1536,
+        2048,
+        3072,
+        4096,
+        6144,
+        8192,
+        12288,
+        16384,
+        24576,
+        32768,
+        49152,
+    ]
     FEATURE_BUCKETS = [4, 8, 16, 32, 48, 64, 96, 128, 192, 256, 320, 384, 512, 768, 1024]
     CONTEXT_RATIO_BUCKETS = [0.30, 0.40, 0.50, 0.60, 0.70, 0.80]
 
@@ -242,15 +254,12 @@ class NoriTrainer:
             )
         else:
             sample_buckets = tuple(
-                int(value)
-                for value in cls.SAMPLE_BUCKETS
-                if cfg.min_samples <= int(value) <= cfg.max_samples
+                int(value) for value in cls.SAMPLE_BUCKETS if cfg.min_samples <= int(value) <= cfg.max_samples
             )
             feature_buckets = tuple(
                 int(value)
                 for value in cls.FEATURE_BUCKETS
-                if cfg.min_features <= int(value) <= cfg.max_features
-                and int(value) % cfg.features_per_group == 0
+                if cfg.min_features <= int(value) <= cfg.max_features and int(value) % cfg.features_per_group == 0
             )
             shapes = tuple(
                 (rows, features)
@@ -270,13 +279,13 @@ class NoriTrainer:
         sample_buckets = tuple(sorted({rows for rows, _ in shapes}))
         feature_buckets = tuple(sorted({features for _, features in shapes}))
         return {
-            'shapes': shapes,
-            'sample_buckets': sample_buckets,
-            'feature_buckets': feature_buckets,
-            'min_samples': sample_buckets[0],
-            'max_samples': sample_buckets[-1],
-            'min_features': feature_buckets[0],
-            'max_features': feature_buckets[-1],
+            "shapes": shapes,
+            "sample_buckets": sample_buckets,
+            "feature_buckets": feature_buckets,
+            "min_samples": sample_buckets[0],
+            "max_samples": sample_buckets[-1],
+            "min_features": feature_buckets[0],
+            "max_features": feature_buckets[-1],
         }
 
     def _sample_data_params(self):
@@ -291,9 +300,7 @@ class NoriTrainer:
 
         explicit_shape = bool(cfg.shape_palette)
         if explicit_shape:
-            weights = np.asarray(
-                [entry[2] for entry in cfg.shape_palette], dtype=np.float64
-            )
+            weights = np.asarray([entry[2] for entry in cfg.shape_palette], dtype=np.float64)
             weights /= weights.sum()
             shape_index = int(rng.choice(len(cfg.shape_palette), p=weights))
             n_samples, n_features, _weight = cfg.shape_palette[shape_index]
@@ -321,9 +328,7 @@ class NoriTrainer:
 
         budget = cfg.max_sample_feature_budget
         if explicit_shape and n_samples * n_features > budget:
-            raise ValueError(
-                f"Explicit shape {n_samples}x{n_features} exceeds budget {budget}"
-            )
+            raise ValueError(f"Explicit shape {n_samples}x{n_features} exceeds budget {budget}")
         if not explicit_shape and n_samples * n_features > budget:
             max_feat = budget // n_samples
             max_feat -= max_feat % cfg.features_per_group
@@ -337,25 +342,19 @@ class NoriTrainer:
 
         if not explicit_shape:
             support = self.effective_shape_support
-            valid_s = [
-                bucket for bucket in support['sample_buckets']
-                if bucket <= n_samples
-            ]
-            valid_f = [
-                bucket for bucket in support['feature_buckets']
-                if bucket <= n_features
-            ]
-            n_samples = max(valid_s) if valid_s else support['min_samples']
-            n_features = max(valid_f) if valid_f else support['min_features']
+            valid_s = [bucket for bucket in support["sample_buckets"] if bucket <= n_samples]
+            valid_f = [bucket for bucket in support["feature_buckets"] if bucket <= n_features]
+            n_samples = max(valid_s) if valid_s else support["min_samples"]
+            n_features = max(valid_f) if valid_f else support["min_features"]
 
-        if cfg.task_type == 'both':
-            task_type = 'reg' if rng.random() < cfg.regression_ratio else 'cls'
+        if cfg.task_type == "both":
+            task_type = "reg" if rng.random() < cfg.regression_ratio else "cls"
         else:
             rng.random()
             task_type = cfg.task_type
 
         n_classes = None
-        if task_type == 'cls':
+        if task_type == "cls":
             n_classes = int(rng.integers(cfg.min_classes, cfg.max_classes + 1))
 
         if cfg.context_ratio_palette:
@@ -363,8 +362,9 @@ class NoriTrainer:
             context_ratio = cfg.context_ratio_palette[ratio_index]
         else:
             context_ratio = rng.uniform(cfg.context_ratio_min, cfg.context_ratio_max)
-            valid_cr = [cr for cr in self.CONTEXT_RATIO_BUCKETS
-                        if cr >= cfg.context_ratio_min and cr <= cfg.context_ratio_max]
+            valid_cr = [
+                cr for cr in self.CONTEXT_RATIO_BUCKETS if cr >= cfg.context_ratio_min and cr <= cfg.context_ratio_max
+            ]
             if valid_cr:
                 context_ratio = min(valid_cr, key=lambda cr: abs(cr - context_ratio))
 
@@ -382,61 +382,60 @@ class NoriTrainer:
         """Build keyword arguments dict for generate_batch from config."""
         cfg = self.config
         return {
-            'batch_size': cfg.batch_size,
-            'n_samples': n_samples,
-            'n_features': n_features,
-            'task_type': task_type,
-            'n_classes': n_classes,
-            'augment': cfg.synth_v2,
-            'augment_v3': cfg.synth_v3,
-            'rich_reg_targets': cfg.rich_reg_targets,
+            "batch_size": cfg.batch_size,
+            "n_samples": n_samples,
+            "n_features": n_features,
+            "task_type": task_type,
+            "n_classes": n_classes,
+            "augment": cfg.synth_v2,
+            "augment_v3": cfg.synth_v3,
+            "rich_reg_targets": cfg.rich_reg_targets,
             # Context normalization removes positive affine target scaling.
             # Keep the dead transform off even for legacy configs that set it.
-            'scale_variation': False,
-            'augment_v4': cfg.synth_v4,
-            'v4_filter': cfg.v4_filter,
-            'learnability_filter': cfg.learnability_filter,
-            'v4_no_edge_noise': cfg.v4_no_edge_noise,
-            'synth_v5': cfg.synth_v5,
-            'synth_v5_mixture': cfg.synth_v5_mixture,
-            'reg_prior_prob': cfg.reg_prior_prob,
-            'reg_denoise': cfg.reg_denoise,
-            'reg_deterministic_prob': cfg.reg_deterministic_prob,
-            'reg_dense': cfg.reg_dense,
-            'scm_prior': cfg.scm_prior,
-            'scm_prior_prob': cfg.scm_prior_prob,
-            'probabilistic_labels': cfg.probabilistic_labels,
-            'nominal_categoricals': cfg.nominal_categoricals,
-            'enhanced_missingness': cfg.enhanced_missingness,
-            'clean_lowdim_prob': cfg.clean_lowdim_prob,
-            'tree_prior_prob': cfg.tree_prior_prob,
-            'lookup_prior_prob': cfg.lookup_prior_prob,
-            'quadratic_surface_prob': cfg.quadratic_surface_prob,
-            'sparse_nonlinear_prob': cfg.sparse_nonlinear_prob,
-            'gp_prior_prob': cfg.gp_prior_prob,
-            'cat_dominant_prob': getattr(cfg, 'cat_dominant_prob', 0.0),
-            'binary_fingerprint_prob': getattr(cfg, 'binary_fingerprint_prob', 0.0),
-            'temporal_prior_prob': getattr(cfg, 'temporal_prior_prob', 0.0),
-            'train_feature_augment_prob': getattr(cfg, 'train_feature_augment_prob', 0.0),
-            'context_missingness_prob': cfg.context_missingness_prob,
-            'realistic_augmentation_prob': cfg.realistic_augmentation_prob,
-            'y_transform_prob': cfg.y_transform_prob,
-            'cap_injection_prob': cfg.cap_injection_prob,
-            'heavy_tail_prior_prob': cfg.heavy_tail_prior_prob,
-            'pareto_importance_prob': cfg.pareto_importance_prob,
-            'latent_factor_prob': cfg.latent_factor_prob,
-            'high_cap_prob': cfg.high_cap_prob,
-            'low_unique_y_prob': cfg.low_unique_y_prob,
-            'learnability_filter_cls_min_score': cfg.learnability_filter_cls_min_score,
-            'learnability_filter_cls_margin': cfg.learnability_filter_cls_margin,
-            'learnability_filter_reg_min_score': cfg.learnability_filter_reg_min_score,
-            'icl_scaling_filter': cfg.icl_scaling_filter,
-            'icl_scaling_min_improvement': cfg.icl_scaling_min_improvement,
-            'quality_rules': self.quality_rules,
-            'filter_max_retries': cfg.quality_filter_max_retries,
-            'context_rows': (
-                min(max(1, int(n_samples * context_ratio)), n_samples - 1)
-                if context_ratio is not None else None
+            "scale_variation": False,
+            "augment_v4": cfg.synth_v4,
+            "v4_filter": cfg.v4_filter,
+            "learnability_filter": cfg.learnability_filter,
+            "v4_no_edge_noise": cfg.v4_no_edge_noise,
+            "synth_v5": cfg.synth_v5,
+            "synth_v5_mixture": cfg.synth_v5_mixture,
+            "reg_prior_prob": cfg.reg_prior_prob,
+            "reg_denoise": cfg.reg_denoise,
+            "reg_deterministic_prob": cfg.reg_deterministic_prob,
+            "reg_dense": cfg.reg_dense,
+            "scm_prior": cfg.scm_prior,
+            "scm_prior_prob": cfg.scm_prior_prob,
+            "probabilistic_labels": cfg.probabilistic_labels,
+            "nominal_categoricals": cfg.nominal_categoricals,
+            "enhanced_missingness": cfg.enhanced_missingness,
+            "clean_lowdim_prob": cfg.clean_lowdim_prob,
+            "tree_prior_prob": cfg.tree_prior_prob,
+            "lookup_prior_prob": cfg.lookup_prior_prob,
+            "quadratic_surface_prob": cfg.quadratic_surface_prob,
+            "sparse_nonlinear_prob": cfg.sparse_nonlinear_prob,
+            "gp_prior_prob": cfg.gp_prior_prob,
+            "cat_dominant_prob": getattr(cfg, "cat_dominant_prob", 0.0),
+            "binary_fingerprint_prob": getattr(cfg, "binary_fingerprint_prob", 0.0),
+            "temporal_prior_prob": getattr(cfg, "temporal_prior_prob", 0.0),
+            "train_feature_augment_prob": getattr(cfg, "train_feature_augment_prob", 0.0),
+            "context_missingness_prob": cfg.context_missingness_prob,
+            "realistic_augmentation_prob": cfg.realistic_augmentation_prob,
+            "y_transform_prob": cfg.y_transform_prob,
+            "cap_injection_prob": cfg.cap_injection_prob,
+            "heavy_tail_prior_prob": cfg.heavy_tail_prior_prob,
+            "pareto_importance_prob": cfg.pareto_importance_prob,
+            "latent_factor_prob": cfg.latent_factor_prob,
+            "high_cap_prob": cfg.high_cap_prob,
+            "low_unique_y_prob": cfg.low_unique_y_prob,
+            "learnability_filter_cls_min_score": cfg.learnability_filter_cls_min_score,
+            "learnability_filter_cls_margin": cfg.learnability_filter_cls_margin,
+            "learnability_filter_reg_min_score": cfg.learnability_filter_reg_min_score,
+            "icl_scaling_filter": cfg.icl_scaling_filter,
+            "icl_scaling_min_improvement": cfg.icl_scaling_min_improvement,
+            "quality_rules": self.quality_rules,
+            "filter_max_retries": cfg.quality_filter_max_retries,
+            "context_rows": (
+                min(max(1, int(n_samples * context_ratio)), n_samples - 1) if context_ratio is not None else None
             ),
         }
 
@@ -473,7 +472,7 @@ class NoriTrainer:
 
     def _set_target_aware_scale(self, scale: float) -> None:
         bare_model = self._get_bare_model()
-        if hasattr(bare_model, 'target_aware_scale'):
+        if hasattr(bare_model, "target_aware_scale"):
             bare_model.target_aware_scale = float(scale)
 
     def _submit_prefetch(
@@ -507,14 +506,17 @@ class NoriTrainer:
           ``'org/repo'``      -- download from an arbitrary HuggingFace repo
           local file path     -- used as-is
         """
-        if model_path == 'limix':
+        if model_path == "limix":
             from synthefy_nori.hf import download_limix
+
             return download_limix()
-        if model_path == 'hf':
+        if model_path == "hf":
             from synthefy_nori.hf import download_checkpoint
+
             return download_checkpoint()
-        if '/' in model_path and not os.path.exists(model_path):
+        if "/" in model_path and not os.path.exists(model_path):
             from synthefy_nori.hf import download_checkpoint
+
             return download_checkpoint(repo_id=model_path)
         return model_path
 
@@ -528,6 +530,7 @@ class NoriTrainer:
         """
         model_path = self._resolve_icl_filter_path(model_path)
         from synthefy_nori.utils.loading import load_model
+
         m = load_model(model_path, mask_prediction=True)
         m.eval()
         m.to(self.device)
@@ -542,7 +545,7 @@ class NoriTrainer:
         self,
         X_batch,
         y_batch,
-        task_type='reg',
+        task_type="reg",
         n_classes=None,
         *,
         context_ratio=None,
@@ -575,7 +578,7 @@ class NoriTrainer:
         y_batch,
         n_ctx,
         *,
-        task_type='reg',
+        task_type="reg",
     ):
         """Reject invalid numeric episodes before model-based filtering."""
         X_batch = np.asarray(X_batch)
@@ -583,18 +586,13 @@ class NoriTrainer:
         if X_batch.ndim != 3 or y_batch.ndim != 2:
             raise ValueError("ICL filter expects X=[B,N,F] and y=[B,N]")
         if X_batch.shape[:2] != y_batch.shape:
-            raise ValueError(
-                f"ICL filter X/y shape mismatch: X={X_batch.shape}, "
-                f"y={y_batch.shape}"
-            )
+            raise ValueError(f"ICL filter X/y shape mismatch: X={X_batch.shape}, y={y_batch.shape}")
         if not 0 < n_ctx < X_batch.shape[1]:
-            raise ValueError(
-                f"ICL filter context rows must be in [1, N-1], got {n_ctx}"
-            )
+            raise ValueError(f"ICL filter context rows must be in [1, N-1], got {n_ctx}")
 
         healthy = np.isfinite(y_batch).all(axis=1)
         healthy &= ~np.isinf(X_batch).any(axis=(1, 2))
-        if task_type != 'reg':
+        if task_type != "reg":
             return healthy
 
         y_ctx = y_batch[:, :n_ctx]
@@ -608,10 +606,7 @@ class NoriTrainer:
         ctx_min = np.min(np.where(ctx_finite, x_ctx, np.inf), axis=1)
         ctx_max = np.max(np.where(ctx_finite, x_ctx, -np.inf), axis=1)
         variable_ctx_feature = (
-            (finite_count >= 2)
-            & np.isfinite(ctx_min)
-            & np.isfinite(ctx_max)
-            & ((ctx_max - ctx_min) > 1e-8)
+            (finite_count >= 2) & np.isfinite(ctx_min) & np.isfinite(ctx_max) & ((ctx_max - ctx_min) > 1e-8)
         )
         query_observed = np.isfinite(X_batch[:, n_ctx:, :]).any(axis=1)
         healthy &= np.any(variable_ctx_feature & query_observed, axis=1)
@@ -621,7 +616,7 @@ class NoriTrainer:
         self,
         X_batch,
         y_batch,
-        task_type='reg',
+        task_type="reg",
         n_classes=None,
         *,
         context_ratio=None,
@@ -659,7 +654,7 @@ class NoriTrainer:
 
         X_sub = np.nan_to_num(X_sub, nan=0.0).astype(np.float32)
 
-        if task_type == 'cls':
+        if task_type == "cls":
             nc = min(n_classes or 10, 10)
             y_sub = np.clip(y_sub, 0, nc - 1).astype(np.float32)
         else:
@@ -677,7 +672,7 @@ class NoriTrainer:
                 with torch.autocast(
                     device_type=self.device.type,
                     dtype=torch.bfloat16,
-                    enabled=self.device.type == 'cuda',
+                    enabled=self.device.type == "cuda",
                 ):
                     out = self._icl_filter_model(
                         x_t,
@@ -685,17 +680,17 @@ class NoriTrainer:
                         eval_pos=n_ctx,
                         task_type=task_type,
                     )
-                if task_type == 'cls':
-                    logits = out['cls_output'][:, :n_qry, :nc].float().cpu().numpy()
+                if task_type == "cls":
+                    logits = out["cls_output"][:, :n_qry, :nc].float().cpu().numpy()
                     preds = logits.argmax(axis=-1)
-                    true = y_np[:, n_ctx:n_ctx + n_qry].astype(np.int64)
+                    true = y_np[:, n_ctx : n_ctx + n_qry].astype(np.int64)
                     acc = (preds == true).mean(axis=-1)
                     chance = 1.0 / nc
                     margin = cfg.icl_filter_cls_min_auc - 0.5
                     return acc > (chance + margin)
                 else:
-                    preds = out['reg_output'][:, :n_qry, 0].float().cpu().numpy()
-                    true = y_np[:, n_ctx:n_ctx + n_qry]
+                    preds = out["reg_output"][:, :n_qry, 0].float().cpu().numpy()
+                    true = y_np[:, n_ctx : n_ctx + n_qry]
                     ss_res = ((true - preds) ** 2).sum(axis=-1)
                     ss_tot = ((true - true.mean(axis=-1, keepdims=True)) ** 2).sum(axis=-1)
                     r2 = 1.0 - ss_res / np.maximum(ss_tot, 1e-8)
@@ -704,7 +699,7 @@ class NoriTrainer:
                 torch.cuda.empty_cache()
                 return None
             except RuntimeError as exc:
-                if 'out of memory' not in str(exc).lower():
+                if "out of memory" not in str(exc).lower():
                     raise
                 torch.cuda.empty_cache()
                 return None
@@ -717,11 +712,10 @@ class NoriTrainer:
 
         # OOM: fall back to per-episode
         for b, original_idx in enumerate(healthy_idx):
-            result = _eval_batch(X_sub[b:b+1], y_sub[b:b+1])
+            result = _eval_batch(X_sub[b : b + 1], y_sub[b : b + 1])
             if result is None:
                 raise RuntimeError(
-                    "ICL filter OOM on a single episode; refusing to accept an "
-                    "unscored synthetic episode"
+                    "ICL filter OOM on a single episode; refusing to accept an unscored synthetic episode"
                 )
             passed[original_idx] = result[0]
 
@@ -731,7 +725,7 @@ class NoriTrainer:
         self,
         X_batch,
         y_batch,
-        task_type='reg',
+        task_type="reg",
         n_classes=None,
         n_samples=None,
         n_features=None,
@@ -755,7 +749,7 @@ class NoriTrainer:
                                           (numerator for exhaustion rate)
         """
         cfg = self.config
-        max_rounds = max(1, int(getattr(cfg, 'icl_filter_max_rounds', 6)))
+        max_rounds = max(1, int(getattr(cfg, "icl_filter_max_rounds", 6)))
 
         n_samples = int(n_samples or X_batch.shape[1])
         n_features = int(n_features or X_batch.shape[2])
@@ -777,8 +771,7 @@ class NoriTrainer:
         self._icl_first_round_reject += n_rejected
 
         if self.is_main and self.global_step % self.config.log_interval == 0:
-            print(f"  [ICL-GPU] Rejected {n_rejected}/{len(passed)} episodes "
-                  f"(round budget={max_rounds})")
+            print(f"  [ICL-GPU] Rejected {n_rejected}/{len(passed)} episodes (round budget={max_rounds})")
 
         gen_kwargs = self._build_gen_kwargs(
             n_samples,
@@ -787,8 +780,8 @@ class NoriTrainer:
             n_classes,
             context_ratio=context_ratio,
         )
-        gen_kwargs.pop('icl_filter_model', None)
-        gen_kwargs.pop('batch_size', None)
+        gen_kwargs.pop("icl_filter_model", None)
+        gen_kwargs.pop("batch_size", None)
 
         # Track per-episode "rounds needed". -1 means still bad after all
         # rounds; otherwise records 1..max_rounds (1 = passed after round 1).
@@ -799,10 +792,8 @@ class NoriTrainer:
             if len(bad_idx) == 0:
                 break
             for i in bad_idx:
-                rng_replace = np.random.default_rng(
-                    int(self.rng.integers(0, 2**63)))
-                generated = generate_batch(
-                    batch_size=1, rng=rng_replace, **gen_kwargs)
+                rng_replace = np.random.default_rng(int(self.rng.integers(0, 2**63)))
+                generated = generate_batch(batch_size=1, rng=rng_replace, **gen_kwargs)
                 X_new, y_new = generated[:2]
                 X_batch[i] = X_new[0]
                 y_batch[i] = y_new[0]
@@ -835,8 +826,7 @@ class NoriTrainer:
 
         return X_batch, y_batch
 
-    def _apply_cat_target_encoding(self, X_batch, y_batch, eval_pos,
-                                    p_col=0.25):
+    def _apply_cat_target_encoding(self, X_batch, y_batch, eval_pos, p_col=0.25):
         """Replace cat-like columns with target-encoded versions per episode.
 
         Detection heuristic (per col, per episode):
@@ -1032,7 +1022,7 @@ class NoriTrainer:
         # quantile, class N = highest. Without shuffling, the model learns
         # "class ordering = magnitude ordering" instead of treating labels
         # as arbitrary identifiers. Apply random bijection per episode.
-        if task_type == 'cls' and n_classes is not None and n_classes > 1:
+        if task_type == "cls" and n_classes is not None and n_classes > 1:
             for b in range(batch_size):
                 perm = self.rng.permutation(n_classes)
                 y_int = y_batch[b].astype(np.int64).clip(0, n_classes - 1)
@@ -1045,7 +1035,7 @@ class NoriTrainer:
         # Re-normalize regression targets from the actual sampled context.
         # Generators receive a planned context budget, while this boundary is
         # authoritative and remains the final inference-parity guard.
-        if task_type == 'reg':
+        if task_type == "reg":
             context_y = y_batch[:, :eval_pos]
             y_ctx_mean = context_y.mean(axis=-1, keepdims=True)
             y_ctx_std = context_y.std(axis=-1, keepdims=True)
@@ -1059,10 +1049,9 @@ class NoriTrainer:
         # cat_target_encode_prob per col, replace a cat-like col with its
         # target-encoded version (mean-y per category) computed from CONTEXT
         # rows only — query y is masked, so no label leakage.
-        cte_prob = float(getattr(cfg, 'cat_target_encode_prob', 0.0))
-        if cte_prob > 0.0 and task_type == 'reg':
-            X_batch = self._apply_cat_target_encoding(
-                X_batch, y_batch, eval_pos, cte_prob)
+        cte_prob = float(getattr(cfg, "cat_target_encode_prob", 0.0))
+        if cte_prob > 0.0 and task_type == "reg":
+            X_batch = self._apply_cat_target_encoding(X_batch, y_batch, eval_pos, cte_prob)
 
         # Frequency / count encoding (V12r3 audit-driven addition).
         # For real benchmarks like chscase_foot (cat cardinality 236 in train,
@@ -1075,10 +1064,9 @@ class NoriTrainer:
         # Runs AFTER cat_target_encode so they don't both fire on the same
         # column (target encode produces continuous mean-y, breaking the
         # integer-check that gates freq encoding).
-        fce_prob = float(getattr(cfg, 'freq_count_encode_prob', 0.0))
-        if fce_prob > 0.0 and task_type == 'reg':
-            X_batch = self._apply_freq_count_encoding(
-                X_batch, eval_pos, fce_prob)
+        fce_prob = float(getattr(cfg, "freq_count_encode_prob", 0.0))
+        if fce_prob > 0.0 and task_type == "reg":
+            X_batch = self._apply_freq_count_encoding(X_batch, eval_pos, fce_prob)
 
         n_query = n_samples - eval_pos
 
@@ -1130,58 +1118,56 @@ class NoriTrainer:
                 n_zero += 1
             if not math.isfinite(norm):
                 continue
-            if 'transformer_encoder' in name:
-                key = 'tfm'
-            elif 'cls_y_decoder' in name:
-                key = 'cls_dec'
-            elif 'reg_y_decoder' in name:
-                key = 'reg_dec'
-            elif 'feature_decoder' in name:
-                key = 'feat_dec'
-            elif 'encoder_x' in name:
-                key = 'x_enc'
-            elif 'cls_y_encoder' in name:
-                key = 'cls_enc'
-            elif 'reg_y_encoder' in name:
-                key = 'reg_enc'
-            elif 'x_preprocess' in name:
-                key = 'preproc'
-            elif 'feature_positional' in name:
-                key = 'feat_pos'
+            if "transformer_encoder" in name:
+                key = "tfm"
+            elif "cls_y_decoder" in name:
+                key = "cls_dec"
+            elif "reg_y_decoder" in name:
+                key = "reg_dec"
+            elif "feature_decoder" in name:
+                key = "feat_dec"
+            elif "encoder_x" in name:
+                key = "x_enc"
+            elif "cls_y_encoder" in name:
+                key = "cls_enc"
+            elif "reg_y_encoder" in name:
+                key = "reg_enc"
+            elif "x_preprocess" in name:
+                key = "preproc"
+            elif "feature_positional" in name:
+                key = "feat_pos"
             else:
-                key = 'other'
+                key = "other"
             component_norms.setdefault(key, 0.0)
-            component_norms[key] += norm ** 2
+            component_norms[key] += norm**2
 
-        component_norms = {k: v ** 0.5 for k, v in component_norms.items()}
-        total_norm = sum(v ** 2 for v in component_norms.values()) ** 0.5
+        component_norms = {k: v**0.5 for k, v in component_norms.items()}
+        total_norm = sum(v**2 for v in component_norms.values()) ** 0.5
 
         scale = self.scaler.get_scale()
         parts = " ".join(f"{k}={v:.4e}" for k, v in sorted(component_norms.items()))
-        print(f"  [DIAG] grad_norm={total_norm:.4e} scale={scale:.0f} "
-              f"zero_grad={n_zero}/{n_total}")
+        print(f"  [DIAG] grad_norm={total_norm:.4e} scale={scale:.0f} zero_grad={n_zero}/{n_total}")
         print(f"  [DIAG] {parts}")
 
         # --- Output statistics ---
-        if 'cls_output' in output and output['cls_output'].numel() > 0:
-            co = output['cls_output'].detach().float()
+        if "cls_output" in output and output["cls_output"].numel() > 0:
+            co = output["cls_output"].detach().float()
             probs = torch.softmax(co, dim=-1)
             max_prob = probs.max(dim=-1).values.mean()
-            print(f"  [DIAG] cls: logit_mean={co.mean():.4f} logit_std={co.std():.4f} "
-                  f"max_prob={max_prob:.4f}")
-        if 'reg_output' in output and output['reg_output'].numel() > 0:
-            ro = output['reg_output'].detach().float()
+            print(f"  [DIAG] cls: logit_mean={co.mean():.4f} logit_std={co.std():.4f} max_prob={max_prob:.4f}")
+        if "reg_output" in output and output["reg_output"].numel() > 0:
+            ro = output["reg_output"].detach().float()
             print(f"  [DIAG] reg: mean={ro.mean():.4f} std={ro.std():.4f}")
 
-        feature_pred = output.get('feature_pred')
+        feature_pred = output.get("feature_pred")
         if torch.is_tensor(feature_pred) and feature_pred.numel() > 0:
             fp = feature_pred.detach().float()
             print(f"  [DIAG] feat_pred: mean={fp.mean():.4f} std={fp.std():.4f}")
 
         # --- Process config sanity ---
-        pc = output['process_config']
-        if pc.get('std_for_normalization') is not None:
-            std_n = pc['std_for_normalization'].detach()
+        pc = output["process_config"]
+        if pc.get("std_for_normalization") is not None:
+            std_n = pc["std_for_normalization"].detach()
             n_zero_std = (std_n.abs() < 1e-6).sum().item()
             if n_zero_std > 0:
                 print(f"  [DIAG] WARNING: {n_zero_std}/{std_n.numel()} near-zero std features")
@@ -1194,8 +1180,7 @@ class NoriTrainer:
         """
         if not self.config.distributed:
             return should_skip
-        skip_tensor = torch.tensor(
-            [1.0 if should_skip else 0.0], device=self.device)
+        skip_tensor = torch.tensor([1.0 if should_skip else 0.0], device=self.device)
         torch.distributed.all_reduce(skip_tensor, op=torch.distributed.ReduceOp.MAX)
         return skip_tensor.item() > 0.5
 
@@ -1216,23 +1201,18 @@ class NoriTrainer:
             raise fatal_error
         if fatal_error is not None:
             raise RuntimeError(
-                f"Fatal {phase} error on rank {self.config.local_rank}: "
-                f"{type(fatal_error).__name__}: {fatal_error}"
+                f"Fatal {phase} error on rank {self.config.local_rank}: {type(fatal_error).__name__}: {fatal_error}"
             ) from fatal_error
-        raise RuntimeError(
-            f"Fatal {phase} error on another rank; see that rank's log"
-        )
+        raise RuntimeError(f"Fatal {phase} error on another rank; see that rank's log")
 
     @staticmethod
     def _prefetch_worker_exception(error):
         """Reconstruct known worker outcomes without masking programming bugs."""
-        if error.err_type == 'SyntheticDataFilterError':
+        if error.err_type == "SyntheticDataFilterError":
             return SyntheticDataFilterError(error.err_msg)
-        if error.err_type == 'ICLFilterExhaustedError':
+        if error.err_type == "ICLFilterExhaustedError":
             return ICLFilterExhaustedError(error.err_msg)
-        return RuntimeError(
-            f"Worker error ({error.err_type}): {error.err_msg}\n{error.tb}"
-        )
+        return RuntimeError(f"Worker error ({error.err_type}): {error.err_msg}\n{error.tb}")
 
     def train_step(self):
         """Execute one training step with synchronized DDP phase boundaries.
@@ -1251,15 +1231,11 @@ class NoriTrainer:
         # All shared_rng consumption happens here, before any error-prone code,
         # so even if generate_batch/forward fails on one rank, shared_rng stays
         # in sync across all ranks.
-        if (self.prefetcher is not None
-                and hasattr(self, '_prefetch_params_queue')
-                and self._prefetch_params_queue):
+        if self.prefetcher is not None and hasattr(self, "_prefetch_params_queue") and self._prefetch_params_queue:
             # Async path: params were pre-sampled during prefill/previous step.
-            n_samples, n_features, task_type, n_classes, context_ratio = \
-                self._prefetch_params_queue.pop(0)
+            n_samples, n_features, task_type, n_classes, context_ratio = self._prefetch_params_queue.pop(0)
         else:
-            n_samples, n_features, task_type, n_classes, context_ratio = \
-                self._sample_data_params()
+            n_samples, n_features, task_type, n_classes, context_ratio = self._sample_data_params()
 
         current_feature_loss_weight = self._get_current_feature_loss_weight()
         current_tae_scale = self._get_current_target_aware_scale()
@@ -1268,17 +1244,19 @@ class NoriTrainer:
         # Build skip-result template
         def _skip_result():
             return {
-                'total_loss': 0, 'y_loss': 0, 'feat_loss': 0,
-                'skipped': True,
-                'lr': self.scheduler.get_last_lr()[0],
-                'task_type': task_type,
-                'n_samples': n_samples,
-                'n_features': n_features,
-                'eval_pos': 0,
-                'feature_loss_weight': current_feature_loss_weight,
-                'target_aware_scale': current_tae_scale,
-                'optimizer_stepped': False,
-                'optimizer_step': self.optimizer_step,
+                "total_loss": 0,
+                "y_loss": 0,
+                "feat_loss": 0,
+                "skipped": True,
+                "lr": self.scheduler.get_last_lr()[0],
+                "task_type": task_type,
+                "n_samples": n_samples,
+                "n_features": n_features,
+                "eval_pos": 0,
+                "feature_loss_weight": current_feature_loss_weight,
+                "target_aware_scale": current_tae_scale,
+                "optimizer_stepped": False,
+                "optimizer_step": self.optimizer_step,
             }
 
         should_skip = False
@@ -1299,6 +1277,7 @@ class NoriTrainer:
                 # already drawn when this batch was submitted).
                 result = self.prefetcher.get()
                 from synthefy_nori.training.prefetch import _ErrorSentinel
+
                 if isinstance(result, _ErrorSentinel):
                     raise self._prefetch_worker_exception(result)
                 X_batch, y_batch, n_classes = result
@@ -1320,19 +1299,16 @@ class NoriTrainer:
             # all episodes (~31ms for batch=8), replacing unlearnable ones.
             if self._icl_filter_model is not None:
                 X_batch, y_batch = self._filter_and_replace(
-                    X_batch, y_batch, task_type, n_classes,
-                    n_samples, n_features, context_ratio)
+                    X_batch, y_batch, task_type, n_classes, n_samples, n_features, context_ratio
+                )
 
-            x_input, y_input, eval_pos, x_original, feature_mask, y_query = \
-                self._prepare_batch(X_batch, y_batch, task_type, n_classes,
-                                    context_ratio)
+            x_input, y_input, eval_pos, x_original, feature_mask, y_query = self._prepare_batch(
+                X_batch, y_batch, task_type, n_classes, context_ratio
+            )
 
         except (ICLFilterExhaustedError, SyntheticDataFilterError) as error:
             if self.is_main:
-                print(
-                    f"  [SKIP] Synthetic filter exhausted at step "
-                    f"{self.global_step}: {error}"
-                )
+                print(f"  [SKIP] Synthetic filter exhausted at step {self.global_step}: {error}")
             should_skip = True
         except RuntimeError as error:
             if "out of memory" in str(error).lower():
@@ -1365,10 +1341,8 @@ class NoriTrainer:
         should_skip = False
         fatal_error = None
         try:
-
             # Forward pass
-            with torch.autocast(device_type='cuda', dtype=torch.bfloat16,
-                                enabled=cfg.mixed_precision):
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=cfg.mixed_precision):
                 output = self.model(
                     x=x_input,
                     y=y_input,
@@ -1379,7 +1353,7 @@ class NoriTrainer:
             # Pull bar-borders buffer from model (may be None for non-bar
             # losses or if model wasn't built with bar_distribution head).
             _bare = self._get_bare_model()
-            _bar_borders = getattr(_bare, 'bar_borders_buffer', None)
+            _bar_borders = getattr(_bare, "bar_borders_buffer", None)
 
             # Compute loss outside autocast for float32 precision
             loss, loss_dict = compute_ccmm_loss(
@@ -1401,41 +1375,46 @@ class NoriTrainer:
                 bar_borders_high=cfg.bar_borders_high,
                 bar_target_sigma=cfg.bar_target_sigma,
                 bar_borders=_bar_borders,
-                bar_target_sigma_y=getattr(cfg, 'bar_target_sigma_y', 0.0),
-                bar_aux_mse_weight=getattr(cfg, 'bar_aux_mse_weight', 0.0),
+                bar_target_sigma_y=getattr(cfg, "bar_target_sigma_y", 0.0),
+                bar_aux_mse_weight=getattr(cfg, "bar_aux_mse_weight", 0.0),
                 compile_pinball_loss=cfg.compile_pinball_loss,
             )
-            loss_dict['feature_loss_weight'] = current_feature_loss_weight
-            loss_dict['target_aware_scale'] = current_tae_scale
+            loss_dict["feature_loss_weight"] = current_feature_loss_weight
+            loss_dict["target_aware_scale"] = current_tae_scale
 
             loss_val = loss.item()
 
             # NaN / Inf check
             if not math.isfinite(loss_val):
                 if self.is_main:
-                    print(f"  [SKIP] NaN/Inf loss at step {self.global_step} "
-                          f"(task={task_type}, n={n_samples}, f={n_features})")
+                    print(
+                        f"  [SKIP] NaN/Inf loss at step {self.global_step} "
+                        f"(task={task_type}, n={n_samples}, f={n_features})"
+                    )
                 should_skip = True
 
             # Loss spike check
-            elif (self._loss_ema is not None
-                  and loss_val > self._loss_spike_threshold * self._loss_ema
-                  and self._loss_ema > 0):
+            elif (
+                self._loss_ema is not None
+                and loss_val > self._loss_spike_threshold * self._loss_ema
+                and self._loss_ema > 0
+            ):
                 if self.is_main:
-                    y_l = loss_dict.get('y_loss', 0)
-                    f_l = loss_dict.get('feat_loss', 0)
-                    print(f"  [SKIP] Loss spike at step {self.global_step}: "
-                          f"{loss_val:.4f} > {self._loss_spike_threshold}x EMA "
-                          f"({self._loss_ema:.4f}) "
-                          f"[y={y_l:.2f} feat={f_l:.2f} task={task_type}]")
+                    y_l = loss_dict.get("y_loss", 0)
+                    f_l = loss_dict.get("feat_loss", 0)
+                    print(
+                        f"  [SKIP] Loss spike at step {self.global_step}: "
+                        f"{loss_val:.4f} > {self._loss_spike_threshold}x EMA "
+                        f"({self._loss_ema:.4f}) "
+                        f"[y={y_l:.2f} feat={f_l:.2f} task={task_type}]"
+                    )
                 should_skip = True
 
         except RuntimeError as error:
             if "out of memory" in str(error).lower():
                 if self.is_main:
                     print(
-                        f"  [SKIP] OOM during forward/loss at step "
-                        f"{self.global_step} (n={n_samples}, f={n_features})"
+                        f"  [SKIP] OOM during forward/loss at step {self.global_step} (n={n_samples}, f={n_features})"
                     )
                 torch.cuda.empty_cache()
                 should_skip = True
@@ -1474,8 +1453,7 @@ class NoriTrainer:
         if self._loss_ema is None:
             self._loss_ema = loss_val
         else:
-            self._loss_ema = (self._loss_ema_alpha * loss_val +
-                              (1 - self._loss_ema_alpha) * self._loss_ema)
+            self._loss_ema = self._loss_ema_alpha * loss_val + (1 - self._loss_ema_alpha) * self._loss_ema
 
         # --- Backward pass ---
         # In DDP mode, backward triggers gradient all-reduce across ranks.
@@ -1501,7 +1479,7 @@ class NoriTrainer:
         # find_unused_parameters=True).  Adding 0 * sum(p) creates autograd
         # edges without changing the gradient values.
         if cfg.distributed:
-            raw_model = self.model.module if hasattr(self.model, 'module') else self.model
+            raw_model = self.model.module if hasattr(self.model, "module") else self.model
             loss = loss + 0.0 * sum(p.sum() for p in raw_model.parameters() if p.requires_grad)
 
         # Use no_sync() for intermediate gradient accumulation steps.
@@ -1520,8 +1498,7 @@ class NoriTrainer:
                 self.scaler.scale(loss).backward()
             except RuntimeError as e:
                 if "out of memory" in str(e).lower():
-                    print(f"  [SKIP] OOM in backward at step {self.global_step} "
-                          f"(n={n_samples}, f={n_features})")
+                    print(f"  [SKIP] OOM in backward at step {self.global_step} (n={n_samples}, f={n_features})")
                     torch.cuda.empty_cache()
                     self.optimizer.zero_grad()
                     self.accumulated_micro_steps = 0
@@ -1536,8 +1513,7 @@ class NoriTrainer:
 
             # Debug NPZ dump: capture unscaled, pre-clip gradients for the
             # first debug_dump_steps optimizer steps (reproduction harness).
-            _dbg_dump = (bool(cfg.debug_dump_dir) and self.is_main
-                         and self.optimizer_step < cfg.debug_dump_steps)
+            _dbg_dump = bool(cfg.debug_dump_dir) and self.is_main and self.optimizer_step < cfg.debug_dump_steps
             _dbg_grads = None
             if _dbg_dump:
                 _dbg_grads = {
@@ -1550,8 +1526,7 @@ class NoriTrainer:
             if cfg.log_interval > 0 and ((self.optimizer_step + 1) % cfg.log_interval == 0) and self.is_main:
                 self._log_diagnostics(output)
 
-            grad_norm = torch.nn.utils.clip_grad_norm_(
-                self.model.parameters(), cfg.gradient_clip)
+            grad_norm = torch.nn.utils.clip_grad_norm_(self.model.parameters(), cfg.gradient_clip)
 
             self.scaler.step(self.optimizer)
             self.scaler.update()
@@ -1565,25 +1540,31 @@ class NoriTrainer:
             if _dbg_dump:
                 self._write_debug_dump(
                     step=self.optimizer_step - 1,
-                    X_batch=X_batch, y_batch=y_batch,
-                    x_input=x_input, y_input=y_input, eval_pos=eval_pos,
-                    loss_val=loss_val, loss_dict=loss_dict,
-                    grad_norm=float(grad_norm), grads=_dbg_grads,
+                    X_batch=X_batch,
+                    y_batch=y_batch,
+                    x_input=x_input,
+                    y_input=y_input,
+                    eval_pos=eval_pos,
+                    loss_val=loss_val,
+                    loss_dict=loss_dict,
+                    grad_norm=float(grad_norm),
+                    grads=_dbg_grads,
                 )
 
-        loss_dict['skipped'] = False
-        loss_dict['lr'] = self.scheduler.get_last_lr()[0]
-        loss_dict['task_type'] = task_type
-        loss_dict['n_samples'] = n_samples
-        loss_dict['n_features'] = n_features
-        loss_dict['eval_pos'] = eval_pos
-        loss_dict['optimizer_stepped'] = optimizer_stepped
-        loss_dict['optimizer_step'] = self.optimizer_step
+        loss_dict["skipped"] = False
+        loss_dict["lr"] = self.scheduler.get_last_lr()[0]
+        loss_dict["task_type"] = task_type
+        loss_dict["n_samples"] = n_samples
+        loss_dict["n_features"] = n_features
+        loss_dict["eval_pos"] = eval_pos
+        loss_dict["optimizer_stepped"] = optimizer_stepped
+        loss_dict["optimizer_step"] = self.optimizer_step
 
         return loss_dict
 
-    def _write_debug_dump(self, *, step, X_batch, y_batch, x_input, y_input,
-                          eval_pos, loss_val, loss_dict, grad_norm, grads):
+    def _write_debug_dump(
+        self, *, step, X_batch, y_batch, x_input, y_input, eval_pos, loss_val, loss_dict, grad_norm, grads
+    ):
         """Write one per-step NPZ for the reproduction harness.
 
         Observation-only — runs only when config.debug_dump_dir is set. Each
@@ -1601,27 +1582,27 @@ class NoriTrainer:
             return np.asarray(t)
 
         payload = {
-            'X_batch': _np_of(X_batch),
-            'y_batch': _np_of(y_batch),
-            'x_input': _np_of(x_input),
-            'y_input': _np_of(y_input),
-            'eval_pos': np.int64(eval_pos),
-            'loss': np.float64(loss_val),
-            'grad_norm': np.float64(grad_norm),
+            "X_batch": _np_of(X_batch),
+            "y_batch": _np_of(y_batch),
+            "x_input": _np_of(x_input),
+            "y_input": _np_of(y_input),
+            "eval_pos": np.int64(eval_pos),
+            "loss": np.float64(loss_val),
+            "grad_norm": np.float64(grad_norm),
         }
         for k, v in (loss_dict or {}).items():
             if isinstance(v, bool):
                 continue
             if isinstance(v, (int, float)):
-                payload[f'loss_dict.{k}'] = np.float64(v)
+                payload[f"loss_dict.{k}"] = np.float64(v)
             elif isinstance(v, torch.Tensor) and v.ndim == 0:
-                payload[f'loss_dict.{k}'] = np.float64(v.item())
+                payload[f"loss_dict.{k}"] = np.float64(v.item())
         for n, g in (grads or {}).items():
-            payload[f'grad.{n}'] = g
+            payload[f"grad.{n}"] = g
         for n, p in bare.named_parameters():
-            payload[f'weight.{n}'] = p.detach().float().cpu().numpy()
+            payload[f"weight.{n}"] = p.detach().float().cpu().numpy()
 
-        path = os.path.join(d, f'step{step}.npz')
+        path = os.path.join(d, f"step{step}.npz")
         np.savez(path, **payload)
         print(f"  [debug-dump] step {step} -> {path} ({len(payload)} arrays)")
 
@@ -1629,18 +1610,15 @@ class NoriTrainer:
         """Return the unwrapped model (handles DDP and torch.compile wrapping)."""
         model = self.model
         # Unwrap DDP
-        if hasattr(model, 'module'):
+        if hasattr(model, "module"):
             model = model.module
         # Unwrap torch.compile
-        if hasattr(model, '_orig_mod'):
+        if hasattr(model, "_orig_mod"):
             model = model._orig_mod
         return model
 
     def _clone_current_model_state(self):
-        return {
-            name: tensor.detach().clone()
-            for name, tensor in self._get_bare_model().state_dict().items()
-        }
+        return {name: tensor.detach().clone() for name, tensor in self._get_bare_model().state_dict().items()}
 
     def _update_ema(self):
         if self.ema_state_dict is None:
@@ -1669,27 +1647,24 @@ class NoriTrainer:
 
         if path is None:
             os.makedirs(self.config.checkpoint_dir, exist_ok=True)
-            path = os.path.join(
-                self.config.checkpoint_dir,
-                f"checkpoint_step_{self.global_step}.pt"
-            )
+            path = os.path.join(self.config.checkpoint_dir, f"checkpoint_step_{self.global_step}.pt")
 
         save_dict = {
-            'model_state_dict': self._get_bare_model().state_dict(),
-            'optimizer_state_dict': self.optimizer.state_dict(),
-            'scheduler_state_dict': self.scheduler.state_dict(),
-            'scaler_state_dict': self.scaler.state_dict(),
-            'global_step': self.global_step,
-            'optimizer_step': self.optimizer_step,
-            'accumulated_micro_steps': self.accumulated_micro_steps,
-            'best_loss': self.best_loss,
-            'config': self.config,
+            "model_state_dict": self._get_bare_model().state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "scheduler_state_dict": self.scheduler.state_dict(),
+            "scaler_state_dict": self.scaler.state_dict(),
+            "global_step": self.global_step,
+            "optimizer_step": self.optimizer_step,
+            "accumulated_micro_steps": self.accumulated_micro_steps,
+            "best_loss": self.best_loss,
+            "config": self.config,
         }
         if self.ema_state_dict is not None:
-            save_dict['ema_state_dict'] = self.ema_state_dict
-            save_dict['ema_decay'] = self.ema_decay
+            save_dict["ema_state_dict"] = self.ema_state_dict
+            save_dict["ema_decay"] = self.ema_decay
         if self.model_config is not None:
-            save_dict['model_config'] = self.model_config
+            save_dict["model_config"] = self.model_config
         torch.save(save_dict, path)
         print(f"Checkpoint saved to {path}")
         if self.on_checkpoint_saved is not None:
@@ -1707,9 +1682,7 @@ class NoriTrainer:
         # added 2026-05-03 for V10) to be loaded from their fresh init when
         # FT'ing from older checkpoints. Missing/unexpected keys are logged so
         # the user notices unintended schema mismatches.
-        missing, unexpected = self._get_bare_model().load_state_dict(
-            ckpt['model_state_dict'], strict=False
-        )
+        missing, unexpected = self._get_bare_model().load_state_dict(ckpt["model_state_dict"], strict=False)
         if (missing or unexpected) and self.is_main:
             if missing:
                 print(f"  [load_checkpoint] missing keys (using fresh init): {missing}")
@@ -1723,9 +1696,9 @@ class NoriTrainer:
             self.global_step = 0
             self.optimizer_step = 0
             self.accumulated_micro_steps = 0
-            self.best_loss = float('inf')
+            self.best_loss = float("inf")
             if self.ema_state_dict is not None:
-                loaded_ema = ckpt.get('ema_state_dict')
+                loaded_ema = ckpt.get("ema_state_dict")
                 if loaded_ema is None:
                     self.ema_state_dict = self._clone_current_model_state()
                 else:
@@ -1739,24 +1712,21 @@ class NoriTrainer:
                     self.ema_state_dict = current_state
             self._set_target_aware_scale(self._get_current_target_aware_scale())
             if self.is_main:
-                print(
-                    f'Checkpoint weights loaded from {path}; '
-                    'optimizer, scheduler, scaler, and step counters reset.'
-                )
+                print(f"Checkpoint weights loaded from {path}; optimizer, scheduler, scaler, and step counters reset.")
             return
 
-        self.optimizer.load_state_dict(ckpt['optimizer_state_dict'])
-        self.scheduler.load_state_dict(ckpt['scheduler_state_dict'])
-        self.scaler.load_state_dict(ckpt['scaler_state_dict'])
-        self.global_step = ckpt['global_step']
-        self.optimizer_step = ckpt.get('optimizer_step', max(self.scheduler.last_epoch, 0))
-        loaded_accumulated_micro_steps = ckpt.get('accumulated_micro_steps', 0)
+        self.optimizer.load_state_dict(ckpt["optimizer_state_dict"])
+        self.scheduler.load_state_dict(ckpt["scheduler_state_dict"])
+        self.scaler.load_state_dict(ckpt["scaler_state_dict"])
+        self.global_step = ckpt["global_step"]
+        self.optimizer_step = ckpt.get("optimizer_step", max(self.scheduler.last_epoch, 0))
+        loaded_accumulated_micro_steps = ckpt.get("accumulated_micro_steps", 0)
         # Checkpoints do not serialize in-flight parameter gradients, so resuming
         # mid accumulation would otherwise step with missing micro-batch grads.
         self.accumulated_micro_steps = 0
-        self.best_loss = ckpt.get('best_loss', float('inf'))
+        self.best_loss = ckpt.get("best_loss", float("inf"))
         if self.ema_state_dict is not None:
-            loaded_ema = ckpt.get('ema_state_dict')
+            loaded_ema = ckpt.get("ema_state_dict")
             if loaded_ema is None:
                 self.ema_state_dict = self._clone_current_model_state()
             else:
@@ -1771,22 +1741,21 @@ class NoriTrainer:
         # load_state_dict overwrites param_groups with checkpoint LR;
         # we need to set it to the current effective LR.
         new_lr = self.config.lr
-        self.optimizer.defaults['lr'] = new_lr
+        self.optimizer.defaults["lr"] = new_lr
         for pg in self.optimizer.param_groups:
-            pg['lr'] = new_lr
-            pg['initial_lr'] = new_lr
+            pg["lr"] = new_lr
+            pg["initial_lr"] = new_lr
         self.scheduler.base_lrs = [new_lr] * len(self.scheduler.base_lrs)
         self.optimizer.zero_grad()
 
         if self.is_main:
             if loaded_accumulated_micro_steps:
                 print(
-                    'Checkpoint had '
-                    f'accumulated_micro_steps={loaded_accumulated_micro_steps}; '
-                    'reset to 0 because accumulated gradients are not serialized.'
+                    "Checkpoint had "
+                    f"accumulated_micro_steps={loaded_accumulated_micro_steps}; "
+                    "reset to 0 because accumulated gradients are not serialized."
                 )
-            print(f'Checkpoint loaded from {path}, step={self.global_step}, '
-                  f'lr={new_lr:.2e}')
+            print(f"Checkpoint loaded from {path}, step={self.global_step}, lr={new_lr:.2e}")
 
     def train(self):
         """Main training loop."""
@@ -1795,6 +1764,7 @@ class NoriTrainer:
         if cfg.use_wandb and self.is_main:
             try:
                 import wandb
+
                 wandb_kwargs = {
                     "project": cfg.wandb_project,
                     "config": vars(cfg),
@@ -1850,8 +1820,10 @@ class NoriTrainer:
                 eff_batch = cfg.batch_size * cfg.world_size * accum
                 print(f"  Effective batch size: {eff_batch}")
             print(f"  Learning rate: {cfg.lr}")
-            if (cfg.feature_loss_weight_end is not None
-                    and cfg.feature_loss_decay_end_step > cfg.feature_loss_decay_start_step):
+            if (
+                cfg.feature_loss_weight_end is not None
+                and cfg.feature_loss_decay_end_step > cfg.feature_loss_decay_start_step
+            ):
                 print(
                     f"  Feature loss schedule: {cfg.feature_loss_weight:.3f} -> "
                     f"{cfg.feature_loss_weight_end:.3f} "
@@ -1869,17 +1841,16 @@ class NoriTrainer:
             if cfg.compile:
                 print(f"  torch.compile: enabled")
             if self.prefetcher is not None:
-                print(f"  Async prefetch: {cfg.prefetch_workers} workers, "
-                      f"{cfg.prefetch_count} prefetch")
+                print(f"  Async prefetch: {cfg.prefetch_workers} workers, {cfg.prefetch_count} prefetch")
 
         if target_optimizer_step <= start_optimizer_step:
             if self.is_main:
                 print(
-                    f"No training steps to run: optimizer_step={start_optimizer_step}, "
-                    f"target={target_optimizer_step}."
+                    f"No training steps to run: optimizer_step={start_optimizer_step}, target={target_optimizer_step}."
                 )
             if cfg.use_wandb and self.wandb_run:
                 import wandb
+
                 wandb.finish()
             return
 
@@ -1921,20 +1892,14 @@ class NoriTrainer:
         first_log_pending = self.global_step == 0 and self.optimizer_step == 0
 
         # Debug NPZ dump: snapshot initial weights once, before any step.
-        if (self.config.debug_dump_dir and self.is_main
-                and self.optimizer_step == 0):
+        if self.config.debug_dump_dir and self.is_main and self.optimizer_step == 0:
             os.makedirs(self.config.debug_dump_dir, exist_ok=True)
             _bare = self._get_bare_model()
-            _init = {f'weight.{n}': p.detach().float().cpu().numpy()
-                     for n, p in _bare.named_parameters()}
-            np.savez(os.path.join(self.config.debug_dump_dir,
-                                  'init_weights.npz'), **_init)
-            print(f"  [debug-dump] init weights -> "
-                  f"{self.config.debug_dump_dir}/init_weights.npz "
-                  f"({len(_init)} params)")
+            _init = {f"weight.{n}": p.detach().float().cpu().numpy() for n, p in _bare.named_parameters()}
+            np.savez(os.path.join(self.config.debug_dump_dir, "init_weights.npz"), **_init)
+            print(f"  [debug-dump] init weights -> {self.config.debug_dump_dir}/init_weights.npz ({len(_init)} params)")
 
         while self.optimizer_step < target_optimizer_step:
-
             # train_step handles all errors internally (OOM, ValueError, NaN,
             # spike) and syncs skip decisions across DDP ranks. Never raises
             # except for truly fatal errors.
@@ -1948,20 +1913,20 @@ class NoriTrainer:
                 self._prefetch_params_queue.append(params)
                 self._submit_prefetch(ns, nf, tt, nc, cr)
 
-            if not loss_dict.get('skipped', False):
-                running_loss += loss_dict['total_loss']
-                running_y_loss += loss_dict['y_loss']
-                running_feat_loss += loss_dict['feat_loss']
+            if not loss_dict.get("skipped", False):
+                running_loss += loss_dict["total_loss"]
+                running_y_loss += loss_dict["y_loss"]
+                running_feat_loss += loss_dict["feat_loss"]
                 log_count += 1
                 # Per-task-type loss tracking
-                if loss_dict.get('task_type') == 'cls':
-                    running_cls_y_loss += loss_dict['y_loss']
+                if loss_dict.get("task_type") == "cls":
+                    running_cls_y_loss += loss_dict["y_loss"]
                     cls_count += 1
-                elif loss_dict.get('task_type') == 'reg':
-                    running_reg_y_loss += loss_dict['y_loss']
+                elif loss_dict.get("task_type") == "reg":
+                    running_reg_y_loss += loss_dict["y_loss"]
                     reg_count += 1
 
-            stepped = loss_dict.get('optimizer_stepped', False)
+            stepped = loss_dict.get("optimizer_stepped", False)
             should_log = False
             if log_count > 0 and self.is_main:
                 if first_log_pending:
@@ -1991,41 +1956,41 @@ class NoriTrainer:
 
                 if cfg.use_wandb and self.wandb_run:
                     import wandb
+
                     log_dict = {
-                        'train/loss': avg_loss,
-                        'train/y_loss': avg_y,
-                        'train/feat_loss': avg_feat,
-                        'train/lr': loss_dict['lr'],
-                        'train/feature_loss_weight': loss_dict.get(
-                            'feature_loss_weight', cfg.feature_loss_weight),
-                        'train/target_aware_scale': loss_dict.get(
-                            'target_aware_scale', 1.0),
-                        'train/steps_per_sec': steps_per_sec,
-                        'data/n_samples': loss_dict['n_samples'],
-                        'data/n_features': loss_dict['n_features'],
+                        "train/loss": avg_loss,
+                        "train/y_loss": avg_y,
+                        "train/feat_loss": avg_feat,
+                        "train/lr": loss_dict["lr"],
+                        "train/feature_loss_weight": loss_dict.get("feature_loss_weight", cfg.feature_loss_weight),
+                        "train/target_aware_scale": loss_dict.get("target_aware_scale", 1.0),
+                        "train/steps_per_sec": steps_per_sec,
+                        "data/n_samples": loss_dict["n_samples"],
+                        "data/n_features": loss_dict["n_features"],
                     }
                     if cls_count > 0:
-                        log_dict['train/cls_y_loss'] = running_cls_y_loss / cls_count
+                        log_dict["train/cls_y_loss"] = running_cls_y_loss / cls_count
                     if reg_count > 0:
-                        log_dict['train/reg_y_loss'] = running_reg_y_loss / reg_count
+                        log_dict["train/reg_y_loss"] = running_reg_y_loss / reg_count
                     # ICL-filter telemetry — only emit when we saw episodes
                     # this window (denominator > 0). Resets immediately below.
                     if self._icl_total_episodes > 0:
                         denom = float(self._icl_total_episodes)
                         reject_rate = self._icl_first_round_reject / denom
                         exhaustion_rate = self._icl_escape_count / denom
-                        log_dict['train/icl_filter_reject_rate'] = reject_rate
-                        log_dict['train/icl_filter_exhaustion_rate'] = exhaustion_rate
-                        log_dict['train/icl_filter_episodes'] = int(self._icl_total_episodes)
+                        log_dict["train/icl_filter_reject_rate"] = reject_rate
+                        log_dict["train/icl_filter_exhaustion_rate"] = exhaustion_rate
+                        log_dict["train/icl_filter_episodes"] = int(self._icl_total_episodes)
                         if self._icl_first_round_reject > 0:
-                            avg_rounds = (self._icl_rounds_used_sum
-                                          / float(self._icl_first_round_reject))
-                            log_dict['train/icl_filter_avg_rounds'] = avg_rounds
+                            avg_rounds = self._icl_rounds_used_sum / float(self._icl_first_round_reject)
+                            log_dict["train/icl_filter_avg_rounds"] = avg_rounds
                         # Echo the rates to stdout — operators care about
                         # Exhaustion is a bounded skip, never silent acceptance.
-                        print(f"  [ICL-GPU/win] reject={reject_rate*100:.1f}% "
-                              f"exhausted={exhaustion_rate*100:.2f}% "
-                              f"(over {int(denom)} eps)")
+                        print(
+                            f"  [ICL-GPU/win] reject={reject_rate * 100:.1f}% "
+                            f"exhausted={exhaustion_rate * 100:.2f}% "
+                            f"(over {int(denom)} eps)"
+                        )
                     wandb.log(log_dict, step=opt_step)
 
                 # Reset ICL-filter counters at every log window so each metric
@@ -2060,13 +2025,11 @@ class NoriTrainer:
 
         if cfg.use_wandb and self.wandb_run:
             import wandb
+
             wandb.finish()
 
         if self.is_main:
             if self.optimizer_step >= cfg.total_steps:
                 print("Training complete!")
             else:
-                print(
-                    f"Training segment complete at optimizer step "
-                    f"{self.optimizer_step}/{cfg.total_steps}."
-                )
+                print(f"Training segment complete at optimizer step {self.optimizer_step}/{cfg.total_steps}.")

--- a/src/synthefy_nori/utils/data_utils.py
+++ b/src/synthefy_nori/utils/data_utils.py
@@ -10,8 +10,7 @@ class DistributedInferenceDataset(Dataset):
     def __init__(self, x_test: torch.Tensor):
         if x_test.ndim != 2:
             raise ValueError(
-                "distributed inference expects X_test with shape "
-                f"[rows, features], got {tuple(x_test.shape)}"
+                f"distributed inference expects X_test with shape [rows, features], got {tuple(x_test.shape)}"
             )
         self.x_test = x_test
 

--- a/src/synthefy_nori/utils/inference_utils.py
+++ b/src/synthefy_nori/utils/inference_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from torch.utils.data import DistributedSampler
 
 
-
 class NonPaddingDistributedSampler(DistributedSampler):
     def __init__(self, dataset, num_replicas=None, rank=None, shuffle=False):
         super().__init__(dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle)
@@ -12,8 +11,9 @@ class NonPaddingDistributedSampler(DistributedSampler):
 
     def __iter__(self):
         indices = list(range(len(self.dataset)))
-        indices = indices[self.rank:self.total_size:self.num_replicas]
+        indices = indices[self.rank : self.total_size : self.num_replicas]
         return iter(indices)
+
 
 def swap_rows_back(tensor, indices):
     """

--- a/src/synthefy_nori/utils/loading.py
+++ b/src/synthefy_nori/utils/loading.py
@@ -33,6 +33,7 @@ def _safe_torch_load(path):
         with torch.serialization.safe_globals([TrainingConfig]):
             return torch.load(path, map_location="cpu", weights_only=True)
 
+
 # The attention-scale flags and their defaults. ``finalize_arch_config`` stamps
 # this table into every new checkpoint's ``model_config``; ``build_model`` falls
 # back to it for checkpoints saved before it did. One table, so the value a run
@@ -98,66 +99,64 @@ def finalize_arch_config(model_config: dict) -> dict:
     """
     if bool(model_config.get("use_qassmax", False)):
         env_mode = os.environ.get("SYNTHEFY_QASS_MODE")
-        model_config["qass_mode"] = (
-            env_mode.strip().lower() if env_mode else resolve_qass_mode(model_config)
-        )
+        model_config["qass_mode"] = env_mode.strip().lower() if env_mode else resolve_qass_mode(model_config)
     for key, default in _ATTENTION_SCALE_DEFAULTS.items():
         model_config.setdefault(key, default)
     return model_config
 
 
-def build_model(config:dict):
+def build_model(config: dict):
     # Pre-``finalize_arch_config`` checkpoints omit these; fall back to the same
     # table finalize stamps in, so old and new checkpoints agree.
     attn_scale = {k: config.get(k, v) for k, v in _ATTENTION_SCALE_DEFAULTS.items()}
-    use_qassmax = bool(config.get('use_qassmax', False))
+    use_qassmax = bool(config.get("use_qassmax", False))
     model = FeaturesTransformer(
-        preprocess_config_x=config['preprocess_config_x'],
-        encoder_config_x=config['encoder_config_x'],
-        encoder_config_y=config['encoder_config_y'],
-        decoder_config=config['decoder_config'],
-        feature_positional_embedding_type=config.get('feature_positional_embedding_type', "subortho"),
-        feature_positional_embedding_num_slots=config.get('feature_positional_embedding_num_slots', 1000),
-        nlayers=config['nlayers'],
-        nhead=config['nhead'],
-        embed_dim=config['embed_dim'],
-        hid_dim=config['hid_dim'],
-        mask_prediction=config.get('mask_prediction', False),
-        features_per_group=config['features_per_group'],
-        dropout=config['dropout'],
-        pre_norm=config.get('pre_norm', True),
-        activation=config.get('activation', 'gelu'),
-        layer_norm_eps=config.get('layer_norm_eps', 1e-5),
-        device=config.get('device', None),
-        dtype=config.get('dtype', None),
-        recompute_attn=config['recompute_attn'],
+        preprocess_config_x=config["preprocess_config_x"],
+        encoder_config_x=config["encoder_config_x"],
+        encoder_config_y=config["encoder_config_y"],
+        decoder_config=config["decoder_config"],
+        feature_positional_embedding_type=config.get("feature_positional_embedding_type", "subortho"),
+        feature_positional_embedding_num_slots=config.get("feature_positional_embedding_num_slots", 1000),
+        nlayers=config["nlayers"],
+        nhead=config["nhead"],
+        embed_dim=config["embed_dim"],
+        hid_dim=config["hid_dim"],
+        mask_prediction=config.get("mask_prediction", False),
+        features_per_group=config["features_per_group"],
+        dropout=config["dropout"],
+        pre_norm=config.get("pre_norm", True),
+        activation=config.get("activation", "gelu"),
+        layer_norm_eps=config.get("layer_norm_eps", 1e-5),
+        device=config.get("device", None),
+        dtype=config.get("dtype", None),
+        recompute_attn=config["recompute_attn"],
         # Kept as a fail-fast compatibility input: True was historically a
         # silent no-op and must not continue pretending to select an architecture.
-        mlp_use_residual=config.get('mlp_use_residual', False),
-        layer_arch=config.get('layer_arch', 'fmfmsm'),
-        norm_type=config.get('norm_type', 'layernorm'),
-        deepnorm_alpha=config.get('deepnorm_alpha', None),
-        self_share_all_kv_heads=config.get('self_share_all_kv_heads', False),
-        cross_share_all_kv_heads=config.get('cross_share_all_kv_heads', True),
-        seq_attn_isolated=config.get('seq_attn_isolated', False),
-        seq_attn_serial=config.get('seq_attn_serial', False),
+        mlp_use_residual=config.get("mlp_use_residual", False),
+        layer_arch=config.get("layer_arch", "fmfmsm"),
+        norm_type=config.get("norm_type", "layernorm"),
+        deepnorm_alpha=config.get("deepnorm_alpha", None),
+        self_share_all_kv_heads=config.get("self_share_all_kv_heads", False),
+        cross_share_all_kv_heads=config.get("cross_share_all_kv_heads", True),
+        seq_attn_isolated=config.get("seq_attn_isolated", False),
+        seq_attn_serial=config.get("seq_attn_serial", False),
         use_qassmax=use_qassmax,
         # Resolved here, once, from this config — not read back out of the
         # environment inside QASSMaxScaling.
         qass_mode=resolve_qass_mode(config) if use_qassmax else None,
-        use_target_aware_embedding=config.get('use_target_aware_embedding', False),
-        use_column_specific_y_aware=config.get('use_column_specific_y_aware', False),
-        use_logn_attention=bool(attn_scale['use_logn_attention']),
-        use_learnable_attn_temperature=bool(attn_scale['use_learnable_attn_temperature']),
-        attn_n_ref=float(attn_scale['attn_n_ref']),
+        use_target_aware_embedding=config.get("use_target_aware_embedding", False),
+        use_column_specific_y_aware=config.get("use_column_specific_y_aware", False),
+        use_logn_attention=bool(attn_scale["use_logn_attention"]),
+        use_learnable_attn_temperature=bool(attn_scale["use_learnable_attn_temperature"]),
+        attn_n_ref=float(attn_scale["attn_n_ref"]),
         # Legacy configs omit this flag and therefore retain the decoder. That
         # preserves their state-dict schema for strict checkpoint loading.
-        omit_feature_decoder=bool(config.get('omit_feature_decoder', False)),
+        omit_feature_decoder=bool(config.get("omit_feature_decoder", False)),
     )
     return model
 
-def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None,
-               native_rms_norm:bool=True):
+
+def load_model(model_path, mask_prediction: bool = False, base_config_path: str = None, native_rms_norm: bool = True):
     """Load a Nori checkpoint for inference.
 
     ``native_rms_norm`` selects PyTorch's fused ``F.rms_norm`` over the
@@ -173,15 +172,15 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
     state_dict = _safe_torch_load(model_path)
 
     # Support both pretrained (.ckpt) and training checkpoint (.pt) formats
-    if 'model_config' in state_dict:
+    if "model_config" in state_dict:
         # Training checkpoint format (new): has architecture config embedded.
         # `model_config` is the architecture record -- read it and nothing else.
         # `state_dict['config']` is the TrainingConfig (hyperparameters, no
         # architecture); merging it in here would make the resolved QASS mode a
         # function of the container format instead of the model.
-        config = state_dict['model_config']
-        weights = state_dict.get('ema_state_dict') or state_dict['model_state_dict']
-    elif 'model_state_dict' in state_dict:
+        config = state_dict["model_config"]
+        weights = state_dict.get("ema_state_dict") or state_dict["model_state_dict"]
+    elif "model_state_dict" in state_dict:
         # Training checkpoint format (legacy): no model_config saved
         # Fall back to extracting config from base pretrained checkpoint
         if base_config_path is None:
@@ -191,32 +190,33 @@ def load_model(model_path, mask_prediction:bool=False, base_config_path:str=None
             )
         print(f"Loading model architecture config from {base_config_path}")
         base_state = _safe_torch_load(base_config_path)
-        config = base_state['config']
-        weights = state_dict.get('ema_state_dict') or state_dict['model_state_dict']
+        config = base_state["config"]
+        weights = state_dict.get("ema_state_dict") or state_dict["model_state_dict"]
     else:
         # Pretrained .ckpt format: {'state_dict': ..., 'config': ...}
-        config = state_dict['config']
-        weights = state_dict['state_dict']
+        config = state_dict["config"]
+        weights = state_dict["state_dict"]
 
     # Copy before mutating: `config` is a dict embedded in the loaded checkpoint,
     # and callers (e.g. the eval harness) reuse that object.
     config = dict(config)
-    if mask_prediction and bool(config.get('omit_feature_decoder', False)):
+    if mask_prediction and bool(config.get("omit_feature_decoder", False)):
         raise ValueError(
             "mask_prediction=True requires a checkpoint with feature_decoder; "
             "this checkpoint explicitly omits that head"
         )
-    config['mask_prediction'] = mask_prediction
+    config["mask_prediction"] = mask_prediction
 
     # Strip torch.compile "_orig_mod." prefix if present
-    if any(k.startswith('_orig_mod.') for k in weights):
-        weights = {k.removeprefix('_orig_mod.'): v for k, v in weights.items()}
+    if any(k.startswith("_orig_mod.") for k in weights):
+        weights = {k.removeprefix("_orig_mod."): v for k, v in weights.items()}
 
     model = build_model(config)
     model.load_state_dict(weights)
 
     if native_rms_norm:
         from synthefy_nori.model.layer import RMSNorm
+
         for module in model.modules():
             if isinstance(module, RMSNorm):
                 module.use_native = True

--- a/tests/embedding/test_embedding_clustering.py
+++ b/tests/embedding/test_embedding_clustering.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.slow
 def _embed_test_rows(X_train, y_train, X_test):
     """Fit on the context, return mean-over-ensemble test embeddings [n, dim]."""
     model = NoriRegressor(model="nori-6m").fit(X_train, y_train)
-    emb = model.get_embeddings(X_test, data_source="test")   # (n_est, n, dim)
+    emb = model.get_embeddings(X_test, data_source="test")  # (n_est, n, dim)
     return emb.mean(axis=0)
 
 
@@ -50,8 +50,7 @@ def test_binary_classification_embeddings_separate_by_class():
     encodes the (predicted) class — should separate the two moons much better."""
     X, y = make_moons(n_samples=500, noise=0.18, random_state=0)
     X = X.astype(np.float32)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.4, random_state=0, stratify=y)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4, random_state=0, stratify=y)
 
     Z = _embed_test_rows(X_train, y_train.astype(np.float64), X_test)
     Xs = StandardScaler().fit_transform(X_test)  # fair raw baseline (scaled)
@@ -59,17 +58,16 @@ def test_binary_classification_embeddings_separate_by_class():
     sil_emb, sil_raw = silhouette_score(Z, y_test), silhouette_score(Xs, y_test)
     ari_emb, ari_raw = _kmeans_ari(Z, y_test, 2), _kmeans_ari(Xs, y_test, 2)
     # Unsupervised kNN probe on the embeddings (leave-one-out style via CV).
-    knn_acc = accuracy_score(
-        y_test, cross_val_predict(KNeighborsClassifier(15), Z, y_test, cv=5))
+    knn_acc = accuracy_score(y_test, cross_val_predict(KNeighborsClassifier(15), Z, y_test, cv=5))
 
     print(f"\n[moons] silhouette  embed={sil_emb:+.3f} raw={sil_raw:+.3f}")
     print(f"[moons] KMeans ARI  embed={ari_emb:+.3f} raw={ari_raw:+.3f}")
     print(f"[moons] kNN acc on embeddings = {knn_acc:.3f}")
 
-    assert sil_emb > sil_raw                 # embeddings are more clusterable
-    assert ari_emb > ari_raw + 0.10          # KMeans recovers classes far better
-    assert ari_emb > 0.5                      # and recovers them well in absolute terms
-    assert knn_acc > 0.9                      # near-perfectly class-separated
+    assert sil_emb > sil_raw  # embeddings are more clusterable
+    assert ari_emb > ari_raw + 0.10  # KMeans recovers classes far better
+    assert ari_emb > 0.5  # and recovers them well in absolute terms
+    assert knn_acc > 0.9  # near-perfectly class-separated
 
 
 def test_regression_embeddings_organize_by_target():
@@ -79,8 +77,7 @@ def test_regression_embeddings_organize_by_target():
     rng = np.random.default_rng(0)
     X = rng.uniform(-2.0, 2.0, size=(500, 5)).astype(np.float32)
     y = (np.sin(X[:, 0]) + X[:, 1] ** 2 + 0.5 * X[:, 2] * X[:, 3]).astype(np.float64)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.4, random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4, random_state=0)
 
     Z = _embed_test_rows(X_train, y_train, X_test)
     Xs = StandardScaler().fit_transform(X_test)
@@ -89,13 +86,12 @@ def test_regression_embeddings_organize_by_target():
     bins = np.digitize(y_test, np.quantile(y_test, [1 / 3, 2 / 3]))
     sil_emb, sil_raw = silhouette_score(Z, bins), silhouette_score(Xs, bins)
     ari_emb, ari_raw = _kmeans_ari(Z, bins, 3), _kmeans_ari(Xs, bins, 3)
-    knn_r2 = r2_score(
-        y_test, cross_val_predict(KNeighborsRegressor(15), Z, y_test, cv=5))
+    knn_r2 = r2_score(y_test, cross_val_predict(KNeighborsRegressor(15), Z, y_test, cv=5))
 
     print(f"\n[reg] silhouette(target-bins)  embed={sil_emb:+.3f} raw={sil_raw:+.3f}")
     print(f"[reg] KMeans ARI(target-bins)  embed={ari_emb:+.3f} raw={ari_raw:+.3f}")
     print(f"[reg] kNN-on-embeddings R2 = {knn_r2:.3f}")
 
-    assert sil_emb > sil_raw                 # embeddings group same-target points
-    assert ari_emb > ari_raw                 # and KMeans recovers target groups better
-    assert knn_r2 > 0.85                      # embedding neighbors share the target
+    assert sil_emb > sil_raw  # embeddings group same-target points
+    assert ari_emb > ari_raw  # and KMeans recovers target groups better
+    assert knn_r2 > 0.85  # embedding neighbors share the target

--- a/tests/embedding/test_examples_smoke.py
+++ b/tests/embedding/test_examples_smoke.py
@@ -7,6 +7,7 @@ guards the exact public construction API the examples/README rely on; the slow
 tests import each example module and run its own ``extract_embeddings`` end-to-end
 on tiny data against the real checkpoint.
 """
+
 import importlib.util
 import pathlib
 
@@ -55,8 +56,7 @@ def test_example_extract_embeddings_end_to_end(name):
     rng = np.random.default_rng(0)
     X = rng.uniform(-2.0, 2.0, size=(60, 5)).astype(np.float32)
     y = (np.sin(X[:, 0]) + X[:, 1] ** 2).astype(np.float64)
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.4, random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.4, random_state=0)
 
     Z_train, Z_test, native = module.extract_embeddings(X_train, y_train, X_test)
 

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -71,9 +71,7 @@ def test_fit_resolves_and_reuses_device_for_named_text_encoder(monkeypatch):
             pass
 
         def fit_transform(self, frame):
-            return pd.DataFrame(
-                np.zeros((len(frame), 2), dtype=np.float32), index=frame.index
-            )
+            return pd.DataFrame(np.zeros((len(frame), 2), dtype=np.float32), index=frame.index)
 
     monkeypatch.setattr(api, "_as_device", lambda device: torch.device("mps"))
     monkeypatch.setattr(api, "DataFramePreprocessor", FakePreprocessor)

--- a/tests/test_attention_map_capture.py
+++ b/tests/test_attention_map_capture.py
@@ -89,8 +89,6 @@ def test_stack_returns_final_layer_maps_not_an_earlier_capture(monkeypatch):
 def test_no_diagnostic_flags_returns_no_maps():
     stack = _build_stack(3, "smf", True)
     with torch.no_grad():
-        _, feature_attention, sample_attention = stack(
-            torch.randn(1, 6, 3, 8), feature_atten_mask=None, eval_pos=4
-        )
+        _, feature_attention, sample_attention = stack(torch.randn(1, 6, 3, 8), feature_atten_mask=None, eval_pos=4)
     assert feature_attention is None
     assert sample_attention is None

--- a/tests/test_benchmark_performance.py
+++ b/tests/test_benchmark_performance.py
@@ -172,8 +172,15 @@ def _matches(name, name_filter):
     return name_filter is None or any(s in name for s in name_filter)
 
 
-def load_local_suite(bench_root: Path, cache_subdir: str, list_name: str, source: str,
-                     test_size: float, random_state: int, name_filter=None):
+def load_local_suite(
+    bench_root: Path,
+    cache_subdir: str,
+    list_name: str,
+    source: str,
+    test_size: float,
+    random_state: int,
+    name_filter=None,
+):
     """Load all cached regression datasets for one suite (tabarena/talent)."""
     cache_dir = bench_root / "cache" / cache_subdir
     if not cache_dir.is_dir():
@@ -197,22 +204,22 @@ def load_local_suite(bench_root: Path, cache_subdir: str, list_name: str, source
             entry = None
         if entry is not None:
             entries.append(entry)
-    print(f"  {source}: loaded {len(entries)} datasets"
-          + (f" ({missing} listed but missing from cache)" if missing else ""))
+    print(
+        f"  {source}: loaded {len(entries)} datasets"
+        + (f" ({missing} listed but missing from cache)" if missing else "")
+    )
     return entries
 
 
-def load_openml_regression(test_size: float, random_state: int, max_datasets: int | None,
-                           name_filter=None):
+def load_openml_regression(test_size: float, random_state: int, max_datasets: int | None, name_filter=None):
     """Fetch OpenML regression datasets live (optional; needs the openml package)."""
     try:
         import openml
     except ImportError:
-        print("  [skip] openml: package not installed "
-              "(`uv pip install openml` to enable OpenML datasets)")
+        print("  [skip] openml: package not installed (`uv pip install openml` to enable OpenML datasets)")
         return []
 
-    ids = OPENML_REGRESSION_IDS[: max_datasets] if max_datasets else OPENML_REGRESSION_IDS
+    ids = OPENML_REGRESSION_IDS[:max_datasets] if max_datasets else OPENML_REGRESSION_IDS
     entries = []
     for did in ids:
         try:
@@ -223,9 +230,7 @@ def load_openml_regression(test_size: float, random_state: int, max_datasets: in
             ds = openml.datasets.get_dataset(did, download_data=True)
             target = ds.default_target_attribute
             X_df, y, _, _ = ds.get_data(target=target)
-            X_tr, X_te, y_tr, y_te = train_test_split(
-                X_df, y, test_size=test_size, random_state=random_state
-            )
+            X_tr, X_te, y_tr, y_te = train_test_split(X_df, y, test_size=test_size, random_state=random_state)
             entry = _finalize_entry(X_tr, y_tr, X_te, y_te, ds.name, "openml")
         except Exception as exc:  # noqa: BLE001
             print(f"  [warn] openml/{did}: load failed ({exc})")
@@ -240,34 +245,56 @@ def load_openml_regression(test_size: float, random_state: int, max_datasets: in
 # Main
 # --------------------------------------------------------------------------- #
 def main():
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--bench-root", type=Path, default=DEFAULT_BENCH_ROOT,
-                        help="Outer repo holding cache/ and benchmark_list/ (default: ~/SynthefyPFN)")
-    parser.add_argument("--suites", nargs="+", default=["tabarena", "talent", "openml"],
-                        choices=["tabarena", "talent", "openml"],
-                        help="Benchmark suites to evaluate")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--bench-root",
+        type=Path,
+        default=DEFAULT_BENCH_ROOT,
+        help="Outer repo holding cache/ and benchmark_list/ (default: ~/SynthefyPFN)",
+    )
+    parser.add_argument(
+        "--suites",
+        nargs="+",
+        default=["tabarena", "talent", "openml"],
+        choices=["tabarena", "talent", "openml"],
+        help="Benchmark suites to evaluate",
+    )
     parser.add_argument("--device", default="cuda:0", help="Torch device (e.g. cuda:0, cpu)")
-    parser.add_argument("--model-path", default=None,
-                        help="Local checkpoint path (default: download from HF Hub)")
-    parser.add_argument("--output", type=Path, default=Path("benchmarks/benchmark_results.csv"),
-                        help="Per-dataset results CSV output path")
-    parser.add_argument("--max-train-samples", type=int, default=50000,
-                        help="Cap on context rows per dataset (mirrors outer repo; 0 = no cap)")
-    parser.add_argument("--max-openml", type=int, default=None,
-                        help="Limit number of OpenML datasets (default: all)")
-    parser.add_argument("--test-size", type=float, default=0.3,
-                        help="Train/test split fraction when a dataset has no _test.csv")
+    parser.add_argument("--model-path", default=None, help="Local checkpoint path (default: download from HF Hub)")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("benchmarks/benchmark_results.csv"),
+        help="Per-dataset results CSV output path",
+    )
+    parser.add_argument(
+        "--max-train-samples",
+        type=int,
+        default=50000,
+        help="Cap on context rows per dataset (mirrors outer repo; 0 = no cap)",
+    )
+    parser.add_argument("--max-openml", type=int, default=None, help="Limit number of OpenML datasets (default: all)")
+    parser.add_argument(
+        "--test-size", type=float, default=0.3, help="Train/test split fraction when a dataset has no _test.csv"
+    )
     parser.add_argument("--random-state", type=int, default=42)
-    parser.add_argument("--max-elements-budget", type=int, default=16_000_000,
-                        help="SYNTHEFY_MAX_ELEMENTS_BUDGET for inference chunking (H200-friendly)")
-    parser.add_argument("--retry-budget", type=int, default=8_000_000,
-                        help="On a CUDA/inference error, retry the dataset once at this lower "
-                             "element budget (forces finer test chunking). 0 disables retry.")
-    parser.add_argument("--limit", type=int, default=None,
-                        help="Evaluate only the first N datasets (smoke test)")
-    parser.add_argument("--dataset", nargs="+", default=None,
-                        help="Only evaluate datasets whose name contains one of these substrings")
+    parser.add_argument(
+        "--max-elements-budget",
+        type=int,
+        default=16_000_000,
+        help="SYNTHEFY_MAX_ELEMENTS_BUDGET for inference chunking (H200-friendly)",
+    )
+    parser.add_argument(
+        "--retry-budget",
+        type=int,
+        default=8_000_000,
+        help="On a CUDA/inference error, retry the dataset once at this lower "
+        "element budget (forces finer test chunking). 0 disables retry.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Evaluate only the first N datasets (smoke test)")
+    parser.add_argument(
+        "--dataset", nargs="+", default=None, help="Only evaluate datasets whose name contains one of these substrings"
+    )
     args = parser.parse_args()
 
     # The predictor re-reads this env var on every predict() call, so we can lower
@@ -285,14 +312,15 @@ def main():
     print(f"Loading datasets from {bench_root} (suites: {', '.join(args.suites)})")
     datasets = []
     if "tabarena" in args.suites:
-        datasets += load_local_suite(bench_root, "tabarena_reg", "tabarena_reg.csv",
-                                      "tabarena", args.test_size, args.random_state, args.dataset)
+        datasets += load_local_suite(
+            bench_root, "tabarena_reg", "tabarena_reg.csv", "tabarena", args.test_size, args.random_state, args.dataset
+        )
     if "talent" in args.suites:
-        datasets += load_local_suite(bench_root, "talent_reg", "talent_reg.csv",
-                                      "talent", args.test_size, args.random_state, args.dataset)
+        datasets += load_local_suite(
+            bench_root, "talent_reg", "talent_reg.csv", "talent", args.test_size, args.random_state, args.dataset
+        )
     if "openml" in args.suites:
-        datasets += load_openml_regression(args.test_size, args.random_state, args.max_openml,
-                                           args.dataset)
+        datasets += load_openml_regression(args.test_size, args.random_state, args.max_openml, args.dataset)
 
     if args.limit:
         datasets = datasets[: args.limit]
@@ -322,8 +350,7 @@ def main():
             # lower element budget, which the predictor honors per-call and which
             # forces finer test chunking. Only retry if it actually shrinks.
             if args.retry_budget and args.retry_budget < base_budget:
-                print(f"{tag:<60} error ({err.splitlines()[0][:50]}) -- retrying "
-                      f"at budget={args.retry_budget}")
+                print(f"{tag:<60} error ({err.splitlines()[0][:50]}) -- retrying at budget={args.retry_budget}")
                 torch.cuda.empty_cache()
                 os.environ["SYNTHEFY_MAX_ELEMENTS_BUDGET"] = str(args.retry_budget)
                 try:
@@ -336,22 +363,41 @@ def main():
 
         if err == "" and pred is not None:
             metrics = compute_reg_metrics(ds["y_test"], pred)
-            print(f"{tag:<60} R2={metrics['r2']:.4f}  RMSE={metrics['rmse']:.4f}  "
-                  f"MAE={metrics['mae']:.4f}  ({elapsed:.1f}s, n={n_train}/{n_test}, "
-                  f"f={ds['n_features']})" + (f"  [{note}]" if note else ""))
-            rows.append({
-                "dataset": ds["name"], "source": ds["source"],
-                "n_train": n_train, "n_test": n_test, "n_features": ds["n_features"],
-                "latency_s": elapsed, **metrics, "note": note, "error": "",
-            })
+            print(
+                f"{tag:<60} R2={metrics['r2']:.4f}  RMSE={metrics['rmse']:.4f}  "
+                f"MAE={metrics['mae']:.4f}  ({elapsed:.1f}s, n={n_train}/{n_test}, "
+                f"f={ds['n_features']})" + (f"  [{note}]" if note else "")
+            )
+            rows.append(
+                {
+                    "dataset": ds["name"],
+                    "source": ds["source"],
+                    "n_train": n_train,
+                    "n_test": n_test,
+                    "n_features": ds["n_features"],
+                    "latency_s": elapsed,
+                    **metrics,
+                    "note": note,
+                    "error": "",
+                }
+            )
         else:
             print(f"{tag:<60} ERROR: {err}")
-            rows.append({
-                "dataset": ds["name"], "source": ds["source"],
-                "n_train": n_train, "n_test": n_test, "n_features": ds["n_features"],
-                "latency_s": float("nan"), "r2": float("nan"), "rmse": float("nan"),
-                "mae": float("nan"), "note": note, "error": err,
-            })
+            rows.append(
+                {
+                    "dataset": ds["name"],
+                    "source": ds["source"],
+                    "n_train": n_train,
+                    "n_test": n_test,
+                    "n_features": ds["n_features"],
+                    "latency_s": float("nan"),
+                    "r2": float("nan"),
+                    "rmse": float("nan"),
+                    "mae": float("nan"),
+                    "note": note,
+                    "error": err,
+                }
+            )
 
     # ----- save + summarize ----------------------------------------------- #
     df = pd.DataFrame(rows)
@@ -364,14 +410,17 @@ def main():
         print("\n=== Summary by source (mean over datasets) ===")
         by_src = ok.groupby("source").agg(
             n=("dataset", "count"),
-            r2=("r2", "mean"), rmse=("rmse", "mean"), mae=("mae", "mean"),
+            r2=("r2", "mean"),
+            rmse=("rmse", "mean"),
+            mae=("mae", "mean"),
         )
         for src, r in by_src.iterrows():
-            print(f"  {src:<12} n={int(r['n']):<4} "
-                  f"R2={r['r2']:.4f}  RMSE={r['rmse']:.4f}  MAE={r['mae']:.4f}")
+            print(f"  {src:<12} n={int(r['n']):<4} R2={r['r2']:.4f}  RMSE={r['rmse']:.4f}  MAE={r['mae']:.4f}")
         print(f"\n=== Overall (n={len(ok)}) ===")
-        print(f"  mean R2={ok['r2'].mean():.4f}  median R2={ok['r2'].median():.4f}  "
-              f"mean RMSE={ok['rmse'].mean():.4f}  mean MAE={ok['mae'].mean():.4f}")
+        print(
+            f"  mean R2={ok['r2'].mean():.4f}  median R2={ok['r2'].median():.4f}  "
+            f"mean RMSE={ok['rmse'].mean():.4f}  mean MAE={ok['mae'].mean():.4f}"
+        )
     n_err = int((df["error"] != "").sum())
     if n_err:
         print(f"\n{n_err} dataset(s) errored -- see the 'error' column in {args.output}")

--- a/tests/test_ci_routing.py
+++ b/tests/test_ci_routing.py
@@ -29,11 +29,7 @@ def _workflow() -> dict:
 
 
 def _run_steps(job: dict) -> list[str]:
-    return [
-        step["run"]
-        for step in job["steps"]
-        if isinstance(step, dict) and "run" in step
-    ]
+    return [step["run"] for step in job["steps"] if isinstance(step, dict) and "run" in step]
 
 
 def test_ordinary_pr_ci_always_reports_and_collects_the_root_test_tree():
@@ -81,11 +77,7 @@ def test_cutover_rehearsal_covers_all_three_clean_package_combinations():
     workflow = _workflow()
     job = workflow["jobs"]["cutover-rehearsal"]
     scripts = "\n".join(_run_steps(job))
-    names = {
-        step.get("name")
-        for step in job["steps"]
-        if isinstance(step, dict)
-    }
+    names = {step.get("name") for step in job["steps"] if isinstance(step, dict)}
 
     assert {
         "Build both candidate wheels",
@@ -120,15 +112,9 @@ def test_required_test_context_fails_closed_over_every_offline_package_gate():
     step = aggregate["steps"][0]
     assert step["env"] == {
         "UNIT_RESULT": "${{ needs.unit.result }}",
-        "SYNTHEFY_ARTIFACT_RESULT": (
-            "${{ needs['synthefy-artifact'].result }}"
-        ),
-        "DISTRIBUTION_BOUNDARIES_RESULT": (
-            "${{ needs['distribution-boundaries'].result }}"
-        ),
-        "CUTOVER_REHEARSAL_RESULT": (
-            "${{ needs['cutover-rehearsal'].result }}"
-        ),
+        "SYNTHEFY_ARTIFACT_RESULT": ("${{ needs['synthefy-artifact'].result }}"),
+        "DISTRIBUTION_BOUNDARIES_RESULT": ("${{ needs['distribution-boundaries'].result }}"),
+        "CUTOVER_REHEARSAL_RESULT": ("${{ needs['cutover-rehearsal'].result }}"),
     }
     assert "CUTOVER_REHEARSAL_RESULT" in step["run"]
     assert "exit 1" in step["run"]
@@ -141,7 +127,7 @@ def test_modal_prewarm_includes_the_consolidated_workspace_member():
     assert member in body
     assert body.index(member) < body.index(".run_commands")
     assert '"/build/libs/synthefy"' in body
-    assert "copy=True" in body[body.index(member):body.index(".run_commands")]
+    assert "copy=True" in body[body.index(member) : body.index(".run_commands")]
 
 
 def test_ordinary_pr_ci_never_receives_live_validation_credentials():
@@ -157,8 +143,6 @@ def test_ordinary_pr_ci_never_receives_live_validation_credentials():
         r"[A-Z0-9_]*KEY\b",
     )
     matches = {
-        pattern: match.group(0)
-        for pattern in forbidden
-        if (match := re.search(pattern, workflow, flags=re.IGNORECASE))
+        pattern: match.group(0) for pattern in forbidden if (match := re.search(pattern, workflow, flags=re.IGNORECASE))
     }
     assert not matches

--- a/tests/test_compiled_pinball_loss.py
+++ b/tests/test_compiled_pinball_loss.py
@@ -386,11 +386,15 @@ def test_preflight_cache_keys_exact_shape_stride_and_weights(monkeypatch):
     )
     assert len(preflight_calls) == 2
 
-    strided_pred = torch.randn(
-        args[0].shape[0],
-        args[0].shape[2],
-        args[0].shape[1],
-    ).transpose(1, 2).requires_grad_(True)
+    strided_pred = (
+        torch.randn(
+            args[0].shape[0],
+            args[0].shape[2],
+            args[0].shape[1],
+        )
+        .transpose(1, 2)
+        .requires_grad_(True)
+    )
     assert strided_pred.shape == args[0].shape
     assert strided_pred.stride() != args[0].stride()
     stride_args = (strided_pred, *args[1:])
@@ -511,9 +515,7 @@ def test_real_cuda_inductor_pinball_forward_and_backward():
         per_ep_var,
         *weights,
     )
-    signature = loss_module._pinball_preflight_signature(
-        (compiled_pred, target, quantiles, per_ep_var, *weights)
-    )
+    signature = loss_module._pinball_preflight_signature((compiled_pred, target, quantiles, per_ep_var, *weights))
     assert loss_module._pinball_compile_failed is False
     assert loss_module._compiled_pinball_objective is not None
     assert signature in loss_module._compiled_pinball_preflight_signatures

--- a/tests/test_config_routing.py
+++ b/tests/test_config_routing.py
@@ -17,6 +17,7 @@ from synthefy_nori.configs import (
     config_path,
 )
 
+
 def test_default_inference_config_ships():
     path = pathlib.Path(config_path(DEFAULT_INFERENCE_CONFIG))
     assert path.exists(), f"{DEFAULT_INFERENCE_CONFIG} is not bundled"
@@ -72,8 +73,6 @@ def test_no_source_file_writes_the_config_name_by_hand():
     src = pathlib.Path(__file__).resolve().parents[1] / "src" / "synthefy_nori"
     owner = src / "configs" / "__init__.py"
     offenders = [
-        str(p.relative_to(src))
-        for p in src.rglob("*.py")
-        if p != owner and DEFAULT_INFERENCE_CONFIG in p.read_text()
+        str(p.relative_to(src)) for p in src.rglob("*.py") if p != owner and DEFAULT_INFERENCE_CONFIG in p.read_text()
     ]
     assert not offenders, f"config filename hard-coded outside configs/__init__.py: {offenders}"

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -33,6 +33,7 @@ Two tiers of test here:
     ``slow`` and skip when a checkpoint is not reachable (no network / no HF cache).
     They run on CPU.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -46,10 +47,11 @@ N_TRAIN, N_TEST, N_FEATURES = 300, 120, 8
 def bare_model():
     """The bare FeaturesTransformer from nori-6m, or skip when unreachable."""
     from synthefy_nori.api import NoriRegressor
+
     try:
         reg = NoriRegressor(model="nori-6m", device="cpu")
         pred = reg._get_predictor()
-    except Exception as exc:                                    # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         pytest.skip(f"no reachable Nori checkpoint: {type(exc).__name__}: {exc}")
     model = pred._bare_model()
     model.eval()
@@ -63,8 +65,8 @@ def table():
     rng = np.random.default_rng(0)
     x = rng.normal(size=(N_TRAIN + N_TEST, N_FEATURES)).astype(np.float32)
     y = (np.sin(x[:, 0] * 2) - x[:, 1] + 0.1 * rng.normal(size=len(x))).astype(np.float32)
-    xt = torch.from_numpy(x).unsqueeze(0)          # [1, N, F]
-    yt = torch.from_numpy(y).unsqueeze(0)          # [1, N]
+    xt = torch.from_numpy(x).unsqueeze(0)  # [1, N, F]
+    yt = torch.from_numpy(y).unsqueeze(0)  # [1, N]
     return xt, yt
 
 
@@ -111,17 +113,20 @@ def _nonfinite_table(sentinel):
     y = np.sin(x[:, 0]).astype(np.float32)
     x[N_TRAIN:, 0] += 5.0
     if sentinel is not None:
-        x[N_TRAIN + 3::7, 0] = sentinel
+        x[N_TRAIN + 3 :: 7, 0] = sentinel
     return torch.from_numpy(x).unsqueeze(0), torch.from_numpy(y).unsqueeze(0)
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("sentinel,label", [
-    pytest.param(None, "finite", id="finite-baseline"),
-    pytest.param(float("nan"), "NaN", id="nan"),
-    pytest.param(float("inf"), "+Inf", id="pos-inf"),
-    pytest.param(float("-inf"), "-Inf", id="neg-inf"),
-])
+@pytest.mark.parametrize(
+    "sentinel,label",
+    [
+        pytest.param(None, "finite", id="finite-baseline"),
+        pytest.param(float("nan"), "NaN", id="nan"),
+        pytest.param(float("inf"), "+Inf", id="pos-inf"),
+        pytest.param(float("-inf"), "-Inf", id="neg-inf"),
+    ],
+)
 def test_apply_matches_transductive_on_nonfinite_query_values(bare_model, sentinel, label):
     # NanEncoder imputes NaN/Inf with the CONTEXT column mean, computed from
     # x[:, :eval_pos]. On the apply path eval_pos spans the query rows, so without
@@ -140,7 +145,8 @@ def test_apply_matches_transductive_on_nonfinite_query_values(bare_model, sentin
     assert delta < 1e-3, (
         f"cached apply diverged from the transductive path on {label} query values: "
         f"max |Δ|={delta:.3e} (float reassociation alone is ~3e-05). The context's "
-        f"train-derived imputation stats are not reaching the query rows.")
+        f"train-derived imputation stats are not reaching the query rows."
+    )
 
 
 def test_nan_encoder_frozen_mean_overrides_the_eval_pos_split():
@@ -152,7 +158,7 @@ def test_nan_encoder_frozen_mean_overrides_the_eval_pos_split():
     from synthefy_nori.model.encoders import NanEncoder
 
     enc = NanEncoder(in_keys=["data"], out_key="nan_encoding")
-    x = torch.tensor([[[1.0], [3.0], [float("nan")]]])          # [1, 3, 1]
+    x = torch.tensor([[[1.0], [3.0], [float("nan")]]])  # [1, 3, 1]
 
     free = enc({"data": x.clone(), "eval_pos": 3})
     # Own split: calc_mean is nansum/non-NaN-count, so (1+3)/2 = 2.0
@@ -162,7 +168,8 @@ def test_nan_encoder_frozen_mean_overrides_the_eval_pos_split():
     frozen = torch.tensor([[-7.0]])
     out = enc({"data": x.clone(), "eval_pos": 3, "_frozen_nan_mean": frozen})
     assert out["data"][0, 2, 0].item() == pytest.approx(-7.0), (
-        "frozen context mean was ignored; NanEncoder recomputed from these rows")
+        "frozen context mean was ignored; NanEncoder recomputed from these rows"
+    )
     assert out["_nan_mean"].item() == pytest.approx(-7.0)
     # Finite entries are untouched either way -- only NaN/Inf cells are filled.
     assert out["data"][0, 0, 0].item() == pytest.approx(1.0)
@@ -183,11 +190,9 @@ def test_nan_encoder_excludes_inf_from_its_mean_and_honors_a_frozen_mean():
     assert healthy["data"][0, 2, 0].item() == pytest.approx(2.0)
     assert torch.isfinite(healthy["data"]).all()
 
-    frozen = enc({"data": x.clone(), "eval_pos": 3,
-                  "_frozen_nan_mean": torch.tensor([[-7.0]])})
+    frozen = enc({"data": x.clone(), "eval_pos": 3, "_frozen_nan_mean": torch.tensor([[-7.0]])})
     assert frozen["data"][0, 2, 0].item() == pytest.approx(-7.0)
-    assert torch.isfinite(frozen["data"]).all(), (
-        "frozen context mean did not keep the query column finite")
+    assert torch.isfinite(frozen["data"]).all(), "frozen context mean did not keep the query column finite"
 
 
 @pytest.mark.slow
@@ -198,7 +203,7 @@ def test_build_context_cache_captures_the_nan_fill(bare_model, table):
     torch.manual_seed(0)
     with torch.no_grad():
         bundle = bare_model.build_context_cache(xt[:, :N_TRAIN], yt[:, :N_TRAIN])
-        half = bare_model.build_context_cache(xt[:, :N_TRAIN // 2], yt[:, :N_TRAIN // 2])
+        half = bare_model.build_context_cache(xt[:, : N_TRAIN // 2], yt[:, : N_TRAIN // 2])
     assert bundle.nan_mean is not None, "context build did not capture NanEncoder's fill"
     assert torch.isfinite(bundle.nan_mean).all()
     # The fill is a per-feature-group reduction over rows ([B, n_groups,
@@ -209,7 +214,8 @@ def test_build_context_cache_captures_the_nan_fill(bare_model, table):
     assert bundle.nan_mean.shape == half.nan_mean.shape, (
         f"fill shape tracks the context row count ({tuple(bundle.nan_mean.shape)} for "
         f"{N_TRAIN} rows vs {tuple(half.nan_mean.shape)} for {N_TRAIN // 2}) -- it "
-        f"cannot then be re-applied to an arbitrary query batch")
+        f"cannot then be re-applied to an arbitrary query batch"
+    )
     assert N_TRAIN not in bundle.nan_mean.shape
 
 
@@ -230,8 +236,8 @@ def test_one_bundle_scores_multiple_query_batches(bare_model, table):
         p_all = bare_model.apply_context_cache(x_q, bundle, row_chunk_size=0)
     joined = torch.cat([p_a, p_b], dim=1)
     assert torch.equal(joined, p_all), (
-        f"per-batch scoring diverged from whole-block (max |Δ|="
-        f"{(joined - p_all).abs().max().item():.2e})")
+        f"per-batch scoring diverged from whole-block (max |Δ|={(joined - p_all).abs().max().item():.2e})"
+    )
 
 
 @pytest.mark.slow
@@ -249,7 +255,7 @@ def test_context_build_runs_once_not_per_apply(bare_model, table):
         calls["n"] += 1
         return orig(*a, **k)
 
-    enc.build_train_cache = counting                            # type: ignore[assignment]
+    enc.build_train_cache = counting  # type: ignore[assignment]
     try:
         torch.manual_seed(0)
         with torch.no_grad():
@@ -259,21 +265,22 @@ def test_context_build_runs_once_not_per_apply(bare_model, table):
                 bare_model.apply_context_cache(xt[:, ep:], bundle, row_chunk_size=0)
         assert calls["n"] == 1, (
             f"context forward re-ran on apply: build_train_cache called {calls['n']}x "
-            f"(expected 1) -- amortization is broken")
+            f"(expected 1) -- amortization is broken"
+        )
     finally:
-        enc.build_train_cache = orig                            # type: ignore[assignment]
+        enc.build_train_cache = orig  # type: ignore[assignment]
 
 
 def _regressor(*, reuse_context_cache: bool = True):
     """A NoriRegressor whose predict() takes the cached path, or skip."""
     from synthefy_nori.api import NoriRegressor
+
     # Small element budget forces chunk_size to its floor so n_test > chunk_size
     # and the cached (build/apply) path engages -- same trick as test_memory_policy_e2e.
     reg = NoriRegressor(
         model="nori-6m",
         device="cpu",
-        memory_policy={"elements_budget": 5_000,
-                       "reuse_context_cache": reuse_context_cache},
+        memory_policy={"elements_budget": 5_000, "reuse_context_cache": reuse_context_cache},
     )
     try:
         reg._get_predictor()
@@ -313,7 +320,7 @@ def test_context_built_once_across_multiple_predicts(monkeypatch):
     x = rng.normal(size=(600 + 800, 8)).astype(np.float32)
     y = (np.cos(x[:, 0]) + x[:, 2]).astype(np.float32)
     x_tr, y_tr = x[:600], y[:600]
-    x_te_a, x_te_b = x[600:1000], x[1000:]      # 400 + 400 query rows
+    x_te_a, x_te_b = x[600:1000], x[1000:]  # 400 + 400 query rows
 
     reg = _regressor().fit(x_tr, y_tr)
     bare = reg._get_predictor()._bare_model()
@@ -330,10 +337,11 @@ def test_context_built_once_across_multiple_predicts(monkeypatch):
         pytest.skip("cached path did not engage on this shape/box")
     after_first = calls["n"]
     assert after_first >= 1, "first predict never built a context cache"
-    reg.predict(x_te_b)          # different queries, same context
+    reg.predict(x_te_b)  # different queries, same context
     assert calls["n"] == after_first, (
         f"context rebuilt on the second predict: {calls['n']} total builds "
-        f"(expected {after_first}) -- cross-call amortization is broken")
+        f"(expected {after_first}) -- cross-call amortization is broken"
+    )
 
 
 @pytest.mark.slow
@@ -352,7 +360,7 @@ def test_repeated_apply_is_deterministic_and_bundle_immutable(bare_model, table)
     assert [id(c) for c in bundle.caches] == cache_ids, "apply mutated the bundle caches"
 
 
-_ELEMENTS_BUDGET = 5_000        # must match _regressor()'s memory_policy
+_ELEMENTS_BUDGET = 5_000  # must match _regressor()'s memory_policy
 
 
 def _assert_cached_path_reachable(n_train: int, n_test: int, n_features: int):
@@ -375,7 +383,8 @@ def _assert_cached_path_reachable(n_train: int, n_test: int, n_features: int):
         f"n_test={n_test} does not exceed chunk_size={chunk} for n_train={n_train}, "
         f"n_features={n_features}, elements_budget={_ELEMENTS_BUDGET}: predict would "
         f"take the UNCACHED loop and these tests would silently skip. Raise n_test or "
-        f"n_train (larger n_train lowers chunk_size).")
+        f"n_train (larger n_train lowers chunk_size)."
+    )
 
 
 def _dataset(seed: int, n_train: int = 600, n_test: int = 300, n_features: int = 8):
@@ -422,18 +431,15 @@ def test_serving_lifecycle_matches_uncached_predictions(monkeypatch):
     y_tr_c = y_tr_c.copy()
     y_tr_c[5], y_tr_c[17] = y_tr_c[17], y_tr_c[5]
     requests.append((x_tr_c, y_tr_c, x_te_c))
-    assert _legacy_summary_fingerprint(torch.from_numpy(y_tr_c).unsqueeze(0)) == \
-        _legacy_summary_fingerprint(torch.from_numpy(requests[0][1]).unsqueeze(0)), \
-        "dataset C no longer collides with A -- the mis-serve case is not covered"
+    assert _legacy_summary_fingerprint(torch.from_numpy(y_tr_c).unsqueeze(0)) == _legacy_summary_fingerprint(
+        torch.from_numpy(requests[0][1]).unsqueeze(0)
+    ), "dataset C no longer collides with A -- the mis-serve case is not covered"
 
     # Ground truth: every request answered by a FRESH predictor with reuse off,
     # so no bundle can carry between them.
-    expected = [
-        _regressor(reuse_context_cache=False).fit(xt, yt).predict(xq)
-        for xt, yt, xq in requests
-    ]
+    expected = [_regressor(reuse_context_cache=False).fit(xt, yt).predict(xq) for xt, yt, xq in requests]
 
-    reg = _regressor()                                  # one long-lived estimator
+    reg = _regressor()  # one long-lived estimator
     # A, B, C, then A again: fit -> predict -> fit -> predict with the context changing
     # each time, and the trailing revisit making a stale single-slot entry observable.
     # The exhaustive alternation is covered instantly by the hermetic lifecycle test;
@@ -448,7 +454,8 @@ def test_serving_lifecycle_matches_uncached_predictions(monkeypatch):
         maxdiff = np.abs(np.asarray(got) - np.asarray(expected[i])).max()
         assert maxdiff < 5e-3, (
             f"step {step} (request {i}): cached serving diverged from a cold predictor "
-            f"by {maxdiff:.2e} -- a stale context bundle reached a caller")
+            f"by {maxdiff:.2e} -- a stale context bundle reached a caller"
+        )
 
 
 @pytest.mark.slow
@@ -468,14 +475,15 @@ def test_refit_with_a_new_context_rebuilds_it(monkeypatch):
     after_a = calls["n"]
     assert after_a >= 1
 
-    reg.predict(x_te_a)                                 # same context -> reuse
+    reg.predict(x_te_a)  # same context -> reuse
     assert calls["n"] == after_a, "same context rebuilt"
 
-    reg.fit(x_b, y_b)                                   # new context -> rebuild
+    reg.fit(x_b, y_b)  # new context -> rebuild
     reg.predict(x_te_b)
     assert calls["n"] == 2 * after_a, (
         f"refit on a new context did not rebuild: {calls['n']} builds "
-        f"(expected {2 * after_a}) -- the new caller would be served the old context")
+        f"(expected {2 * after_a}) -- the new caller would be served the old context"
+    )
 
 
 @pytest.mark.slow
@@ -494,11 +502,12 @@ def test_memory_policy_change_between_predicts_rebuilds(monkeypatch):
     assert reg.memory_report_.get("cache_dtype") == "bf16"
 
     reg.memory_policy = {"elements_budget": 5_000, "cache_dtype": "int8"}
-    reg.predict(x_te)                                   # same context, new rung
+    reg.predict(x_te)  # same context, new rung
     assert reg.memory_report_.get("cache_dtype") == "int8", "policy change was ignored"
     assert calls["n"] == 2 * after_first, (
         f"bundle survived a cache_dtype change: {calls['n']} builds (expected "
-        f"{2 * after_first}) -- an int8 request would be served bf16 K/V")
+        f"{2 * after_first}) -- an int8 request would be served bf16 K/V"
+    )
 
 
 @pytest.mark.slow
@@ -519,10 +528,9 @@ def test_typed_policy_disables_reuse_on_every_predict(monkeypatch):
     for i in range(2, 4):
         reg.predict(x_te)
         assert calls["n"] == i * per_predict, (
-            f"predict {i} reused a bundle with reuse disabled: {calls['n']} builds "
-            f"(expected {i * per_predict})")
-    assert not getattr(reg._get_predictor(), "_context_cache", {}), (
-        "reuse_context_cache=False populated the cache")
+            f"predict {i} reused a bundle with reuse disabled: {calls['n']} builds (expected {i * per_predict})"
+        )
+    assert not getattr(reg._get_predictor(), "_context_cache", {}), "reuse_context_cache=False populated the cache"
 
     # Re-enable through the public policy: the first call builds, then the next hits.
     reg.memory_policy = {"elements_budget": 5_000, "reuse_context_cache": True}
@@ -547,6 +555,7 @@ def test_typed_policy_disables_reuse_on_every_predict(monkeypatch):
 # means caller B's rows scored against caller A's context, returned as if correct.
 # --------------------------------------------------------------------------------
 
+
 class _StubBundle:
     """Stands in for a ContextCache, remembering what it was built from."""
 
@@ -564,10 +573,8 @@ class _StubModel:
     def __init__(self):
         self.builds: list[_StubBundle] = []
 
-    def build_context_cache(self, x_train, y_train, *, cache_dtype,
-                            offload_kv_cache, fit_row_chunk):
-        bundle = _StubBundle(x_train, y_train,
-                             (cache_dtype, offload_kv_cache, fit_row_chunk))
+    def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
+        bundle = _StubBundle(x_train, y_train, (cache_dtype, offload_kv_cache, fit_row_chunk))
         self.builds.append(bundle)
         return bundle
 
@@ -585,19 +592,32 @@ def _predictor(seed: int = 0):
     from synthefy_nori.inference.predictor import NoriPredictor
 
     class _NoCheckpointPredictor(NoriPredictor):
-        def __init__(self, seed):                       # noqa: D107 - see above
+        def __init__(self, seed):  # noqa: D107 - see above
             self.seed = seed
 
     pred = _NoCheckpointPredictor(seed)
 
-    def get(model, x, y, *, id_pipe=0, cache_dtype="bf16",
-            offload_kv_cache=False, fit_row_chunk=None,
-            reuse_context_cache=True):
+    def get(
+        model,
+        x,
+        y,
+        *,
+        id_pipe=0,
+        cache_dtype="bf16",
+        offload_kv_cache=False,
+        fit_row_chunk=None,
+        reuse_context_cache=True,
+    ):
         return pred._get_or_build_context(
-            model, id_pipe, x_train_t=x, y_train_t=y,
-            cache_dtype=cache_dtype, offload_kv_cache=offload_kv_cache,
+            model,
+            id_pipe,
+            x_train_t=x,
+            y_train_t=y,
+            cache_dtype=cache_dtype,
+            offload_kv_cache=offload_kv_cache,
             fit_row_chunk=fit_row_chunk,
-            reuse_context_cache=reuse_context_cache)
+            reuse_context_cache=reuse_context_cache,
+        )
 
     return pred, get
 
@@ -624,21 +644,31 @@ def _legacy_summary_fingerprint(t: torch.Tensor) -> tuple:
     nan_ct = int(torch.isnan(t).sum().item()) if t.numel() else 0
     tf = torch.nan_to_num(t.detach().to(torch.float64), nan=0.0, posinf=0.0, neginf=0.0)
     flat = tf.flatten()
-    return (tuple(t.shape), nan_ct,
-            float(tf.sum().item()), float((tf * tf).sum().item()),
-            float(flat[0].item()), float(flat[-1].item()))
+    return (
+        tuple(t.shape),
+        nan_ct,
+        float(tf.sum().item()),
+        float((tf * tf).sum().item()),
+        float(flat[0].item()),
+        float(flat[-1].item()),
+    )
 
 
 def _built_from(bundle, x, y) -> bool:
     """Was `bundle` built from exactly this context? Bitwise, so NaN matches NaN."""
+
     def same(a, b):
-        return (a.shape == b.shape and a.dtype == b.dtype
-                and torch.equal(a.contiguous().view(torch.uint8),
-                                b.contiguous().view(torch.uint8)))
+        return (
+            a.shape == b.shape
+            and a.dtype == b.dtype
+            and torch.equal(a.contiguous().view(torch.uint8), b.contiguous().view(torch.uint8))
+        )
+
     return same(bundle.x, x) and same(bundle.y, y)
 
 
 # --- same context reuses the cache -------------------------------------------------
+
 
 def test_same_context_reuses_the_cache():
     # The amortization itself: an equal-but-distinct context must HIT. Distinct
@@ -705,6 +735,7 @@ def test_separate_pipes_keep_separate_bundles():
 
 # --- deliberately colliding contexts ----------------------------------------------
 
+
 def test_colliding_y_does_not_share_a_bundle():
     # THE collision case. Swapping two INTERIOR target values leaves shape, NaN count,
     # sum, sum-of-squares and both endpoints untouched -- an exact collision under the
@@ -718,7 +749,8 @@ def test_colliding_y_does_not_share_a_bundle():
 
     # The collision is real, not stipulated: prove it against the old digest.
     assert _legacy_summary_fingerprint(y_a) == _legacy_summary_fingerprint(y_b), (
-        "test is not exercising a collision -- the summary stats differ")
+        "test is not exercising a collision -- the summary stats differ"
+    )
     assert not torch.equal(y_a, y_b), "the two contexts are not actually different"
 
     first = get(model, x, y_a)
@@ -738,12 +770,13 @@ def test_colliding_x_does_not_share_a_bundle():
     model = _StubModel()
     x_a, y = _ctx()
     perm = torch.arange(x_a.shape[1])
-    interior = perm[1:-1].flip(0).clone()          # reverse rows 1..N-2, pin 0 and N-1
+    interior = perm[1:-1].flip(0).clone()  # reverse rows 1..N-2, pin 0 and N-1
     perm[1:-1] = interior
     x_b = x_a[:, perm].contiguous()
 
     assert _legacy_summary_fingerprint(x_a) == _legacy_summary_fingerprint(x_b), (
-        "test is not exercising a collision -- the summary stats differ")
+        "test is not exercising a collision -- the summary stats differ"
+    )
     assert not torch.equal(x_a, x_b)
 
     first = get(model, x_a, y)
@@ -769,7 +802,8 @@ def test_colliding_nan_layout_does_not_share_a_bundle():
     y_b[0, 9] = float("nan")
 
     assert _legacy_summary_fingerprint(y_a) == _legacy_summary_fingerprint(y_b), (
-        "test is not exercising a collision -- the summary stats differ")
+        "test is not exercising a collision -- the summary stats differ"
+    )
 
     first = get(model, x, y_a)
     second = get(model, x.clone(), y_b)
@@ -779,6 +813,7 @@ def test_colliding_nan_layout_does_not_share_a_bundle():
 
 
 # --- changed context or memory policy rebuilds it ---------------------------------
+
 
 def _perturb(t, idx):
     out = t.clone()
@@ -792,15 +827,17 @@ def _with_nan(t, idx):
     return out
 
 
-@pytest.mark.parametrize("mutate", [
-    pytest.param(lambda x, y: (_perturb(x, (0, 9, 2)), y), id="one-x-value"),
-    pytest.param(lambda x, y: (x, _perturb(y, (0, 9))), id="one-y-value"),
-    pytest.param(lambda x, y: (x[:, :-1].contiguous(), y[:, :-1].contiguous()),
-                 id="fewer-context-rows"),
-    pytest.param(lambda x, y: (x[:, :, :-1].contiguous(), y), id="fewer-features"),
-    pytest.param(lambda x, y: (x.double(), y), id="different-dtype"),
-    pytest.param(lambda x, y: (_with_nan(x, (0, 9, 2)), y), id="value-becomes-nan"),
-])
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda x, y: (_perturb(x, (0, 9, 2)), y), id="one-x-value"),
+        pytest.param(lambda x, y: (x, _perturb(y, (0, 9))), id="one-y-value"),
+        pytest.param(lambda x, y: (x[:, :-1].contiguous(), y[:, :-1].contiguous()), id="fewer-context-rows"),
+        pytest.param(lambda x, y: (x[:, :, :-1].contiguous(), y), id="fewer-features"),
+        pytest.param(lambda x, y: (x.double(), y), id="different-dtype"),
+        pytest.param(lambda x, y: (_with_nan(x, (0, 9, 2)), y), id="value-becomes-nan"),
+    ],
+)
 def test_changed_context_rebuilds(mutate):
     # Every way the context can differ must MISS -- including a single value moving by
     # one float step, a shape change, and a value turning into NaN.
@@ -817,11 +854,14 @@ def test_changed_context_rebuilds(mutate):
     assert _built_from(second, x2, y2)
 
 
-@pytest.mark.parametrize("params", [
-    pytest.param({"cache_dtype": "int8"}, id="cache_dtype"),
-    pytest.param({"offload_kv_cache": True}, id="offload_to_host"),
-    pytest.param({"fit_row_chunk": 128}, id="context_row_chunk"),
-])
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param({"cache_dtype": "int8"}, id="cache_dtype"),
+        pytest.param({"offload_kv_cache": True}, id="offload_to_host"),
+        pytest.param({"fit_row_chunk": 128}, id="context_row_chunk"),
+    ],
+)
 def test_changed_memory_policy_rebuilds(params):
     # cache_dtype / offload_to_host / context_row_chunk all change WHAT the bundle
     # contains (quantized vs bf16, host vs device, chunked build). A server re-reads
@@ -860,6 +900,7 @@ def test_changed_seed_rebuilds():
 
 # --- typed reuse_context_cache=False always rebuilds -------------------------------
 
+
 def test_reuse_disabled_rebuilds_every_call():
     # The typed setting is absolute: no hits and nothing retained, so turning reuse
     # back on later cannot resurrect a bundle from the disabled window.
@@ -867,15 +908,11 @@ def test_reuse_disabled_rebuilds_every_call():
     model = _StubModel()
     x, y = _ctx()
 
-    bundles = [
-        get(model, x.clone(), y.clone(), reuse_context_cache=False)
-        for _ in range(4)
-    ]
+    bundles = [get(model, x.clone(), y.clone(), reuse_context_cache=False) for _ in range(4)]
 
     assert len(model.builds) == 4, "reuse_context_cache=False did not rebuild"
     assert len({id(b) for b in bundles}) == 4, "disabled reuse returned a cached bundle"
-    assert not getattr(fake, "_context_cache", {}), (
-        "disabled reuse retained context-derived state")
+    assert not getattr(fake, "_context_cache", {}), "disabled reuse retained context-derived state"
 
 
 def test_policy_change_clears_a_warm_bundle_before_rebuilding():
@@ -902,6 +939,7 @@ def test_policy_change_clears_a_warm_bundle_before_rebuilding():
 
 # --- serving's fit -> predict -> fit -> predict lifecycle --------------------------
 
+
 def test_serving_fit_predict_lifecycle_never_serves_a_stale_bundle():
     # The shape of a real server: ONE predictor, re-fit per request, contexts
     # alternating between callers, and each fit followed by several predicts. Asserts
@@ -919,19 +957,21 @@ def test_serving_fit_predict_lifecycle_never_serves_a_stale_bundle():
     ctx_c = (x_c, y_c)
     assert _legacy_summary_fingerprint(ctx_c[1]) == _legacy_summary_fingerprint(ctx_a[1])
 
-    for _ in range(3):                                  # several request rounds
+    for _ in range(3):  # several request rounds
         for x, y in (ctx_a, ctx_b, ctx_c):
-            for _ in range(2):                          # fit once, predict twice
+            for _ in range(2):  # fit once, predict twice
                 bundle = get(model, x.clone(), y.clone())
                 assert _built_from(bundle, x, y), (
                     "served a bundle built from a DIFFERENT context -- one caller's "
-                    "rows would be scored against another's")
+                    "rows would be scored against another's"
+                )
 
     # 3 rounds x 3 contexts = 9 fits, each followed by 2 predicts. The context changes
     # between fits, so every fit rebuilds; the second predict of each pair reuses.
     assert len(model.builds) == 9, (
         f"expected one build per fit (9), got {len(model.builds)} -- either the second "
-        f"predict of a pair rebuilt, or a fit reused a stale bundle")
+        f"predict of a pair rebuilt, or a fit reused a stale bundle"
+    )
 
 
 def test_refitting_the_same_context_reuses_the_bundle():
@@ -943,10 +983,9 @@ def test_refitting_the_same_context_reuses_the_bundle():
     x, y = _ctx(seed=3, nans=True)
 
     first = get(model, x, y)
-    for _ in range(4):                                  # re-fit + predict, same table
+    for _ in range(4):  # re-fit + predict, same table
         assert get(model, x.clone(), y.clone()) is first
-    assert len(model.builds) == 1, (
-        f"re-fitting an identical context rebuilt it ({len(model.builds)} builds)")
+    assert len(model.builds) == 1, f"re-fitting an identical context rebuilt it ({len(model.builds)} builds)"
 
 
 def test_failed_build_is_not_cached():
@@ -987,11 +1026,11 @@ def test_failed_build_is_not_cached():
 # budget is never retained, and smaller ones are evicted oldest-first to stay under it.
 # ---------------------------------------------------------------------------------
 
+
 class _FakePredictor:
     """Just enough of NoriPredictor to exercise the eviction arithmetic on CPU."""
 
-    _bundle_device_bytes = staticmethod(
-        lambda bundle: int(bundle["bytes"]))          # stand in for the tensor walk
+    _bundle_device_bytes = staticmethod(lambda bundle: int(bundle["bytes"]))  # stand in for the tensor walk
 
     def __init__(self, budget_bytes):
         self._budget = budget_bytes
@@ -1001,6 +1040,7 @@ class _FakePredictor:
 
     # the real implementations, bound to this stub
     from synthefy_nori.inference.predictor import NoriPredictor as _NP
+
     _evict_context_cache_for = _NP._evict_context_cache_for
 
 
@@ -1023,7 +1063,7 @@ def test_context_cache_refuses_a_bundle_larger_than_the_budget():
 
 def test_context_cache_evicts_oldest_until_the_new_bundle_fits():
     p = _FakePredictor(budget_bytes=10 * 1024**3)
-    cache = {f"pipe{i}": _entry(3 * 1024**3) for i in range(3)}   # 9 GiB held
+    cache = {f"pipe{i}": _entry(3 * 1024**3) for i in range(3)}  # 9 GiB held
     keep = p._evict_context_cache_for(cache, {"bytes": 3 * 1024**3})
     assert keep is True
     # 9 + 3 > 10, so exactly one (the oldest) is dropped to make room.
@@ -1046,7 +1086,7 @@ def test_context_cache_is_unbounded_when_the_device_has_no_accelerator_memory():
     non-CUDA device and read 0 as "retain nothing". That silently disabled the context
     cache for every CPU user and turned one build into one build *per query*.
     """
-    p = _FakePredictor(budget_bytes=None)               # None = "no device limit applies"
+    p = _FakePredictor(budget_bytes=None)  # None = "no device limit applies"
     cache = {"pipe0": _entry(1)}
     assert p._evict_context_cache_for(cache, {"bytes": 10**12}) is True
     assert "pipe0" in cache, "nothing is evicted when there is no device limit"

--- a/tests/test_dataframe_features.py
+++ b/tests/test_dataframe_features.py
@@ -79,8 +79,7 @@ def test_documented_mixed_dataframe_example_runs_without_a_checkpoint(monkeypatc
                         len(value),
                         value.count(" "),
                         sum(map(ord, value)) % 97,
-                        sum((index + 1) * ord(char) for index, char in enumerate(value))
-                        % 101,
+                        sum((index + 1) * ord(char) for index, char in enumerate(value)) % 101,
                     ]
                     for value in texts
                 ],
@@ -99,9 +98,7 @@ def test_documented_mixed_dataframe_example_runs_without_a_checkpoint(monkeypatc
             return np.zeros(len(X_test), dtype=np.float32)
 
     monkeypatch.setattr(text_features_module, "_make_encoder", make_test_encoder)
-    monkeypatch.setattr(
-        NoriRegressor, "_get_predictor", lambda self: PredictorStub()
-    )
+    monkeypatch.setattr(NoriRegressor, "_get_predictor", lambda self: PredictorStub())
 
     X_train = pd.DataFrame(
         {
@@ -158,9 +155,7 @@ def test_direct_estimator_auto_encodes_raw_strings_without_text_runtime(monkeypa
 def test_estimator_strict_modes_and_query_schema_errors_are_actionable():
     frame = pd.DataFrame({"amount": [1.0, 2.0], "plan": ["free", "pro"], "note": ["a", "b"]})
     with pytest.raises(ValueError) as caught:
-        NoriRegressor(
-            model_path="unused.pt", categorical_columns=["plan"]
-        ).fit(frame, [1.0, 2.0])
+        NoriRegressor(model_path="unused.pt", categorical_columns=["plan"]).fit(frame, [1.0, 2.0])
     message = str(caught.value)
     assert "'note' (" in message
     assert "text_columns" in message
@@ -213,9 +208,7 @@ def test_dataframe_feature_configuration_survives_grid_search(monkeypatch):
 
     search.fit(X, np.arange(8, dtype=np.float64))
 
-    assert search.best_estimator_._feature_preprocessor.categorical_columns_ == [
-        "plan"
-    ]
+    assert search.best_estimator_._feature_preprocessor.categorical_columns_ == ["plan"]
 
 
 def test_deprecated_text_cardinality_alias_is_explicit_and_checked():

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -1,4 +1,5 @@
 """Unit tests for synthefy_nori.discretize + the discretize=/categorical_levels= API wiring."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -95,14 +96,12 @@ class TestDiscretizePredictions:
     def test_median_cell_crosses_half(self):
         taus = (np.arange(99) + 1.0) / 100.0
         row = np.where(taus < 0.4, 3.0, 7.0) + np.linspace(0, 0.01, 99)
-        out = discretize_predictions(
-            "median-cell", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
+        out = discretize_predictions("median-cell", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
         assert out.tolist() == [7.0]
 
     def test_unsorted_duplicate_levels_normalized(self):
         Q, taus = _bank_from_normal([7.0], [0.05])
-        out = discretize_predictions(
-            "map-cell", np.array([7.0, 3.0, 5.0, 3.0]), Q=Q, taus=taus)
+        out = discretize_predictions("map-cell", np.array([7.0, 3.0, 5.0, 3.0]), Q=Q, taus=taus)
         assert out.tolist() == [7.0]
 
     def test_single_level_cell_method(self):
@@ -113,8 +112,7 @@ class TestDiscretizePredictions:
     def test_expected_level_matches_posterior_mean(self):
         taus = (np.arange(99) + 1.0) / 100.0
         row = np.where(taus < 0.4, 3.0, 7.0) + np.linspace(0, 0.01, 99)
-        out = discretize_predictions(
-            "expected-level", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
+        out = discretize_predictions("expected-level", np.array([3.0, 5.0, 7.0]), Q=row[None, :], taus=taus)
         # ~40% mass at 3, ~60% at 7 -> expectation ~ 5.4 (continuous, off-lattice)
         assert 5.0 < out[0] < 5.8
         assert out[0] not in (3.0, 5.0, 7.0)
@@ -122,8 +120,7 @@ class TestDiscretizePredictions:
     def test_prior_match_matches_train_frequencies(self):
         y_train = np.array([3.0] * 6 + [5.0] * 3 + [7.0] * 3)  # 50/25/25
         point = np.linspace(0, 10, 8)
-        out = discretize_predictions(
-            "prior-match", np.array([3.0, 5.0, 7.0]), point=point, y_train=y_train)
+        out = discretize_predictions("prior-match", np.array([3.0, 5.0, 7.0]), point=point, y_train=y_train)
         vals, counts = np.unique(out, return_counts=True)
         assert vals.tolist() == [3.0, 5.0, 7.0]
         assert counts.tolist() == [4, 2, 2]  # 8 rows at 50/25/25
@@ -133,8 +130,7 @@ class TestDiscretizePredictions:
 
     def test_prior_match_requires_y_train(self):
         with pytest.raises(ValueError, match="y_train"):
-            discretize_predictions("prior-match", np.array([1.0, 2.0]),
-                                   point=np.array([1.0]))
+            discretize_predictions("prior-match", np.array([1.0, 2.0]), point=np.array([1.0]))
 
     def test_prior_match_direct_zero_overlap_raises(self):
         with pytest.raises(ValueError, match="no training values"):
@@ -170,7 +166,6 @@ class TestPackageSurface:
         assert set(DISCRETIZE_METHOD_DESCRIPTIONS) == set(DISCRETIZE_METHODS)
         assert all(len(v) > 40 for v in DISCRETIZE_METHOD_DESCRIPTIONS.values())
 
-
     def test_submodule_attribute_access(self):
         # docs promise `synthefy_nori.discretize.snap_to_levels` works
         import synthefy_nori
@@ -188,17 +183,16 @@ class TestPredictCategoricalAPI:
         model.fit(X, y)
         Q, taus = _bank_from_normal([6.9, 3.1, 5.0], [0.1, 0.1, 0.1])
         monkeypatch.setattr(
-            NoriRegressor, "_predict_distribution",
-            lambda self, X, *, output_type, quantiles:
-                {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
+            NoriRegressor,
+            "_predict_distribution",
+            lambda self, X, *, output_type, quantiles: {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
         )
         return model
 
     def test_map_cell_default_via_levels_only(self, monkeypatch):
         # categorical_levels alone activates with the default (map-cell) strategy
         model = self._fitted(monkeypatch)
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            categorical_levels=[3.0, 5.0, 7.0])
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), categorical_levels=[3.0, 5.0, 7.0])
         assert out.tolist() == [7.0, 3.0, 5.0]
 
     def test_snap_mean_forces_mean_collapse(self, monkeypatch):
@@ -210,8 +204,7 @@ class TestPredictCategoricalAPI:
             return np.array([6.6, 2.0, 4.9])
 
         monkeypatch.setattr(NoriRegressor, "_predict_point", fake_point)
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            discretize="snap-mean")
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize="snap-mean")
         assert out.tolist() == [7.0, 3.0, 5.0]
         # snap-mean must snap the MEAN even if the regressor was configured
         # with a different quantile_collapse
@@ -226,15 +219,13 @@ class TestPredictCategoricalAPI:
             return np.array([6.6, 2.0, 4.9])
 
         monkeypatch.setattr(NoriRegressor, "_predict_point", fake_point)
-        model.predict(np.zeros((3, 2), dtype=np.float32),
-                      discretize="snap-median")
+        model.predict(np.zeros((3, 2), dtype=np.float32), discretize="snap-median")
         assert seen["collapse"] == ("median", "median")
 
     def test_categorical_levels_override(self, monkeypatch):
         model = self._fitted(monkeypatch)
         # supply a lattice richer than the fitted y (e.g. known 1-9 scale)
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            categorical_levels=np.arange(1.0, 10.0))
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), categorical_levels=np.arange(1.0, 10.0))
         assert out.tolist() == [7.0, 3.0, 5.0]
 
     def test_discretize_alone_activates(self, monkeypatch):
@@ -243,8 +234,7 @@ class TestPredictCategoricalAPI:
         model = self._fitted(monkeypatch)
         out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize="median-cell")
         assert set(out.tolist()) <= {3.0, 5.0, 7.0}
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            categorical_levels=[3.0, 5.0, 7.0])
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), categorical_levels=[3.0, 5.0, 7.0])
         assert set(out.tolist()) <= {3.0, 5.0, 7.0}
 
     def test_infer_helper_implication(self, monkeypatch):
@@ -253,14 +243,16 @@ class TestPredictCategoricalAPI:
 
         Q, taus = _bank_from_normal([6.9, 3.1, 5.0], [0.1, 0.1, 0.1])
         monkeypatch.setattr(
-            NoriRegressor, "_predict_distribution",
-            lambda self, X, *, output_type, quantiles:
-                {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
+            NoriRegressor,
+            "_predict_distribution",
+            lambda self, X, *, output_type, quantiles: {"quantiles": Q, "taus": taus, "mean": Q.mean(axis=1)},
         )
-        out = infer(np.zeros((6, 2), dtype=np.float32),
-                    np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]),
-                    np.zeros((3, 2), dtype=np.float32),
-                    discretize="map-cell")
+        out = infer(
+            np.zeros((6, 2), dtype=np.float32),
+            np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]),
+            np.zeros((3, 2), dtype=np.float32),
+            discretize="map-cell",
+        )
         assert out.tolist() == [7.0, 3.0, 5.0]
 
     def test_flag_is_gone(self, monkeypatch):
@@ -273,8 +265,7 @@ class TestPredictCategoricalAPI:
     def test_rejects_output_type_combo(self, monkeypatch):
         model = self._fitted(monkeypatch)
         with pytest.raises(ValueError, match="categorical output"):
-            model.predict(np.zeros((3, 2), dtype=np.float32),
-                          discretize="map-cell", output_type="median")
+            model.predict(np.zeros((3, 2), dtype=np.float32), discretize="map-cell", output_type="median")
 
     def test_unknown_strategy_raises(self, monkeypatch):
         model = self._fitted(monkeypatch)
@@ -293,23 +284,21 @@ class TestPredictCategoricalAPI:
 
     def test_requires_fit(self):
         with pytest.raises(ValueError, match="fit"):
-            NoriRegressor().predict(np.zeros((1, 2), dtype=np.float32),
-                                    discretize="map-cell")
+            NoriRegressor().predict(np.zeros((1, 2), dtype=np.float32), discretize="map-cell")
 
     def test_expected_level_via_predict(self, monkeypatch):
         model = self._fitted(monkeypatch)
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            discretize="expected-level")
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize="expected-level")
         assert out.shape == (3,)  # continuous, near the per-row bank means
 
     def test_prior_match_via_predict(self, monkeypatch):
         model = self._fitted(monkeypatch)
         monkeypatch.setattr(
-            NoriRegressor, "_predict_point",
-            lambda self, X, *, quantile_collapse, bar_point_estimator:
-                np.array([6.6, 2.0, 4.9]))
-        out = model.predict(np.zeros((3, 2), dtype=np.float32),
-                            discretize="prior-match")
+            NoriRegressor,
+            "_predict_point",
+            lambda self, X, *, quantile_collapse, bar_point_estimator: np.array([6.6, 2.0, 4.9]),
+        )
+        out = model.predict(np.zeros((3, 2), dtype=np.float32), discretize="prior-match")
         # fitted y is 2x each of {3,5,7} -> 3 rows get one of each, rank-ordered
         assert sorted(out.tolist()) == [3.0, 5.0, 7.0]
         assert out.tolist() == [7.0, 3.0, 5.0]
@@ -336,29 +325,26 @@ class TestSklearnEcosystem:
     def test_constructor_params_drive_predict(self, monkeypatch):
         self._patch_distribution(monkeypatch)
         model = NoriRegressor(discretize="map-cell")
-        model.fit(np.zeros((6, 2), dtype=np.float32),
-                  np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
+        model.fit(np.zeros((6, 2), dtype=np.float32), np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
         out = model.predict(np.zeros((4, 2), dtype=np.float32))
         assert out.tolist() == [5.0, 5.0, 5.0, 5.0]
 
     def test_per_call_override_wins(self, monkeypatch):
         self._patch_distribution(monkeypatch)
         model = NoriRegressor(discretize="median-cell")
-        model.fit(np.zeros((6, 2), dtype=np.float32),
-                  np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
+        model.fit(np.zeros((6, 2), dtype=np.float32), np.array([3.0, 3.0, 5.0, 5.0, 7.0, 7.0]))
         monkeypatch.setattr(
-            NoriRegressor, "_predict_point",
-            lambda self, X, *, quantile_collapse, bar_point_estimator:
-                np.array([5.37] * np.asarray(X).shape[0]))
-        out = model.predict(np.zeros((2, 2), dtype=np.float32),
-                            discretize="map-cell")
+            NoriRegressor,
+            "_predict_point",
+            lambda self, X, *, quantile_collapse, bar_point_estimator: np.array([5.37] * np.asarray(X).shape[0]),
+        )
+        out = model.predict(np.zeros((2, 2), dtype=np.float32), discretize="map-cell")
         assert set(out.tolist()) <= {3.0, 5.0, 7.0}  # per-call strategy override
 
     def test_clone_roundtrip(self):
         from sklearn.base import clone
 
-        model = NoriRegressor(discretize="median-cell",
-                              categorical_levels=[1.0, 2.0, 3.0])
+        model = NoriRegressor(discretize="median-cell", categorical_levels=[1.0, 2.0, 3.0])
         params = clone(model).get_params()
         assert params["discretize"] == "median-cell"
         assert params["categorical_levels"] == [1.0, 2.0, 3.0]
@@ -370,8 +356,7 @@ class TestSklearnEcosystem:
         X = np.zeros((12, 2), dtype=np.float32)
         y = np.tile([3.0, 5.0, 7.0], 4)
         gs = GridSearchCV(
-            NoriRegressor(),
-            {"discretize": ["map-cell", "median-cell"]},
-            scoring="accuracy", cv=2, error_score="raise")
+            NoriRegressor(), {"discretize": ["map-cell", "median-cell"]}, scoring="accuracy", cv=2, error_score="raise"
+        )
         gs.fit(X, y)
         assert gs.best_params_["discretize"] in ("map-cell", "median-cell")

--- a/tests/test_distribution_boundaries.py
+++ b/tests/test_distribution_boundaries.py
@@ -300,7 +300,5 @@ def test_sdist_rebuild_with_same_paths_but_different_bytes_is_rejected(tmp_path)
         extra_runtime_files=("synthefy/client.py",),
     )
 
-    with pytest.raises(
-        validator.BoundaryError, match="member_fingerprints"
-    ):
+    with pytest.raises(validator.BoundaryError, match="member_fingerprints"):
         validator.validate_artifacts(**artifacts)

--- a/tests/test_dynamic_compile_and_loader_rms.py
+++ b/tests/test_dynamic_compile_and_loader_rms.py
@@ -8,6 +8,7 @@ shape-generic kernels, so it needs no palette and leaves the curriculum alone.
 inference and evaluation path reaches the model through it, while training
 builds via `build_model` and is therefore unaffected.
 """
+
 from __future__ import annotations
 
 import subprocess
@@ -24,7 +25,9 @@ from synthefy_nori.model.layer import RMSNorm
 def _run_cli(*args):
     return subprocess.run(
         [sys.executable, "-m", "synthefy_nori.training.cli", *args],
-        capture_output=True, text=True, timeout=180,
+        capture_output=True,
+        text=True,
+        timeout=180,
     )
 
 
@@ -58,8 +61,7 @@ class _TinyNet(nn.Module):
 def _patch_loader(monkeypatch, model):
     import synthefy_nori.utils.loading as loading
 
-    monkeypatch.setattr(loading, "_safe_torch_load",
-                        lambda *a, **k: {"config": {}, "state_dict": {}})
+    monkeypatch.setattr(loading, "_safe_torch_load", lambda *a, **k: {"config": {}, "state_dict": {}})
     monkeypatch.setattr(loading, "build_model", lambda cfg: model)
     monkeypatch.setattr(model, "load_state_dict", lambda *a, **k: None)
     return loading

--- a/tests/test_evaluation_datasets.py
+++ b/tests/test_evaluation_datasets.py
@@ -18,25 +18,28 @@ def registry(tmp_path):
 def _make_frames():
     # Column "a": train median is 4.0 (NaN excluded); test has a NaN and a
     # deliberately different value distribution so train/test medians differ.
-    X_train = pd.DataFrame({
-        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 4.0, 4.0, 4.0, 4.0, np.nan],
-        "b": [np.nan] * 12,
-        "c": np.arange(12, dtype=float),
-    })
+    X_train = pd.DataFrame(
+        {
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 4.0, 4.0, 4.0, 4.0, np.nan],
+            "b": [np.nan] * 12,
+            "c": np.arange(12, dtype=float),
+        }
+    )
     y_train = pd.Series(np.arange(12, dtype=float))
-    X_test = pd.DataFrame({
-        "a": [100.0, np.nan, 100.0],
-        "b": [np.nan, np.nan, np.nan],
-        "c": [1.0, 2.0, 3.0],
-    })
+    X_test = pd.DataFrame(
+        {
+            "a": [100.0, np.nan, 100.0],
+            "b": [np.nan, np.nan, np.nan],
+            "c": [1.0, 2.0, 3.0],
+        }
+    )
     y_test = pd.Series([1.0, 2.0, 3.0])
     return X_train, y_train, X_test, y_test
 
 
 def test_numeric_nan_filled_with_train_median(registry):
     X_train, y_train, X_test, y_test = _make_frames()
-    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
-                                         X_test=X_test, y_test=y_test)
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit", X_test=X_test, y_test=y_test)
     assert entry is not None
     # Train NaN in "a" (row 11) -> train median 4.0, not 0.
     assert entry.X_train[11, 0] == pytest.approx(4.0)
@@ -44,8 +47,7 @@ def test_numeric_nan_filled_with_train_median(registry):
 
 def test_test_nan_filled_with_train_median_not_test_median(registry):
     X_train, y_train, X_test, y_test = _make_frames()
-    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
-                                         X_test=X_test, y_test=y_test)
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit", X_test=X_test, y_test=y_test)
     # Test NaN in "a" (row 1) -> TRAIN median 4.0; the test median (100.0)
     # must not leak in, and the legacy zero-fill must not return.
     assert entry.X_test[1, 0] == pytest.approx(4.0)
@@ -53,8 +55,7 @@ def test_test_nan_filled_with_train_median_not_test_median(registry):
 
 def test_all_missing_column_filled_with_zero(registry):
     X_train, y_train, X_test, y_test = _make_frames()
-    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
-                                         X_test=X_test, y_test=y_test)
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit", X_test=X_test, y_test=y_test)
     # "b" has no observed train values -> median is NaN -> falls back to 0
     # in both frames.
     assert np.all(entry.X_train[:, 1] == 0.0)
@@ -63,8 +64,7 @@ def test_all_missing_column_filled_with_zero(registry):
 
 def test_no_nan_survives_preprocessing(registry):
     X_train, y_train, X_test, y_test = _make_frames()
-    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit",
-                                         X_test=X_test, y_test=y_test)
+    entry = registry._make_entry_from_df(X_train, y_train, "toy", "unit", X_test=X_test, y_test=y_test)
     assert np.isfinite(entry.X_train).all()
     assert np.isfinite(entry.X_test).all()
 

--- a/tests/test_feature_decoder_architecture.py
+++ b/tests/test_feature_decoder_architecture.py
@@ -46,9 +46,7 @@ def test_legacy_config_keeps_decoder_and_strict_state_schema():
 
 
 def test_legacy_wide_head_is_inferred_as_evenly_spaced_pinball():
-    model = build_model(
-        _tiny_model_config(decoder_config={"num_reg_quantiles": 2})
-    )
+    model = build_model(_tiny_model_config(decoder_config={"num_reg_quantiles": 2}))
 
     assert model.regression_loss == "pinball"
     assert model.regression_quantiles == pytest.approx((1 / 3, 2 / 3))
@@ -70,9 +68,7 @@ def test_model_rejects_nonfinite_quantile_metadata():
 def test_explicit_omission_removes_only_feature_decoder_parameters():
     legacy = build_model(_tiny_model_config())
     omitted = build_model(_tiny_model_config(omit_feature_decoder=True))
-    decoder_parameters = sum(
-        parameter.numel() for parameter in legacy.feature_decoder.parameters()
-    )
+    decoder_parameters = sum(parameter.numel() for parameter in legacy.feature_decoder.parameters())
 
     assert omitted.feature_decoder is None
     assert not any(key.startswith("feature_decoder.") for key in omitted.state_dict())

--- a/tests/test_featurize.py
+++ b/tests/test_featurize.py
@@ -122,9 +122,7 @@ def test_auto_high_cardinality_column_requires_explicit_role():
 def test_datetime_column_requires_explicit_conversion():
     with pytest.raises(ValueError, match="unsupported dtype"):
         align_and_featurize(
-            pd.DataFrame(
-                {"a": [0.0, 1.0], "d": pd.to_datetime(["2024-01-01", "2024-01-02"])}
-            ),
+            pd.DataFrame({"a": [0.0, 1.0], "d": pd.to_datetime(["2024-01-01", "2024-01-02"])}),
             pd.DataFrame({"a": [2.0], "d": pd.to_datetime(["2024-01-03"])}),
         )
 
@@ -180,9 +178,7 @@ def test_numeric_category_dtype_is_respected_as_categorical():
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # must NOT warn / drop / explode
         Xtr, Xte = align_and_featurize(
-            pd.DataFrame(
-                {"a": [0.0, 1.0, 2.0], "r": pd.Categorical([1, 2, 3], categories=[1, 2, 3])}
-            ),
+            pd.DataFrame({"a": [0.0, 1.0, 2.0], "r": pd.Categorical([1, 2, 3], categories=[1, 2, 3])}),
             pd.DataFrame({"a": [5.0], "r": pd.Categorical([2], categories=[1, 2, 3])}),
         )
     # Pandas categorical dtype is a semantic declaration even when levels are numbers.

--- a/tests/test_filter_split_boundary.py
+++ b/tests/test_filter_split_boundary.py
@@ -10,19 +10,17 @@ from synthefy_nori.training import data_generator as dg
 
 def _row_id_data(n_rows: int, n_features: int = 4):
     row_ids = np.arange(n_rows, dtype=np.float64)
-    X = np.column_stack([
-        row_ids,
-        *[
-            np.sin(row_ids / (feature + 2.0))
-            for feature in range(n_features - 1)
-        ],
-    ])
+    X = np.column_stack(
+        [
+            row_ids,
+            *[np.sin(row_ids / (feature + 2.0)) for feature in range(n_features - 1)],
+        ]
+    )
     y = row_ids * 0.25 + np.cos(row_ids)
     return X, y
 
 
-def test_extra_trees_filter_fits_context_and_scores_query_with_15_rows(
-        monkeypatch):
+def test_extra_trees_filter_fits_context_and_scores_query_with_15_rows(monkeypatch):
     instances = []
 
     class SplitSpyExtraTrees:
@@ -42,8 +40,7 @@ def test_extra_trees_filter_fits_context_and_scores_query_with_15_rows(
             self.score_ids = X[:, 0].astype(np.int64)
             return 1.0
 
-    monkeypatch.setattr(
-        sklearn.ensemble, "ExtraTreesRegressor", SplitSpyExtraTrees)
+    monkeypatch.setattr(sklearn.ensemble, "ExtraTreesRegressor", SplitSpyExtraTrees)
     X, y = _row_id_data(64)
 
     assert dg._check_learnability(X, y, context_rows=15)
@@ -72,8 +69,7 @@ def test_scaling_filter_uses_context_ladder_and_fixed_query(monkeypatch):
             self.score_ids = X[:, 0].astype(np.int64)
             return len(self.fit_ids) / 100.0
 
-    monkeypatch.setattr(
-        sklearn.ensemble, "ExtraTreesRegressor", ScalingSpyExtraTrees)
+    monkeypatch.setattr(sklearn.ensemble, "ExtraTreesRegressor", ScalingSpyExtraTrees)
     X, y = _row_id_data(80)
 
     assert dg._check_icl_scaling(X, y, context_rows=40)
@@ -83,8 +79,7 @@ def test_scaling_filter_uses_context_ladder_and_fixed_query(monkeypatch):
         assert np.all(model.score_ids >= 40)
     expected_query_ids = np.sort(instances[0].score_ids)
     for model in instances[1:]:
-        np.testing.assert_array_equal(
-            np.sort(model.score_ids), expected_query_ids)
+        np.testing.assert_array_equal(np.sort(model.score_ids), expected_query_ids)
 
 
 def test_legacy_icl_filter_preserves_context_query_sides(monkeypatch):
@@ -98,8 +93,7 @@ def test_legacy_icl_filter_preserves_context_query_sides(monkeypatch):
             captured["eval_pos"] = eval_pos
             return {"reg_output": y[:, eval_pos:].unsqueeze(-1)}
 
-    monkeypatch.setattr(
-        dg, "_get_icl_filter_model", lambda _path: SplitSpyModel())
+    monkeypatch.setattr(dg, "_get_icl_filter_model", lambda _path: SplitSpyModel())
     X, y = _row_id_data(80)
 
     assert dg._check_learnability_icl(
@@ -119,14 +113,10 @@ def test_legacy_icl_filter_preserves_context_query_sides(monkeypatch):
 def test_generate_batch_omitted_context_keeps_legacy_filter_mode(monkeypatch):
     seen_context_rows = []
 
-    def tree_episode(
-            n_samples, n_features, task_type, n_classes, rng,
-            context_rows=None, **_kwargs):
+    def tree_episode(n_samples, n_features, task_type, n_classes, rng, context_rows=None, **_kwargs):
         del task_type, n_classes, rng
         row_ids = np.arange(n_samples, dtype=np.float64)
-        X = np.column_stack([
-            row_ids + feature for feature in range(n_features)
-        ])
+        X = np.column_stack([row_ids + feature for feature in range(n_features)])
         return {
             "X": X,
             "y": row_ids.astype(np.float32),
@@ -134,9 +124,7 @@ def test_generate_batch_omitted_context_keeps_legacy_filter_mode(monkeypatch):
             "meta": {"generator_family": "tree_prior"},
         }
 
-    def learnability_filter(
-            X, y, task_type, *, reg_min_score=0.10,
-            context_rows=None, **_kwargs):
+    def learnability_filter(X, y, task_type, *, reg_min_score=0.10, context_rows=None, **_kwargs):
         del X, y, task_type, reg_min_score
         seen_context_rows.append(context_rows)
         return True

--- a/tests/test_generator_pipeline_invariants.py
+++ b/tests/test_generator_pipeline_invariants.py
@@ -33,18 +33,15 @@ class _QueryPerturbingFeatureRng:
 
     def _maybe_perturb(self, values):
         values = np.asarray(values)
-        if (self._remaining_feature_draws > 0
-                and values.shape == (self._n_samples,)):
+        if self._remaining_feature_draws > 0 and values.shape == (self._n_samples,):
             self._remaining_feature_draws -= 1
             if self._shift:
                 values = values.copy()
-                values[self._context_rows:] = (
-                    values[self._context_rows:] * 11.0 + self._shift)
+                values[self._context_rows :] = values[self._context_rows :] * 11.0 + self._shift
         return values
 
     def standard_normal(self, *args, **kwargs):
-        return self._maybe_perturb(
-            self._rng.standard_normal(*args, **kwargs))
+        return self._maybe_perturb(self._rng.standard_normal(*args, **kwargs))
 
     def uniform(self, *args, **kwargs):
         return self._maybe_perturb(self._rng.uniform(*args, **kwargs))
@@ -53,32 +50,31 @@ class _QueryPerturbingFeatureRng:
         return self._maybe_perturb(self._rng.beta(*args, **kwargs))
 
     def standard_t(self, *args, **kwargs):
-        return self._maybe_perturb(
-            self._rng.standard_t(*args, **kwargs))
+        return self._maybe_perturb(self._rng.standard_t(*args, **kwargs))
 
 
 def test_feature_tail_missingness_uses_observed_covariates_not_labels():
-    assert list(inspect.signature(
-        dg._apply_feature_dependent_tail_missingness).parameters) == [
-            'X', 'rng', 'context_rows']
-    X = np.column_stack([
-        np.arange(20, dtype=np.float64),
-        np.linspace(-2.0, 2.0, 20),
-        np.ones(20, dtype=np.float64),
-    ])
+    assert list(inspect.signature(dg._apply_feature_dependent_tail_missingness).parameters) == [
+        "X",
+        "rng",
+        "context_rows",
+    ]
+    X = np.column_stack(
+        [
+            np.arange(20, dtype=np.float64),
+            np.linspace(-2.0, 2.0, 20),
+            np.ones(20, dtype=np.float64),
+        ]
+    )
 
     first = X.copy()
     second = X.copy()
     second[12:, :2] = -1_000_000
-    dg._apply_feature_dependent_tail_missingness(
-        first, np.random.default_rng(17), context_rows=12)
-    dg._apply_feature_dependent_tail_missingness(
-        second, np.random.default_rng(17), context_rows=12)
+    dg._apply_feature_dependent_tail_missingness(first, np.random.default_rng(17), context_rows=12)
+    dg._apply_feature_dependent_tail_missingness(second, np.random.default_rng(17), context_rows=12)
 
-    np.testing.assert_array_equal(
-        np.isnan(first[:12]), np.isnan(second[:12]))
-    assert not np.array_equal(
-        np.isnan(first[12:]), np.isnan(second[12:]))
+    np.testing.assert_array_equal(np.isnan(first[:12]), np.isnan(second[:12]))
+    assert not np.array_equal(np.isnan(first[12:]), np.isnan(second[12:]))
     assert np.isnan(first).any()
     assert np.isfinite(first).any()
 
@@ -89,10 +85,9 @@ def test_extra_trees_filter_rejects_scoreability_errors(monkeypatch):
             pass
 
         def fit(self, X, y):
-            raise ValueError('non-finite episode')
+            raise ValueError("non-finite episode")
 
-    monkeypatch.setattr(
-        sklearn.ensemble, 'ExtraTreesRegressor', NumericallyUnscoreableModel)
+    monkeypatch.setattr(sklearn.ensemble, "ExtraTreesRegressor", NumericallyUnscoreableModel)
     X = np.random.default_rng(0).standard_normal((64, 8))
     y = np.random.default_rng(1).standard_normal(64)
     assert dg._check_learnability(X, y) is False
@@ -104,20 +99,22 @@ def test_extra_trees_filter_propagates_programming_errors(monkeypatch):
             pass
 
         def fit(self, X, y):
-            raise TypeError('wrong model API')
+            raise TypeError("wrong model API")
 
-    monkeypatch.setattr(
-        sklearn.ensemble, 'ExtraTreesRegressor', BrokenFilterAPI)
+    monkeypatch.setattr(sklearn.ensemble, "ExtraTreesRegressor", BrokenFilterAPI)
     X = np.random.default_rng(2).standard_normal((64, 8))
     y = np.random.default_rng(3).standard_normal(64)
-    with pytest.raises(TypeError, match='wrong model API'):
+    with pytest.raises(TypeError, match="wrong model API"):
         dg._check_learnability(X, y)
 
 
-@pytest.mark.parametrize('message', [
-    'bad API call',
-    'input contains inferred shape',
-])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "bad API call",
+        "input contains inferred shape",
+    ],
+)
 def test_extra_trees_filter_propagates_api_value_errors(monkeypatch, message):
     class BrokenFilterAPI:
         def __init__(self, **kwargs):
@@ -126,69 +123,71 @@ def test_extra_trees_filter_propagates_api_value_errors(monkeypatch, message):
         def fit(self, X, y):
             raise ValueError(message)
 
-    monkeypatch.setattr(
-        sklearn.ensemble, 'ExtraTreesRegressor', BrokenFilterAPI)
+    monkeypatch.setattr(sklearn.ensemble, "ExtraTreesRegressor", BrokenFilterAPI)
     X = np.random.default_rng(6).standard_normal((64, 8))
     y = np.random.default_rng(7).standard_normal(64)
     with pytest.raises(ValueError, match=message):
         dg._check_learnability(X, y)
 
 
-@pytest.mark.parametrize('message', [
-    'Input contains NaN',
-    'Input contains infinity or a value too large',
-    'array must not contain infs or nans',
-    'numerical overflow while scoring',
-])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Input contains NaN",
+        "Input contains infinity or a value too large",
+        "array must not contain infs or nans",
+        "numerical overflow while scoring",
+    ],
+)
 def test_numerical_scoreability_error_classifier_is_boundary_aware(message):
     assert dg._is_numerical_scoreability_error(ValueError(message)) is True
-    assert dg._is_numerical_scoreability_error(
-        ValueError('input contains inferred shape')) is False
+    assert dg._is_numerical_scoreability_error(ValueError("input contains inferred shape")) is False
 
 
 def test_configured_learnability_gates_reject_undersized_episodes(monkeypatch):
     class MustNotRun:
         def __call__(self, *args, **kwargs):
-            raise AssertionError('undersized data must reject before inference')
+            raise AssertionError("undersized data must reject before inference")
 
-    monkeypatch.setattr(dg, '_get_icl_filter_model', lambda _path: MustNotRun())
+    monkeypatch.setattr(dg, "_get_icl_filter_model", lambda _path: MustNotRun())
     X = np.random.default_rng(8).standard_normal((19, 4))
     y = np.linspace(-1, 1, 19, dtype=np.float32)
     assert dg._check_learnability(X, y) is False
-    assert dg._check_learnability_icl(X, y, 'fake-model') is False
+    assert dg._check_learnability_icl(X, y, "fake-model") is False
 
 
 def test_icl_filter_rejects_constant_sampled_context(monkeypatch):
     class MustNotRun:
         def __call__(self, *args, **kwargs):
-            raise AssertionError('constant context must reject before inference')
+            raise AssertionError("constant context must reject before inference")
 
-    monkeypatch.setattr(dg, '_get_icl_filter_model', lambda _path: MustNotRun())
+    monkeypatch.setattr(dg, "_get_icl_filter_model", lambda _path: MustNotRun())
     X = np.random.default_rng(4).standard_normal((96, 8))
-    y = np.concatenate([
-        np.zeros(64, dtype=np.float32),
-        np.linspace(-1, 1, 32, dtype=np.float32),
-    ])
-    assert dg._check_learnability_icl(X, y, 'fake-model') is False
+    y = np.concatenate(
+        [
+            np.zeros(64, dtype=np.float32),
+            np.linspace(-1, 1, 32, dtype=np.float32),
+        ]
+    )
+    assert dg._check_learnability_icl(X, y, "fake-model") is False
 
 
 def test_icl_filter_propagates_model_api_failures(monkeypatch):
     class BrokenModel:
         def __call__(self, *args, **kwargs):
-            raise RuntimeError('broken forward contract')
+            raise RuntimeError("broken forward contract")
 
-    monkeypatch.setattr(dg, '_get_icl_filter_model', lambda _path: BrokenModel())
+    monkeypatch.setattr(dg, "_get_icl_filter_model", lambda _path: BrokenModel())
     X = np.random.default_rng(5).standard_normal((96, 8))
     y = np.linspace(-2, 2, 96, dtype=np.float32)
-    with pytest.raises(RuntimeError, match='broken forward contract'):
-        dg._check_learnability_icl(X, y, 'fake-model')
+    with pytest.raises(RuntimeError, match="broken forward contract"):
+        dg._check_learnability_icl(X, y, "fake-model")
 
 
 def test_max_parents_is_an_inclusive_limit():
     observed = set()
     for seed in range(100):
-        lcs = dg.LocalCausalStructure(
-            8, [], np.random.default_rng(seed), max_parents=4)
+        lcs = dg.LocalCausalStructure(8, [], np.random.default_rng(seed), max_parents=4)
         observed.update(len(parents) for parents in lcs.parents.values())
     assert 4 in observed
     assert max(observed) == 4
@@ -204,19 +203,18 @@ def test_hard_negatives_are_nan_safe_and_do_not_overwrite_protected_columns():
         protected_before = X[:, :3].copy()
         metadata = {}
         X_after, y_after = dg._add_latent_bayes_error(
-            X.copy(), rng.standard_normal(128), 12, rng,
-            protected_cols={0, 1, 2}, metadata=metadata)
+            X.copy(), rng.standard_normal(128), 12, rng, protected_cols={0, 1, 2}, metadata=metadata
+        )
         assert np.isfinite(y_after).all()
         assert not np.any(np.all(np.isnan(X_after), axis=0))
-        np.testing.assert_allclose(
-            X_after[:, :3], protected_before, equal_nan=True)
-        if metadata.get('hard_negative_cols'):
+        np.testing.assert_allclose(X_after[:, :3], protected_before, equal_nan=True)
+        if metadata.get("hard_negative_cols"):
             saw_hard_negative = True
-            assert set(metadata['hard_negative_cols']).isdisjoint({0, 1, 2})
+            assert set(metadata["hard_negative_cols"]).isdisjoint({0, 1, 2})
     assert saw_hard_negative
 
 
-@pytest.mark.parametrize('op', [0, 1, 2])
+@pytest.mark.parametrize("op", [0, 1, 2])
 def test_groupby_context_effect_is_invariant_to_query_composition(op):
     class FixedOpRng:
         def __init__(self, seed, fixed_op):
@@ -239,17 +237,15 @@ def test_groupby_context_effect_is_invariant_to_query_composition(op):
     n_samples, n_features, context_rows = 240, 8, 96
     X_a = np.random.default_rng(44).standard_normal((n_samples, n_features))
     X_b = X_a.copy()
-    X_b[context_rows:, 1:] = (
-        X_b[context_rows:, 1:] * 50.0 + 1000.0)
+    X_b[context_rows:, 1:] = X_b[context_rows:, 1:] * 50.0 + 1000.0
 
     effect_a, _ = dg._create_groupby_relative_numeric(
-        X_a, 0, n_samples, FixedOpRng(91, op), 10,
-        n_features, set(), {0}, context_rows=context_rows)
+        X_a, 0, n_samples, FixedOpRng(91, op), 10, n_features, set(), {0}, context_rows=context_rows
+    )
     effect_b, _ = dg._create_groupby_relative_numeric(
-        X_b, 0, n_samples, FixedOpRng(91, op), 10,
-        n_features, set(), {0}, context_rows=context_rows)
-    np.testing.assert_allclose(
-        effect_a[:context_rows], effect_b[:context_rows], atol=0.0, rtol=0.0)
+        X_b, 0, n_samples, FixedOpRng(91, op), 10, n_features, set(), {0}, context_rows=context_rows
+    )
+    np.testing.assert_allclose(effect_a[:context_rows], effect_b[:context_rows], atol=0.0, rtol=0.0)
 
 
 def test_entity_signal_mixture_scale_uses_context_only():
@@ -261,14 +257,9 @@ def test_entity_signal_mixture_scale_uses_context_only():
     effect_b = effect_a.copy()
     y_b[context_rows:] = y_b[context_rows:] * 100.0 + 300.0
     effect_b[context_rows:] = effect_b[context_rows:] * 50.0 - 200.0
-    out_a = dg._add_entity_lookup_signal(
-        y_a, effect_a, np.random.default_rng(5), {},
-        context_rows=context_rows)
-    out_b = dg._add_entity_lookup_signal(
-        y_b, effect_b, np.random.default_rng(5), {},
-        context_rows=context_rows)
-    np.testing.assert_allclose(
-        out_a[:context_rows], out_b[:context_rows], atol=0.0, rtol=0.0)
+    out_a = dg._add_entity_lookup_signal(y_a, effect_a, np.random.default_rng(5), {}, context_rows=context_rows)
+    out_b = dg._add_entity_lookup_signal(y_b, effect_b, np.random.default_rng(5), {}, context_rows=context_rows)
+    np.testing.assert_allclose(out_a[:context_rows], out_b[:context_rows], atol=0.0, rtol=0.0)
 
 
 def test_rich_target_component_scale_uses_context_only():
@@ -280,12 +271,9 @@ def test_rich_target_component_scale_uses_context_only():
     extra_b = extra_a.copy()
     y_b[context_rows:] = y_b[context_rows:] * 100.0 + 500.0
     extra_b[context_rows:] = extra_b[context_rows:] * 80.0 - 300.0
-    scaled_a = dg._scale_rich_target_component(
-        extra_a, y_a, np.random.default_rng(8), context_rows=context_rows)
-    scaled_b = dg._scale_rich_target_component(
-        extra_b, y_b, np.random.default_rng(8), context_rows=context_rows)
-    np.testing.assert_allclose(
-        scaled_a[:context_rows], scaled_b[:context_rows], atol=0.0, rtol=0.0)
+    scaled_a = dg._scale_rich_target_component(extra_a, y_a, np.random.default_rng(8), context_rows=context_rows)
+    scaled_b = dg._scale_rich_target_component(extra_b, y_b, np.random.default_rng(8), context_rows=context_rows)
+    np.testing.assert_allclose(scaled_a[:context_rows], scaled_b[:context_rows], atol=0.0, rtol=0.0)
 
 
 def test_tail_missingness_control_flow_ignores_query_only_tails():
@@ -297,59 +285,69 @@ def test_tail_missingness_control_flow_ignores_query_only_tails():
     shifted[context_rows:, 0] += 10.0
 
     base_applied = dg._apply_feature_dependent_tail_missingness(
-        base, np.random.default_rng(0), context_rows=context_rows)
+        base, np.random.default_rng(0), context_rows=context_rows
+    )
     shifted_applied = dg._apply_feature_dependent_tail_missingness(
-        shifted, np.random.default_rng(0), context_rows=context_rows)
+        shifted, np.random.default_rng(0), context_rows=context_rows
+    )
 
     assert base_applied is False
     assert shifted_applied is False
-    np.testing.assert_array_equal(
-        base[:context_rows], shifted[:context_rows])
+    np.testing.assert_array_equal(base[:context_rows], shifted[:context_rows])
     assert not np.isnan(base).any()
     assert np.isnan(shifted[context_rows:]).any()
 
 
-@pytest.mark.parametrize('transform_kwargs', [
-    {'realistic_augmentation_prob': 1.0},
-    {'y_transform_prob': 1.0},
-    {'low_unique_y_prob': 1.0},
-    {'cap_injection_prob': 1.0, 'cap_high_fraction_prob': 1.0},
-    {'heavy_tail_prior_prob': 1.0},
-])
+@pytest.mark.parametrize(
+    "transform_kwargs",
+    [
+        {"realistic_augmentation_prob": 1.0},
+        {"y_transform_prob": 1.0},
+        {"low_unique_y_prob": 1.0},
+        {"cap_injection_prob": 1.0, "cap_high_fraction_prob": 1.0},
+        {"heavy_tail_prior_prob": 1.0},
+    ],
+)
 def test_final_target_transforms_fit_context_only(monkeypatch, transform_kwargs):
     n_samples, n_features, context_rows = 128, 8, 64
     base_y = np.linspace(-2.0, 2.0, n_samples, dtype=np.float32)
     query_shifted_y = base_y.copy()
-    query_shifted_y[context_rows:] = (
-        query_shifted_y[context_rows:] * 20.0 + 100.0)
-    state = {'shift_query': False}
+    query_shifted_y[context_rows:] = query_shifted_y[context_rows:] * 20.0 + 100.0
+    state = {"shift_query": False}
 
-    def tree_episode(
-            _n_samples, _n_features, task_type, n_classes, rng,
-            context_rows=None, **_kwargs):
+    def tree_episode(_n_samples, _n_features, task_type, n_classes, rng, context_rows=None, **_kwargs):
         del task_type, n_classes, rng, context_rows
-        X = np.random.default_rng(77).standard_normal(
-            (_n_samples, _n_features)).astype(np.float32)
-        y = query_shifted_y if state['shift_query'] else base_y
-        return {'X': X, 'y': y.copy(), 'filtered': False, 'meta': {}}
+        X = np.random.default_rng(77).standard_normal((_n_samples, _n_features)).astype(np.float32)
+        y = query_shifted_y if state["shift_query"] else base_y
+        return {"X": X, "y": y.copy(), "filtered": False, "meta": {}}
 
-    monkeypatch.setattr(dg, '_generate_tree_prior_episode', tree_episode)
+    monkeypatch.setattr(dg, "_generate_tree_prior_episode", tree_episode)
     saw_context_transform = False
     for seed in range(20):
-        state['shift_query'] = False
+        state["shift_query"] = False
         _, y_a, _ = dg.generate_batch(
-            1, n_samples, n_features, 'reg', rng=np.random.default_rng(seed),
-            tree_prior_prob=1.0, context_rows=context_rows,
-            **transform_kwargs)
-        state['shift_query'] = True
+            1,
+            n_samples,
+            n_features,
+            "reg",
+            rng=np.random.default_rng(seed),
+            tree_prior_prob=1.0,
+            context_rows=context_rows,
+            **transform_kwargs,
+        )
+        state["shift_query"] = True
         _, y_b, _ = dg.generate_batch(
-            1, n_samples, n_features, 'reg', rng=np.random.default_rng(seed),
-            tree_prior_prob=1.0, context_rows=context_rows,
-            **transform_kwargs)
-        np.testing.assert_array_equal(
-            y_a[0, :context_rows], y_b[0, :context_rows])
-        saw_context_transform |= not np.array_equal(
-            y_a[0, :context_rows], base_y[:context_rows])
+            1,
+            n_samples,
+            n_features,
+            "reg",
+            rng=np.random.default_rng(seed),
+            tree_prior_prob=1.0,
+            context_rows=context_rows,
+            **transform_kwargs,
+        )
+        np.testing.assert_array_equal(y_a[0, :context_rows], y_b[0, :context_rows])
+        saw_context_transform |= not np.array_equal(y_a[0, :context_rows], base_y[:context_rows])
     assert saw_context_transform
 
 
@@ -359,11 +357,9 @@ def test_complete_noise_vector_matches_requested_empirical_r2():
     raw_noise = rng.standard_normal(512)
     raw_noise[:20] *= 30.0
     for requested in (0.3, 0.5, 0.8, 0.98):
-        noise, realized = dg._calibrate_noise_to_target_r2(
-            signal, raw_noise, requested)
+        noise, realized = dg._calibrate_noise_to_target_r2(signal, raw_noise, requested)
         noisy = signal + noise
-        empirical = 1.0 - np.sum(noise ** 2) / np.sum(
-            (noisy - noisy.mean()) ** 2)
+        empirical = 1.0 - np.sum(noise**2) / np.sum((noisy - noisy.mean()) ** 2)
         assert realized == pytest.approx(requested, abs=1e-12)
         assert empirical == pytest.approx(requested, abs=1e-12)
 
@@ -378,12 +374,9 @@ def test_noise_calibration_scale_is_invariant_to_query_composition():
     signal_b[context_rows:] = signal_b[context_rows:] * 100.0 + 500.0
     raw_noise_b[context_rows:] = raw_noise_b[context_rows:] * 80.0 - 300.0
 
-    noise_a, realized_a = dg._calibrate_noise_to_target_r2(
-        signal_a, raw_noise_a, 0.73, context_rows=context_rows)
-    noise_b, realized_b = dg._calibrate_noise_to_target_r2(
-        signal_b, raw_noise_b, 0.73, context_rows=context_rows)
-    np.testing.assert_array_equal(
-        noise_a[:context_rows], noise_b[:context_rows])
+    noise_a, realized_a = dg._calibrate_noise_to_target_r2(signal_a, raw_noise_a, 0.73, context_rows=context_rows)
+    noise_b, realized_b = dg._calibrate_noise_to_target_r2(signal_b, raw_noise_b, 0.73, context_rows=context_rows)
+    np.testing.assert_array_equal(noise_a[:context_rows], noise_b[:context_rows])
     assert realized_a == pytest.approx(0.73, abs=1e-12)
     assert realized_b == pytest.approx(0.73, abs=1e-12)
 
@@ -402,54 +395,50 @@ def test_special_prior_context_targets_ignore_query_feature_values():
             control = generator(
                 n_samples,
                 n_features,
-                'reg',
+                "reg",
                 None,
-                _QueryPerturbingFeatureRng(
-                    seed, n_samples, n_features, context_rows, shift=0.0),
+                _QueryPerturbingFeatureRng(seed, n_samples, n_features, context_rows, shift=0.0),
                 context_rows=context_rows,
             )
             perturbed = generator(
                 n_samples,
                 n_features,
-                'reg',
+                "reg",
                 None,
-                _QueryPerturbingFeatureRng(
-                    seed, n_samples, n_features, context_rows, shift=100.0),
+                _QueryPerturbingFeatureRng(seed, n_samples, n_features, context_rows, shift=100.0),
                 context_rows=context_rows,
             )
             np.testing.assert_array_equal(
-                control['y'][:context_rows],
-                perturbed['y'][:context_rows],
+                control["y"][:context_rows],
+                perturbed["y"][:context_rows],
             )
             np.testing.assert_array_equal(
-                control['X'][:context_rows],
-                perturbed['X'][:context_rows],
+                control["X"][:context_rows],
+                perturbed["X"][:context_rows],
             )
 
 
-@pytest.mark.parametrize('generator', [
-    dg._generate_gp_prior_episode,
-    dg._generate_quadratic_surface_episode,
-    dg._generate_sparse_nonlinear_episode,
-    dg._generate_lookup_prior_episode,
-])
-def test_special_prior_classification_ignores_regression_context_contract(
-        generator):
-    control = generator(
-        128, 12, 'cls', 3, np.random.default_rng(23))
-    with_context = generator(
-        128, 12, 'cls', 3, np.random.default_rng(23), context_rows=64)
+@pytest.mark.parametrize(
+    "generator",
+    [
+        dg._generate_gp_prior_episode,
+        dg._generate_quadratic_surface_episode,
+        dg._generate_sparse_nonlinear_episode,
+        dg._generate_lookup_prior_episode,
+    ],
+)
+def test_special_prior_classification_ignores_regression_context_contract(generator):
+    control = generator(128, 12, "cls", 3, np.random.default_rng(23))
+    with_context = generator(128, 12, "cls", 3, np.random.default_rng(23), context_rows=64)
 
-    np.testing.assert_array_equal(control['X'], with_context['X'])
-    np.testing.assert_array_equal(control['y'], with_context['y'])
-    assert with_context['task_type'] == 'cls'
-    assert with_context['n_classes'] == 3
+    np.testing.assert_array_equal(control["X"], with_context["X"])
+    np.testing.assert_array_equal(control["y"], with_context["y"])
+    assert with_context["task_type"] == "cls"
+    assert with_context["n_classes"] == 3
 
 
 def test_generate_batch_keeps_public_classification_three_tuple():
-    result = dg.generate_batch(
-        1, 128, 12, 'cls', n_classes=3,
-        rng=np.random.default_rng(31), gp_prior_prob=1.0)
+    result = dg.generate_batch(1, 128, 12, "cls", n_classes=3, rng=np.random.default_rng(31), gp_prior_prob=1.0)
 
     assert len(result) == 3
     X, y, n_classes = result
@@ -463,11 +452,10 @@ def test_duplicate_rows_never_copy_query_labels_into_context():
     saw_context_to_query = False
     for seed in range(20):
         src, dst = dg._sample_context_safe_duplicate_indices(
-            100, 50, np.random.default_rng(seed),
-            context_rows=context_rows)
+            100, 50, np.random.default_rng(seed), context_rows=context_rows
+        )
         assert not np.any((src >= context_rows) & (dst < context_rows))
-        saw_context_to_query |= bool(np.any(
-            (src < context_rows) & (dst >= context_rows)))
+        saw_context_to_query |= bool(np.any((src < context_rows) & (dst >= context_rows)))
     assert saw_context_to_query
 
 
@@ -478,19 +466,20 @@ def test_basic_health_cannot_be_rescued_by_query_only_variation():
     y[6:] = np.arange(6, dtype=np.float64)
 
     assert dg._passes_basic_episode_health(X, y)
-    assert not dg._passes_basic_episode_health(
-        X, y, context_rows=6)
+    assert not dg._passes_basic_episode_health(X, y, context_rows=6)
 
 
-@pytest.mark.parametrize('family', [
-    'regression',
-    'tree',
-])
-def test_family_target_pipeline_ignores_query_composition_when_fitting_stats(
-        monkeypatch, family):
+@pytest.mark.parametrize(
+    "family",
+    [
+        "regression",
+        "tree",
+    ],
+)
+def test_family_target_pipeline_ignores_query_composition_when_fitting_stats(monkeypatch, family):
     """Exercise each real family, perturbing only stats-visible query values."""
     n_samples, n_features, context_rows = 128, 12, 64
-    perturb_query = {'enabled': False}
+    perturb_query = {"enabled": False}
     calibration_calls = 0
     normalization_calls = 0
     original_calibrate = dg._calibrate_noise_to_target_r2
@@ -502,11 +491,10 @@ def test_family_target_pipeline_ignores_query_composition_when_fitting_stats(
         assert context_rows == 64
         signal = np.asarray(signal).copy()
         raw_noise = np.asarray(raw_noise).copy()
-        if perturb_query['enabled']:
+        if perturb_query["enabled"]:
             signal[64:] = signal[64:] * 100.0 + 500.0
             raw_noise[64:] = raw_noise[64:] * 80.0 - 300.0
-        return original_calibrate(
-            signal, raw_noise, target_r2, context_rows=context_rows)
+        return original_calibrate(signal, raw_noise, target_r2, context_rows=context_rows)
 
     def normalize(y, y_clean, context_rows=None):
         nonlocal normalization_calls
@@ -514,92 +502,80 @@ def test_family_target_pipeline_ignores_query_composition_when_fitting_stats(
         assert context_rows == 64
         y = np.asarray(y).copy()
         y_clean = np.asarray(y_clean).copy()
-        if perturb_query['enabled']:
+        if perturb_query["enabled"]:
             y[64:] = y[64:] * 20.0 + 100.0
             y_clean[64:] = y_clean[64:] * 20.0 + 100.0
         return original_normalize(y, y_clean, context_rows=context_rows)
 
-    monkeypatch.setattr(dg, '_calibrate_noise_to_target_r2', calibrate)
-    monkeypatch.setattr(dg, '_normalize_target_pair', normalize)
+    monkeypatch.setattr(dg, "_calibrate_noise_to_target_r2", calibrate)
+    monkeypatch.setattr(dg, "_normalize_target_pair", normalize)
 
     def generate():
         rng = np.random.default_rng(103)
-        if family == 'regression':
+        if family == "regression":
             return dg._generate_regression_prior(
-                n_samples, n_features, rng,
+                n_samples,
+                n_features,
+                rng,
                 reg_deterministic_prob=0.0,
                 preserve_target_features=True,
-                context_rows=context_rows)
-        if family == 'tree':
-            return dg._generate_tree_prior_episode(
-                n_samples, n_features, 'reg', None, rng,
-                context_rows=context_rows)
-        if family == 'gp':
-            return dg._generate_gp_prior_episode(
-                n_samples, n_features, 'reg', None, rng,
-                context_rows=context_rows)
-        if family == 'quadratic':
+                context_rows=context_rows,
+            )
+        if family == "tree":
+            return dg._generate_tree_prior_episode(n_samples, n_features, "reg", None, rng, context_rows=context_rows)
+        if family == "gp":
+            return dg._generate_gp_prior_episode(n_samples, n_features, "reg", None, rng, context_rows=context_rows)
+        if family == "quadratic":
             return dg._generate_quadratic_surface_episode(
-                n_samples, n_features, 'reg', None, rng,
-                context_rows=context_rows)
-        if family == 'sparse':
+                n_samples, n_features, "reg", None, rng, context_rows=context_rows
+            )
+        if family == "sparse":
             return dg._generate_sparse_nonlinear_episode(
-                n_samples, n_features, 'reg', None, rng,
-                context_rows=context_rows)
-        if family == 'lookup':
-            return dg._generate_lookup_prior_episode(
-                n_samples, n_features, 'reg', None, rng,
-                context_rows=context_rows)
-        return dg._generate_clean_lowdim_episode(
-            n_samples, n_features, 'reg', None, rng,
-            context_rows=context_rows)
+                n_samples, n_features, "reg", None, rng, context_rows=context_rows
+            )
+        if family == "lookup":
+            return dg._generate_lookup_prior_episode(n_samples, n_features, "reg", None, rng, context_rows=context_rows)
+        return dg._generate_clean_lowdim_episode(n_samples, n_features, "reg", None, rng, context_rows=context_rows)
 
     data_a = generate()
     calls_after_a = (calibration_calls, normalization_calls)
-    perturb_query['enabled'] = True
+    perturb_query["enabled"] = True
     data_b = generate()
 
     assert calls_after_a[0] >= 1
     assert calls_after_a[1] >= 1
     assert calibration_calls == 2 * calls_after_a[0]
     assert normalization_calls == 2 * calls_after_a[1]
-    np.testing.assert_array_equal(data_a['X'], data_b['X'])
-    np.testing.assert_array_equal(
-        data_a['y'][:context_rows], data_b['y'][:context_rows])
-    assert not np.array_equal(
-        data_a['y'][context_rows:], data_b['y'][context_rows:])
+    np.testing.assert_array_equal(data_a["X"], data_b["X"])
+    np.testing.assert_array_equal(data_a["y"][:context_rows], data_b["y"][:context_rows])
+    assert not np.array_equal(data_a["y"][context_rows:], data_b["y"][context_rows:])
 
 
 def test_tree_family_raw_query_signal_cannot_change_context_snr(monkeypatch):
     n_samples, n_features, context_rows = 128, 12, 64
-    query_shifted = {'enabled': False}
+    query_shifted = {"enabled": False}
     raw_signal = np.sin(np.linspace(-3.0, 3.0, n_samples))
 
-    def controlled_tree_prediction(
-            X, feature_cols, rng, depth, context_rows=None):
+    def controlled_tree_prediction(X, feature_cols, rng, depth, context_rows=None):
         del X, feature_cols, rng, depth
         assert context_rows == 64
         signal = raw_signal.copy()
-        if query_shifted['enabled']:
-            signal[context_rows:] = (
-                signal[context_rows:] * 100.0 + 500.0)
+        if query_shifted["enabled"]:
+            signal[context_rows:] = signal[context_rows:] * 100.0 + 500.0
         return signal
 
-    monkeypatch.setattr(
-        dg, '_random_decision_tree_predict', controlled_tree_prediction)
+    monkeypatch.setattr(dg, "_random_decision_tree_predict", controlled_tree_prediction)
     data_a = dg._generate_tree_prior_episode(
-        n_samples, n_features, 'reg', None, np.random.default_rng(211),
-        context_rows=context_rows)
-    query_shifted['enabled'] = True
+        n_samples, n_features, "reg", None, np.random.default_rng(211), context_rows=context_rows
+    )
+    query_shifted["enabled"] = True
     data_b = dg._generate_tree_prior_episode(
-        n_samples, n_features, 'reg', None, np.random.default_rng(211),
-        context_rows=context_rows)
+        n_samples, n_features, "reg", None, np.random.default_rng(211), context_rows=context_rows
+    )
 
-    np.testing.assert_array_equal(data_a['X'], data_b['X'])
-    np.testing.assert_array_equal(
-        data_a['y'][:context_rows], data_b['y'][:context_rows])
-    assert not np.array_equal(
-        data_a['y'][context_rows:], data_b['y'][context_rows:])
+    np.testing.assert_array_equal(data_a["X"], data_b["X"])
+    np.testing.assert_array_equal(data_a["y"][:context_rows], data_b["y"][:context_rows])
+    assert not np.array_equal(data_a["y"][context_rows:], data_b["y"][context_rows:])
 
 
 def test_tree_split_thresholds_fit_context_features_only():
@@ -608,60 +584,57 @@ def test_tree_split_thresholds_fit_context_features_only():
     X_b = X_a.copy()
     X_b[context_rows:] = X_b[context_rows:] * 100.0 + 500.0
     pred_a = dg._random_decision_tree_predict(
-        X_a, np.arange(6), np.random.default_rng(213), depth=4,
-        context_rows=context_rows)
+        X_a, np.arange(6), np.random.default_rng(213), depth=4, context_rows=context_rows
+    )
     pred_b = dg._random_decision_tree_predict(
-        X_b, np.arange(6), np.random.default_rng(213), depth=4,
-        context_rows=context_rows)
-    np.testing.assert_array_equal(
-        pred_a[:context_rows], pred_b[:context_rows])
+        X_b, np.arange(6), np.random.default_rng(213), depth=4, context_rows=context_rows
+    )
+    np.testing.assert_array_equal(pred_a[:context_rows], pred_b[:context_rows])
 
 
-@pytest.mark.parametrize('seed', [0, 5, 15])
+@pytest.mark.parametrize("seed", [0, 5, 15])
 def test_regression_hybrid_target_fit_ignores_query_feature_composition(seed):
     n_samples, n_features, context_rows = 128, 12, 64
-    X_a = np.random.default_rng(214).standard_normal(
-        (n_samples, n_features)).astype(np.float32)
+    X_a = np.random.default_rng(214).standard_normal((n_samples, n_features)).astype(np.float32)
     X_b = X_a.copy()
     X_b[context_rows:] = X_b[context_rows:] * 100.0 + 500.0
     data_a = dg._generate_regression_prior(
-        n_samples, n_features, np.random.default_rng(seed),
-        X_scm=X_a, preserve_target_features=True,
-        reg_deterministic_prob=0.0, context_rows=context_rows)
+        n_samples,
+        n_features,
+        np.random.default_rng(seed),
+        X_scm=X_a,
+        preserve_target_features=True,
+        reg_deterministic_prob=0.0,
+        context_rows=context_rows,
+    )
     data_b = dg._generate_regression_prior(
-        n_samples, n_features, np.random.default_rng(seed),
-        X_scm=X_b, preserve_target_features=True,
-        reg_deterministic_prob=0.0, context_rows=context_rows)
-    np.testing.assert_array_equal(
-        data_a['y'][:context_rows], data_b['y'][:context_rows])
-    np.testing.assert_array_equal(
-        data_a['y_clean'][:context_rows],
-        data_b['y_clean'][:context_rows])
-    np.testing.assert_array_equal(
-        data_a['X'][:context_rows], data_b['X'][:context_rows])
+        n_samples,
+        n_features,
+        np.random.default_rng(seed),
+        X_scm=X_b,
+        preserve_target_features=True,
+        reg_deterministic_prob=0.0,
+        context_rows=context_rows,
+    )
+    np.testing.assert_array_equal(data_a["y"][:context_rows], data_b["y"][:context_rows])
+    np.testing.assert_array_equal(data_a["y_clean"][:context_rows], data_b["y_clean"][:context_rows])
+    np.testing.assert_array_equal(data_a["X"][:context_rows], data_b["X"][:context_rows])
 
 
 def test_regression_prior_reports_realized_target_r2():
     for seed in range(30):
         data = dg._generate_regression_prior(
-            256, 24, np.random.default_rng(seed),
+            256,
+            24,
+            np.random.default_rng(seed),
             reg_deterministic_prob=0.0,
             preserve_target_features=True,
-            context_rows=128)
-        meta = data['meta']
-        assert meta['realized_target_r2'] == pytest.approx(
-            meta['target_r2'], abs=1e-10)
-        assert meta['context_realized_target_r2'] == pytest.approx(
-            meta['target_r2'], abs=1e-10)
-        assert meta['context_rows'] == 128
-
-
-
-
-
-
-
-
+            context_rows=128,
+        )
+        meta = data["meta"]
+        assert meta["realized_target_r2"] == pytest.approx(meta["target_r2"], abs=1e-10)
+        assert meta["context_realized_target_r2"] == pytest.approx(meta["target_r2"], abs=1e-10)
+        assert meta["context_rows"] == 128
 
 
 def test_filter_exhaustion_raises_instead_of_returning_rejected_data(monkeypatch):
@@ -671,39 +644,34 @@ def test_filter_exhaustion_raises_instead_of_returning_rejected_data(monkeypatch
         nonlocal calls
         calls += 1
         return {
-            'X': np.ones((32, 4), dtype=np.float32),
-            'y': np.zeros(32, dtype=np.float32),
-            'filtered': False,
-            'meta': {},
+            "X": np.ones((32, 4), dtype=np.float32),
+            "y": np.zeros(32, dtype=np.float32),
+            "filtered": False,
+            "meta": {},
         }
 
-    monkeypatch.setattr(dg, 'generate_dataset', constant_episode)
+    monkeypatch.setattr(dg, "generate_dataset", constant_episode)
     with pytest.raises(dg.SyntheticDataFilterError):
-        dg.generate_dataset_filtered(32, 4, 'reg', max_retries=2)
+        dg.generate_dataset_filtered(32, 4, "reg", max_retries=2)
     assert calls == 3
 
 
 def test_special_prior_retries_its_actual_target_on_failed_health(monkeypatch):
     calls = 0
 
-    def tree_episode(
-            n_samples, n_features, task_type, n_classes, rng,
-            context_rows=None, **_kwargs):
+    def tree_episode(n_samples, n_features, task_type, n_classes, rng, context_rows=None, **_kwargs):
         del task_type, n_classes, rng, context_rows
         nonlocal calls
         calls += 1
         X = np.tile(np.arange(n_features), (n_samples, 1)).astype(np.float32)
         X[:, 0] = np.arange(n_samples)
-        y = (
-            np.zeros(n_samples, dtype=np.float32)
-            if calls == 1 else np.linspace(-1, 1, n_samples, dtype=np.float32)
-        )
-        return {'X': X, 'y': y, 'filtered': False, 'meta': {}}
+        y = np.zeros(n_samples, dtype=np.float32) if calls == 1 else np.linspace(-1, 1, n_samples, dtype=np.float32)
+        return {"X": X, "y": y, "filtered": False, "meta": {}}
 
-    monkeypatch.setattr(dg, '_generate_tree_prior_episode', tree_episode)
+    monkeypatch.setattr(dg, "_generate_tree_prior_episode", tree_episode)
     X, y, _ = dg.generate_batch(
-        1, 64, 8, 'reg', rng=np.random.default_rng(0),
-        tree_prior_prob=1.0, filter_max_retries=2)
+        1, 64, 8, "reg", rng=np.random.default_rng(0), tree_prior_prob=1.0, filter_max_retries=2
+    )
     assert calls == 2
     assert X.shape == (1, 64, 8)
     assert np.std(y[0]) > 0
@@ -711,33 +679,27 @@ def test_special_prior_retries_its_actual_target_on_failed_health(monkeypatch):
 
 def test_lookup_prior_keeps_ids_at_narrow_width_and_adds_cold_start():
     for seed in range(30):
-        data = dg._generate_lookup_prior_episode(
-            50, 2, 'reg', None, np.random.default_rng(seed),
-            context_rows=15)
-        meta = data['meta']
-        assert meta['n_id_cols'] == 1
-        assert np.equal(data['X'][:, 0], np.round(data['X'][:, 0])).all()
-        assert all(count >= 1 for count in meta['minimum_context_counts'])
-        assert all(count >= 1 for count in meta['unseen_cardinalities'])
-        assert all(0.04 <= frac <= 0.21
-                   for frac in meta['query_unseen_fractions'])
+        data = dg._generate_lookup_prior_episode(50, 2, "reg", None, np.random.default_rng(seed), context_rows=15)
+        meta = data["meta"]
+        assert meta["n_id_cols"] == 1
+        assert np.equal(data["X"][:, 0], np.round(data["X"][:, 0])).all()
+        assert all(count >= 1 for count in meta["minimum_context_counts"])
+        assert all(count >= 1 for count in meta["unseen_cardinalities"])
+        assert all(0.04 <= frac <= 0.21 for frac in meta["query_unseen_fractions"])
 
 
 def test_final_feature_safety_is_affine_and_bounded():
     X = np.zeros((1, 256, 3), dtype=np.float64)
     X[0, :, 0] = np.exp(np.linspace(-20, 20, 256))
-    X[0, :, 1] = np.sign(np.linspace(-1e6, 1e6, 256)) * (
-        np.linspace(-1e6, 1e6, 256) ** 2)
+    X[0, :, 1] = np.sign(np.linspace(-1e6, 1e6, 256)) * (np.linspace(-1e6, 1e6, 256) ** 2)
     X[0, 10, 2] = np.nan
     stabilized, affine, bounded = dg._finalize_feature_batch(X)
     assert set(affine) == {(0, 0), (0, 1)}
     assert bounded == []
     assert np.nanmax(np.abs(stabilized)) <= 1e4
     assert np.isnan(stabilized[0, 10, 2])
-    np.testing.assert_array_equal(
-        np.argsort(X[0, :, 0]), np.argsort(stabilized[0, :, 0]))
-    np.testing.assert_array_equal(
-        np.argsort(X[0, :, 1]), np.argsort(stabilized[0, :, 1]))
+    np.testing.assert_array_equal(np.argsort(X[0, :, 0]), np.argsort(stabilized[0, :, 0]))
+    np.testing.assert_array_equal(np.argsort(X[0, :, 1]), np.argsort(stabilized[0, :, 1]))
 
 
 @pytest.mark.parametrize(
@@ -750,8 +712,15 @@ def test_final_feature_safety_is_affine_and_bounded():
 def test_realistic_monotone_warps_preserve_distinct_query_tails(warp, limit):
     values = np.array(
         [
-            -1e6, -200.0, -limit - 1.0, -limit, 0.0,
-            limit, limit + 1.0, 200.0, 1e6,
+            -1e6,
+            -200.0,
+            -limit - 1.0,
+            -limit,
+            0.0,
+            limit,
+            limit + 1.0,
+            200.0,
+            1e6,
         ],
         dtype=np.float64,
     )
@@ -765,26 +734,23 @@ def test_feature_transforms_fit_only_the_context_prefix():
     context_rows = 32
     base = np.arange(384, dtype=np.float64).reshape(64, 6) / 10.0
     shifted = base.copy()
-    shifted[context_rows:] = (
-        shifted[context_rows:] * 100.0 + 10_000.0)
+    shifted[context_rows:] = shifted[context_rows:] * 100.0 + 10_000.0
 
     correlated_base = base.copy()
     correlated_shifted = shifted.copy()
     dg._apply_invertible_feature_correlation(
-        correlated_base, [0, 1, 2], np.random.default_rng(9), rho=0.5,
-        context_rows=context_rows)
+        correlated_base, [0, 1, 2], np.random.default_rng(9), rho=0.5, context_rows=context_rows
+    )
     dg._apply_invertible_feature_correlation(
-        correlated_shifted, [0, 1, 2], np.random.default_rng(9), rho=0.5,
-        context_rows=context_rows)
+        correlated_shifted, [0, 1, 2], np.random.default_rng(9), rho=0.5, context_rows=context_rows
+    )
     np.testing.assert_array_equal(
         correlated_base[:context_rows],
         correlated_shifted[:context_rows],
     )
 
-    stabilized_base = dg._affine_stabilize_feature_column(
-        base[:, 0], context_rows=context_rows)
-    stabilized_shifted = dg._affine_stabilize_feature_column(
-        shifted[:, 0], context_rows=context_rows)
+    stabilized_base = dg._affine_stabilize_feature_column(base[:, 0], context_rows=context_rows)
+    stabilized_shifted = dg._affine_stabilize_feature_column(shifted[:, 0], context_rows=context_rows)
     np.testing.assert_array_equal(
         stabilized_base[:context_rows],
         stabilized_shifted[:context_rows],
@@ -795,8 +761,7 @@ def test_final_feature_safety_rejects_infinity_but_preserves_nan():
     X = np.zeros((1, 16, 2), dtype=np.float64)
     X[0, 3, 0] = np.nan
     X[0, 4, 1] = np.inf
-    with pytest.raises(
-            dg.SyntheticDataFilterError, match='contains infinity'):
+    with pytest.raises(dg.SyntheticDataFilterError, match="contains infinity"):
         dg._finalize_feature_batch(X)
 
 
@@ -807,10 +772,8 @@ def test_final_feature_safety_does_not_rescale_context_for_query_extremes():
     shifted[:, context_rows:, 0] = 1e12
     shifted[:, context_rows:, 1] = np.inf
 
-    base_out, _, _ = dg._finalize_feature_batch(
-        base, context_rows=context_rows)
-    shifted_out, affine, bounded = dg._finalize_feature_batch(
-        shifted, context_rows=context_rows)
+    base_out, _, _ = dg._finalize_feature_batch(base, context_rows=context_rows)
+    shifted_out, affine, bounded = dg._finalize_feature_batch(shifted, context_rows=context_rows)
 
     np.testing.assert_array_equal(
         base_out[:, :context_rows],
@@ -825,15 +788,15 @@ def test_final_feature_safety_does_not_rescale_context_for_query_extremes():
 def test_query_only_feature_bound_invalidates_oracle(monkeypatch):
     context_rows = 8
 
-    def tree_episode(
-            n_samples, n_features, task_type, n_classes, rng,
-            context_rows=None, **_kwargs):
+    def tree_episode(n_samples, n_features, task_type, n_classes, rng, context_rows=None, **_kwargs):
         del task_type, n_classes, rng
         assert context_rows == 8
-        X = np.column_stack([
-            np.arange(n_samples, dtype=np.float64),
-            np.arange(n_samples, dtype=np.float64) * 2.0,
-        ])
+        X = np.column_stack(
+            [
+                np.arange(n_samples, dtype=np.float64),
+                np.arange(n_samples, dtype=np.float64) * 2.0,
+            ]
+        )
         X[context_rows:, 0] = 1e12
         y = np.arange(n_samples, dtype=np.float32)
         return {
@@ -854,7 +817,7 @@ def test_query_only_feature_bound_invalidates_oracle(monkeypatch):
         1,
         16,
         2,
-        'reg',
+        "reg",
         rng=np.random.default_rng(0),
         tree_prior_prob=1.0,
         context_rows=context_rows,
@@ -869,9 +832,17 @@ def test_query_only_feature_bound_invalidates_oracle(monkeypatch):
 
 def test_realistic_augmentation_cannot_escape_final_feature_contract():
     X, y, _ = dg.generate_batch(
-        24, 256, 32, 'reg', rng=np.random.default_rng(123),
-        augment_v4=True, synth_v5=True, synth_v5_mixture=True,
-        realistic_augmentation_prob=1.0, context_rows=128)
+        24,
+        256,
+        32,
+        "reg",
+        rng=np.random.default_rng(123),
+        augment_v4=True,
+        synth_v5=True,
+        synth_v5_mixture=True,
+        realistic_augmentation_prob=1.0,
+        context_rows=128,
+    )
     assert X.dtype == np.float32
     assert np.nanmax(np.abs(X)) <= 1e4
     assert not np.isinf(X).any()
@@ -879,11 +850,13 @@ def test_realistic_augmentation_cannot_escape_final_feature_contract():
 
 
 def test_health_stats_tolerate_all_nan_columns_with_warnings_as_errors():
-    X = np.array([
-        [np.nan, 0.0],
-        [np.nan, 1.0],
-        [np.nan, 2.0],
-    ])
+    X = np.array(
+        [
+            [np.nan, 0.0],
+            [np.nan, 1.0],
+            [np.nan, 2.0],
+        ]
+    )
     y = np.arange(3, dtype=np.float64)
 
     with warnings.catch_warnings():
@@ -908,14 +881,13 @@ def test_health_stats_tolerate_all_nan_columns_with_warnings_as_errors():
         (512, 32, 64, 4180),
     ],
 )
-def test_context_fitted_target_transform_stays_finite_without_warnings(
-        n_samples, n_features, context_rows, seed):
+def test_context_fitted_target_transform_stays_finite_without_warnings(n_samples, n_features, context_rows, seed):
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)
         data = dg.generate_dataset(
             n_samples,
             n_features,
-            'reg',
+            "reg",
             rng=np.random.default_rng(seed),
             augment_v4=True,
             synth_v5=True,
@@ -934,7 +906,7 @@ def test_missingness_skips_all_nan_context_driver_without_warning():
         data = dg.generate_dataset(
             128,
             16,
-            'reg',
+            "reg",
             rng=np.random.default_rng(14),
             augment_v4=True,
             synth_v5=True,
@@ -948,12 +920,11 @@ def test_missingness_skips_all_nan_context_driver_without_warning():
 
 
 def test_generate_batch_does_not_mutate_warning_filters(monkeypatch):
-    def tree_episode(
-            n_samples, n_features, task_type, n_classes, rng,
-            context_rows=None, **_kwargs):
+    def tree_episode(n_samples, n_features, task_type, n_classes, rng, context_rows=None, **_kwargs):
         del task_type, n_classes, rng, context_rows
         X = np.arange(
-            n_samples * n_features, dtype=np.float32,
+            n_samples * n_features,
+            dtype=np.float32,
         ).reshape(n_samples, n_features)
         y = np.linspace(-1.0, 1.0, n_samples, dtype=np.float32)
         return {"X": X, "y": y, "filtered": False, "meta": {}}
@@ -965,7 +936,7 @@ def test_generate_batch_does_not_mutate_warning_filters(monkeypatch):
             1,
             32,
             4,
-            'reg',
+            "reg",
             rng=np.random.default_rng(0),
             tree_prior_prob=1.0,
             realistic_augmentation_prob=1.0,

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -12,7 +12,7 @@ def test_model_variant_registry_resolution():
     # friendly variant names -> HF repo ids
     assert hf.resolve_model_repo("nori-30m") == "Synthefy/Nori-30M"
     assert hf.resolve_model_repo("nori-100m") == "Synthefy/Nori-100M"
-    assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID    # ~6M base
+    assert hf.resolve_model_repo("nori-6m") == hf.DEFAULT_MODEL_REPO_ID  # ~6M base
     # A size is required -- None and a bare "nori" both raise (there is no default).
     for missing in (None, "nori"):
         with pytest.raises(ValueError, match=r"model is required"):

--- a/tests/test_inference_e2e.py
+++ b/tests/test_inference_e2e.py
@@ -17,6 +17,7 @@ Override the checkpoint location without touching HF by setting
 ``SYNTHEFY_NORI_TEST_CHECKPOINT=/abs/path/to/checkpoint.pt`` in the
 environment.
 """
+
 from __future__ import annotations
 
 import os
@@ -52,9 +53,7 @@ def _linear_signal_data():
     return X_train, y_train, X_test, X_test @ true_w
 
 
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="requires an MPS-capable macOS host"
-)
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS-capable macOS host")
 def test_default_devices_run_nori_and_minilm_on_mps():
     """One smoke covers automatic model and named-text placement end to end."""
     X_train = pd.DataFrame(
@@ -64,13 +63,9 @@ def test_default_devices_run_nori_and_minilm_on_mps():
         }
     )
     y_train = np.linspace(-1.0, 1.0, 8, dtype=np.float32)
-    X_test = pd.DataFrame(
-        {"amount": [2.5, 7.5], "description": ["small order", "large order"]}
-    )
+    X_test = pd.DataFrame({"amount": [2.5, 7.5], "description": ["small order", "large order"]})
 
-    model = NoriRegressor(
-        **_checkpoint_kwargs(), text_columns=["description"], svd_dim=4
-    ).fit(X_train, y_train)
+    model = NoriRegressor(**_checkpoint_kwargs(), text_columns=["description"], svd_dim=4).fit(X_train, y_train)
     predictions = model.predict(X_test)
 
     assert model.device_ == torch.device("mps")
@@ -79,9 +74,7 @@ def test_default_devices_run_nori_and_minilm_on_mps():
     assert model._predictor.mix_precision is False
 
 
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="requires an MPS-capable macOS host"
-)
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires an MPS-capable macOS host")
 def test_mps_regressor_matches_cpu_quality():
     """MPS must preserve CPU task quality, not merely return finite numbers."""
     X_train, y_train, X_test, y_truth = _linear_signal_data()

--- a/tests/test_inference_execution_overrides.py
+++ b/tests/test_inference_execution_overrides.py
@@ -12,6 +12,7 @@ Both are applied per call and undone afterwards: ``NoriPredictor(model=...)``
 may be handed a module the caller also trains with, and a leaked
 ``_skip_feature_decoder`` would silently zero its feature-reconstruction loss.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -22,8 +23,7 @@ from synthefy_nori.inference.predictor import NoriPredictor
 from synthefy_nori.model.layer import RMSNorm
 
 
-def _stub_predictor(model, *, mask_prediction=False,
-                    skip_unused_feature_decoder=True, native_rms_norm=None):
+def _stub_predictor(model, *, mask_prediction=False, skip_unused_feature_decoder=True, native_rms_norm=None):
     """A NoriPredictor with only the attributes _execution_overrides reads.
 
     Bypasses __init__ so the test stays on CPU and off the config/pipeline
@@ -159,18 +159,18 @@ def test_forward_parity_reg_output_is_bit_identical():
     from synthefy_nori.utils.loading import build_model
 
     mc = load_model_config(None)
-    mc['mask_prediction'] = True
-    mc['embed_dim'] = 32
-    mc['hid_dim'] = 64
-    mc['nlayers'] = 2
-    mc['nhead'] = 2
-    for sub_key in ('encoder_config_x', 'encoder_config_y'):
+    mc["mask_prediction"] = True
+    mc["embed_dim"] = 32
+    mc["hid_dim"] = 64
+    mc["nlayers"] = 2
+    mc["nhead"] = 2
+    for sub_key in ("encoder_config_x", "encoder_config_y"):
         sub = mc.get(sub_key, {})
-        for field in ('embedding_size', 'mask_embedding_size'):
+        for field in ("embedding_size", "mask_embedding_size"):
             if field in sub:
                 sub[field] = 32
 
-    model = build_model(mc).to('cpu').eval()
+    model = build_model(mc).to("cpu").eval()
 
     torch.manual_seed(0)
     x = torch.randn(1, 16, 4)
@@ -180,15 +180,15 @@ def test_forward_parity_reg_output_is_bit_identical():
     def run():
         torch.manual_seed(1234)  # feature positional embeddings are re-drawn
         with torch.inference_mode():
-            return model(x=x, y=y, eval_pos=eval_pos, task_type='reg')
+            return model(x=x, y=y, eval_pos=eval_pos, task_type="reg")
 
     baseline = run()
-    assert baseline['feature_pred'] is not None
+    assert baseline["feature_pred"] is not None
 
     predictor = _stub_predictor(model)
     with predictor._execution_overrides():
         skipped = run()
 
-    assert skipped['feature_pred'] is None
-    assert torch.equal(baseline['reg_output'], skipped['reg_output'])
-    assert torch.equal(baseline['cls_output'], skipped['cls_output'])
+    assert skipped["feature_pred"] is None
+    assert torch.equal(baseline["reg_output"], skipped["reg_output"])
+    assert torch.equal(baseline["cls_output"], skipped["cls_output"])

--- a/tests/test_inference_output_fixes.py
+++ b/tests/test_inference_output_fixes.py
@@ -35,9 +35,7 @@ def test_quantile_collapse_uses_an_mps_supported_tau_dtype(
 
     class FakeQuantiles:
         def __init__(self):
-            self.values = torch.tensor(
-                [[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]
-            )
+            self.values = torch.tensor([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]])
             self.shape = self.values.shape
             self.device = torch.device(device_type)
 

--- a/tests/test_interpretability.py
+++ b/tests/test_interpretability.py
@@ -11,10 +11,10 @@ def test_regressor_is_sklearn_estimator_and_clones():
     from sklearn.base import clone, is_regressor
 
     m = NoriRegressor(model_path="local.pt", augmentations=("yj",))
-    assert is_regressor(m)                       # RegressorMixin -> PDP/SFS treat it as regressor
+    assert is_regressor(m)  # RegressorMixin -> PDP/SFS treat it as regressor
     params = m.get_params()
     assert params["model_path"] == "local.pt"
-    c = clone(m)                                 # required by SequentialFeatureSelector/cross_val
+    c = clone(m)  # required by SequentialFeatureSelector/cross_val
     assert c.get_params()["model_path"] == "local.pt"
     assert c.inference_config.endswith("default_inference.json")
 
@@ -28,7 +28,7 @@ def test_imputation_explainer_requires_shapiq_or_runs():
     X = rng.normal(size=(40, 4))
     w = np.array([2.0, -1.0, 0.5, 0.0])
 
-    class _StubRegressor:                        # behaves like a fitted regressor
+    class _StubRegressor:  # behaves like a fitted regressor
         def predict(self, x):
             return np.asarray(x) @ w
 
@@ -59,7 +59,8 @@ def test_pdp_and_feature_selection_wrappers_plumbing():
     from synthefy_nori.interpretability.pdp import partial_dependence_plots
 
     rng = np.random.default_rng(1)
-    X = rng.normal(size=(60, 4)); y = X @ np.array([3.0, 0.0, -2.0, 0.0]) + rng.normal(scale=0.1, size=60)
+    X = rng.normal(size=(60, 4))
+    y = X @ np.array([3.0, 0.0, -2.0, 0.0]) + rng.normal(scale=0.1, size=60)
     est = LinearRegression().fit(X, y)
 
     disp = partial_dependence_plots(est, X, features=[0, 2], kind="average")
@@ -67,6 +68,6 @@ def test_pdp_and_feature_selection_wrappers_plumbing():
 
     res = feature_selection(est, X, y, n_features_to_select=2, cv=3, feature_names=list("abcd"))
     assert len(res.selected_indices) == 2
-    assert set(res.selected_indices) == {0, 2}            # the two signal features
+    assert set(res.selected_indices) == {0, 2}  # the two signal features
     assert res.selected_names == ["a", "c"]
     assert res.selected_score_mean >= res.baseline_score_mean - 0.05

--- a/tests/test_kv_cache_scaling.py
+++ b/tests/test_kv_cache_scaling.py
@@ -1,4 +1,5 @@
 """Standalone tests for WS1 KV-cache scaling (torch-only, CPU-runnable)."""
+
 import torch
 
 # A normal package import. The internal tier co-locates this file next to the module and
@@ -12,6 +13,7 @@ from synthefy_nori.model.kv_cache_scaling import (
     scale_caches,
 )
 
+
 def test_quant_roundtrip():
     t = torch.randn(4, 100, 2, 3, 16)
     q, s = quantize_int8(t)
@@ -19,11 +21,13 @@ def test_quant_roundtrip():
     rel = (dequantize_int8(q, s, t.dtype) - t).abs().max() / t.abs().max()
     assert rel < 0.02, f"int8 rel err too high: {rel}"
 
+
 def test_identity_when_off():
     kv = torch.randn(2, 50, 2, 4, 8)
     c = ScalableSeqKV(kv, 2, 5, quantize=False, offload=False, device=torch.device("cpu"))
     assert c["batch"] == 2 and c["groups"] == 5
     assert torch.equal(c["kv"], kv)
+
 
 def test_quantized_close():
     kv = torch.randn(2, 50, 2, 4, 8)
@@ -31,21 +35,27 @@ def test_quantized_close():
     rel = (c["kv"] - kv).abs().max() / kv.abs().max()
     assert rel < 0.02, rel
 
+
 def test_offload_transparent():
     kv = torch.randn(2, 50, 2, 4, 8)
     c = ScalableSeqKV(kv, 2, 5, quantize=False, offload=True, device=torch.device("cpu"))
     assert torch.equal(c["kv"], kv) and c.resident_gpu_bytes() == 0
 
+
 def test_scale_caches_inplace_and_noop():
     mk = lambda: [{"seq_kv": {"kv": torch.randn(1, 10, 2, 2, 4), "batch": 1, "groups": 1}}]
-    c0 = mk(); assert scale_caches(c0, quantize=False, offload=False) is c0
+    c0 = mk()
+    assert scale_caches(c0, quantize=False, offload=False) is c0
     assert isinstance(c0[0]["seq_kv"], dict)  # untouched
-    c1 = mk(); scale_caches(c1, quantize=True, offload=True, device=torch.device("cpu"))
-    assert isinstance(c1[0]["seq_kv"], ScalableSeqKV) and c1[0]["seq_kv"]["kv"].shape == (1,10,2,2,4)
+    c1 = mk()
+    scale_caches(c1, quantize=True, offload=True, device=torch.device("cpu"))
+    assert isinstance(c1[0]["seq_kv"], ScalableSeqKV) and c1[0]["seq_kv"]["kv"].shape == (1, 10, 2, 2, 4)
+
 
 def _chunks(kv, size):
     """Split kv along the row axis (dim 1) the way the fit-time build does."""
-    return [kv[:, i:i + size] for i in range(0, kv.shape[1], size)]
+    return [kv[:, i : i + size] for i in range(0, kv.shape[1], size)]
+
 
 def test_rowchunked_int8_is_bit_identical_to_quantizing_the_whole_tensor():
     """Quantizing per row-slice must equal quantizing after the concat.
@@ -57,52 +67,56 @@ def test_rowchunked_int8_is_bit_identical_to_quantizing_the_whole_tensor():
     per-tensor, as TabPFN-3 does it -- this test fails and the row-chunked build
     would have to change with it.
     """
-    kv = torch.randn(3, 257, 2, 4, 16)      # 257 rows: deliberately not a multiple
+    kv = torch.randn(3, 257, 2, 4, 16)  # 257 rows: deliberately not a multiple
     whole_q, whole_scale = quantize_int8(kv)
     built = ScalableSeqKV.from_row_slices(
-        iter(_chunks(kv, 64)), 3, 4, quantize=True, offload=False,
-        device=torch.device("cpu"), dtype=kv.dtype)
+        iter(_chunks(kv, 64)), 3, 4, quantize=True, offload=False, device=torch.device("cpu"), dtype=kv.dtype
+    )
     assert torch.equal(built._q, whole_q), "int8 payload differs from whole-tensor quant"
     assert torch.equal(built._scale, whole_scale), "scales differ from whole-tensor quant"
     # ...and therefore the dequantized read is identical too.
     assert torch.equal(built["kv"], dequantize_int8(whole_q, whole_scale, kv.dtype))
 
+
 def test_rowchunked_bf16_reassembles_exactly():
     kv = torch.randn(2, 100, 2, 3, 8)
     out = ScalableSeqKV.from_row_slices(
-        iter(_chunks(kv, 32)), 2, 3, quantize=False, offload=False,
-        device=torch.device("cpu"), dtype=kv.dtype)
+        iter(_chunks(kv, 32)), 2, 3, quantize=False, offload=False, device=torch.device("cpu"), dtype=kv.dtype
+    )
     assert torch.equal(out["kv"], kv)
+
 
 def test_rowchunked_offload_keeps_nothing_resident():
     kv = torch.randn(2, 100, 2, 3, 8)
     out = ScalableSeqKV.from_row_slices(
-        iter(_chunks(kv, 32)), 2, 3, quantize=True, offload=True,
-        device=torch.device("cpu"), dtype=kv.dtype)
+        iter(_chunks(kv, 32)), 2, 3, quantize=True, offload=True, device=torch.device("cpu"), dtype=kv.dtype
+    )
     assert out.resident_gpu_bytes() == 0
     assert out["kv"].shape == kv.shape
+
 
 def test_rowchunked_matches_the_unchunked_scalable_cache():
     """One slice == no chunking: the builder and ScalableSeqKV must agree."""
     kv = torch.randn(2, 64, 2, 3, 8)
-    direct = ScalableSeqKV(kv, 2, 3, quantize=True, offload=False,
-                           device=torch.device("cpu"))
+    direct = ScalableSeqKV(kv, 2, 3, quantize=True, offload=False, device=torch.device("cpu"))
     built = ScalableSeqKV.from_row_slices(
-        iter([kv]), 2, 3, quantize=True, offload=False,
-        device=torch.device("cpu"), dtype=kv.dtype)
+        iter([kv]), 2, 3, quantize=True, offload=False, device=torch.device("cpu"), dtype=kv.dtype
+    )
     assert torch.equal(built["kv"], direct["kv"])
+
 
 if __name__ == "__main__":
     for n, f in sorted(globals().items()):
         if n.startswith("test_") and callable(f):
-            f(); print("PASS", n)
+            f()
+            print("PASS", n)
     print("all kv-cache-scaling tests passed")
+
 
 def test_from_row_slices_rejects_an_empty_iterator():
     # A cache with no rows is an upstream bug, not a state worth representing.
     try:
-        ScalableSeqKV.from_row_slices(iter([]), 1, 1, quantize=True,
-                                      device=torch.device("cpu"), dtype=torch.float32)
+        ScalableSeqKV.from_row_slices(iter([]), 1, 1, quantize=True, device=torch.device("cpu"), dtype=torch.float32)
     except ValueError:
         return
     raise AssertionError("expected ValueError on an empty slice iterator")

--- a/tests/test_large_context_policy.py
+++ b/tests/test_large_context_policy.py
@@ -13,6 +13,7 @@ on:
 The API-level tests monkeypatch the predictor rather than load weights, so they check
 the wiring (threshold, dispatch, report, fit invalidation) and not the model.
 """
+
 from __future__ import annotations
 
 import ast
@@ -56,19 +57,20 @@ def make_table(n_train=600, n_test=80, n_features=4, seed=0):
 
 def make_base(window=50, seed=0, **kwargs):
     X_train, y_train, _ = make_table(seed=seed, **kwargs)
-    return large_context.build_problem(
-        ridge_predict, X_train, y_train, window=window, seed=seed)
+    return large_context.build_problem(ridge_predict, X_train, y_train, window=window, seed=seed)
 
 
 # ------------------------------------------------------------------ the threshold
-@pytest.mark.parametrize("n_train,policy,threshold,expected", [
-    (60_000, "cluster_route", 50_000, True),
-    (50_000, "cluster_route", 50_000, False),   # strictly greater, not >=
-    (60_000, None, 50_000, False),              # opt-in: no policy, no dispatch
-    (10, "cluster_route", 5, True),
-])
-def test_large_context_applies_is_strictly_above_the_threshold(n_train, policy, threshold,
-                                                         expected):
+@pytest.mark.parametrize(
+    "n_train,policy,threshold,expected",
+    [
+        (60_000, "cluster_route", 50_000, True),
+        (50_000, "cluster_route", 50_000, False),  # strictly greater, not >=
+        (60_000, None, 50_000, False),  # opt-in: no policy, no dispatch
+        (10, "cluster_route", 5, True),
+    ],
+)
+def test_large_context_applies_is_strictly_above_the_threshold(n_train, policy, threshold, expected):
     assert large_context.large_context_applies(n_train, policy, threshold) is expected
 
 
@@ -109,8 +111,7 @@ def test_parameters_bind_through_the_spec():
     name, fn = large_context.resolve_large_context_policy("cluster_route[groups=3]")
     assert name == "cluster_route[groups=3]"
     base = make_base(window=40, n_train=400)
-    preds, report = large_context.run_policy(base, make_table(n_test=60)[2],
-                                       policy_spec="cluster_route[groups=3]")
+    preds, report = large_context.run_policy(base, make_table(n_test=60)[2], policy_spec="cluster_route[groups=3]")
     assert report["nori_calls"] == 3
 
 
@@ -148,8 +149,7 @@ def test_a_table_inside_the_window_predicts_from_full_context_and_says_so():
 def test_the_gate_records_which_candidate_it_deployed():
     base = make_base(window=40, n_train=400)
     _, _, X_test = make_table(n_test=60)
-    _, report = large_context.run_policy(base, X_test,
-                                   policy_spec=["random", "cluster_route"])
+    _, report = large_context.run_policy(base, X_test, policy_spec=["random", "cluster_route"])
     assert report["gate_winner"] in ("random", "cluster_route")
     # The gate pays for its whole holdout sweep plus the winner's real run.
     assert report["nori_calls"] > 1
@@ -172,8 +172,7 @@ def test_a_different_candidate_list_is_gated_separately():
     base = make_base(window=40, n_train=400)
     _, _, X_test = make_table(n_test=60)
     large_context.run_policy(base, X_test, policy_spec=["random"])
-    _, report = large_context.run_policy(base, X_test,
-                                   policy_spec=["random", "cluster_route"])
+    _, report = large_context.run_policy(base, X_test, policy_spec=["random", "cluster_route"])
     # A two-arm menu must run its own sweep, not inherit the one-arm menu's winner.
     assert report["nori_calls"] > 2
 
@@ -199,11 +198,11 @@ def test_the_shipped_policies_never_read_y_test():
 
 # ------------------------------------------------------------------ shard guards
 def test_boosting_falls_back_to_random_when_the_table_affords_one_shard():
-    base = make_base(window=400, n_train=600)   # 1 shard
+    base = make_base(window=400, n_train=600)  # 1 shard
     _, _, X_test = make_table()
     with pytest.warns(pol.LargeContextPolicyFallbackWarning, match="falling back to `random`"):
         preds, report = large_context.run_policy(base, X_test, policy_spec="safeboost")
-    assert report["nori_calls"] == 1                        # one random window
+    assert report["nori_calls"] == 1  # one random window
     assert preds.shape == (80,)
 
 
@@ -220,7 +219,7 @@ def test_the_fallback_is_a_degradation_so_strict_pipeline_makes_it_fatal():
 
 
 def test_boosting_below_the_shard_floor_warns_but_still_runs():
-    base = make_base(window=150, n_train=600)    # 4 shards, floor is 8
+    base = make_base(window=150, n_train=600)  # 4 shards, floor is 8
     _, _, X_test = make_table()
     with pytest.warns(pol.LargeContextPolicyWarning, match="below the 8"):
         preds, _ = large_context.run_policy(base, X_test, policy_spec="safeboost")
@@ -231,7 +230,7 @@ def test_a_routing_policy_has_no_shard_floor():
     base = make_base(window=150, n_train=600)
     _, _, X_test = make_table()
     with warnings.catch_warnings():
-        warnings.simplefilter("error")                       # any warning fails this
+        warnings.simplefilter("error")  # any warning fails this
         large_context.run_policy(base, X_test, policy_spec="cluster_route[groups=2]")
 
 
@@ -334,7 +333,7 @@ def test_a_view_populating_train_state_lazily_reaches_the_fitted_problem():
     assert "select_view" not in base.train_state
 
     view = base.with_queries(make_table(n_test=25)[2])
-    computed = view.select_view                       # lazily, on the throwaway view
+    computed = view.select_view  # lazily, on the throwaway view
 
     assert base.train_state["select_view"] is computed, "the work died with the view"
     later = base.with_queries(make_table(n_test=30)[2])
@@ -375,7 +374,7 @@ def test_a_subproblem_does_not_inherit_the_train_cache():
     would be wrong for it. This is what keeps the gate honest."""
     base = make_base(window=40, n_train=400)
     base.train_cache[("safeboost", 0.5, None)] = ["sentinel"]
-    base.select_view                                  # populate train_state too
+    base.select_view  # populate train_state too
     sub = base.subproblem(np.arange(200), np.arange(200, 260))
     assert sub.train_cache == {}
     assert sub.train_state == {}, "a subproblem has different train rows"
@@ -403,8 +402,7 @@ def _one_column_problem(impute: bool) -> pol.Problem:
 def test_the_inference_path_hands_missing_values_through_untouched():
     """NoriPredictor owns missing-value handling. Imputing in the policy first would
     change what the model sees relative to an ordinary predict() on the same rows."""
-    ctx, = _one_column_problem(impute=False).impute_from_context(
-        np.array([[np.nan], [1.0]], dtype=np.float32))
+    (ctx,) = _one_column_problem(impute=False).impute_from_context(np.array([[np.nan], [1.0]], dtype=np.float32))
     assert np.isnan(ctx[0, 0]), "the NaN was filled before the predictor saw it"
 
 
@@ -413,15 +411,13 @@ def test_the_benchmark_path_still_imputes():
     production path opts out. The default is the harness's, so a benchmark that does
     not mention imputation keeps the behavior its numbers were measured under."""
     problem = _one_column_problem(impute=True)
-    assert pol.Problem(ridge_predict, np.zeros((2, 1)), np.zeros(2),
-                       np.zeros((1, 1)), None, window=2).impute is True
-    ctx, = problem.impute_from_context(problem.X_train)
+    assert pol.Problem(ridge_predict, np.zeros((2, 1)), np.zeros(2), np.zeros((1, 1)), None, window=2).impute is True
+    (ctx,) = problem.impute_from_context(problem.X_train)
     assert np.isfinite(ctx).all()
 
 
 def test_build_problem_opts_out_of_imputation():
-    assert large_context.build_problem(
-        ridge_predict, np.zeros((10, 2)), np.zeros(10), window=5).impute is False
+    assert large_context.build_problem(ridge_predict, np.zeros((10, 2)), np.zeros(10), window=5).impute is False
 
 
 def test_call_limit_stops_a_gate_before_the_next_predictor_call():
@@ -474,9 +470,11 @@ def test_the_estimator_pushes_its_cache_capacity_onto_the_predictor(monkeypatch)
 
     est = NoriRegressor(model_path="unused", large_context_cache_entries=6)
     stub = StubPredictor()
-    monkeypatch.setattr(NoriRegressor, "_get_predictor",
-                        lambda self: (setattr(stub, "context_cache_entries",
-                                              self.large_context_cache_entries) or stub))
+    monkeypatch.setattr(
+        NoriRegressor,
+        "_get_predictor",
+        lambda self: setattr(stub, "context_cache_entries", self.large_context_cache_entries) or stub,
+    )
     est.fit(*make_table(n_train=400)[:2])
     est.predict(make_table(n_test=40)[2])
     assert stub.context_cache_entries == 6
@@ -485,12 +483,12 @@ def test_the_estimator_pushes_its_cache_capacity_onto_the_predictor(monkeypatch)
 def test_the_kv_cache_retains_every_pool_of_a_rotation_at_capacity():
     """Tier 1. At capacity 1 a policy that rotates between pools evicts on every call
     and never hits; the point of the multi-entry cache is that the rotation survives."""
+
     class FakeBare:
         def __init__(self):
             self.builds = 0
 
-        def build_context_cache(self, x_train, y_train, *, cache_dtype,
-                                offload_kv_cache, fit_row_chunk):
+        def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
             self.builds += 1
             return ("bundle", self.builds)
 
@@ -499,17 +497,24 @@ def test_the_kv_cache_retains_every_pool_of_a_rotation_at_capacity():
     holder = NoriPredictor.__new__(NoriPredictor)
     holder.seed = 0
     bare = FakeBare()
-    pools = [torch.arange(6, dtype=torch.float32).reshape(1, 3, 2) + offset
-             for offset in (0.0, 10.0, 20.0)]
+    pools = [torch.arange(6, dtype=torch.float32).reshape(1, 3, 2) + offset for offset in (0.0, 10.0, 20.0)]
     y = torch.zeros(1, 3)
 
     def call(x, entries):
         return NoriPredictor._get_or_build_context(
-            holder, bare, 0, x_train_t=x, y_train_t=y, cache_dtype="bf16",
-            offload_kv_cache=False, fit_row_chunk=None, reuse_context_cache=True,
-            cache_entries=entries)
+            holder,
+            bare,
+            0,
+            x_train_t=x,
+            y_train_t=y,
+            cache_dtype="bf16",
+            offload_kv_cache=False,
+            fit_row_chunk=None,
+            reuse_context_cache=True,
+            cache_entries=entries,
+        )
 
-    for pool in pools:                        # capacity 1: three builds, no reuse
+    for pool in pools:  # capacity 1: three builds, no reuse
         call(pool, 1)
     for pool in pools:
         call(pool, 1)
@@ -517,10 +522,10 @@ def test_the_kv_cache_retains_every_pool_of_a_rotation_at_capacity():
 
     bare.builds = 0
     holder._context_cache = {}
-    for pool in pools:                        # capacity 3: warm once...
+    for pool in pools:  # capacity 3: warm once...
         call(pool, 3)
     assert bare.builds == 3
-    for pool in pools:                        # ...then every pool is a hit
+    for pool in pools:  # ...then every pool is a hit
         call(pool, 3)
     assert bare.builds == 3, "the rotation was not retained at capacity"
 
@@ -528,6 +533,7 @@ def test_the_kv_cache_retains_every_pool_of_a_rotation_at_capacity():
 def test_shrinking_capacity_between_calls_trims_the_cache():
     """A shared engine re-declares its policy per request, so the CURRENT call's
     capacity has to be what is honoured -- otherwise a bundle outlives its budget."""
+
     class FakeBare:
         def build_context_cache(self, x_train, y_train, **kwargs):
             return "bundle"
@@ -540,16 +546,30 @@ def test_shrinking_capacity_between_calls_trims_the_cache():
     y = torch.zeros(1, 2)
     for offset in (0.0, 10.0, 20.0):
         NoriPredictor._get_or_build_context(
-            holder, bare, 0,
+            holder,
+            bare,
+            0,
             x_train_t=torch.arange(4, dtype=torch.float32).reshape(1, 2, 2) + offset,
-            y_train_t=y, cache_dtype="bf16", offload_kv_cache=False,
-            fit_row_chunk=None, reuse_context_cache=True, cache_entries=3)
+            y_train_t=y,
+            cache_dtype="bf16",
+            offload_kv_cache=False,
+            fit_row_chunk=None,
+            reuse_context_cache=True,
+            cache_entries=3,
+        )
     assert len(holder._context_cache[0]) == 3
     NoriPredictor._get_or_build_context(
-        holder, bare, 0,
-        x_train_t=torch.full((1, 2, 2), 99.0), y_train_t=y, cache_dtype="bf16",
-        offload_kv_cache=False, fit_row_chunk=None, reuse_context_cache=True,
-        cache_entries=1)
+        holder,
+        bare,
+        0,
+        x_train_t=torch.full((1, 2, 2), 99.0),
+        y_train_t=y,
+        cache_dtype="bf16",
+        offload_kv_cache=False,
+        fit_row_chunk=None,
+        reuse_context_cache=True,
+        cache_entries=1,
+    )
     assert len(holder._context_cache[0]) == 1
 
 
@@ -559,6 +579,7 @@ def test_shrinking_capacity_trims_on_a_cache_HIT_too():
     as it kept asking for a context already in the list -- precisely when it is trying
     to release VRAM. Each entry is a full K/V cache, so that is the OOM this knob exists
     to prevent."""
+
     class FakeBare:
         def build_context_cache(self, x_train, y_train, **kwargs):
             return "bundle"
@@ -569,14 +590,21 @@ def test_shrinking_capacity_trims_on_a_cache_HIT_too():
     holder.seed = 0
     bare = FakeBare()
     y = torch.zeros(1, 2)
-    pools = [torch.arange(4, dtype=torch.float32).reshape(1, 2, 2) + offset
-             for offset in (0.0, 10.0, 20.0)]
+    pools = [torch.arange(4, dtype=torch.float32).reshape(1, 2, 2) + offset for offset in (0.0, 10.0, 20.0)]
 
     def call(x, entries):
         return NoriPredictor._get_or_build_context(
-            holder, bare, 0, x_train_t=x, y_train_t=y, cache_dtype="bf16",
-            offload_kv_cache=False, fit_row_chunk=None, reuse_context_cache=True,
-            cache_entries=entries)
+            holder,
+            bare,
+            0,
+            x_train_t=x,
+            y_train_t=y,
+            cache_dtype="bf16",
+            offload_kv_cache=False,
+            fit_row_chunk=None,
+            reuse_context_cache=True,
+            cache_entries=entries,
+        )
 
     for pool in pools:
         call(pool, 3)
@@ -638,16 +666,14 @@ def test_no_policy_means_one_full_context_call(monkeypatch):
 
 
 def test_below_the_threshold_the_policy_does_not_engage(monkeypatch):
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="cluster_route", large_context_threshold=1000)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="cluster_route", large_context_threshold=1000)
     est.predict(X_test)
     assert stub.contexts == [400]
     assert est.large_context_report_ is None
 
 
 def test_a_direct_predict_clears_the_previous_large_context_report(monkeypatch):
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="random", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="random", large_context_threshold=100)
     est.predict(X_test)
     assert est.large_context_report_["policy"] == "random"
 
@@ -658,8 +684,7 @@ def test_a_direct_predict_clears_the_previous_large_context_report(monkeypatch):
 
 
 def test_above_the_threshold_the_policy_runs_and_reports(monkeypatch):
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="cluster_route[groups=4]", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="cluster_route[groups=4]", large_context_threshold=100)
     preds = est.predict(X_test)
     assert preds.shape == (40,)
     assert stub.contexts == [50] * 4, "every context must be within the window"
@@ -680,8 +705,7 @@ def test_an_unknown_policy_fails_at_fit_not_deep_into_predict(monkeypatch):
 def test_refitting_invalidates_the_chain_so_it_cannot_serve_new_rows(monkeypatch):
     """The cache is keyed to the table. A chain built on the previous fit's rows
     serving this one would be a wrong answer, not a slow one."""
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="safeboost", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="safeboost", large_context_threshold=100)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
         est.predict(X_test)
@@ -698,8 +722,7 @@ def test_refitting_invalidates_the_chain_so_it_cannot_serve_new_rows(monkeypatch
 
 
 def test_a_second_predict_reuses_the_fitted_problem(monkeypatch):
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="random", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="random", large_context_threshold=100)
     est.predict(X_test)
     first = est._large_context_problem
     est.predict(X_test[:10])
@@ -714,8 +737,7 @@ def test_predictions_are_denormalized_back_to_original_units(monkeypatch):
 
     X_train, y_train, X_test = make_table(n_train=400, n_test=40)
     y_shifted = y_train * 100.0 + 5000.0
-    est = NoriRegressor(model_path="unused", large_context_policy="random",
-                        large_context_threshold=100)
+    est = NoriRegressor(model_path="unused", large_context_policy="random", large_context_threshold=100)
     monkeypatch.setattr(est, "_get_predictor", lambda: StubPredictor())
     est.fit(X_train, y_shifted)
     preds = est.predict(X_test)
@@ -742,13 +764,15 @@ def test_a_chain_built_under_one_decoder_is_not_replayed_under_another(monkeypat
     residual labels and return numbers no cold median run would produce."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
-        est, _, X_test = fitted(monkeypatch, stub=DecoderStub(),
-                                large_context_policy="safeboost", large_context_threshold=100)
-        mean_preds = est.predict(X_test)                      # builds the mean chain
+        est, _, X_test = fitted(
+            monkeypatch, stub=DecoderStub(), large_context_policy="safeboost", large_context_threshold=100
+        )
+        mean_preds = est.predict(X_test)  # builds the mean chain
         median_preds = est.predict(X_test, output_type="median")
 
-        cold, _, _ = fitted(monkeypatch, stub=DecoderStub(),
-                            large_context_policy="safeboost", large_context_threshold=100)
+        cold, _, _ = fitted(
+            monkeypatch, stub=DecoderStub(), large_context_policy="safeboost", large_context_threshold=100
+        )
         cold_median = cold.predict(X_test, output_type="median")
 
     assert not np.allclose(mean_preds, median_preds), "the stub decoder does nothing"
@@ -760,8 +784,9 @@ def test_each_decoder_derives_its_own_chain_once(monkeypatch):
     already has a chain must replay it rather than pay for it twice."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
-        est, _, X_test = fitted(monkeypatch, stub=DecoderStub(),
-                                large_context_policy="safeboost", large_context_threshold=100)
+        est, _, X_test = fitted(
+            monkeypatch, stub=DecoderStub(), large_context_policy="safeboost", large_context_threshold=100
+        )
         est.predict(X_test)
         assert est.large_context_report_["reused_train_state"] is False
 
@@ -770,7 +795,7 @@ def test_each_decoder_derives_its_own_chain_once(monkeypatch):
         est.predict(X_test, output_type="median")
         assert est.large_context_report_["reused_train_state"] is True
 
-        est.predict(X_test)             # back to mean: its chain is still there
+        est.predict(X_test)  # back to mean: its chain is still there
         assert est.large_context_report_["reused_train_state"] is True
 
 
@@ -791,17 +816,25 @@ def test_a_chain_is_not_replayed_across_memory_precision(monkeypatch):
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
-        est, _, X_test = fitted(monkeypatch, stub=PrecisionStub(),
-                                memory_policy={"cache_dtype": "bf16"},
-                                large_context_policy="safeboost", large_context_threshold=100)
+        est, _, X_test = fitted(
+            monkeypatch,
+            stub=PrecisionStub(),
+            memory_policy={"cache_dtype": "bf16"},
+            large_context_policy="safeboost",
+            large_context_threshold=100,
+        )
         bf16_preds = est.predict(X_test)
         est.memory_policy = {"cache_dtype": "int8"}
         warm_int8 = est.predict(X_test)
         assert est.large_context_report_["reused_train_state"] is False
 
-        cold, _, _ = fitted(monkeypatch, stub=PrecisionStub(),
-                            memory_policy={"cache_dtype": "int8"},
-                            large_context_policy="safeboost", large_context_threshold=100)
+        cold, _, _ = fitted(
+            monkeypatch,
+            stub=PrecisionStub(),
+            memory_policy={"cache_dtype": "int8"},
+            large_context_policy="safeboost",
+            large_context_threshold=100,
+        )
         cold_int8 = cold.predict(X_test)
 
     assert not np.allclose(bf16_preds, warm_int8), "the precision stub does nothing"
@@ -818,8 +851,7 @@ def test_the_train_cache_is_partitioned_by_scope_and_the_arrays_are_not():
 
     mean_view.train_cache["chain"] = "mean-chain"
     assert "chain" not in median_view.train_cache
-    assert base.with_queries(X_test, cache_scope=("mean", "mean")).train_cache[
-        "chain"] == "mean-chain"
+    assert base.with_queries(X_test, cache_scope=("mean", "mean")).train_cache["chain"] == "mean-chain"
     assert mean_view.train_state is median_view.train_state
 
 
@@ -829,14 +861,13 @@ def test_the_window_is_recomputed_per_call_not_frozen_at_the_first_predict(monke
     later, smaller elements_budget must shrink the context the policy emits. Frozen, the
     policy kept emitting the old size -- to be randomly subsampled underneath or to
     raise ContextTooLargeError -- while the report still advertised the old window."""
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="random", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="random", large_context_threshold=100)
     est.predict(X_test)
     assert est.large_context_report_["window"] == 50
     assert stub.contexts == [50]
     first = est._large_context_problem
 
-    stub.window = 25                        # a smaller budget on the next call
+    stub.window = 25  # a smaller budget on the next call
     est.predict(X_test)
     assert est.large_context_report_["window"] == 25
     assert stub.contexts[-1] == 25, "the policy emitted the stale window"
@@ -848,8 +879,7 @@ def test_a_changed_window_invalidates_the_chain(monkeypatch):
     chain -- replaying the old one would be a wrong answer, not a stale cost."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
-        est, stub, X_test = fitted(
-            monkeypatch, large_context_policy="safeboost", large_context_threshold=100)
+        est, stub, X_test = fitted(monkeypatch, large_context_policy="safeboost", large_context_threshold=100)
         est.predict(X_test)
         est.predict(X_test)
         assert est.large_context_report_["reused_train_state"] is True
@@ -862,8 +892,7 @@ def test_a_changed_window_invalidates_the_chain(monkeypatch):
 
 def test_an_unchanged_window_still_reuses_the_fitted_problem(monkeypatch):
     """The recompute must not become a rebuild-every-call: same budget, same Problem."""
-    est, _, X_test = fitted(
-        monkeypatch, large_context_policy="cluster_route[groups=2]", large_context_threshold=100)
+    est, _, X_test = fitted(monkeypatch, large_context_policy="cluster_route[groups=2]", large_context_threshold=100)
     est.predict(X_test)
     first = est._large_context_problem
     est.predict(X_test)
@@ -879,7 +908,7 @@ def test_the_gate_leaves_the_candidates_a_full_window_of_context():
 
     def strict_predict(X_ctx, y_ctx, X_query):
         seen.append(len(X_ctx))
-        if len(X_ctx) == 0:                 # what a real predictor does
+        if len(X_ctx) == 0:  # what a real predictor does
             raise ValueError("empty context")
         return ridge_predict(X_ctx, y_ctx, X_query)
 
@@ -887,8 +916,7 @@ def test_the_gate_leaves_the_candidates_a_full_window_of_context():
     base = large_context.build_problem(strict_predict, X_train, y_train, window=50, seed=1)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
-        preds, report = large_context.run_policy(
-            base, X_test, policy_spec=["random", "cluster_route"])
+        preds, report = large_context.run_policy(base, X_test, policy_spec=["random", "cluster_route"])
     assert preds.shape == (60,)
     assert report["gate_winner"] in ("random", "cluster_route")
     assert min(seen) == 50, "the holdout ate into the candidates' window"
@@ -922,15 +950,15 @@ def test_reuse_is_reported_from_reads_that_hit_not_from_a_non_empty_cache():
     X_train, y_train, X_test = make_table(n_train=800, n_test=60)
     base = large_context.build_problem(ridge_predict, X_train, y_train, window=50, seed=1)
 
-    assert large_context.run_policy(base, X_test, policy_spec="random")[1][
-        "reused_train_state"] is False
-    assert large_context.run_policy(base, X_test, policy_spec="cluster_route")[1][
-        "reused_train_state"] is False, "nothing was on hand to reuse yet"
-    assert large_context.run_policy(base, X_test, policy_spec="cluster_route")[1][
-        "reused_train_state"] is True, "the train routing space"
+    assert large_context.run_policy(base, X_test, policy_spec="random")[1]["reused_train_state"] is False
+    assert large_context.run_policy(base, X_test, policy_spec="cluster_route")[1]["reused_train_state"] is False, (
+        "nothing was on hand to reuse yet"
+    )
+    assert large_context.run_policy(base, X_test, policy_spec="cluster_route")[1]["reused_train_state"] is True, (
+        "the train routing space"
+    )
     # Warm Problem, but `random` still reads none of it.
-    assert large_context.run_policy(base, X_test, policy_spec="random")[1][
-        "reused_train_state"] is False
+    assert large_context.run_policy(base, X_test, policy_spec="random")[1]["reused_train_state"] is False
 
 
 def test_the_shared_state_counts_only_hits_on_earlier_calls_work():
@@ -967,17 +995,25 @@ def test_policies_does_not_depend_on_the_evaluation_package():
     # Also enforce the repository's top-level import convention. A deferred dependency
     # can otherwise remain invisible until the affected policy runs, potentially
     # minutes into a prediction on a large table.
-    nested = [n for body in tree.body if isinstance(body, ast.FunctionDef)
-              for n in ast.walk(body) if isinstance(n, (ast.Import, ast.ImportFrom))]
+    nested = [
+        n
+        for body in tree.body
+        if isinstance(body, ast.FunctionDef)
+        for n in ast.walk(body)
+        if isinstance(n, (ast.Import, ast.ImportFrom))
+    ]
     assert not nested, [ast.unparse(n) for n in nested]
 
 
-@pytest.mark.parametrize("y_true,y_pred,expected", [
-    ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], 1.0),
-    ([1.0, 2.0, 3.0, np.nan], [1.0, 2.0, 3.0, 99.0], 1.0),     # pairwise-finite mask
-    ([1.0, 2.0, 3.0], [1.0, np.inf, np.nan], float("nan")),    # <2 survivors -> NaN
-    ([], [], float("nan")),
-])
+@pytest.mark.parametrize(
+    "y_true,y_pred,expected",
+    [
+        ([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], 1.0),
+        ([1.0, 2.0, 3.0, np.nan], [1.0, 2.0, 3.0, 99.0], 1.0),  # pairwise-finite mask
+        ([1.0, 2.0, 3.0], [1.0, np.inf, np.nan], float("nan")),  # <2 survivors -> NaN
+        ([], [], float("nan")),
+    ],
+)
 def test_r2_matches_the_evaluation_harness_semantics(y_true, y_pred, expected):
     """Same contract as `compute_reg_metrics(...)["r2"]`, which this replaced: drop
     non-finite pairs, NaN below two survivors."""
@@ -994,13 +1030,12 @@ def test_the_window_recompute_does_not_rescan_the_table_every_predict(monkeypatc
     (~5s on 1M x 130), and repaying it per predict is the cost this whole path exists
     to remove. Only the element budget -- cheap, and the part that actually moves -- is
     re-resolved."""
-    est, stub, X_test = fitted(
-        monkeypatch, large_context_policy="random", large_context_threshold=100)
+    est, stub, X_test = fitted(monkeypatch, large_context_policy="random", large_context_threshold=100)
     for _ in range(3):
         est.predict(X_test)
     assert stub.budget_scans == 1
 
-    est.fit(*make_table(n_train=400, seed=5)[:2])    # a new table is a new scan
+    est.fit(*make_table(n_train=400, seed=5)[:2])  # a new table is a new scan
     est.predict(X_test)
     assert stub.budget_scans == 2
 
@@ -1013,14 +1048,12 @@ def test_a_policy_refusal_is_not_reported_as_a_checkpoint_problem(monkeypatch):
     or discretize strategy over a problem that was neither."""
     from synthefy_nori.inference.large_context import LargeContextUnsupportedOutputError
 
-    est, _, X_test = fitted(monkeypatch, large_context_policy="cluster_route",
-                            large_context_threshold=100)
+    est, _, X_test = fitted(monkeypatch, large_context_policy="cluster_route", large_context_threshold=100)
     with pytest.raises(LargeContextUnsupportedOutputError, match="large_context_policy"):
         est.predict(X_test, output_type="full")
     with pytest.raises(LargeContextUnsupportedOutputError, match="large_context_policy") as caught:
         est.predict(X_test, discretize="map-cell", categorical_levels=[0.0, 1.0])
-    assert "bar_distribution" not in str(caught.value), (
-        "a policy refusal was re-reported as a checkpoint limitation")
+    assert "bar_distribution" not in str(caught.value), "a policy refusal was re-reported as a checkpoint limitation"
 
 
 def test_a_changed_window_keeps_the_train_arrays_and_drops_the_decisions(monkeypatch):
@@ -1029,9 +1062,9 @@ def test_a_changed_window_keeps_the_train_arrays_and_drops_the_decisions(monkeyp
     # A gate over cluster_route touches BOTH stores: the routing space is an array in
     # train_state, the chosen winner is a decision in train_cache.
     stub = StubPredictor(window=50)
-    est, _, X_test = fitted(monkeypatch, stub=stub,
-                            large_context_policy=["random", "cluster_route"],
-                            large_context_threshold=100)
+    est, _, X_test = fitted(
+        monkeypatch, stub=stub, large_context_policy=["random", "cluster_route"], large_context_threshold=100
+    )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
         est.predict(X_test)
@@ -1043,7 +1076,7 @@ def test_a_changed_window_keeps_the_train_arrays_and_drops_the_decisions(monkeyp
     assert arrays, "nothing was cached to carry"
     assert decisions, "no decision was cached to invalidate"
 
-    stub.window = 40                                  # a smaller elements_budget
+    stub.window = 40  # a smaller elements_budget
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
         est.predict(X_test)
@@ -1053,22 +1086,23 @@ def test_a_changed_window_keeps_the_train_arrays_and_drops_the_decisions(monkeyp
     assert rebuilt.train_state is arrays, "the imputed train block was re-derived"
     # Identity, not emptiness: the second predict re-derives its own decision under the
     # new window, so the question is whether the OLD store was carried over.
-    assert rebuilt._train_caches is not decisions, (
-        "window-sized decisions were carried across a window change")
+    assert rebuilt._train_caches is not decisions, "window-sized decisions were carried across a window change"
 
 
 def test_adopt_train_state_refuses_a_different_table():
     base = make_base(window=40, n_train=400)
-    other = large_context.build_problem(
-        ridge_predict, *make_table(n_train=400, seed=7)[:2], window=40, seed=0)
+    other = large_context.build_problem(ridge_predict, *make_table(n_train=400, seed=7)[:2], window=40, seed=0)
     with pytest.raises(ValueError, match="same fitted table"):
         other.adopt_train_state(base)
 
 
-@pytest.mark.parametrize("mutate", [
-    lambda s: s.setdefault("k", 99),
-    lambda s: s.update({"k": 99}),
-])
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda s: s.setdefault("k", 99),
+        lambda s: s.update({"k": 99}),
+    ],
+)
 def test_every_mutator_routes_through_the_hit_counter(mutate):
     """`get`/`__getitem__`/`__setitem__` were counted but `setdefault`/`update` were
     not, so a policy reaching for one would silently under-report reuse."""
@@ -1090,8 +1124,8 @@ def test_setdefault_on_an_existing_key_counts_as_reuse():
 def test_pop_forgets_that_this_call_derived_the_key():
     state = pol.SharedTrainState()
     state.begin_call()
-    state["k"] = 1                      # derived by THIS call
+    state["k"] = 1  # derived by THIS call
     state.pop("k")
-    state["k"] = 2                      # re-derived, still this call
+    state["k"] = 2  # re-derived, still this call
     assert state["k"] == 2
     assert state.hits == 0, "a key this call derived was counted as earlier work"

--- a/tests/test_long_context_nonfinite.py
+++ b/tests/test_long_context_nonfinite.py
@@ -39,13 +39,19 @@ FP16_OVERFLOW_START = 65520
 # 1. Root cause: log(n) must be computed before the cast, not after.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("key_len", [
-    65519,                  # last row count fp16 still rounds to a finite value
-    FP16_OVERFLOW_START,    # first row count that overflowed fp16
-    65535, 65536, 65537,    # the boundary named in the issue
-    70000,                  # a reported failing context
-    100000,                 # a reported failing context
-])
+
+@pytest.mark.parametrize(
+    "key_len",
+    [
+        65519,  # last row count fp16 still rounds to a finite value
+        FP16_OVERFLOW_START,  # first row count that overflowed fp16
+        65535,
+        65536,
+        65537,  # the boundary named in the issue
+        70000,  # a reported failing context
+        100000,  # a reported failing context
+    ],
+)
 def test_qassmax_finite_above_fp16_row_count_limit(key_len):
     """A context longer than fp16 can represent must not poison the q scale."""
     m = QASSMaxScaling(num_heads=2, head_dim=4).half()
@@ -111,6 +117,7 @@ def test_qassmax_respects_fp32_and_bf16():
 # 2. A non-finite forward must never become a silent constant prediction.
 # ---------------------------------------------------------------------------
 
+
 class _Stub:
     """Minimal carrier for the real unbound method under test."""
 
@@ -120,8 +127,7 @@ class _Stub:
 
 def test_finite_output_passes_through_untouched():
     out = torch.tensor([1.0, -2.5, 0.0])
-    got = _Stub()._reject_nonfinite_output(
-        out, path="cached", n_train=10, n_test=3)
+    got = _Stub()._reject_nonfinite_output(out, path="cached", n_train=10, n_test=3)
     assert got is out
 
 
@@ -130,8 +136,7 @@ def test_nonfinite_output_raises_instead_of_zero_filling(bad):
     out = torch.tensor([1.0, bad, 3.0])
 
     with pytest.raises(RuntimeError) as exc:
-        _Stub()._reject_nonfinite_output(
-            out, path="cached (resident_bf16)", n_train=93729, n_test=4096)
+        _Stub()._reject_nonfinite_output(out, path="cached (resident_bf16)", n_train=93729, n_test=4096)
 
     msg = str(exc.value)
     # The message has to carry enough to act on: where, how big, and why a
@@ -147,8 +152,7 @@ def test_partial_nonfinite_also_raises():
     out = torch.cat([torch.randn(4095), torch.tensor([float("nan")])])
 
     with pytest.raises(RuntimeError, match="1/4096 non-finite"):
-        _Stub()._reject_nonfinite_output(
-            out, path="plain chunked loop", n_train=70000, n_test=4096)
+        _Stub()._reject_nonfinite_output(out, path="plain chunked loop", n_train=70000, n_test=4096)
 
 
 def test_there_is_no_env_opt_out(monkeypatch):
@@ -157,19 +161,21 @@ def test_there_is_no_env_opt_out(monkeypatch):
     An opt-out here can only produce a number indistinguishable from a working
     prediction while carrying no signal, which is exactly the #439 failure mode.
     """
-    for name in ("SYNTHEFY_ALLOW_NONFINITE_PREDICTIONS",
-                 "SYNTHEFY_ALLOW_NONFINITE",
-                 "SYNTHEFY_DISABLE_NONFINITE_CHECK"):
+    for name in (
+        "SYNTHEFY_ALLOW_NONFINITE_PREDICTIONS",
+        "SYNTHEFY_ALLOW_NONFINITE",
+        "SYNTHEFY_DISABLE_NONFINITE_CHECK",
+    ):
         monkeypatch.setenv(name, "1")
 
     with pytest.raises(RuntimeError):
-        _Stub()._reject_nonfinite_output(
-            torch.tensor([float("nan")]), path="cached", n_train=70000, n_test=1)
+        _Stub()._reject_nonfinite_output(torch.tensor([float("nan")]), path="cached", n_train=70000, n_test=1)
 
 
 # ---------------------------------------------------------------------------
 # 3. End-to-end at the boundary (needs a GPU + the real checkpoint).
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.slow
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -10,6 +10,7 @@ it encodes the decision that int8 is *not* charged to requests with no memory
 problem. That is exactly the kind of default that regresses silently a year later,
 because "int8 is basically free" is true per-request and wrong as a policy.
 """
+
 from __future__ import annotations
 
 import io
@@ -30,8 +31,8 @@ from synthefy_nori.inference.memory_policy import (
 # The deployed ~5.87M checkpoint's shape, as used by the WS1 Stage 2 matrix.
 NORI_6M = dict(nlayers=16, embed_dim=128, bytes_per_element=2)
 H100_80GB_VRAM = 79.6
-H100_BUDGET = DEFAULT_GPU_BUDGET_FRAC * H100_80GB_VRAM          # ~31.8 GiB at the default fraction
-HEAD_DIM = 64                                # embed_dim 128 / nhead 2
+H100_BUDGET = DEFAULT_GPU_BUDGET_FRAC * H100_80GB_VRAM  # ~31.8 GiB at the default fraction
+HEAD_DIM = 64  # embed_dim 128 / nhead 2
 BIG_RAM = 1024.0
 
 
@@ -58,16 +59,14 @@ def resolve(est_gb: float, policy: MemoryPolicy | None = None, **kwargs) -> Memo
     """Resolve a policy for the 6M model on an 80 GB H100 with ample host RAM."""
     kwargs.setdefault("total_vram_gb", H100_80GB_VRAM)
     kwargs.setdefault("total_ram_gb", BIG_RAM)
-    return (policy or MemoryPolicy()).resolve(
-        est_cache_gb=est_gb, bytes_per_element=2, head_dim=HEAD_DIM, **kwargs
-    )
+    return (policy or MemoryPolicy()).resolve(est_cache_gb=est_gb, bytes_per_element=2, head_dim=HEAD_DIM, **kwargs)
 
 
 class TestFootprintArithmetic:
     def test_cache_scales_with_layers_rows_groups_and_width(self):
         # One key and one value vector of width embed_dim per (layer, group, row)
         # -> the factor 2.
-        expected = (16 * 8 * 50_000 * 2 * 128 * 2) / (1024 ** 3)
+        expected = (16 * 8 * 50_000 * 2 * 128 * 2) / (1024**3)
         assert cache_gb(50_000, 8) == pytest.approx(expected)
 
     def test_int8_saves_about_1_9x_against_bf16_not_4x(self):
@@ -75,7 +74,7 @@ class TestFootprintArithmetic:
         # scale (one per head_dim vector) -> ~1.9x. Over-claiming here is exactly
         # what makes a resident budget optimistic.
         int8_gb = int8_footprint_gb(8.0, bytes_per_element=2, head_dim=HEAD_DIM)
-        assert int8_gb == pytest.approx(4.25)          # 4.0 payload + 0.25 scale
+        assert int8_gb == pytest.approx(4.25)  # 4.0 payload + 0.25 scale
         assert 8.0 / int8_gb == pytest.approx(1.88, abs=0.01)
 
     def test_scale_overhead_shrinks_as_head_dim_grows(self):
@@ -96,9 +95,7 @@ class TestFootprintArithmetic:
         assert _mp._cgroup_memory_limit_gb() == 2.0
         assert limit_file.closed
 
-    def test_cgroup_limit_does_not_leak_resource_warning_into_notes(
-        self, monkeypatch, tmp_path
-    ):
+    def test_cgroup_limit_does_not_leak_resource_warning_into_notes(self, monkeypatch, tmp_path):
         limit_path = tmp_path / "memory.max"
         limit_path.write_text(str(2 * _mp.BYTES_PER_GIB), encoding="utf-8")
         monkeypatch.setattr(_mp, "_CGROUP_LIMIT_PATHS", (str(limit_path),))
@@ -131,7 +128,7 @@ class TestBudgets:
 
     def test_out_of_range_fractions_are_rejected(self):
         with pytest.raises(ValidationError):
-            MemoryPolicy(gpu_budget_frac=40)        # 40x VRAM, surely a typo
+            MemoryPolicy(gpu_budget_frac=40)  # 40x VRAM, surely a typo
         with pytest.raises(ValidationError):
             MemoryPolicy(gpu_budget_frac=0)
         with pytest.raises(ValidationError):
@@ -198,8 +195,7 @@ class TestAutoLadder:
         # Growing the table may only move us down the ladder, never back up. These
         # four row counts walk every rung in order on an 80 GB card.
         expected = ["resident_bf16", "resident_int8", "offload_bf16", "plain_loop"]
-        seen = [resolve(cache_gb(n, 8)).rung
-                for n in (10_000, 655_000, 2_000_000, 20_000_000)]
+        seen = [resolve(cache_gb(n, 8)).rung for n in (10_000, 655_000, 2_000_000, 20_000_000)]
         assert seen == expected
 
     def test_ineligible_request_reports_no_cache(self):
@@ -285,7 +281,7 @@ class TestConfigSurface:
         with pytest.raises(ValidationError):
             MemoryPolicy.coerce({"gpu_budget": 20})
         with pytest.raises(ValidationError):
-            MemoryPolicy.coerce({"offload": True})       # renamed to offload_to_host
+            MemoryPolicy.coerce({"offload": True})  # renamed to offload_to_host
 
     def test_unknown_preset_and_wrong_type_are_rejected(self):
         with pytest.raises(ValueError, match="unknown memory preset"):
@@ -325,8 +321,7 @@ class TestEscalation:
     def test_subsample_count_is_recorded(self):
         # The reviewer's question: where does a dropped context show up? Here, so it
         # survives past the log line into memory_report_.
-        policy = resolve(cache_gb(50_000, 8)).escalated(
-            "plain_loop", dropped_context_rows=1234)
+        policy = resolve(cache_gb(50_000, 8)).escalated("plain_loop", dropped_context_rows=1234)
         assert policy.dropped_context_rows == 1234
         assert "DROPPED 1234 context rows" in policy.describe()
 
@@ -348,10 +343,10 @@ class TestPermissionsInsteadOfSentinels:
         # The reviewer's point: reading the signature should tell you what happens
         # without looking anything up. No field defaults to "auto".
         policy = MemoryPolicy()
-        assert policy.cache_dtype == "bf16"          # a precision, not "auto"
+        assert policy.cache_dtype == "bf16"  # a precision, not "auto"
         assert policy.allow_quantization is True
         assert policy.offload_to_host is True
-        assert policy.context_row_chunk is None          # off, plainly
+        assert policy.context_row_chunk is None  # off, plainly
         assert policy.gpu_budget_frac == DEFAULT_GPU_BUDGET_FRAC
         for field in MemoryPolicy.model_fields.values():
             assert field.default != "auto", "an 'auto' sentinel crept back in"
@@ -378,7 +373,7 @@ class TestPermissionsInsteadOfSentinels:
     def test_offload_prefers_the_smallest_candidate_that_host_can_hold(self):
         # bf16 (128 GiB) will not fit a 100 GiB host budget but int8 (~68 GiB) will.
         est = H100_BUDGET * 4
-        policy = resolve(est, total_ram_gb=400.0)     # host budget = 100 GiB
+        policy = resolve(est, total_ram_gb=400.0)  # host budget = 100 GiB
         assert policy.rung == "offload_int8"
 
     def test_offload_stays_bf16_when_quantization_is_forbidden(self):
@@ -395,14 +390,20 @@ class TestPredictorEnvSurface:
         # _coerced_memory_policy() touches only self.memory_policy and the environment, so a bare
         # instance is enough — no checkpoint load required.
         from synthefy_nori.inference.predictor import NoriPredictor
+
         predictor = NoriPredictor.__new__(NoriPredictor)
         predictor.memory_policy = memory_policy
         return predictor._coerced_memory_policy()
 
     def test_no_env_var_configures_the_policy(self, monkeypatch):
-        for name in ("SYNTHEFY_KV_CACHE_DTYPE", "SYNTHEFY_KV_INT8",
-                     "SYNTHEFY_KV_OFFLOAD", "SYNTHEFY_KV_GPU_BUDGET_FRAC",
-                     "SYNTHEFY_CACHE_HOST_MAX_GB", "SYNTHEFY_FIT_ROW_CHUNK"):
+        for name in (
+            "SYNTHEFY_KV_CACHE_DTYPE",
+            "SYNTHEFY_KV_INT8",
+            "SYNTHEFY_KV_OFFLOAD",
+            "SYNTHEFY_KV_GPU_BUDGET_FRAC",
+            "SYNTHEFY_CACHE_HOST_MAX_GB",
+            "SYNTHEFY_FIT_ROW_CHUNK",
+        ):
             monkeypatch.setenv(name, "int8" if "DTYPE" in name else "1")
         policy = self._policy_of()
         assert policy == MemoryPolicy(), "an env var leaked into the policy"
@@ -441,12 +442,15 @@ class TestIncoherentConfigsAreRejected:
         with pytest.raises(ValidationError, match="not a\n?\\s*reachable configuration"):
             MemoryPolicy(cache=False, context_row_chunk=2048)
 
-    @pytest.mark.parametrize("lever", [
-        {"context_row_chunk": 2048},
-        {"cache_dtype": "int8"},
-        {"offload_to_host": True},
-        {"allow_quantization": False},
-    ])
+    @pytest.mark.parametrize(
+        "lever",
+        [
+            {"context_row_chunk": 2048},
+            {"cache_dtype": "int8"},
+            {"offload_to_host": True},
+            {"allow_quantization": False},
+        ],
+    )
     def test_every_cache_only_lever_is_rejected_with_cache_off(self, lever):
         with pytest.raises(ValidationError, match="cache=False cannot be combined"):
             MemoryPolicy(cache=False, **lever)
@@ -474,12 +478,12 @@ class TestIncoherentConfigsAreRejected:
     def test_every_combination_either_works_or_raises_clearly(self):
         """Sweep the field space: no combination may silently drop a lever."""
         from itertools import product
+
         checked = rejected = 0
         for cache, dtype, allow_q, offload, chunk in product(
-                [True, False], ["bf16", "int8"], [True, False], [True, False],
-                [None, 2048]):
-            kwargs = dict(cache=cache, cache_dtype=dtype,
-                          allow_quantization=allow_q, offload_to_host=offload)
+            [True, False], ["bf16", "int8"], [True, False], [True, False], [None, 2048]
+        ):
+            kwargs = dict(cache=cache, cache_dtype=dtype, allow_quantization=allow_q, offload_to_host=offload)
             if chunk is not None:
                 kwargs["context_row_chunk"] = chunk
             checked += 1
@@ -489,8 +493,7 @@ class TestIncoherentConfigsAreRejected:
             except ValidationError:
                 rejected += 1
                 # Every rejection must have one of the two documented reasons.
-                assert (not cache) or contradictory, (
-                    f"unexplained rejection: {kwargs}")
+                assert (not cache) or contradictory, f"unexplained rejection: {kwargs}"
                 continue
             assert cache and not contradictory, f"should have been rejected: {kwargs}"
             # Accepted => the cache is on, so every lever can actually take effect.
@@ -511,8 +514,7 @@ class TestResolutionIsValidated:
 
     def test_escalated_rejects_a_negative_row_count(self):
         with pytest.raises(ValidationError):
-            resolve(cache_gb(50_000, 8)).escalated("plain_loop",
-                                                   dropped_context_rows=-5)
+            resolve(cache_gb(50_000, 8)).escalated("plain_loop", dropped_context_rows=-5)
 
     def test_resolved_policy_may_report_cache_false_with_a_concrete_dtype(self):
         # The coherence check must NOT fire on outputs: plain_loop legitimately has
@@ -522,8 +524,7 @@ class TestResolutionIsValidated:
         assert policy.cache is False and policy.cache_dtype in ("bf16", "int8")
 
     def test_escalating_a_resolved_policy_round_trips(self):
-        policy = resolve(cache_gb(50_000, 8)).escalated("context_row_chunk",
-                                                        context_row_chunk=2048)
+        policy = resolve(cache_gb(50_000, 8)).escalated("context_row_chunk", context_row_chunk=2048)
         assert MemoryPolicy(**policy.model_dump()) == policy
 
 
@@ -531,15 +532,13 @@ class TestNoCacheReportsNoBudget:
     def test_no_cache_does_not_invent_a_budget(self):
         # Previously reported 9.6 GiB (0.4 x ASSUMED_VRAM_GB) even on an 80 GB card,
         # for a decision where no budget was consulted at all.
-        policy = MemoryPolicy().resolve(
-            est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
+        policy = MemoryPolicy().resolve(est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
         assert policy.rung == "no_cache"
         assert policy.gpu_budget_absolute_gb is None
         assert policy.host_budget_absolute_gb is None
 
     def test_describe_survives_absent_budgets(self):
-        policy = MemoryPolicy().resolve(
-            est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
+        policy = MemoryPolicy().resolve(est_cache_gb=0.0, bytes_per_element=1, head_dim=1, cache_eligible=False)
         assert policy.describe() == "no_cache"
 
     def test_a_real_rung_still_reports_both_budgets(self):
@@ -602,32 +601,44 @@ class TestOffloadReachability:
         # request needs to spill and offload cannot help, so say so.
         policy = MemoryPolicy(gpu_budget_absolute_gb=70.0)
         with pytest.warns(UserWarning, match="offload_to_host could not help"):
-            policy.resolve(est_cache_gb=200.0, bytes_per_element=2, head_dim=HEAD_DIM,
-                           total_vram_gb=H100_80GB_VRAM, total_ram_gb=200.0)
+            policy.resolve(
+                est_cache_gb=200.0,
+                bytes_per_element=2,
+                head_dim=HEAD_DIM,
+                total_vram_gb=H100_80GB_VRAM,
+                total_ram_gb=200.0,
+            )
 
     def test_silent_on_untouched_defaults_even_when_ram_is_small(self):
         # The regression this replaced: warning up-front fired for anyone whose RAM is
         # under ~1.6x their VRAM, on a request that never left the GPU.
         import warnings as _w
+
         with _w.catch_warnings():
             _w.simplefilter("error")
-            MemoryPolicy().resolve(est_cache_gb=0.2, bytes_per_element=2,
-                                   head_dim=HEAD_DIM, total_vram_gb=80.0,
-                                   total_ram_gb=128.0)
+            MemoryPolicy().resolve(
+                est_cache_gb=0.2, bytes_per_element=2, head_dim=HEAD_DIM, total_vram_gb=80.0, total_ram_gb=128.0
+            )
 
     def test_silent_when_offload_can_actually_rescue_something(self):
         import warnings as _w
+
         with _w.catch_warnings():
-            _w.simplefilter("error")            # any warning fails the test
-            resolve(cache_gb(50_000, 8))        # host 256 GiB > gpu 31.8 GiB
+            _w.simplefilter("error")  # any warning fails the test
+            resolve(cache_gb(50_000, 8))  # host 256 GiB > gpu 31.8 GiB
 
     def test_no_warning_when_offload_is_disabled(self):
         import warnings as _w
+
         with _w.catch_warnings():
             _w.simplefilter("error")
             MemoryPolicy(offload_to_host=False).resolve(
-                est_cache_gb=1.0, bytes_per_element=2, head_dim=HEAD_DIM,
-                total_vram_gb=H100_80GB_VRAM, total_ram_gb=200.0)
+                est_cache_gb=1.0,
+                bytes_per_element=2,
+                head_dim=HEAD_DIM,
+                total_vram_gb=H100_80GB_VRAM,
+                total_ram_gb=200.0,
+            )
 
 
 class TestOffloadReachabilityAtConstruction:
@@ -645,6 +656,7 @@ class TestOffloadReachabilityAtConstruction:
 
     def test_host_above_gpu_is_silent(self):
         import warnings as _w
+
         with _w.catch_warnings():
             _w.simplefilter("error")
             MemoryPolicy(gpu_budget_absolute_gb=20.0, host_budget_absolute_gb=200.0)
@@ -652,6 +664,7 @@ class TestOffloadReachabilityAtConstruction:
     def test_fraction_case_is_deferred_to_resolve(self):
         # Cannot be decided here: 0.25 x RAM vs 0.4 x VRAM depends on the box.
         import warnings as _w
+
         with _w.catch_warnings():
             _w.simplefilter("error")
             MemoryPolicy(gpu_budget_frac=0.9, host_budget_frac=0.05)

--- a/tests/test_memory_policy_e2e.py
+++ b/tests/test_memory_policy_e2e.py
@@ -12,6 +12,7 @@ pass, because the policy unit tests never construct an estimator.
 Needs a checkpoint, so it skips when one is not reachable (no network / no HF cache).
 Runs on CPU; slow but not GPU-bound.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -43,9 +44,10 @@ def table():
 def regressor_cls():
     """NoriRegressor, or skip when no checkpoint is reachable."""
     from synthefy_nori.api import NoriRegressor
+
     try:
         NoriRegressor(model="nori-6m", device="cpu")._get_predictor()
-    except Exception as exc:                                   # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         pytest.skip(f"no reachable Nori checkpoint: {type(exc).__name__}: {exc}")
     return NoriRegressor
 
@@ -54,9 +56,9 @@ def _predict(regressor_cls, table, memory_policy):
     """Fit + predict under one memory policy, returning (predictions, report)."""
     x_train, y_train, x_test = table
     model = regressor_cls(
-        model="nori-6m", device="cpu",
-        memory_policy={**({} if memory_policy is None else memory_policy),
-                "elements_budget": SMALL_ELEMENTS_BUDGET},
+        model="nori-6m",
+        device="cpu",
+        memory_policy={**({} if memory_policy is None else memory_policy), "elements_budget": SMALL_ELEMENTS_BUDGET},
     )
     model.fit(x_train, y_train)
     return np.asarray(model.predict(x_test), dtype=np.float64), model.memory_report_
@@ -71,9 +73,10 @@ class TestPolicyReachesInference:
         _, report = _predict(regressor_cls, table, None)
         assert report is not None, "memory_policy= never reached the predictor"
         assert report["rung"] == "resident_bf16", (
-            f'expected the cached path to engage; got {report["rung"]}. If this is '
+            f"expected the cached path to engage; got {report['rung']}. If this is "
             f'"no_cache", SMALL_ELEMENTS_BUDGET is too large for this table and the '
-            f'rest of this suite is testing nothing.')
+            f"rest of this suite is testing nothing."
+        )
         assert MemoryPolicy(**report).is_bit_exact
 
     def test_report_round_trips_into_the_policy_type(self, regressor_cls, table):
@@ -107,8 +110,7 @@ class TestPolicyReachesInference:
 
 
 class TestPredictionsAgreeAcrossPolicies:
-    def test_cached_and_uncached_agree_within_mixed_precision_tolerance(
-            self, regressor_cls, table):
+    def test_cached_and_uncached_agree_within_mixed_precision_tolerance(self, regressor_cls, table):
         # NOT bit-identical: the two paths reduce in a different order, which the
         # README documents at ~1.5e-3. Asserting equality here would be wrong.
         cached, cached_report = _predict(regressor_cls, table, None)
@@ -124,13 +126,14 @@ class TestPredictionsAgreeAcrossPolicies:
 
 
 class TestIncoherentConfigFailsAtFit:
-    def test_row_chunking_without_caching_raises_before_any_compute(
-            self, regressor_cls, table):
+    def test_row_chunking_without_caching_raises_before_any_compute(self, regressor_cls, table):
         # Must fail before inference, not silently do nothing at predict time.
         from pydantic import ValidationError
+
         x_train, y_train, x_test = table
         model = regressor_cls(
-            model="nori-6m", device="cpu",
+            model="nori-6m",
+            device="cpu",
             memory_policy={"cache": False, "context_row_chunk": 2048},
         )
         # fit(), not predict(): the point is to fail before any inference runs.
@@ -139,9 +142,9 @@ class TestIncoherentConfigFailsAtFit:
 
     def test_unknown_key_raises(self, regressor_cls, table):
         from pydantic import ValidationError
+
         x_train, y_train, x_test = table
-        model = regressor_cls(model="nori-6m", device="cpu",
-                              memory_policy={"gpu_budget": 20})
+        model = regressor_cls(model="nori-6m", device="cpu", memory_policy={"gpu_budget": 20})
         with pytest.raises(ValidationError):
             model.fit(x_train, y_train)
 
@@ -149,8 +152,8 @@ class TestIncoherentConfigFailsAtFit:
 class TestSklearnContract:
     def test_clone_round_trips_every_memory_form(self, regressor_cls):
         from sklearn.base import clone
-        for policy in (None, "exact", {"gpu_budget_frac": 0.25},
-                       MemoryPolicy(cache_dtype="bf16")):
+
+        for policy in (None, "exact", {"gpu_budget_frac": 0.25}, MemoryPolicy(cache_dtype="bf16")):
             estimator = regressor_cls(model="nori-6m", memory_policy=policy)
             # sklearn's param name follows the constructor argument, so the rename moves
             # this key too -- get_params()["memory"] would silently KeyError-free to nothing.
@@ -181,7 +184,8 @@ class TestSubsamplingIsNeverSilent:
         x_test = rng.normal(size=(64, 8)).astype(np.float32)
 
         model = regressor_cls(
-            model="nori-6m", device="cpu",
+            model="nori-6m",
+            device="cpu",
             # A budget this context cannot fit, with the shrink forbidden.
             memory_policy={"elements_budget": 2000, "allow_subsample": False},
         )
@@ -200,8 +204,7 @@ class TestSubsamplingIsNeverSilent:
         y_train = (0.5 + 0.4 * (x_train[:, 0] - x_train[:, 1])).astype(np.float64)
         x_test = rng.normal(size=(64, 8)).astype(np.float32)
 
-        model = regressor_cls(model="nori-6m", device="cpu",
-                              memory_policy={"elements_budget": 2000})
+        model = regressor_cls(model="nori-6m", device="cpu", memory_policy={"elements_budget": 2000})
         model.fit(x_train, y_train)
         with pytest.warns(UserWarning, match="context subsampled"):
             predictions = model.predict(x_test)
@@ -226,50 +229,55 @@ class TestWarningVolume:
         """Predict under a config guaranteed to hit the plain-loop fallback."""
         x_train, y_train, x_test = table
         model = regressor_cls(
-            model="nori-6m", device="cpu",
+            model="nori-6m",
+            device="cpu",
             # BOTH budgets capped: capping only the GPU lets offload succeed against
             # this box's real RAM, which never reaches the plain-loop rung.
-            memory_policy={"elements_budget": SMALL_ELEMENTS_BUDGET,
-                    "gpu_budget_absolute_gb": 0.001,
-                    "host_budget_absolute_gb": 0.0005},
+            memory_policy={
+                "elements_budget": SMALL_ELEMENTS_BUDGET,
+                "gpu_budget_absolute_gb": 0.001,
+                "host_budget_absolute_gb": 0.0005,
+            },
         )
         model.fit(x_train, y_train)
         for _ in range(n_calls):
             model.predict(x_test)
         return model
 
-    def test_fallback_warns_once_per_call_not_once_per_pipeline(
-            self, regressor_cls, table):
+    def test_fallback_warns_once_per_call_not_once_per_pipeline(self, regressor_cls, table):
         import warnings as _w
+
         with _w.catch_warnings(record=True) as caught:
-            _w.simplefilter("always")          # defeat dedup, so we count raw emissions
+            _w.simplefilter("always")  # defeat dedup, so we count raw emissions
             model = self._broken_config_predict(regressor_cls, table, n_calls=1)
         if model.memory_report_["rung"] != "plain_loop":
             pytest.skip("config did not reach the plain-loop rung on this shape")
-        fallbacks = [w for w in caught
-                     if "fell back to the plain chunked loop" in str(w.message)]
+        fallbacks = [w for w in caught if "fell back to the plain chunked loop" in str(w.message)]
         assert len(fallbacks) == 1, (
             f"one predict emitted {len(fallbacks)} copies of the fallback warning; "
-            f"it must be de-duplicated per call, not per inference pipeline")
+            f"it must be de-duplicated per call, not per inference pipeline"
+        )
 
     def test_a_second_call_warns_again(self, regressor_cls, table):
         # Per-CALL, not per-process: each request is a fact about that request, so a
         # second predict that also falls back must say so again.
         import warnings as _w
+
         with _w.catch_warnings(record=True) as caught:
             _w.simplefilter("always")
             model = self._broken_config_predict(regressor_cls, table, n_calls=2)
         if model.memory_report_["rung"] != "plain_loop":
             pytest.skip("config did not reach the plain-loop rung on this shape")
-        fallbacks = [w for w in caught
-                     if "fell back to the plain chunked loop" in str(w.message)]
+        fallbacks = [w for w in caught if "fell back to the plain chunked loop" in str(w.message)]
         assert len(fallbacks) == 2, f"expected one per call, got {len(fallbacks)}"
 
     def test_log_lines_are_deduplicated_too(self, regressor_cls, table, caplog):
         import logging
+
         with caplog.at_level(logging.INFO, logger="synthefy_nori.inference.predictor"):
             self._broken_config_predict(regressor_cls, table, n_calls=1)
         rung_lines = [r for r in caplog.records if "serving-memory rung" in r.message]
         assert len(rung_lines) == 1, (
             f"one predict logged the rung {len(rung_lines)} times; logging has no "
-            f"de-duplication of its own, so it must be done at the call site")
+            f"de-duplication of its own, so it must be done at the call site"
+        )

--- a/tests/test_model_encoder_invariants.py
+++ b/tests/test_model_encoder_invariants.py
@@ -56,9 +56,7 @@ def _tiny_model(
         n_kernels=8,
     )
     if legacy_random_rbf_flag is not None:
-        config["encoder_config_x"]["RBF_config"]["use_random_kernels"] = (
-            legacy_random_rbf_flag
-        )
+        config["encoder_config_x"]["RBF_config"]["use_random_kernels"] = legacy_random_rbf_flag
     config["encoder_config_y"].update(
         embedding_size=12,
         nan_handling_y_encoder=nan_handling_y_encoder,
@@ -77,22 +75,28 @@ def test_valid_feature_count_uses_context_and_can_be_frozen():
     direct = encoder({"data": whole.clone(), "eval_pos": 2})
     assert direct["_valid_feature_num"].item() == 1
 
-    frozen = encoder({
-        "data": query.clone(),
-        "eval_pos": 1,
-        "_frozen_valid_feature_num": direct["_valid_feature_num"],
-    })
+    frozen = encoder(
+        {
+            "data": query.clone(),
+            "eval_pos": 1,
+            "_frozen_valid_feature_num": direct["_valid_feature_num"],
+        }
+    )
     torch.testing.assert_close(frozen["data"], direct["data"][:, 2:])
 
 
 def test_direct_preprocessing_and_prediction_do_not_depend_on_query_batch():
     model = _tiny_model()
-    context = torch.tensor([[
-        [0.0, 1.0, 1.0, 0.0, 4.0, 7.0],
-        [1.0, 1.0, 1.0, 1.0, 4.0, 7.0],
-        [2.0, 1.0, 1.0, 2.0, 4.0, 7.0],
-        [3.0, 1.0, 1.0, 3.0, 4.0, 7.0],
-    ]])
+    context = torch.tensor(
+        [
+            [
+                [0.0, 1.0, 1.0, 0.0, 4.0, 7.0],
+                [1.0, 1.0, 1.0, 1.0, 4.0, 7.0],
+                [2.0, 1.0, 1.0, 2.0, 4.0, 7.0],
+                [3.0, 1.0, 1.0, 3.0, 4.0, 7.0],
+            ]
+        ]
+    )
     common_query = torch.tensor([[[4.0, 10.0, 1.0, 4.0, 9.0, 7.0]]])
     extra_query = torch.tensor([[[5.0, 1.0, 20.0, 5.0, 8.0, 9.0]]])
     y_train = torch.arange(4.0).unsqueeze(0)
@@ -132,12 +136,16 @@ def test_features_per_group_three_padding_matches_direct_and_cache(num_features,
 
 def test_nan_encoder_excludes_every_nonfinite_value_and_keeps_signed_indicator():
     encoder = NanEncoder()
-    values = torch.tensor([[
-        [1.0, float("inf"), 1.0],
-        [3.0, float("-inf"), 2.0],
-        [float("inf"), float("nan"), 3.0],
-        [float("nan"), float("nan"), 4.0],
-    ]])
+    values = torch.tensor(
+        [
+            [
+                [1.0, float("inf"), 1.0],
+                [3.0, float("-inf"), 2.0],
+                [float("inf"), float("nan"), 3.0],
+                [float("nan"), float("nan"), 4.0],
+            ]
+        ]
+    )
 
     result = encoder({"data": values, "eval_pos": 4})
     torch.testing.assert_close(result["_nan_mean"], torch.tensor([[2.0, 0.0, 2.5]]))
@@ -160,14 +168,18 @@ def test_nonfinite_values_are_missing_and_direct_matches_cache(
         nan_handling_y_encoder=nan_handling_enabled,
         use_nan_indicator=use_nan_indicator,
     )
-    values = torch.tensor([[
-        [0.0, 1.0, 2.0, 3.0],
-        [1.0, 2.0, float("inf"), 4.0],
-        [2.0, float("nan"), 4.0, 5.0],
-        [3.0, 4.0, 5.0, 6.0],
-        [4.0, float("-inf"), 6.0, 7.0],
-        [5.0, 6.0, 7.0, float("inf")],
-    ]])
+    values = torch.tensor(
+        [
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [1.0, 2.0, float("inf"), 4.0],
+                [2.0, float("nan"), 4.0, 5.0],
+                [3.0, 4.0, 5.0, 6.0],
+                [4.0, float("-inf"), 6.0, 7.0],
+                [5.0, 6.0, 7.0, float("inf")],
+            ]
+        ]
+    )
     y_train = torch.tensor([[0.0, 1.0, 2.0, 3.0]])
 
     inputs, _ = model._build_x_preprocess_inputs(values, 4)
@@ -302,13 +314,17 @@ def test_nan_handling_disabled_has_no_nan_stage_and_mask_metadata_still_works():
         nan_handling_y_encoder=False,
     )
     assert not any(isinstance(stage, NanEncoder) for stage in model.x_preprocess)
-    values = torch.tensor([[
-        [0.0, 1.0, 2.0, 3.0],
-        [1.0, 1.0, 2.0, 4.0],
-        [2.0, float("inf"), 2.0, 5.0],
-        [3.0, 9.0, 8.0, 6.0],
-        [4.0, float("-inf"), 6.0, 7.0],
-    ]])
+    values = torch.tensor(
+        [
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [1.0, 1.0, 2.0, 4.0],
+                [2.0, float("inf"), 2.0, 5.0],
+                [3.0, 9.0, 8.0, 6.0],
+                [4.0, float("-inf"), 6.0, 7.0],
+            ]
+        ]
+    )
     y_train = torch.tensor([[0.0, 1.0, 2.0]])
 
     with torch.no_grad():
@@ -339,9 +355,11 @@ def test_mask_embedding_nan_to_zero_flag_uses_the_numeric_zero_path():
         },
     )
     values = torch.tensor([[[[float("nan")]], [[0.0]]]])
-    result = encoder({
-        "data": values,
-        "nan_encoding": torch.zeros_like(values),
-        "eval_pos": 1,
-    })["data"]
+    result = encoder(
+        {
+            "data": values,
+            "nan_encoding": torch.zeros_like(values),
+            "eval_pos": 1,
+        }
+    )["data"]
     torch.testing.assert_close(result[:, 0], result[:, 1])

--- a/tests/test_nori_ts.py
+++ b/tests/test_nori_ts.py
@@ -5,6 +5,7 @@ no checkpoint (they need the `forecasting` extra: gluonts, statsmodels, datasets
 The end-to-end forecast is marked `slow` — it downloads a checkpoint and runs
 real inference.
 """
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -36,9 +37,7 @@ def _tsdf(n=60, freq="h", item_id=0, start="2020-01-01", gappy=False):
 def test_quantiles_sorted_in_ctor():
     # Non-ascending input must be sorted so column labels stay aligned with the
     # value-sorted forecast rows.
-    assert NoriTSForecaster(
-        mode="local", model="nori-30m", quantiles=[0.9, 0.1, 0.5]
-    ).quantiles == [0.1, 0.5, 0.9]
+    assert NoriTSForecaster(mode="local", model="nori-30m", quantiles=[0.9, 0.1, 0.5]).quantiles == [0.1, 0.5, 0.9]
 
 
 def test_generate_test_X_horizon():
@@ -64,9 +63,7 @@ def test_generate_test_X_gappy_uses_explicit_freq():
 def test_feature_columns_match_and_nan_split():
     train = _tsdf(n=60, freq="h")
     test = generate_test_X(train, prediction_length=12, freq="h")
-    tr, te = FeatureTransformer(_default_features()).transform(
-        train, test, target_column=_TARGET
-    )
+    tr, te = FeatureTransformer(_default_features()).transform(train, test, target_column=_TARGET)
     tr_cols = sorted(c for c in tr.columns if c != _TARGET)
     te_cols = sorted(c for c in te.columns if c != _TARGET)
     assert tr_cols == te_cols  # identical feature schema across the boundary
@@ -77,9 +74,7 @@ def test_feature_columns_match_and_nan_split():
 def test_running_index_contiguous_across_boundary():
     train = _tsdf(n=40, freq="h")
     test = generate_test_X(train, prediction_length=8, freq="h")
-    tr, te = FeatureTransformer(_default_features()).transform(
-        train, test, target_column=_TARGET
-    )
+    tr, te = FeatureTransformer(_default_features()).transform(train, test, target_column=_TARGET)
     ri = np.concatenate([tr["running_index"].to_numpy(), te["running_index"].to_numpy()])
     assert (np.diff(ri) == 1).all()  # continues, doesn't restart at the horizon
 
@@ -104,15 +99,18 @@ def test_generators_group_per_series_on_a_multi_series_frame():
     for item in (0, 1, 2):
         ts = pd.date_range("2021-01-01", periods=48, freq="h")
         t = np.arange(48)
-        frames.append(pd.DataFrame({
-            "item_id": item, "timestamp": ts,
-            "target": 10.0 + item + np.sin(2 * np.pi * t / 24),
-        }))
+        frames.append(
+            pd.DataFrame(
+                {
+                    "item_id": item,
+                    "timestamp": ts,
+                    "target": 10.0 + item + np.sin(2 * np.pi * t / 24),
+                }
+            )
+        )
     train = TimeSeriesDataFrame.from_data_frame(pd.concat(frames, ignore_index=True))
     test = generate_test_X(train, prediction_length=6, freq="h")
-    tr, te = FeatureTransformer(_default_features()).transform(
-        train, test, target_column=_TARGET
-    )
+    tr, te = FeatureTransformer(_default_features()).transform(train, test, target_column=_TARGET)
     for item in (0, 1, 2):
         ri = tr.xs(item, level="item_id")["running_index"].to_numpy()
         assert ri[0] == 0, f"series {item} running_index must restart at 0, got {ri[0]}"
@@ -128,9 +126,7 @@ def test_generated_feature_columns_are_float32():
     # inference — but the target must keep its own dtype.
     train = _tsdf(n=48, freq="h")
     test = generate_test_X(train, prediction_length=6, freq="h")
-    tr, _ = FeatureTransformer(_default_features()).transform(
-        train, test, target_column=_TARGET
-    )
+    tr, _ = FeatureTransformer(_default_features()).transform(train, test, target_column=_TARGET)
     generated = [c for c in tr.columns if c != _TARGET]
     assert generated, "expected generated feature columns"
     # Only float64 columns are downcast; integer features (running_index, year) keep
@@ -150,9 +146,7 @@ def test_feature_transformer_static_features_merge():
     train = _tsdf(n=30, freq="h")
     test = generate_test_X(train, prediction_length=6, freq="h")
     train.static_features = pd.DataFrame({"cat": [7]}, index=pd.Index([0], name="item_id"))
-    tr, te = FeatureTransformer(_default_features()).transform(
-        train, test, target_column=_TARGET
-    )
+    tr, te = FeatureTransformer(_default_features()).transform(train, test, target_column=_TARGET)
     assert tr.static_features is not None
     assert set(tr.static_features.index) == {0}
     assert te.static_features.loc[0, "cat"] == 7
@@ -165,12 +159,10 @@ def test_predict_df_end_to_end():
     n = 300
     t = np.arange(n)
     series = 10 + 5 * np.sin(2 * np.pi * t / 24) + rng.normal(0, 0.3, n)
-    hist = pd.DataFrame(
-        {"timestamp": pd.date_range("2021-01-01", periods=n, freq="h"), "target": series}
+    hist = pd.DataFrame({"timestamp": pd.date_range("2021-01-01", periods=n, freq="h"), "target": series})
+    out = NoriTSForecaster(mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]).predict_df(
+        hist, prediction_length=24
     )
-    out = NoriTSForecaster(
-        mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]
-    ).predict_df(hist, prediction_length=24)
     assert len(out) == 24
     assert {"0.1", "0.5", "0.9"}.issubset(set(out.columns))
     assert np.isfinite(out["0.5"].to_numpy()).all()
@@ -198,9 +190,9 @@ def test_predict_df_end_to_end_custom_target_multiseries():
         )
     history = pd.concat(frames, ignore_index=True)
 
-    output = NoriTSForecaster(
-        mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]
-    ).predict_df(history, prediction_length=12, target_column="sales")
+    output = NoriTSForecaster(mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]).predict_df(
+        history, prediction_length=12, target_column="sales"
+    )
 
     assert set(output.index.get_level_values("item_id")) == {0, 1}
     assert len(output) == 24
@@ -229,9 +221,9 @@ def test_predict_df_end_to_end_future_known_covariate():
         }
     )
 
-    output = NoriTSForecaster(
-        mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]
-    ).predict_df(history, future_df=future)
+    output = NoriTSForecaster(mode="local", model="nori-6m", quantiles=[0.1, 0.5, 0.9]).predict_df(
+        history, future_df=future
+    )
 
     assert len(output) == horizon
     assert np.isfinite(output["0.5"].to_numpy()).all()

--- a/tests/test_nori_ts_backend.py
+++ b/tests/test_nori_ts_backend.py
@@ -29,9 +29,7 @@ class _RecordingClient:
                 "kwargs": kwargs,
             }
         )
-        return np.vstack(
-            [np.full(len(X_test), level * 10.0) for level in kwargs["quantiles"]]
-        )
+        return np.vstack([np.full(len(X_test), level * 10.0) for level in kwargs["quantiles"]])
 
 
 def _multi_series_frame():
@@ -39,11 +37,7 @@ def _multi_series_frame():
     for item in (0, 1):
         timestamps = pd.date_range("2021-01-01", periods=48, freq="h")
         target = item + np.sin(2 * np.pi * np.arange(48) / 24)
-        frames.append(
-            pd.DataFrame(
-                {"item_id": item, "timestamp": timestamps, "target": target}
-            )
-        )
+        frames.append(pd.DataFrame({"item_id": item, "timestamp": timestamps, "target": target}))
     return TimeSeriesDataFrame.from_data_frame(pd.concat(frames, ignore_index=True))
 
 
@@ -106,16 +100,12 @@ def test_auto_mode_is_rejected():
         ),
     ],
 )
-def test_forecaster_constructs_the_client_with_exact_configuration(
-    monkeypatch, kwargs, expected
-):
+def test_forecaster_constructs_the_client_with_exact_configuration(monkeypatch, kwargs, expected):
     class RecordingConstructor:
         def __init__(self, **received):
             self.received = received
 
-    monkeypatch.setattr(
-        "synthefy.nori_ts.core.SynthefyNoriClient", RecordingConstructor
-    )
+    monkeypatch.setattr("synthefy.nori_ts.core.SynthefyNoriClient", RecordingConstructor)
 
     forecaster = NoriTSForecaster(**kwargs)
 

--- a/tests/test_nori_ts_ownership.py
+++ b/tests/test_nori_ts_ownership.py
@@ -43,12 +43,8 @@ def test_v7_legacy_exports_and_deep_modules_are_canonical():
     assert legacy.__all__ == canonical.__all__ == list(_PUBLIC)
     assert all(getattr(legacy, name) is getattr(canonical, name) for name in _PUBLIC)
     for name in _DEEP_MODULES:
-        canonical_module = importlib.import_module(
-            f"synthefy.nori_ts.tsfeatures.{name}"
-        )
-        historical_module = importlib.import_module(
-            f"synthefy_nori.nori_ts.tsfeatures.{name}"
-        )
+        canonical_module = importlib.import_module(f"synthefy.nori_ts.tsfeatures.{name}")
+        historical_module = importlib.import_module(f"synthefy_nori.nori_ts.tsfeatures.{name}")
         assert historical_module is canonical_module
 
 
@@ -83,9 +79,7 @@ def test_facade_falls_back_only_when_the_canonical_owner_is_missing(monkeypatch)
     monkeypatch.setattr(importlib, "import_module", missing_canonical)
     try:
         fallback = importlib.reload(legacy)
-        assert fallback.TimeSeriesDataFrame.__module__ == (
-            "synthefy_nori.nori_ts.tsfeatures.ts_dataframe"
-        )
+        assert fallback.TimeSeriesDataFrame.__module__ == ("synthefy_nori.nori_ts.tsfeatures.ts_dataframe")
         frame = fallback.TimeSeriesDataFrame.from_data_frame(
             pd.DataFrame(
                 {

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -11,6 +11,7 @@ exercise the exact class that owned the lambdas without needing model weights;
 the ``slow`` test covers the full fit -> pickle -> predict round-trip from the
 issue's reproduction.
 """
+
 from __future__ import annotations
 
 import os
@@ -36,8 +37,7 @@ def test_function_transformer_helpers_are_module_level():
     documents the contract that these names exist at module scope.
     """
     x = _sample()
-    for fn in (preprocess._inf_to_nan, preprocess._identity,
-               preprocess._shift_to_nonnegative, preprocess._add_epsilon):
+    for fn in (preprocess._inf_to_nan, preprocess._identity, preprocess._shift_to_nonnegative, preprocess._add_epsilon):
         assert fn.__module__ == preprocess.__name__
         assert "<lambda>" not in fn.__qualname__
         # Each helper pickles by reference and survives a round-trip.

--- a/tests/test_preprocess_svd_rank.py
+++ b/tests/test_preprocess_svd_rank.py
@@ -93,6 +93,7 @@ def test_shipped_config_enables_the_rule():
     import json
 
     from synthefy_nori.training.config import package_config_path
+
     cfg = json.loads(pathlib.Path(package_config_path("default_inference.json")).read_text())
     sels = [m["HighDimFeatureSelector"] for m in cfg if "HighDimFeatureSelector" in m]
     assert sels, "no HighDimFeatureSelector in the shipped config"

--- a/tests/test_qass_mode.py
+++ b/tests/test_qass_mode.py
@@ -106,8 +106,7 @@ def _tiny_arch_config(**overrides) -> dict:
 
 
 def _qass_modes(model) -> set:
-    return {m.qass_mode for m in model.modules()
-            if type(m).__name__ == "QASSMaxScaling"}
+    return {m.qass_mode for m in model.modules() if type(m).__name__ == "QASSMaxScaling"}
 
 
 def _build(config):
@@ -169,6 +168,7 @@ def test_no_qassmax_means_no_mode_is_passed(monkeypatch):
 # the "full" fallback in `resolve_qass_mode` only ever sees older files.
 # ---------------------------------------------------------------------------
 
+
 def _resolved_mode_for(state_dict, monkeypatch, mask_prediction=False):
     """Run load_model's config selection and return the QASS mode it resolves."""
     from synthefy_nori.utils import loading
@@ -208,8 +208,7 @@ def test_same_arch_config_resolves_the_same_in_both_containers(monkeypatch):
     ckpt_mode, _ = _resolved_mode_for(ckpt, monkeypatch)
 
     assert pt_mode == ckpt_mode == "base_only", (
-        f"container format changed the attention temperature: "
-        f".pt -> {pt_mode!r}, .ckpt -> {ckpt_mode!r}"
+        f"container format changed the attention temperature: .pt -> {pt_mode!r}, .ckpt -> {ckpt_mode!r}"
     )
 
 
@@ -243,6 +242,7 @@ def test_load_model_does_not_mutate_the_checkpoint(monkeypatch):
 # ---------------------------------------------------------------------------
 # finalize_arch_config: the write side. Every new checkpoint lands in era 1.
 # ---------------------------------------------------------------------------
+
 
 def test_finalize_pins_the_mode_and_stamps_the_attention_scale(monkeypatch):
     """Finalize records the mode the run will actually train with, and fills in

--- a/tests/test_quantile_dist.py
+++ b/tests/test_quantile_dist.py
@@ -22,11 +22,7 @@ def test_exponential_left_tail_uses_the_anchored_integral():
     q = np.full(8, math.log(2.0), dtype=np.float64)
     q[0] = 0.0
     # The first two points follow q(tau) = log(tau / 0.1), so lambda_L=1.
-    expected = (
-        tau[0] * (q[0] - 1.0)
-        + _mid_area(q, tau)
-        + (1.0 - tau[-1]) * q[-1]
-    )
+    expected = tau[0] * (q[0] - 1.0) + _mid_area(q, tau) + (1.0 - tau[-1]) * q[-1]
 
     actual = quantile_dist_mean_batch(
         torch.from_numpy(q).unsqueeze(0),
@@ -42,11 +38,7 @@ def test_exponential_right_tail_uses_the_anchored_integral():
     q = np.zeros(8, dtype=np.float64)
     q[-1] = math.log(1.5)
     # The last two points follow q(tau) = log(0.3 / (1 - tau)), so lambda_R=1.
-    expected = (
-        tau[0] * q[0]
-        + _mid_area(q, tau)
-        + (1.0 - tau[-1]) * (q[-1] + 1.0)
-    )
+    expected = tau[0] * q[0] + _mid_area(q, tau) + (1.0 - tau[-1]) * (q[-1] + 1.0)
 
     actual = quantile_dist_mean_batch(
         torch.from_numpy(q).unsqueeze(0),

--- a/tests/test_quantile_metadata.py
+++ b/tests/test_quantile_metadata.py
@@ -89,9 +89,7 @@ def test_predictive_mean_uses_nonuniform_checkpoint_levels(mode):
     )
     predictor.quantile_collapse = mode
 
-    collapsed = predictor._apply_quantile_collapse(
-        torch.tensor([[0.0, 10.0, 20.0]])
-    )
+    collapsed = predictor._apply_quantile_collapse(torch.tensor([[0.0, 10.0, 20.0]]))
 
     # Constant tails plus trapezoidal interpolation:
     # .1*0 + .1*(0+10)/2 + .7*(10+20)/2 + .1*20 = 13.
@@ -113,12 +111,7 @@ def test_qdist_exponential_path_uses_checkpoint_levels():
     collapsed = predictor._apply_quantile_collapse(bank)
 
     # lambda_L=1 for q(.1)=0, q(.2)=log(2); the right tail is flat.
-    expected = (
-        0.1 * -1.0
-        + 0.1 * np.log(2.0) / 2.0
-        + 0.6 * np.log(2.0)
-        + 0.2 * np.log(2.0)
-    )
+    expected = 0.1 * -1.0 + 0.1 * np.log(2.0) / 2.0 + 0.6 * np.log(2.0) + 0.2 * np.log(2.0)
     torch.testing.assert_close(collapsed, torch.tensor([expected], dtype=torch.float64))
 
 
@@ -127,9 +120,7 @@ def test_predictor_preserves_dense_grid_for_bfloat16_predictions():
     predictor.model = SimpleNamespace(
         num_reg_quantiles=999,
         regression_loss="pinball",
-        regression_quantiles=tuple(
-            np.arange(1, 1000, dtype=np.float64) / 1000.0
-        ),
+        regression_quantiles=tuple(np.arange(1, 1000, dtype=np.float64) / 1000.0),
     )
     predictor.quantile_collapse = "mean"
     bank = torch.linspace(-2.0, 3.0, 999, dtype=torch.bfloat16).unsqueeze(0)

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -7,9 +7,7 @@ import yaml
 
 _ROOT = Path(__file__).resolve().parents[1]
 _WORKFLOW_ROOT = _ROOT / ".github" / "workflows"
-_PUBLIC_REPOSITORY_GATE = (
-    "github.repository == 'Synthefy/synthefy-nori'"
-)
+_PUBLIC_REPOSITORY_GATE = "github.repository == 'Synthefy/synthefy-nori'"
 _SPECS = {
     "synthefy": {
         "workflow": "publish-synthefy.yml",
@@ -40,18 +38,12 @@ def _load(name: str) -> dict:
 
 
 def _run_scripts(job: dict) -> str:
-    return "\n".join(
-        step["run"]
-        for step in job["steps"]
-        if isinstance(step, dict) and "run" in step
-    )
+    return "\n".join(step["run"] for step in job["steps"] if isinstance(step, dict) and "run" in step)
 
 
 def test_generic_publisher_is_removed_and_namespaced_publishers_are_complete():
     assert not (_WORKFLOW_ROOT / "publish.yml").exists()
-    assert {
-        path.name for path in _WORKFLOW_ROOT.glob("publish*.yml")
-    } == {spec["workflow"] for spec in _SPECS.values()}
+    assert {path.name for path in _WORKFLOW_ROOT.glob("publish*.yml")} == {spec["workflow"] for spec in _SPECS.values()}
 
     for distribution, spec in _SPECS.items():
         workflow = _load(spec["workflow"])
@@ -69,7 +61,7 @@ def test_generic_publisher_is_removed_and_namespaced_publishers_are_complete():
         build = workflow["jobs"]["build"]
         assert spec["tag_prefix"] in build["if"]
         scripts = _run_scripts(build)
-        assert f"expected_tag=\"{spec['tag_prefix']}$version\"" in scripts
+        assert f'expected_tag="{spec["tag_prefix"]}$version"' in scripts
         assert '"$GITHUB_REF" != "refs/tags/$tag"' in scripts
         assert 'git rev-parse "refs/tags/$tag^{}"' in scripts
         assert "git merge-base --is-ancestor" in scripts
@@ -95,16 +87,9 @@ def test_only_public_namespaced_jobs_can_publish_with_oidc():
     for distribution, spec in _SPECS.items():
         workflow = _load(spec["workflow"])
         build = workflow["jobs"]["build"]
-        artifact_names.add(
-            build["outputs"]["artifact"]
-            + distribution
-        )
+        artifact_names.add(build["outputs"]["artifact"] + distribution)
 
-        publish_jobs = {
-            name: job
-            for name, job in workflow["jobs"].items()
-            if name.startswith("publish-")
-        }
+        publish_jobs = {name: job for name, job in workflow["jobs"].items() if name.startswith("publish-")}
         assert set(publish_jobs) == spec["publish_jobs"]
         assert build.get("permissions") is None
 
@@ -117,20 +102,14 @@ def test_only_public_namespaced_jobs_can_publish_with_oidc():
             environment = job["environment"]["name"]
             environments.add(environment)
             assert environment in spec["environments"]
-            uses = [
-                step.get("uses", "")
-                for step in job["steps"]
-                if isinstance(step, dict)
-            ]
+            uses = [step.get("uses", "") for step in job["steps"] if isinstance(step, dict)]
             assert "pypa/gh-action-pypi-publish@release/v1" in uses
 
         for name, job in workflow["jobs"].items():
             if name not in publish_jobs:
                 assert job.get("permissions", {}).get("id-token") != "write"
 
-    assert environments == set().union(
-        *(spec["environments"] for spec in _SPECS.values())
-    )
+    assert environments == set().union(*(spec["environments"] for spec in _SPECS.values()))
     assert len(artifact_names) == 2
 
 

--- a/tests/test_scm_prior_health.py
+++ b/tests/test_scm_prior_health.py
@@ -45,10 +45,7 @@ def test_linear_initialization_preserves_random_function_parameters():
         noise_std=0.0,
     )
 
-    activations = [
-        module for module in scm.modules()
-        if isinstance(module, scm_prior.RandomFunctionActivation)
-    ]
+    activations = [module for module in scm.modules() if isinstance(module, scm_prior.RandomFunctionActivation)]
     assert activations
     for activation in activations:
         assert torch.count_nonzero(activation.freqs) == activation.freqs.numel()
@@ -67,13 +64,17 @@ def test_block_dropout_uses_probability_and_keeps_every_row_and_column(monkeypat
     torch.manual_seed(7)
     dense_blocks = torch.empty(7, 5)
     scm_prior._block_wise_dropout_init(
-        dense_blocks, init_std=1.0, dropout_prob=0.0,
+        dense_blocks,
+        init_std=1.0,
+        dropout_prob=0.0,
     )
 
     torch.manual_seed(7)
     sparse_blocks = torch.empty(7, 5)
     scm_prior._block_wise_dropout_init(
-        sparse_blocks, init_std=1.0, dropout_prob=0.9,
+        sparse_blocks,
+        init_std=1.0,
+        dropout_prob=0.9,
     )
 
     assert torch.all(torch.count_nonzero(sparse_blocks, dim=1) > 0)
@@ -84,13 +85,17 @@ def test_block_dropout_uses_probability_and_keeps_every_row_and_column(monkeypat
 def test_block_dropout_rejects_impossible_probability():
     with pytest.raises(ValueError, match="dropout_prob"):
         scm_prior._block_wise_dropout_init(
-            torch.empty(3, 3), init_std=1.0, dropout_prob=1.0,
+            torch.empty(3, 3),
+            init_std=1.0,
+            dropout_prob=1.0,
         )
 
 
 def test_positive_meta_distribution_has_no_boundary_atom():
     sample = scm_prior.meta_trunc_norm_log_scaled(
-        np.random.default_rng(5), min_mean=0.01, max_mean=0.01,
+        np.random.default_rng(5),
+        min_mean=0.01,
+        max_mean=0.01,
         lower_bound=0.0,
     )
     values = np.array([sample() for _ in range(2_000)])
@@ -116,10 +121,7 @@ def test_random_choice_activation_cannot_choose_itself_recursively():
     factories = scm_prior.get_activations()
     choice_factory = factories[len(factories) // 2]
     assert isinstance(choice_factory, scm_prior.RandomChoiceFactory)
-    assert all(
-        not isinstance(factory, scm_prior.RandomChoiceFactory)
-        for factory in choice_factory.act_factories
-    )
+    assert all(not isinstance(factory, scm_prior.RandomChoiceFactory) for factory in choice_factory.act_factories)
 
 
 def test_failed_mlp_draws_use_an_observable_exactly_learnable_fallback(monkeypatch):
@@ -129,7 +131,11 @@ def test_failed_mlp_draws_use_an_observable_exactly_learnable_fallback(monkeypat
 
     monkeypatch.setattr(scm_prior, "MLPSCM", NumericallyInvalidSCM)
     X, y, meta = scm_prior._generate_mlp(
-        256, 8, _mlp_hyperparams(), np.random.default_rng(13), "cpu",
+        256,
+        8,
+        _mlp_hyperparams(),
+        np.random.default_rng(13),
+        "cpu",
     )
 
     weights = np.arange(4, 0, -1, dtype=np.float32)
@@ -142,12 +148,15 @@ def test_failed_mlp_draws_use_an_observable_exactly_learnable_fallback(monkeypat
     }
 
 
-@pytest.mark.parametrize("error", [
-    TypeError("bad API call"),
-    RuntimeError("shape mismatch"),
-    RuntimeError("Inference tensors cannot be saved for backward"),
-    RuntimeError("inferred shape mismatch"),
-])
+@pytest.mark.parametrize(
+    "error",
+    [
+        TypeError("bad API call"),
+        RuntimeError("shape mismatch"),
+        RuntimeError("Inference tensors cannot be saved for backward"),
+        RuntimeError("inferred shape mismatch"),
+    ],
+)
 def test_programming_errors_are_not_swallowed(monkeypatch, error):
     class BrokenSCM:
         def __init__(self, **_kwargs):
@@ -156,19 +165,26 @@ def test_programming_errors_are_not_swallowed(monkeypatch, error):
     monkeypatch.setattr(scm_prior, "MLPSCM", BrokenSCM)
     with pytest.raises(type(error), match=str(error)):
         scm_prior._generate_mlp(
-            32, 4, _mlp_hyperparams(), np.random.default_rng(13), "cpu",
+            32,
+            4,
+            _mlp_hyperparams(),
+            np.random.default_rng(13),
+            "cpu",
         )
 
 
-@pytest.mark.parametrize("message", [
-    "output contains NaN",
-    "output contains inf",
-    "array must not contain infs or NaNs",
-    "output is infinite",
-    "output is non-finite",
-    "overflow encountered in sampled activation",
-    "sampled numerical failure",
-])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "output contains NaN",
+        "output contains inf",
+        "array must not contain infs or NaNs",
+        "output is infinite",
+        "output is non-finite",
+        "overflow encountered in sampled activation",
+        "sampled numerical failure",
+    ],
+)
 def test_known_numerical_errors_remain_retryable(message):
     assert scm_prior._retryable_generation_exception(RuntimeError(message))
 
@@ -218,8 +234,7 @@ def test_tree_presampled_noise_uses_per_output_scales(monkeypatch):
 
 def test_scm_target_normalization_does_not_inspect_query_targets(monkeypatch):
     n_samples, n_features, context_rows = 12, 3, 6
-    X = np.arange(n_samples * n_features, dtype=np.float32).reshape(
-        n_samples, n_features)
+    X = np.arange(n_samples * n_features, dtype=np.float32).reshape(n_samples, n_features)
     context_y = np.linspace(-2.0, 3.0, context_rows, dtype=np.float32)
     query_a = np.linspace(4.0, 7.0, n_samples - context_rows, dtype=np.float32)
     query_b = query_a * 100.0 + 10_000.0
@@ -241,15 +256,14 @@ def test_scm_target_normalization_does_not_inspect_query_targets(monkeypatch):
 
     monkeypatch.setattr(scm_prior, "_generate_mlp", fixed_mlp)
     first = scm_prior._generate_scm_prior_dataset(
-        n_samples, n_features, "reg", None, np.random.default_rng(8), "cpu",
-        context_rows=context_rows)
+        n_samples, n_features, "reg", None, np.random.default_rng(8), "cpu", context_rows=context_rows
+    )
     state["query"] = query_b
     second = scm_prior._generate_scm_prior_dataset(
-        n_samples, n_features, "reg", None, np.random.default_rng(8), "cpu",
-        context_rows=context_rows)
+        n_samples, n_features, "reg", None, np.random.default_rng(8), "cpu", context_rows=context_rows
+    )
 
-    np.testing.assert_array_equal(
-        first["y"][:context_rows], second["y"][:context_rows])
+    np.testing.assert_array_equal(first["y"][:context_rows], second["y"][:context_rows])
     assert float(np.mean(first["y"][:context_rows])) == pytest.approx(0.0)
     assert float(np.std(first["y"][:context_rows])) == pytest.approx(1.0)
     assert first["meta"]["context_rows"] == context_rows
@@ -266,16 +280,19 @@ def test_scm_feature_stabilization_fits_context_only(array_type):
         shifted = torch.from_numpy(shifted)
 
     first = scm_prior._robust_stabilize_features(
-        base, context_rows=context_rows,
+        base,
+        context_rows=context_rows,
     )
     second = scm_prior._robust_stabilize_features(
-        shifted, context_rows=context_rows,
+        shifted,
+        context_rows=context_rows,
     )
     if isinstance(first, torch.Tensor):
         first = first.numpy()
         second = second.numpy()
     np.testing.assert_array_equal(
-        first[:context_rows], second[:context_rows],
+        first[:context_rows],
+        second[:context_rows],
     )
 
 
@@ -287,7 +304,11 @@ def test_scm_validation_requires_context_variation():
     y[context_rows:] = np.arange(8, dtype=np.float32)
 
     healthy, reason = scm_prior._validate_generated_data(
-        X, y, 16, 3, context_rows=context_rows,
+        X,
+        y,
+        16,
+        3,
+        context_rows=context_rows,
     )
 
     assert healthy is False
@@ -295,7 +316,11 @@ def test_scm_validation_requires_context_variation():
 
     X[:context_rows] = np.arange(24, dtype=np.float32).reshape(8, 3)
     healthy, reason = scm_prior._validate_generated_data(
-        X, y, 16, 3, context_rows=context_rows,
+        X,
+        y,
+        16,
+        3,
+        context_rows=context_rows,
     )
     assert healthy is False
     assert reason == "constant target"
@@ -310,7 +335,11 @@ def test_scm_validation_accepts_finite_singleton_context(array_type):
         y = torch.from_numpy(y)
 
     healthy, reason = scm_prior._validate_generated_data(
-        X, y, 2, 2, context_rows=1,
+        X,
+        y,
+        2,
+        2,
+        context_rows=1,
     )
 
     assert healthy is True
@@ -330,7 +359,11 @@ def test_scm_validation_ignores_query_only_nonfinite_values(array_type):
         y = torch.from_numpy(y)
 
     healthy, reason = scm_prior._validate_generated_data(
-        X, y, 16, 3, context_rows=context_rows,
+        X,
+        y,
+        16,
+        3,
+        context_rows=context_rows,
     )
 
     assert healthy is True
@@ -338,8 +371,7 @@ def test_scm_validation_ignores_query_only_nonfinite_values(array_type):
 
 
 @pytest.mark.parametrize("scm_type", ["mlp", "tree"])
-def test_scm_context_is_invariant_to_query_causes(
-        monkeypatch, scm_type):
+def test_scm_context_is_invariant_to_query_causes(monkeypatch, scm_type):
     n_samples, n_features, context_rows = 64, 4, 32
     state = {"query_mode": "unchanged"}
     original_sample = scm_prior.XSampler.sample
@@ -380,29 +412,42 @@ def test_scm_context_is_invariant_to_query_causes(
             "pre_sample_noise_std": False,
         }
     monkeypatch.setattr(
-        scm_prior, "sample_hyperparams", lambda *_args, **_kwargs: hp,
+        scm_prior,
+        "sample_hyperparams",
+        lambda *_args, **_kwargs: hp,
     )
 
     first = scm_prior.generate_scm_prior_dataset(
-        n_samples, n_features, "reg", rng=np.random.default_rng(31),
+        n_samples,
+        n_features,
+        "reg",
+        rng=np.random.default_rng(31),
         context_rows=context_rows,
     )
     state["query_mode"] = "shifted"
     second = scm_prior.generate_scm_prior_dataset(
-        n_samples, n_features, "reg", rng=np.random.default_rng(31),
+        n_samples,
+        n_features,
+        "reg",
+        rng=np.random.default_rng(31),
         context_rows=context_rows,
     )
 
     np.testing.assert_array_equal(
-        first["X"][:context_rows], second["X"][:context_rows],
+        first["X"][:context_rows],
+        second["X"][:context_rows],
     )
     np.testing.assert_array_equal(
-        first["y"][:context_rows], second["y"][:context_rows],
+        first["y"][:context_rows],
+        second["y"][:context_rows],
     )
 
     state["query_mode"] = "nonfinite"
     nonfinite_query = scm_prior.generate_scm_prior_dataset(
-        n_samples, n_features, "reg", rng=np.random.default_rng(31),
+        n_samples,
+        n_features,
+        "reg",
+        rng=np.random.default_rng(31),
         context_rows=context_rows,
     )
     assert nonfinite_query["meta"]["fallback_used"] is False
@@ -419,8 +464,7 @@ def test_scm_context_is_invariant_to_query_causes(
 
 
 @pytest.mark.parametrize("scm_type", ["mlp", "tree"])
-def test_scm_singleton_context_preserves_a_usable_episode(
-        monkeypatch, scm_type):
+def test_scm_singleton_context_preserves_a_usable_episode(monkeypatch, scm_type):
     if scm_type == "mlp":
         hp = {
             **_mlp_hyperparams(),
@@ -446,11 +490,17 @@ def test_scm_singleton_context_preserves_a_usable_episode(
             "pre_sample_noise_std": False,
         }
     monkeypatch.setattr(
-        scm_prior, "sample_hyperparams", lambda *_args, **_kwargs: hp,
+        scm_prior,
+        "sample_hyperparams",
+        lambda *_args, **_kwargs: hp,
     )
 
     data = scm_prior.generate_scm_prior_dataset(
-        32, 4, "reg", rng=np.random.default_rng(41), context_rows=1,
+        32,
+        4,
+        "reg",
+        rng=np.random.default_rng(41),
+        context_rows=1,
     )
 
     assert data["meta"]["fallback_used"] is (scm_type == "tree")
@@ -469,13 +519,10 @@ def test_context_rows_must_include_at_least_one_labeled_row(module):
 def test_generate_batch_passes_context_rows_to_scm_prior(monkeypatch):
     seen_context_rows = []
 
-    def fake_scm(
-            n_samples, n_features, task_type, n_classes=None,
-            rng=None, device="cpu", context_rows=None):
+    def fake_scm(n_samples, n_features, task_type, n_classes=None, rng=None, device="cpu", context_rows=None):
         del task_type, n_classes, rng, device
         seen_context_rows.append(context_rows)
-        X = np.arange(n_samples * n_features, dtype=np.float32).reshape(
-            n_samples, n_features)
+        X = np.arange(n_samples * n_features, dtype=np.float32).reshape(n_samples, n_features)
         y = np.linspace(-1.0, 1.0, n_samples, dtype=np.float32)
         return {"X": X, "y": y, "meta": {"generator_family": "scm_prior"}}
 

--- a/tests/test_svd_fallback_visibility.py
+++ b/tests/test_svd_fallback_visibility.py
@@ -11,6 +11,7 @@ one ``strict_pipeline()`` makes it fatal, the category tree lets a caller escala
 all degradation or one kind, and the eval runner escalates the SVD fallback so no
 eval can score a degraded run.
 """
+
 import inspect
 import warnings
 
@@ -26,8 +27,7 @@ from synthefy_nori import (
 from synthefy_nori.inference import preprocess as pp
 from synthefy_nori.inference.preprocess import HighDimFeatureSelector
 
-SVD_BLOCK = {"strategy": "svd_all", "svd_components": 64,
-             "n_features_threshold": 256, "binary_threshold": 1.01}
+SVD_BLOCK = {"strategy": "svd_all", "svd_components": 64, "n_features_threshold": 256, "binary_threshold": 1.01}
 
 
 def _data(n=300, p=400, seed=0):
@@ -42,20 +42,25 @@ def _selector(**kw):
 
 def _break_fit(monkeypatch):
     """Make the SVD blow up at fit time."""
+
     class _Boom(pp._TorchTruncatedSVD):
         def fit(self, X, y=None):
             raise np.linalg.LinAlgError("synthetic fit failure")
+
     monkeypatch.setattr(pp, "_TorchTruncatedSVD", _Boom)
 
 
 def _break_transform(sel):
     """Make the already-fitted SVD blow up at transform time."""
+
     def _boom(_X):
         raise np.linalg.LinAlgError("synthetic transform failure")
+
     sel.svd_model_.transform = _boom
 
 
 # --- transform-time failure (the all-zero column) ----------------------------
+
 
 def test_transform_failure_warns_and_zeros():
     X, y = _data()
@@ -64,7 +69,7 @@ def test_transform_failure_warns_and_zeros():
     _break_transform(sel)
     with pytest.warns(SvdFallbackWarning, match="all-zero column"):
         out, cat = sel.transform(X[:5])
-    assert out.shape == (5, 1) and not out.any()   # fallback still taken
+    assert out.shape == (5, 1) and not out.any()  # fallback still taken
     assert cat == []
 
 
@@ -79,9 +84,10 @@ def test_transform_failure_is_fatal_under_strict_pipeline():
 
 def test_svd_binary_transform_failure_warns():
     rng = np.random.default_rng(1)
-    X = (rng.random((300, 400)) < 0.3).astype(float)   # all-binary -> svd_binary
-    sel = HighDimFeatureSelector(strategy="svd_binary", n_features_threshold=256,
-                                 binary_threshold=0.5, svd_components=64)
+    X = (rng.random((300, 400)) < 0.3).astype(float)  # all-binary -> svd_binary
+    sel = HighDimFeatureSelector(
+        strategy="svd_binary", n_features_threshold=256, binary_threshold=0.5, svd_components=64
+    )
     sel.fit(X, [], 0, y=rng.standard_normal(300))
     _break_transform(sel)
     with pytest.warns(SvdFallbackWarning, match="SVD-projected columns"):
@@ -91,6 +97,7 @@ def test_svd_binary_transform_failure_warns():
 
 # --- fit-time failure (passthrough of the raw columns) -----------------------
 
+
 def test_fit_failure_warns_and_passes_through(monkeypatch):
     X, y = _data()
     _break_fit(monkeypatch)
@@ -99,7 +106,7 @@ def test_fit_failure_warns_and_passes_through(monkeypatch):
         sel.fit(X, [], 0, y=y)
     assert sel.passthrough_
     out, _ = sel.transform(X[:5])
-    assert out.shape[1] == 400          # model sees the raw width, not 64
+    assert out.shape[1] == 400  # model sees the raw width, not 64
 
 
 def test_fit_failure_is_fatal_under_strict_pipeline(monkeypatch):
@@ -110,6 +117,7 @@ def test_fit_failure_is_fatal_under_strict_pipeline(monkeypatch):
 
 
 # --- the happy path stays quiet ---------------------------------------------
+
 
 def test_working_svd_is_silent_even_under_strict_pipeline():
     """The guard must not fire on a healthy run, strict or not."""
@@ -122,7 +130,7 @@ def test_working_svd_is_silent_even_under_strict_pipeline():
     assert not [w for w in caught if issubclass(w.category, DegradedPipelineWarning)]
     assert out.shape == (5, 64)
 
-    sel2 = _selector()                      # same run, now strict: still no raise
+    sel2 = _selector()  # same run, now strict: still no raise
     with strict_pipeline():
         sel2.fit(X, [], 0, y=y)
         out2, _ = sel2.transform(X[:5])
@@ -130,6 +138,7 @@ def test_working_svd_is_silent_even_under_strict_pipeline():
 
 
 # --- the category tree is the whole mechanism --------------------------------
+
 
 def test_category_tree():
     """One escalation covers every fallback; a subclass covers just one."""
@@ -160,7 +169,7 @@ def test_strict_pipeline_restores_filters(monkeypatch):
     with strict_pipeline(), pytest.raises(SvdFallbackWarning):
         _selector().fit(X, [], 0, y=y)
     assert warnings.filters == before
-    with pytest.warns(SvdFallbackWarning):          # back to warning
+    with pytest.warns(SvdFallbackWarning):  # back to warning
         _selector().fit(X, [], 0, y=y)
 
 
@@ -184,6 +193,7 @@ def test_no_threaded_argument_survives():
 
 
 # --- an eval can never score a degraded run ---------------------------------
+
 
 class _WarningWrapper:
     """A model whose predict degrades: warns ``category``, then predicts anyway."""
@@ -226,7 +236,8 @@ def _run_runner_with(wrapper, tmp_path):
         y_test=np.arange(3, dtype=np.float64),
     )
     runner = EvalRunner(
-        _Registry(), _Registry(),
+        _Registry(),
+        _Registry(),
         output_dir=tmp_path / "out",
         cache_dir=tmp_path / "cache",
         no_cache=True,
@@ -241,8 +252,8 @@ def _run_runner_with(wrapper, tmp_path):
 def test_runner_records_a_broken_svd_as_failed_not_scored(tmp_path):
     """The guarantee: an eval can never report a degraded pipeline as a score."""
     row = _run_runner_with(_WarningWrapper(SvdFallbackWarning), tmp_path)
-    assert row["r2"] is None or np.isnan(row["r2"])       # NOT scored
-    assert "SvdFallbackWarning" in (row["error"] or "")   # recorded instead
+    assert row["r2"] is None or np.isnan(row["r2"])  # NOT scored
+    assert "SvdFallbackWarning" in (row["error"] or "")  # recorded instead
 
 
 def test_runner_still_scores_a_subsampled_context(tmp_path):
@@ -252,7 +263,7 @@ def test_runner_still_scores_a_subsampled_context(tmp_path):
     ContextSubsampledWarning must not fail the row — memory_policy=
     {'allow_subsample': False} is the knob for refusing that.
     """
-    with pytest.warns(ContextSubsampledWarning):        # warns, but does not fail
+    with pytest.warns(ContextSubsampledWarning):  # warns, but does not fail
         row = _run_runner_with(_WarningWrapper(ContextSubsampledWarning), tmp_path)
     assert row["error"] is None
     assert row["r2"] is not None and not np.isnan(row["r2"])
@@ -260,6 +271,7 @@ def test_runner_still_scores_a_subsampled_context(tmp_path):
 
 class _DistPointDegrader:
     """A second custom wrapper whose point prediction degrades."""
+
     name = "dist-point-degrader"
     device_str = "cpu"
 
@@ -274,11 +286,12 @@ class _DistPointDegrader:
 def test_runner_guards_every_scored_predict(tmp_path):
     """Every scored prediction is guarded by the strict SVD filter."""
     row = _run_runner_with(_DistPointDegrader(), tmp_path)
-    assert "SvdFallbackWarning" in (row["error"] or "")   # recorded as failed
-    assert row["r2"] is None or np.isnan(row["r2"])       # NOT scored
+    assert "SvdFallbackWarning" in (row["error"] or "")  # recorded as failed
+    assert row["r2"] is None or np.isnan(row["r2"])  # NOT scored
 
 
 # --- an escalated warning must not be swallowed as a generic failure ---------
+
 
 def test_yj_ensemble_does_not_swallow_an_escalated_warning(monkeypatch):
     """A Warning IS an Exception, so blanket handlers can eat the escalation.
@@ -294,22 +307,22 @@ def test_yj_ensemble_does_not_swallow_an_escalated_warning(monkeypatch):
 
     def _fake_single(self, x_train, y_train, x_test, return_distribution=False):
         calls["n"] += 1
-        if calls["n"] == 2:                              # the YJ pass only
+        if calls["n"] == 2:  # the YJ pass only
             warnings.warn("Nori: synthetic SVD fit failure", SvdFallbackWarning)
         return np.full(len(x_test), 1.0)
 
     monkeypatch.setattr(NoriPredictor, "_predict_reg_single", _fake_single)
-    pred = NoriPredictor.__new__(NoriPredictor)          # no checkpoint needed
+    pred = NoriPredictor.__new__(NoriPredictor)  # no checkpoint needed
     pred.augmentations = ["yj"]
-    pred.yj_skew_threshold = 0.0                         # force the YJ branch open
-    y = np.array([0.0, 0, 0, 0, 0, 0, 0, 0, 1, 40.0])    # skewed -> gate opens
+    pred.yj_skew_threshold = 0.0  # force the YJ branch open
+    y = np.array([0.0, 0, 0, 0, 0, 0, 0, 0, 1, 40.0])  # skewed -> gate opens
     x_train, x_test = np.zeros((10, 3)), np.zeros((4, 3))
 
     with strict_pipeline(), pytest.raises(SvdFallbackWarning):
         pred._predict_reg(x_train, y, x_test)
     assert calls["n"] == 2, "the YJ pass must actually have run"
 
-    calls["n"] = 0                                       # default stays resilient
+    calls["n"] = 0  # default stays resilient
     with pytest.warns(SvdFallbackWarning):
         out = pred._predict_reg(x_train, y, x_test)
     assert len(out) == 4

--- a/tests/test_synthefy_client_compat.py
+++ b/tests/test_synthefy_client_compat.py
@@ -25,9 +25,7 @@ from synthefy.errors import BadRequestError
 
 _ROOT = Path(__file__).resolve().parents[1]
 _GOLDEN_PATH = _ROOT / "tests" / "compat" / "synthefy_6_3_nori_goldens.json"
-_GOLDEN_SHA256 = (
-    "f357863508260242746021594d8616a8baecb6284736f54fac8f8e771e0e7903"
-)
+_GOLDEN_SHA256 = "f357863508260242746021594d8616a8baecb6284736f54fac8f8e771e0e7903"
 _ORACLE = {
     "repository": "Synthefy/synthefy",
     "commit": "9ecc3d2fad8e37e95869379cc05f328597e258f9",
@@ -112,9 +110,7 @@ def _public_trace(monkeypatch) -> dict:
     )
     trace["remote_dataframe"] = _remote_call(
         {"task": "regression", "predictions": [3.5, 4.5]},
-        pd.DataFrame(
-            {"number": [1.0, 2.0, 3.0], "color": ["red", "blue", None]}
-        ),
+        pd.DataFrame({"number": [1.0, 2.0, 3.0], "color": ["red", "blue", None]}),
         pd.Series([1.0, 2.0, 3.0], name="score"),
         pd.DataFrame(
             {"color": ["green", "red"], "number": [4.0, 5.0]},
@@ -232,9 +228,7 @@ def _public_trace(monkeypatch) -> dict:
         region_name="us-east-1",
     )
     trace["sagemaker_default"] = {
-        "result": _normalized(
-            aws_client.predict([[0.0], [1.0]], [0.0, 1.0], [[2.0]])
-        ),
+        "result": _normalized(aws_client.predict([[0.0], [1.0]], [0.0, 1.0], [[2.0]])),
         "transport": _normalized(aws_capture),
     }
 
@@ -250,9 +244,7 @@ def _public_trace(monkeypatch) -> dict:
             headers={"x-request-id": "req-error"},
         )
 
-    error_client = SynthefyNoriClient(
-        api_key="bad", model="nori-30m", max_retries=0
-    )
+    error_client = SynthefyNoriClient(api_key="bad", model="nori-30m", max_retries=0)
     error_client.close()
     error_client.client = httpx.Client(
         base_url=error_client.base_url,
@@ -285,9 +277,9 @@ def _public_trace(monkeypatch) -> dict:
         ).to_wire(),
         # The golden pins the 6.3 fields. New additive response capabilities
         # have their own contract tests and are excluded from this legacy view.
-        "response": NoriPredictResponse(
-            task="regression", predictions=[1.0, None]
-        ).model_dump(exclude={"large_context_report"}),
+        "response": NoriPredictResponse(task="regression", predictions=[1.0, None]).model_dump(
+            exclude={"large_context_report"}
+        ),
     }
     return trace
 
@@ -312,7 +304,5 @@ def test_migrated_client_matches_frozen_6_3_except_the_v7_categorical_contract(m
     assert golden_dataframe["transport"]["body"]["X_test"][0] == [4.0, -1.0]
     expected_dataframe = copy.deepcopy(golden_dataframe)
     expected_dataframe["transport"]["body"]["X_test"][0] = [4.0, 2.0]
-    expected_dataframe["transport"]["raw"] = expected_dataframe["transport"][
-        "raw"
-    ].replace("[4.0, -1.0]", "[4.0, 2.0]")
+    expected_dataframe["transport"]["raw"] = expected_dataframe["transport"]["raw"].replace("[4.0, -1.0]", "[4.0, 2.0]")
     assert current_dataframe == expected_dataframe

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -17,6 +17,8 @@ except ModuleNotFoundError:  # pragma: no cover - exercised by the Python 3.10 l
 _ROOT = Path(__file__).resolve().parents[1]
 _CLIENT = _ROOT / "libs" / "synthefy"
 _CLIENT_TSFEATURES = _CLIENT / "src" / "synthefy" / "nori_ts" / "tsfeatures"
+
+
 def _toml(path: Path) -> dict:
     return tomllib.loads(path.read_text())
 
@@ -34,8 +36,7 @@ def _declared_version() -> str:
     tree = ast.parse((_CLIENT / "src" / "synthefy" / "__init__.py").read_text())
     for node in tree.body:
         if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id == "__version__"
-            for target in node.targets
+            isinstance(target, ast.Name) and target.id == "__version__" for target in node.targets
         ):
             assert isinstance(node.value, ast.Constant)
             return str(node.value.value)
@@ -139,8 +140,7 @@ def test_published_dependencies_point_only_from_heavy_to_light():
     assert set(client_optionals) == {"aws", "forecasting", "text"}
     assert "local" not in client_optionals
     all_client_requirements = _requirements(
-        client["dependencies"]
-        + [value for values in client_optionals.values() for value in values]
+        client["dependencies"] + [value for values in client_optionals.values() for value in values]
     )
     assert not _named(all_client_requirements, "synthefy-nori")
 
@@ -160,10 +160,7 @@ def test_published_dependencies_point_only_from_heavy_to_light():
     assert base_names.isdisjoint(forbidden_base)
 
     forecasting = _requirements(client_optionals["forecasting"])
-    assert {
-        canonicalize_name(requirement.name): str(requirement.specifier)
-        for requirement in forecasting
-    } == {
+    assert {canonicalize_name(requirement.name): str(requirement.specifier) for requirement in forecasting} == {
         "datasets": ">=2.0",
         "gluonts": ">=0.16",
         "joblib": ">=1.1",
@@ -189,12 +186,8 @@ def test_namespaces_and_imports_do_not_create_a_base_runtime_cycle():
     root = _toml(_ROOT / "pyproject.toml")
     client = _toml(_CLIENT / "pyproject.toml")
 
-    assert root["tool"]["setuptools"]["packages"]["find"]["include"] == [
-        "synthefy_nori*"
-    ]
-    assert client["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == [
-        "src/synthefy"
-    ]
+    assert root["tool"]["setuptools"]["packages"]["find"]["include"] == ["synthefy_nori*"]
+    assert client["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["src/synthefy"]
     assert not (_ROOT / "src" / "synthefy").exists()
     assert not (_CLIENT / "src" / "synthefy_nori").exists()
 
@@ -217,8 +210,7 @@ def test_namespaces_and_imports_do_not_create_a_base_runtime_cycle():
         if any(name.split(".", 1)[0] in client_forbidden for name in _import_time_modules(path)):
             client_offenders.append(str(path.relative_to(_ROOT)))
     assert not client_offenders, (
-        "base synthefy imports a heavy or forecasting-only dependency at module scope: "
-        f"{client_offenders}"
+        f"base synthefy imports a heavy or forecasting-only dependency at module scope: {client_offenders}"
     )
 
     tsfeature_forbidden = {
@@ -231,25 +223,17 @@ def test_namespaces_and_imports_do_not_create_a_base_runtime_cycle():
     }
     tsfeature_offenders = []
     for path in _CLIENT_TSFEATURES.rglob("*.py"):
-        if any(
-            name.split(".", 1)[0] in tsfeature_forbidden
-            for name in _import_time_modules(path)
-        ):
+        if any(name.split(".", 1)[0] in tsfeature_forbidden for name in _import_time_modules(path)):
             tsfeature_offenders.append(str(path.relative_to(_ROOT)))
     assert not tsfeature_offenders, (
-        "model-free time-series preparation imports a heavy/client backend: "
-        f"{tsfeature_offenders}"
+        f"model-free time-series preparation imports a heavy/client backend: {tsfeature_offenders}"
     )
-    assert _import_time_modules(
-        _CLIENT / "src" / "synthefy" / "nori_ts" / "__init__.py"
-    ) == ["synthefy.nori_ts.core"]
+    assert _import_time_modules(_CLIENT / "src" / "synthefy" / "nori_ts" / "__init__.py") == ["synthefy.nori_ts.core"]
 
     facade_offenders = []
     for path in (_ROOT / "src" / "synthefy_nori").rglob("*.py"):
         modules = _import_time_modules(path)
-        if any(
-            name == "synthefy" or name.startswith("synthefy.nori_client") for name in modules
-        ):
+        if any(name == "synthefy" or name.startswith("synthefy.nori_client") for name in modules):
             facade_offenders.append(str(path.relative_to(_ROOT)))
     assert not facade_offenders, (
         f"synthefy_nori imports the lightweight client facade at module scope: {facade_offenders}"
@@ -264,12 +248,8 @@ def test_tabular_preparation_has_one_v7_implementation_owner():
     canonical_tree = ast.parse(canonical_path.read_text())
     client_tree = ast.parse(client_path.read_text())
     legacy_tree = ast.parse(legacy_path.read_text())
-    canonical_defs = {
-        node.name for node in canonical_tree.body if isinstance(node, ast.FunctionDef)
-    }
-    client_defs = {
-        node.name for node in client_tree.body if isinstance(node, ast.FunctionDef)
-    }
+    canonical_defs = {node.name for node in canonical_tree.body if isinstance(node, ast.FunctionDef)}
+    client_defs = {node.name for node in client_tree.body if isinstance(node, ast.FunctionDef)}
     canonical_helpers = {
         "_has_encodable_columns",
         "_numeric_categories_to_values",
@@ -281,23 +261,15 @@ def test_tabular_preparation_has_one_v7_implementation_owner():
     assert not any(isinstance(node, ast.FunctionDef) for node in legacy_tree.body)
 
     builder = next(
-        node
-        for node in client_tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "_build_nori_request"
+        node for node in client_tree.body if isinstance(node, ast.FunctionDef) and node.name == "_build_nori_request"
     )
     canonical_calls = [
         node
         for node in ast.walk(builder)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "_align_and_featurize"
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_align_and_featurize"
     ]
     assert len(canonical_calls) == 1
-    stacklevel = next(
-        keyword.value
-        for keyword in canonical_calls[0].keywords
-        if keyword.arg == "_warning_stacklevel"
-    )
+    stacklevel = next(keyword.value for keyword in canonical_calls[0].keywords if keyword.arg == "_warning_stacklevel")
     assert isinstance(stacklevel, ast.Constant) and stacklevel.value == 5
 
 
@@ -330,10 +302,7 @@ def test_time_series_forecaster_has_one_lightweight_implementation_owner():
     assert "synthefy.nori_ts.tsfeatures" in core_modules
     assert not any(name.startswith("synthefy_nori") for name in core_modules)
     legacy_tree = ast.parse(legacy_core.read_text())
-    assert not any(
-        isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
-        for node in legacy_tree.body
-    )
+    assert not any(isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) for node in legacy_tree.body)
     assert _import_time_modules(legacy_core) == ["synthefy.nori_ts.core"]
     facade = (legacy / "__init__.py").read_text()
     assert '_CANONICAL_PACKAGE = "synthefy.nori_ts.tsfeatures"' in facade
@@ -408,15 +377,13 @@ def test_python_floors_preserve_public_python39_compatibility():
     root = _toml(_ROOT / "pyproject.toml")["project"]
     client = _toml(_CLIENT / "pyproject.toml")["project"]
 
-    assert (
-        "eval-type-backport>=0.2; python_version < '3.10'"
-        in root["dependencies"]
-    )
+    assert "eval-type-backport>=0.2; python_version < '3.10'" in root["dependencies"]
     assert root["requires-python"] == ">=3.9"
     assert client["requires-python"] == ">=3.9"
     assert "Programming Language :: Python :: 3.9" in root["classifiers"]
     assert "Programming Language :: Python :: 3.9" in client["classifiers"]
     assert "Programming Language :: Python :: 3.8" not in client["classifiers"]
+
 
 def test_living_docs_name_supported_install_paths(monkeypatch):
     readme = (_ROOT / "README.md").read_text()

--- a/tests/test_synthetic_pipeline_trainer_guards.py
+++ b/tests/test_synthetic_pipeline_trainer_guards.py
@@ -17,16 +17,12 @@ class _PerfectRecordingFilter:
         self.calls = []
 
     def __call__(self, x, y, eval_pos, task_type):
-        self.calls.append(
-            (x.detach().clone(), y.detach().clone(), eval_pos, task_type)
-        )
+        self.calls.append((x.detach().clone(), y.detach().clone(), eval_pos, task_type))
         if task_type == "reg":
             return {"reg_output": y[:, eval_pos:, None]}
 
         n_classes = max(int(y.max().item()) + 1, 2)
-        logits = torch.nn.functional.one_hot(
-            y[:, eval_pos:].long(), num_classes=n_classes
-        ).float()
+        logits = torch.nn.functional.one_hot(y[:, eval_pos:].long(), num_classes=n_classes).float()
         return {"cls_output": logits * 10.0}
 
 
@@ -62,9 +58,9 @@ def test_icl_filter_uses_exact_training_split_and_prescores_health():
     y = np.broadcast_to(rows[None, :], (5, 10)).copy()
 
     X[0, 0, 1] = np.nan  # ordinary missingness remains valid
-    y[1, 0] = np.nan     # non-finite target
-    y[2] = 1.0           # constant target
-    X[3] = 0.0           # no varying feature
+    y[1, 0] = np.nan  # non-finite target
+    y[2] = 1.0  # constant target
+    X[3] = 0.0  # no varying feature
     X[4, 0, 0] = np.inf  # invalid numeric feature value
 
     passed = trainer._gpu_icl_filter_limix(X, y, context_ratio=0.3)
@@ -73,7 +69,7 @@ def test_icl_filter_uses_exact_training_split_and_prescores_health():
     assert len(model.calls) == 1
     x_seen, _y_seen, eval_pos, task_type = model.calls[0]
     assert x_seen.shape[0] == 1  # unhealthy episodes never reach the model
-    assert eval_pos == 3         # same floor(N * ratio) used by _prepare_batch
+    assert eval_pos == 3  # same floor(N * ratio) used by _prepare_batch
     assert task_type == "reg"
 
 
@@ -104,6 +100,7 @@ def test_icl_filter_propagates_public_task_type(task_type):
     assert passed.tolist() == [True, True]
     assert model.calls[0][3] == task_type
 
+
 def test_synchronous_filter_fails_instead_of_returning_rejected_episode(monkeypatch):
     cfg = TrainingConfig(
         batch_size=1,
@@ -113,8 +110,7 @@ def test_synchronous_filter_fails_instead_of_returning_rejected_episode(monkeypa
     )
     trainer = _bare_filter_trainer(cfg)
     trainer._gpu_icl_filter = types.MethodType(
-        lambda self, X, y, task_type='reg', n_classes=None,
-        context_ratio=None: np.zeros(X.shape[0], dtype=bool),
+        lambda self, X, y, task_type="reg", n_classes=None, context_ratio=None: np.zeros(X.shape[0], dtype=bool),
         trainer,
     )
     X = np.zeros((1, 8, 2), dtype=np.float32)
@@ -126,9 +122,7 @@ def test_synchronous_filter_fails_instead_of_returning_rejected_episode(monkeypa
     )
 
     with pytest.raises(RuntimeError, match="replacement budget"):
-        trainer._filter_and_replace(
-            X.copy(), y.copy(), n_samples=8, n_features=2, context_ratio=0.5
-        )
+        trainer._filter_and_replace(X.copy(), y.copy(), n_samples=8, n_features=2, context_ratio=0.5)
 
     assert trainer._icl_escape_count == 1
 
@@ -141,9 +135,7 @@ def test_generator_scale_variation_is_disabled_after_context_normalization():
     )
     trainer = _bare_filter_trainer(cfg)
 
-    kwargs = trainer._build_gen_kwargs(
-        128, 8, "reg", None, context_ratio=0.4
-    )
+    kwargs = trainer._build_gen_kwargs(128, 8, "reg", None, context_ratio=0.4)
 
     assert kwargs["scale_variation"] is False
     assert kwargs["context_rows"] == 51
@@ -163,10 +155,7 @@ def test_effective_shape_support_exposes_reachable_bucket_endpoints():
     assert (support["min_samples"], support["max_samples"]) == (64, 1536)
     assert (support["min_features"], support["max_features"]) == (4, 192)
     assert len(support["shapes"]) == 62
-    assert all(
-        rows * features <= cfg.max_sample_feature_budget
-        for rows, features in support["shapes"]
-    )
+    assert all(rows * features <= cfg.max_sample_feature_budget for rows, features in support["shapes"])
 
 
 def test_random_shape_range_without_a_bucket_fails_clearly():
@@ -242,6 +231,4 @@ def test_single_process_fatal_error_keeps_original_type():
     trainer.config = TrainingConfig(device="cpu", distributed=False)
 
     with pytest.raises(TypeError, match="programming defect"):
-        trainer._raise_synchronized_step_error(
-            TypeError("programming defect"), "data preparation"
-        )
+        trainer._raise_synchronized_step_error(TypeError("programming defect"), "data preparation")

--- a/tests/test_text_example.py
+++ b/tests/test_text_example.py
@@ -5,13 +5,13 @@ example relies on (no checkpoint / encoder download). The slow test runs the
 example end-to-end against the real checkpoint + MiniLM encoder and asserts the
 text column actually helps — it is skipped when sentence-transformers is absent.
 """
+
 import importlib.util
 import pathlib
 
 import pytest
 
-EXAMPLE = (pathlib.Path(__file__).resolve().parents[1]
-           / "examples" / "text_features_synthetic.py")
+EXAMPLE = pathlib.Path(__file__).resolve().parents[1] / "examples" / "text_features_synthetic.py"
 
 
 def _load():

--- a/tests/test_text_features.py
+++ b/tests/test_text_features.py
@@ -35,11 +35,13 @@ def _fake_embed(texts):
 
 
 def _frame(n_rows):
-    return pd.DataFrame({
-        "price": np.arange(n_rows, dtype=float) * 10.0,
-        "brand": (["A", "B"] * n_rows)[:n_rows],
-        "review": [f"row {i} some free text here" for i in range(n_rows)],
-    })
+    return pd.DataFrame(
+        {
+            "price": np.arange(n_rows, dtype=float) * 10.0,
+            "brand": (["A", "B"] * n_rows)[:n_rows],
+            "review": [f"row {i} some free text here" for i in range(n_rows)],
+        }
+    )
 
 
 def test_lightweight_module_owns_legacy_entry_points():
@@ -48,20 +50,14 @@ def test_lightweight_module_owns_legacy_entry_points():
 
     train = _frame(6)
     legacy = MultimodalPreprocessor(["review"], svd_dim=3, embedder=_fake_embed)
-    canonical = CanonicalMultimodalPreprocessor(
-        ["review"], svd_dim=3, embedder=_fake_embed
-    )
-    np.testing.assert_array_equal(
-        legacy.fit_transform(train), canonical.fit_transform(train)
-    )
+    canonical = CanonicalMultimodalPreprocessor(["review"], svd_dim=3, embedder=_fake_embed)
+    np.testing.assert_array_equal(legacy.fit_transform(train), canonical.fit_transform(train))
 
 
 def test_legacy_wrapper_falls_back_when_only_the_canonical_submodule_is_missing(
     monkeypatch,
 ):
-    original = CanonicalMultimodalPreprocessor(
-        ["review"], svd_dim=3, embedder="minilm"
-    )
+    original = CanonicalMultimodalPreprocessor(["review"], svd_dim=3, embedder="minilm")
     old_pickle = pickle.dumps(original, protocol=0).replace(
         b"csynthefy.text_features\nMultimodalPreprocessor\n",
         b"csynthefy_nori.text_features\nMultimodalPreprocessor\n",
@@ -80,19 +76,11 @@ def test_legacy_wrapper_falls_back_when_only_the_canonical_submodule_is_missing(
     monkeypatch.setattr(builtins, "__import__", missing_canonical)
     try:
         fallback = importlib.reload(legacy_text_features_module)
-        assert fallback.MultimodalPreprocessor.__module__ == (
-            "synthefy_nori._legacy_text_features"
-        )
+        assert fallback.MultimodalPreprocessor.__module__ == ("synthefy_nori._legacy_text_features")
         train = _frame(6)
-        migrated = fallback.MultimodalPreprocessor(
-            ["review"], svd_dim=3, embedder=_fake_embed
-        )
-        canonical = CanonicalMultimodalPreprocessor(
-            ["review"], svd_dim=3, embedder=_fake_embed
-        )
-        np.testing.assert_array_equal(
-            migrated.fit_transform(train), canonical.fit_transform(train)
-        )
+        migrated = fallback.MultimodalPreprocessor(["review"], svd_dim=3, embedder=_fake_embed)
+        canonical = CanonicalMultimodalPreprocessor(["review"], svd_dim=3, embedder=_fake_embed)
+        np.testing.assert_array_equal(migrated.fit_transform(train), canonical.fit_transform(train))
         restored = pickle.loads(old_pickle)
         assert type(restored) is fallback.MultimodalPreprocessor
         assert restored.text_columns == ["review"]
@@ -101,18 +89,13 @@ def test_legacy_wrapper_falls_back_when_only_the_canonical_submodule_is_missing(
         monkeypatch.undo()
         importlib.reload(legacy_text_features_module)
 
-    assert (
-        legacy_text_features_module.MultimodalPreprocessor
-        is CanonicalMultimodalPreprocessor
-    )
+    assert legacy_text_features_module.MultimodalPreprocessor is CanonicalMultimodalPreprocessor
 
 
 def test_legacy_wrapper_does_not_mask_a_transitive_import_failure(monkeypatch):
     real_import = builtins.__import__
 
-    def broken_canonical_dependency(
-        name, globals=None, locals=None, fromlist=(), level=0
-    ):
+    def broken_canonical_dependency(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "synthefy.text_features":
             raise ModuleNotFoundError("No module named 'sklearn'", name="sklearn")
         return real_import(name, globals, locals, fromlist, level)
@@ -128,17 +111,8 @@ def test_legacy_wrapper_does_not_mask_a_transitive_import_failure(monkeypatch):
 
 
 def test_direct_text_import_explains_how_to_install_the_text_extra(monkeypatch):
-    source = (
-        Path(__file__).resolve().parents[1]
-        / "libs"
-        / "synthefy"
-        / "src"
-        / "synthefy"
-        / "text_features.py"
-    )
-    spec = importlib.util.spec_from_file_location(
-        "_synthefy_text_features_without_sklearn", source
-    )
+    source = Path(__file__).resolve().parents[1] / "libs" / "synthefy" / "src" / "synthefy" / "text_features.py"
+    spec = importlib.util.spec_from_file_location("_synthefy_text_features_without_sklearn", source)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     real_import = builtins.__import__
@@ -160,9 +134,7 @@ def test_optional_encoder_guidance_covers_both_public_install_paths(monkeypatch)
 
     real_import = builtins.__import__
 
-    def missing_sentence_transformers(
-        name, globals=None, locals=None, fromlist=(), level=0
-    ):
+    def missing_sentence_transformers(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "sentence_transformers":
             raise ModuleNotFoundError(
                 "No module named 'sentence_transformers'",
@@ -182,9 +154,7 @@ def test_optional_encoder_guidance_covers_both_public_install_paths(monkeypatch)
 
 
 def test_old_legacy_qualified_preprocessor_pickle_still_unpickles():
-    original = CanonicalMultimodalPreprocessor(
-        ["review"], svd_dim=3, embedder="minilm"
-    )
+    original = CanonicalMultimodalPreprocessor(["review"], svd_dim=3, embedder="minilm")
     payload = pickle.dumps(original, protocol=0)
     canonical_global = b"csynthefy.text_features\nMultimodalPreprocessor\n"
     legacy_global = b"csynthefy_nori.text_features\nMultimodalPreprocessor\n"
@@ -202,7 +172,7 @@ def test_build_paragraphs_prefixes_and_missing():
     df = pd.DataFrame({"a": ["x", None], "b": ["y", "z"]})
     paras = build_paragraphs(df, ["a", "b"])
     assert paras[0] == "a: x. b: y."
-    assert paras[1] == "a: . b: z."          # missing -> empty
+    assert paras[1] == "a: . b: z."  # missing -> empty
     assert build_paragraphs(df, []) == ["", ""]  # no text cols
 
 
@@ -220,22 +190,21 @@ def test_widened_matrix_shape_and_layout():
 
 def test_svd_dim_clamped_to_embed_dim():
     mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=128, embedder=_fake_embed)
-    mp.fit_transform(_frame(40))          # 40 rows, 16-d embedding
-    assert mp.n_text_features_ == 16      # clamped to embedding dim
+    mp.fit_transform(_frame(40))  # 40 rows, 16-d embedding
+    assert mp.n_text_features_ == 16  # clamped to embedding dim
 
 
 def test_unseen_category_and_nan_handled_at_transform():
     train = _frame(6)
     mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
     mp.fit_transform(train)
-    unknown_code = len(mp.category_maps_["brand"])   # A,B -> 0,1 ; unseen -> 2
-    test = pd.DataFrame({"price": [5.0, np.nan], "brand": ["A", "C"],
-                         "review": ["seen-ish", "totally new text"]})
+    unknown_code = len(mp.category_maps_["brand"])  # A,B -> 0,1 ; unseen -> 2
+    test = pd.DataFrame({"price": [5.0, np.nan], "brand": ["A", "C"], "review": ["seen-ish", "totally new text"]})
     Xt = mp.transform(test)
     assert Xt.shape[1] == mp.n_features_out_
-    assert Xt[1, 1] == unknown_code                  # 'C' unseen
+    assert Xt[1, 1] == unknown_code  # 'C' unseen
     assert Xt[0, 1] == mp.category_maps_["brand"]["A"]
-    assert np.isnan(Xt[1, 0])                        # numeric missing stays NaN
+    assert np.isnan(Xt[1, 0])  # numeric missing stays NaN
 
 
 def test_transform_before_fit_raises():
@@ -267,8 +236,8 @@ def test_no_text_columns_skips_embedder():
     mp = MultimodalPreprocessor(text_columns=[], embedder=_boom)
     X = mp.fit_transform(_frame(5)[["price", "brand"]])
     assert mp.n_text_features_ == 0
-    assert X.shape == (5, 2)                 # price + brand, no text cols
-    mp.transform(_frame(3)[["price", "brand"]])   # transform path also skips the embedder
+    assert X.shape == (5, 2)  # price + brand, no text cols
+    mp.transform(_frame(3)[["price", "brand"]])  # transform path also skips the embedder
 
 
 def test_csv_loaded_dataframe_matches_pickle(tmp_path):
@@ -294,18 +263,20 @@ def test_categorical_encoding_bounded_by_max_cardinality():
     # get 0..k-1, everything rarer or unseen collapses to the in-range "other" code
     # (no out-of-distribution sentinel).
     n = 60
-    train = pd.DataFrame({
-        "x": np.arange(n, dtype=float),
-        "hc": [f"v{i % 40}" for i in range(n)],     # 40 distinct categories
-        "review": [f"row {i}" for i in range(n)],
-    })
-    mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=4,
-                                embedder=_fake_embed, max_cardinality=5,
-                                categorical_columns=["hc"])
+    train = pd.DataFrame(
+        {
+            "x": np.arange(n, dtype=float),
+            "hc": [f"v{i % 40}" for i in range(n)],  # 40 distinct categories
+            "review": [f"row {i}" for i in range(n)],
+        }
+    )
+    mp = MultimodalPreprocessor(
+        text_columns=["review"], svd_dim=4, embedder=_fake_embed, max_cardinality=5, categorical_columns=["hc"]
+    )
     Xtr = mp.fit_transform(train)
     hc_col = mp.nontext_columns_.index("hc")
-    assert len(mp.category_maps_["hc"]) == 5            # capped to top-5
-    assert Xtr[:, hc_col].max() <= 5                    # rare -> "other" == 5, bounded
+    assert len(mp.category_maps_["hc"]) == 5  # capped to top-5
+    assert Xtr[:, hc_col].max() <= 5  # rare -> "other" == 5, bounded
     # an unseen category at transform also lands on the same in-range "other" code
     test = pd.DataFrame({"x": [1.0], "hc": ["totally_new"], "review": ["new row"]})
     Xte = mp.transform(test)
@@ -316,8 +287,8 @@ def test_svd_dim_none_appends_raw_embedding():
     mp = MultimodalPreprocessor(text_columns=["review"], svd_dim=None, embedder=_fake_embed)
     X = mp.fit_transform(_frame(8))
     assert mp.svd_ is None
-    assert mp.n_text_features_ == 16               # full fake-embedding dim, no reduction
-    assert X.shape[1] == 2 + 16                    # price + brand + raw text
+    assert mp.n_text_features_ == 16  # full fake-embedding dim, no reduction
+    assert X.shape[1] == 2 + 16  # price + brand + raw text
     assert mp.transform(_frame(3)).shape[1] == X.shape[1]
 
 
@@ -335,15 +306,14 @@ def test_text_columns_accepts_lone_string_and_index():
 
 def test_unknown_text_column_raises_at_fit():
     with pytest.raises(ValueError):
-        MultimodalPreprocessor(text_columns=["not_a_column"],
-                               embedder=_fake_embed).fit_transform(_frame(5))
+        MultimodalPreprocessor(text_columns=["not_a_column"], embedder=_fake_embed).fit_transform(_frame(5))
 
 
 def test_missing_text_column_at_transform_raises():
     m = MultimodalPreprocessor(text_columns=["review"], svd_dim=4, embedder=_fake_embed)
     m.fit_transform(_frame(6))
     with pytest.raises(ValueError):
-        m.transform(_frame(3)[["price", "brand"]])   # 'review' dropped
+        m.transform(_frame(3)[["price", "brand"]])  # 'review' dropped
 
 
 def test_zero_width_embedding_raises():
@@ -369,7 +339,7 @@ def test_noriregressor_clone_and_pickle_carry_text_config():
     )
     assert clone(reg).get_params()["text_columns"] == ["review"]
     reg.fit(_frame(8), np.arange(8.0, dtype=float))
-    assert reg.n_features_in_ == 3                 # input cols, not the widened SVD block
+    assert reg.n_features_in_ == 3  # input cols, not the widened SVD block
     assert list(reg.feature_names_in_) == ["price", "brand", "review"]
     round_tripped = pickle.loads(pickle.dumps(reg))
     assert round_tripped._feature_preprocessor.text_columns_ == ["review"]
@@ -379,22 +349,21 @@ def test_noriregressor_clone_and_pickle_carry_text_config():
 def test_categorical_key_canonicalization_int_vs_float():
     # a categorical read as int in train but float in test (NaN promotion) must map
     # to the same code, not collapse to "other".
-    tr = pd.DataFrame({"c": pd.Series([5, 6, 5, 6], dtype=object),
-                       "review": ["a", "b", "a", "b"]})
+    tr = pd.DataFrame({"c": pd.Series([5, 6, 5, 6], dtype=object), "review": ["a", "b", "a", "b"]})
     te = pd.DataFrame({"c": pd.Series([5.0, 6.0], dtype=object), "review": ["a", "b"]})
     m = MultimodalPreprocessor(text_columns=["review"], svd_dim=2, embedder=_fake_embed)
     m.fit_transform(tr)
     Xte = m.transform(te)
     ci = m.nontext_columns_.index("c")
     other = len(m.category_maps_["c"])
-    assert (Xte[:, ci] != other).all()             # 5.0/6.0 hit the int codes, not "other"
+    assert (Xte[:, ci] != other).all()  # 5.0/6.0 hit the int codes, not "other"
 
 
 def test_categorical_tiebreak_is_deterministic():
     df = pd.DataFrame({"c": ["b", "a", "c", "a", "b", "c"], "review": ["x"] * 6})  # a,b,c each 2
-    m = MultimodalPreprocessor(text_columns=["review"], svd_dim=2,
-                               embedder=_fake_embed, max_cardinality=2,
-                               categorical_columns=["c"])
+    m = MultimodalPreprocessor(
+        text_columns=["review"], svd_dim=2, embedder=_fake_embed, max_cardinality=2, categorical_columns=["c"]
+    )
     m.fit_transform(df)
     assert m.category_maps_["c"] == {"a": 0, "b": 1}  # ties broken by key ascending
 

--- a/tests/test_training_smoke.py
+++ b/tests/test_training_smoke.py
@@ -18,6 +18,7 @@ Run explicitly with::
     pytest -m slow tests/test_training_smoke.py
     SYNTHEFY_NORI_SMOKE_DEVICE=cuda:0 pytest -m slow tests/test_training_smoke.py
 """
+
 from __future__ import annotations
 
 import os
@@ -35,14 +36,38 @@ def test_single_training_step_writes_checkpoint(tmp_path):
     device = os.environ.get("SYNTHEFY_NORI_SMOKE_DEVICE", "cpu")
 
     cmd = [
-        sys.executable, "-m", "synthefy_nori.training.cli",
-        "--device", device, "--no-prefetch", "--no-wandb",
-        "--task-type", "reg",
-        "--total-steps", "1", "--run-steps", "1", "--save-interval", "1",
+        sys.executable,
+        "-m",
+        "synthefy_nori.training.cli",
+        "--device",
+        device,
+        "--no-prefetch",
+        "--no-wandb",
+        "--task-type",
+        "reg",
+        "--total-steps",
+        "1",
+        "--run-steps",
+        "1",
+        "--save-interval",
+        "1",
         # Tiny architecture so the step is fast on a CPU runner.
-        "--embed-dim", "32", "--hid-dim", "64", "--nlayers", "2", "--nhead", "2",
-        "--batch-size", "2", "--max-features", "16", "--max-budget", "4000",
-        "--checkpoint-dir", str(checkpoint_dir),
+        "--embed-dim",
+        "32",
+        "--hid-dim",
+        "64",
+        "--nlayers",
+        "2",
+        "--nhead",
+        "2",
+        "--batch-size",
+        "2",
+        "--max-features",
+        "16",
+        "--max-budget",
+        "4000",
+        "--checkpoint-dir",
+        str(checkpoint_dir),
     ]
     # CPU has no autocast support here; on CUDA, keep mixed precision on (default)
     # so the GPU run also exercises the autocast path.
@@ -51,16 +76,16 @@ def test_single_training_step_writes_checkpoint(tmp_path):
 
     env = dict(os.environ, WANDB_MODE="disabled")
     result = subprocess.run(
-        cmd, env=env, capture_output=True, text=True, timeout=600,
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
     )
 
     assert result.returncode == 0, (
-        f"training step failed (exit {result.returncode})\n"
-        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        f"training step failed (exit {result.returncode})\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
 
     checkpoints = list(checkpoint_dir.glob("checkpoint_step_*.pt"))
-    assert checkpoints, (
-        f"no checkpoint written to {checkpoint_dir}\n"
-        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
-    )
+    assert checkpoints, f"no checkpoint written to {checkpoint_dir}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"


### PR DESCRIPTION
## What

Two commits, deliberately separable in review:

1. `style: ruff format the tree (no logic changes)`: `ruff format .` with the locked ruff (0.15.12, the version in `uv.lock`). 119 files, +6930/-6954. Notebooks are excluded from the formatter via `extend-exclude = ["*.ipynb"]` in `pyproject.toml`; six `.ipynb` files would otherwise reflow as JSON that nobody reviews.
2. `ci: gate formatting`: `uv run ruff format --check .` in `ci.yml` right after `ruff check`, and a `ruff-format` hook in `.pre-commit-config.yaml` with `rev` bumped from v0.8.4 to v0.15.12 so pre-commit, CI and `uv.lock` agree on the version.

Closes the public half of Synthefy/synthefy-nori-internal#161.

## Why

The tree was never ruff-formatted and there was no format check, so any PR that touched a file and ran the formatter reflowed hundreds of untouched lines (#161 measured `cli.py` at 1,526 changed lines from formatting alone). Formatting once and gating keeps every future diff logic-only, and makes `ruff format` safe to run anywhere.

`ruff format` is AST-preserving; the first commit changes no behaviour. Review it by skimming the second commit and trusting the suite on the first.

## Cascade note for maintainers

This lands on public and `rebase-sync` carries it down. Staging rebases cleanly (its one commit overlaps only `pyproject.toml`). Internal will **conflict in 55 files**: its 81 unpublished commits touch reformatted files. That alert is expected. The reconcile is already prepared and tested: each internal commit rewritten to a formatted tree so the rebase is conflict-free by construction, plus a re-pin of `libs/synthefy/SOURCE_SNAPSHOT.json` (which pins blob hashes of 16 client files). It will be force-pushed with a pinned lease per the cicd-chain runbook, after a staging follow-up that formats the 10 explainability files public never had.

Every open PR on all three repos will need `ruff format` and a rebase afterwards (8 here, 2 on staging, ~20 on internal).

<details>
<summary>Verification</summary>

- `ruff format --check .` on this branch: 158 files already formatted (idempotent)
- `ruff check src scripts tests ci/...`: clean
- Full suite on the formatted tree (`uv sync --frozen --extra dev && uv run pytest`): **730 passed, 6 skipped**
- Cascade rehearsal in scratch clones of all three repos: staging's commit rebases clean onto this branch; internal's 81 commits, rewritten with a tree filter to formatted trees, rebase with zero formatting conflicts, and the resulting tree is byte-identical to `ruff format` applied to today's internal main. Internal candidate: 1751 passed, `sync_openapi --check` and `validate_variants` clean.

</details>
