### PR TITLE
ci(cla): allowlist ajanbekzat (Synthefy maintainer)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -50,4 +50,4 @@ jobs:
           # sign (the flow requires the PR author to comment the agreement), so a
           # bot-authored PR will sit with a red CLA check. If that ever needs to
           # merge, add the specific bot login here (e.g. copilot-swe-agent[bot]).
-          allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy,minkyu-choi07'
+          allowlist: 'sagarwal-atg,d31003,yogabbagabb,raimishah,adityanarayanan03,PohanLi-Synthefy,minkyu-choi07,ajanbekzat'


### PR DESCRIPTION
Adds `ajanbekzat` (Bekzat Ajan, Synthefy) to the CLA allowlist alongside the other maintainers. Surfaced by Synthefy/synthefy-nori#138, where the `cla` check blocks an employee's commits as if they were an external contribution. One line, no other change.