### PR TITLE
promote: memory-policy streaming and runtime fallback reporting (internal #516, #517)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,20 @@ benchmarks/plots/
 # Environment files — may contain secrets, never commit
 .env
 *.env
+
+# Logs and run output (training/eval run logs, watchdog/nohup output)
+*.log
+*.out
+*.err
+nohup.out
+runs/
+logs/
+# Local experiment run output (scaling-law sweeps, plots, CSVs)
+experiments/
+# Local autonomous optimization run output and compiler caches
+autoresearch/
+# Staged by the deploy's bake step (deploy-baseten.yml), including s3transfer
+# partials from an interrupted download; never committed.
+serving/hosts/baseten/model/weights.pt*
+# Staged by ci/bake_weights.py for the image build; never committed.
+serving/image/nori.pt*

--- a/README.md
+++ b/README.md
@@ -564,7 +564,8 @@ mixed-precision noise (max abs diff ~3e-3, measured below) at identical R². The
 **preprocessing speedups** are **R²-neutral**:
 toggling them shifts individual predictions by a tiny, R²-equivalent amount (below
 cross-environment noise), not bit-for-bit. For the exact un-accelerated path, set
-each to its off value (see below).
+each to its off value (see below). **Pipeline batching** likewise preserves the
+ensemble math but can reassociate mixed-precision GEMMs at the last few bits.
 
 | Env var | Default | What it does |
 |---|---|---|
@@ -573,6 +574,7 @@ each to its off value (see below).
 | `SYNTHEFY_QUANTILE_MAX` / `SYNTHEFY_QUANTILE_SUBSAMPLE` | — | Tune the cap above (max quantiles / fit-subsample size). |
 | `SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE` | `2000` | Fit preprocessing on at most this many rows, apply to all rows. Acts on large context; set `0` to fit on all rows. |
 | `SYNTHEFY_ENABLE_CACHED_INFERENCE` | `1` (on) | Reuse the train-side attention K/V across test chunks (KV cache); ~2-3x faster on large test sets that chunk. Set `0` to disable (or `SYNTHEFY_DISABLE_CACHED_INFERENCE=1`). |
+| `SYNTHEFY_DISABLE_PIPELINE_BATCHING` | `0` (batching on) | Set `1` to run preprocessing-ensemble model calls one at a time. Batching groups up to four same-shaped members when each has at most 256 processed features. |
 | `SYNTHEFY_MAX_ELEMENTS_BUDGET` | VRAM-aware | Inference element budget; raise on large GPUs for full-context inference. Prefer `memory_policy={"elements_budget": N}`. |
 
 > ⚠️ **`SYNTHEFY_CACHE_MAX_GB` has been removed** and now raises if set. It used to
@@ -820,6 +822,27 @@ mean R² unchanged (0.8087 → 0.8089). A large-scale A/B restricted to the tabl
 where they actually engage (n>5000) measured a mean ΔR² of +0.00002 (max |Δ|
 0.0004) — within run-to-run noise.
 
+### Preprocessing-ensemble batching (on by default)
+
+The default eight-member ensemble produces two natural groups of four members
+with identical model-input shapes. Nori now runs each group as one model batch,
+then restores configured member order and averages the full decoder outputs just
+as the one-at-a-time path does. It applies only to ordinary regression with a
+resident full-precision cache (or no cache), deterministic eval-mode models, and
+at most 256 processed features per member. Retrieval, imputation, DDP, dropout,
+int8/offloaded caches, wide tables, and memory-heavy requests stay on the existing
+one-at-a-time path. A CUDA OOM or unsupported output shape also retries the whole
+call there.
+
+On one H200 with the public 6M model, 512 context rows, 48 raw features, and the
+shipped eight-member config, batching reduced hot point-prediction latency from
+1.28 s to 0.80 s without a cache (1.59×), and from 0.88 s to 0.53 s with a reused
+resident cache (1.65×). The maximum point and full 999-quantile-bank differences
+versus one-at-a-time fp16 execution were both 1.90e-3. Peak VRAM rose by 0.74 GiB
+without a cache and 0.26 GiB with a
+resident cache on that workload. Set `SYNTHEFY_DISABLE_PIPELINE_BATCHING=1` for
+the legacy execution order or exact debugging comparisons.
+
 ### KV caching (on by default)
 
 The cached prediction path is **enabled by default**. It projects the train-side
@@ -855,7 +878,7 @@ Reproduce (prints the results table and writes `benchmarks/plots/kv_cache_speed.
 
 # To disable them all (e.g. for exact reproducibility / debugging):
 SYNTHEFY_GPU_SVD=0 SYNTHEFY_CAP_QUANTILES=0 SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE=0 \
-SYNTHEFY_ENABLE_CACHED_INFERENCE=0 \
+SYNTHEFY_ENABLE_CACHED_INFERENCE=0 SYNTHEFY_DISABLE_PIPELINE_BATCHING=1 \
 python your_inference_script.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -604,22 +604,27 @@ NoriRegressor(model="nori-6m", memory_policy="exact")                   # never 
 NoriRegressor(model="nori-6m", memory_policy="max_context")             # fit the biggest table
 NoriRegressor(model="nori-6m", memory_policy="off")                     # no cache at all
 NoriRegressor(model="nori-6m", memory_policy={"gpu_budget_frac": 0.25}) # e.g. from a config file
+NoriRegressor(model="nori-6m", memory_policy={"stream_context": True})  # bounded GPU staging
 ```
 
-Under the hood it walks a ladder, using the cheapest rung that can serve the request:
+The ordinary policy walks a ladder using the cheapest rung that can serve the request;
+explicit streaming reports its own `stream_*` path:
 
 | rung | what it does | exact? |
 |---|---|---|
 | `resident_bf16` | cache fits VRAM at full precision | **yes** |
 | `resident_int8` | quantize to stay on the GPU instead of streaming | ~6e-6 R² |
 | `offload_int8` | cache lives in host RAM, streamed per layer | quantized |
+| `stream_bf16` | explicitly keep context/KV on the host and stage bounded row slices | numerically close |
+| `stream_int8` | the same bounded host-only path with quantized K/V | quantized |
 | `context_row_chunk` | after an OOM: also cap rows per build step | **yes** |
 | `plain_loop` | no cache; several times slower, may drop context rows | **yes** |
 
-**Only the int8 rungs cost accuracy, and `resident_int8` is only reached when full
-precision would not fit.** A table that serves correctly today keeps bit-exact
-predictions — accuracy is spent only to avoid a fallback that is slower or fatal. Use
-`memory_policy="exact"` to forbid quantizing outright (it offloads instead).
+**Only the int8 rungs quantize the cache, and `resident_int8` is only reached when full
+precision would not fit.** Explicit streaming is also not bit-exact, even at BF16,
+because chunked GEMMs and FP32 online attention change reduction order. A small CUDA
+comparison measured max prediction delta 2.93e-3 and mean delta 7.44e-4. Use
+`memory_policy="exact"` to forbid quantizing on the ordinary adaptive ladder.
 
 Budgets are **fractions of your hardware**, so one setting travels from a laptop GPU to
 an H200:
@@ -633,11 +638,26 @@ an H200:
 | `cache_dtype` | `"bf16"` | precision the cache **starts** at |
 | `allow_quantization` | `True` | may bf16 drop to int8 to stay resident? |
 | `offload_to_host` | `True` | may the cache move to host RAM? |
+| `stream_context` | `False` | explicitly keep full context/KV state on the host and bound GPU staging; resolves to `stream_bf16` or `stream_int8` |
 | `context_row_chunk` | `None` | cap context rows per build step (auto after an OOM) |
 | `elements_budget` | auto | per-forward element cap; drives chunking + subsampling |
 | `allow_subsample` | `True` | may context rows be dropped to fit? `False` = raise |
 
-> **Host offload needs RAM > 1.6 × VRAM at these defaults.** Offload only engages once
+Set `memory_policy={"stream_context": True}` when context-attention GPU memory should
+stop scaling with context length. Streaming forces the cache onto the host, disables
+cross-call context reuse, and resolves an omitted `context_row_chunk` from accelerator
+VRAM: **2048** rows below 40 GiB, **8192** rows from 40 GiB, and **16384** rows from
+80 GiB. An explicit value is preserved. The selected number is a maximum staged-row
+cap, not an exact internal block width: runtime may split K/V blocks smaller to stay
+within its attention workspace. After any larger resolved first attempt, fit-time OOMs
+retry the bounded **2048 → 1024 → 512 → 256** row ladder. This is still constant GPU
+memory with respect to total context length because the hardware
+tier does not grow with the dataset. The full context must fit the configured host
+budget. If it does not, Nori raises instead of silently falling back to `plain_loop` or
+dropping the requested mechanism.
+
+> **Ordinary adaptive host offload needs RAM > 1.6 × VRAM at these defaults.**
+> Offload only engages once
 > the cache exceeds the GPU budget, and it can only succeed within the host budget — so
 > `0.25 × RAM` has to exceed `0.4 × VRAM`. Below that ratio the offload rung is
 > unreachable and a spilling request goes straight to `plain_loop`. Concretely, a 143 GB

--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ ensemble math but can reassociate mixed-precision GEMMs at the last few bits.
 | `SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE` | `2000` | Fit preprocessing on at most this many rows, apply to all rows. Acts on large context; set `0` to fit on all rows. |
 | `SYNTHEFY_ENABLE_CACHED_INFERENCE` | `1` (on) | Reuse the train-side attention K/V across test chunks (KV cache); ~2-3x faster on large test sets that chunk. Set `0` to disable (or `SYNTHEFY_DISABLE_CACHED_INFERENCE=1`). |
 | `SYNTHEFY_DISABLE_PIPELINE_BATCHING` | `0` (batching on) | Set `1` to run preprocessing-ensemble model calls one at a time. Batching groups up to four same-shaped members when each has at most 256 processed features. |
+| `SYNTHEFY_EXACT_CACHED_CUDAGRAPHS` | `0` (off) | Set `1` for exact B=1 resident-cache inference accelerated by eager CUDA-graph replay. This disables pipeline batching, requires CUDA plus `setuptools`, and safely falls back to eager B=1 when unavailable. |
 | `SYNTHEFY_MAX_ELEMENTS_BUDGET` | VRAM-aware | Inference element budget; raise on large GPUs for full-context inference. Prefer `memory_policy={"elements_budget": N}`. |
 
 > ⚠️ **`SYNTHEFY_CACHE_MAX_GB` has been removed** and now raises if set. It used to
@@ -842,6 +843,20 @@ versus one-at-a-time fp16 execution were both 1.90e-3. Peak VRAM rose by 0.74 Gi
 without a cache and 0.26 GiB with a
 resident cache on that workload. Set `SYNTHEFY_DISABLE_PIPELINE_BATCHING=1` for
 the legacy execution order or exact debugging comparisons.
+
+For fit-once/serve-many workloads that require bit-exact B=1 predictions, set
+`SYNTHEFY_EXACT_CACHED_CUDAGRAPHS=1`. This keeps all eight ensemble members at
+B=1 but captures the cached encoder-layer eager kernels and replays them without
+Python launch overhead. On the public 100M model (512 context rows, 600 query
+rows, 48 raw features), hot-cache latency fell from 2.81 s to 1.53 s (1.83×),
+with bit-exact point predictions and all 999 quantiles. Current B=4 execution was
+1.38 s on the same workload, so exact mode recovered most of its throughput.
+In separate processes, exact B=1 peaked at 12.63 GiB allocated versus 13.37 GiB
+for B=4. If the resident cache is not selected, this mode remains exact eager B=1
+rather than applying CUDA graphs to the ordinary forward.
+CUDA-graph setup is shape-specific and took a few seconds in this benchmark;
+use it for repeated resident-cache queries, not one-shot or rapidly changing
+table shapes.
 
 ### KV caching (on by default)
 

--- a/benchmarks/bench_attention_fast_paths.py
+++ b/benchmarks/bench_attention_fast_paths.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Paired CUDA benchmark for Nori's exact attention fast paths.
+
+The baseline functions reproduce the implementations used before the fast
+paths landed: generic einsum for cached projections and a conservative 32768
+batch/head cutoff for SDPA. Candidate and baseline calls alternate in one
+process so clock and host-load drift affect both arms similarly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections.abc import Callable
+from pathlib import Path
+
+import torch
+
+import synthefy_nori.model.layer as layer_module
+from synthefy_nori.model.layer import MultiheadAttention
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return value
+
+
+def nonnegative_int(raw: str) -> int:
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return value
+
+
+def timed_call(call: Callable[[], torch.Tensor]) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    output = call()
+    end.record()
+    end.synchronize()
+    del output
+    return float(start.elapsed_time(end))
+
+
+def paired_measure(
+    baseline: Callable[[], torch.Tensor],
+    candidate: Callable[[], torch.Tensor],
+    *,
+    warmup: int,
+    iterations: int,
+) -> tuple[float, float]:
+    for index in range(warmup):
+        order = (baseline, candidate) if index % 2 == 0 else (candidate, baseline)
+        for call in order:
+            timed_call(call)
+
+    durations = {"baseline": [], "candidate": []}
+    for index in range(iterations):
+        order = (
+            (("baseline", baseline), ("candidate", candidate))
+            if index % 2 == 0
+            else (("candidate", candidate), ("baseline", baseline))
+        )
+        for name, call in order:
+            durations[name].append(timed_call(call))
+    return statistics.median(durations["baseline"]), statistics.median(durations["candidate"])
+
+
+def projection_cases(
+    device: torch.device,
+    *,
+    warmup: int,
+    iterations: int,
+) -> tuple[list[dict], list[dict]]:
+    torch.manual_seed(10)
+    attention = MultiheadAttention(
+        embed_dim=96,
+        num_heads=6,
+        qkv_combined=False,
+        device=device,
+        dtype=torch.float32,
+    ).eval()
+    cases = []
+    parity = []
+
+    x_kv = torch.randn(1, 12, 8192, 96, device=device)
+    x_kv_flat = x_kv.reshape(-1, *x_kv.shape[-2:])
+    kv_mha_weights = attention.qkv_proj_weight[1:]
+
+    def baseline_kv_mha() -> torch.Tensor:
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+            return torch.einsum(
+                "... s, j h d s -> ... j h d",
+                x_kv_flat,
+                kv_mha_weights,
+            ).contiguous()
+
+    def candidate_kv_mha() -> torch.Tensor:
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+            return (
+                torch.nn.functional.linear(
+                    x_kv_flat,
+                    kv_mha_weights.reshape(
+                        2 * attention.num_heads * attention.head_dim,
+                        attention.embed_dim,
+                    ),
+                )
+                .view(
+                    *x_kv_flat.shape[:-1],
+                    2,
+                    attention.num_heads,
+                    attention.head_dim,
+                )
+                .contiguous()
+            )
+
+    with torch.no_grad():
+        baseline_output = baseline_kv_mha()
+        candidate_output = candidate_kv_mha()
+    parity.append(
+        {
+            "name": "cached-kv-mha-output",
+            "passed": torch.equal(baseline_output, candidate_output),
+            "max_abs": float((baseline_output - candidate_output).abs().max().item()),
+        }
+    )
+    baseline_ms, candidate_ms = paired_measure(
+        baseline_kv_mha,
+        candidate_kv_mha,
+        warmup=warmup,
+        iterations=iterations,
+    )
+    cases.append(
+        {
+            "name": "cached-kv-mha-g12-n8192",
+            "baseline_ms": baseline_ms,
+            "candidate_ms": candidate_ms,
+        }
+    )
+    del baseline_output, candidate_output
+
+    x_q = torch.randn(1, 192, 384, 96, device=device)
+    x_q_flat = x_q.reshape(-1, *x_q.shape[-2:])
+    q_weights = attention.qkv_proj_weight[0]
+
+    def baseline_q() -> torch.Tensor:
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+            return torch.einsum("... s, h d s -> ... h d", x_q_flat, q_weights)
+
+    def candidate_q() -> torch.Tensor:
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+            return torch.nn.functional.linear(
+                x_q_flat,
+                q_weights.reshape(attention.num_heads * attention.head_dim, attention.embed_dim),
+            ).view(*x_q_flat.shape[:-1], attention.num_heads, attention.head_dim)
+
+    with torch.no_grad():
+        baseline_output = baseline_q()
+        candidate_output = candidate_q()
+    parity.append(
+        {
+            "name": "cached-q-output",
+            "passed": torch.equal(baseline_output, candidate_output),
+            "max_abs": float((baseline_output - candidate_output).abs().max().item()),
+        }
+    )
+    baseline_ms, candidate_ms = paired_measure(
+        baseline_q,
+        candidate_q,
+        warmup=warmup,
+        iterations=iterations,
+    )
+    cases.append(
+        {
+            "name": "cached-q-g192-n384",
+            "baseline_ms": baseline_ms,
+            "candidate_ms": candidate_ms,
+        }
+    )
+    return cases, parity
+
+
+def attention_case(
+    device: torch.device,
+    *,
+    batch: int,
+    sequence: int,
+    warmup: int,
+    iterations: int,
+) -> tuple[dict, list[dict]]:
+    torch.manual_seed(batch + sequence)
+    attention = MultiheadAttention(
+        embed_dim=128,
+        num_heads=2,
+        qkv_combined=False,
+        device=device,
+        dtype=torch.bfloat16,
+    ).eval()
+    q = torch.randn(batch, sequence, 2, 64, device=device, dtype=torch.bfloat16, requires_grad=True)
+    kv = torch.randn(batch, sequence, 2, 2, 64, device=device, dtype=torch.bfloat16, requires_grad=True)
+
+    def step(limit: int) -> torch.Tensor:
+        q.grad = None
+        kv.grad = None
+        layer_module.SDPA_BATCH_HEAD_LIMIT = limit
+        output = attention.compute_attention_by_torch(None, q, kv, None)
+        output.backward(torch.ones_like(output))
+        return output
+
+    def baseline() -> torch.Tensor:
+        return step(32_768)
+
+    def candidate() -> torch.Tensor:
+        return step(65_535)
+
+    baseline_output = baseline().detach()
+    baseline_q_grad = q.grad.detach().clone()
+    baseline_kv_grad = kv.grad.detach().clone()
+    candidate_output = candidate().detach()
+    candidate_q_grad = q.grad.detach().clone()
+    candidate_kv_grad = kv.grad.detach().clone()
+    parity = []
+    for name, expected, actual in (
+        ("output", baseline_output, candidate_output),
+        ("q-gradient", baseline_q_grad, candidate_q_grad),
+        ("kv-gradient", baseline_kv_grad, candidate_kv_grad),
+    ):
+        parity.append(
+            {
+                "name": f"sdpa-b{batch}-s{sequence}-{name}",
+                "passed": torch.equal(expected, actual),
+                "max_abs": float((expected - actual).abs().max().item()),
+            }
+        )
+
+    baseline_ms, candidate_ms = paired_measure(
+        baseline,
+        candidate,
+        warmup=warmup,
+        iterations=iterations,
+    )
+    layer_module.SDPA_BATCH_HEAD_LIMIT = 65_535
+    return (
+        {
+            "name": f"sdpa-forward-backward-b{batch}-s{sequence}-h2-d64",
+            "baseline_ms": baseline_ms,
+            "candidate_ms": candidate_ms,
+        },
+        parity,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--warmup", type=nonnegative_int, default=10)
+    parser.add_argument("--iterations", type=positive_int, default=40)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        parser.error("this benchmark requires CUDA")
+    device = torch.device(args.device)
+    if device.type != "cuda":
+        parser.error("--device must be cuda[:INDEX]")
+    torch.cuda.set_device(device)
+
+    cases, parity = projection_cases(device, warmup=args.warmup, iterations=args.iterations)
+    for batch, sequence in ((24_000, 13), (28_000, 9)):
+        case, checks = attention_case(
+            device,
+            batch=batch,
+            sequence=sequence,
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        cases.append(case)
+        parity.extend(checks)
+
+    speedups = [case["baseline_ms"] / case["candidate_ms"] for case in cases]
+    result = {
+        "status": "complete",
+        "benchmark": "attention-fast-paths",
+        "device": str(device),
+        "device_name": torch.cuda.get_device_name(device),
+        "torch_version": str(torch.__version__),
+        "warmup": args.warmup,
+        "iterations": args.iterations,
+        "geomean_speedup": math.exp(sum(math.log(value) for value in speedups) / len(speedups)),
+        "cases": cases,
+        "parity": parity,
+    }
+    rendered = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    print(rendered, end="")
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_pipeline_batching.py
+++ b/benchmarks/bench_pipeline_batching.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Paired end-to-end benchmark for Nori inference-pipeline batching.
+
+The workload is the measured narrow public-6M case: 512 context rows, 48 raw
+features, and either 256 plain-query rows or 600 hot resident-cache query rows.
+Batching ON/OFF calls alternate on one fitted predictor so model loading and
+machine drift are shared by both arms. Results are emitted as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+SEED = 20260818
+N_TRAIN = 512
+N_PLAIN_TEST = 256
+N_CACHED_TEST = 600
+N_FEATURES = 48
+ELEMENTS_BUDGET = 36_864
+PARITY_ATOL = 5e-3
+PARITY_RTOL = 5e-3
+GIB = 1024**3
+
+
+def at_least_two(raw: str) -> int:
+    value = int(raw)
+    if value < 2:
+        raise argparse.ArgumentTypeError("value must be at least 2")
+    return value
+
+
+def nonnegative_int(raw: str) -> int:
+    value = int(raw)
+    if value < 0:
+        raise argparse.ArgumentTypeError("value must be non-negative")
+    return value
+
+
+def nonnegative_float(raw: str) -> float:
+    value = float(raw)
+    if not math.isfinite(value) or value < 0:
+        raise argparse.ArgumentTypeError("value must be a finite non-negative number")
+    return value
+
+
+def percentile(samples: list[float], fraction: float) -> float:
+    """Linearly interpolated percentile without an optional statistics package."""
+    ordered = sorted(samples)
+    position = (len(ordered) - 1) * fraction
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def make_data() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    generator = np.random.default_rng(SEED)
+    x_train = generator.normal(size=(N_TRAIN, N_FEATURES)).astype(np.float32)
+    x_test = generator.normal(size=(N_CACHED_TEST, N_FEATURES)).astype(np.float32)
+    weights = generator.normal(size=N_FEATURES).astype(np.float32)
+    weights /= np.linalg.norm(weights)
+    noise = generator.normal(scale=0.05, size=N_TRAIN).astype(np.float32)
+    y_train = x_train @ weights + 0.2 * np.sin(2.0 * x_train[:, 0]) + noise
+    return x_train, y_train.astype(np.float32), x_test
+
+
+def to_numpy(value) -> np.ndarray:
+    if torch.is_tensor(value):
+        value = value.detach().cpu().numpy()
+    return np.asarray(value, dtype=np.float64)
+
+
+def delta(name: str, candidate, baseline) -> dict:
+    candidate_array = to_numpy(candidate)
+    baseline_array = to_numpy(baseline)
+    if candidate_array.shape != baseline_array.shape:
+        return {
+            "name": name,
+            "passed": False,
+            "candidate_shape": list(candidate_array.shape),
+            "baseline_shape": list(baseline_array.shape),
+        }
+    absolute = np.abs(candidate_array - baseline_array)
+    tolerance = PARITY_ATOL + PARITY_RTOL * np.abs(baseline_array)
+    denominator = np.maximum(np.abs(baseline_array), PARITY_ATOL)
+    return {
+        "name": name,
+        "passed": bool(np.all(absolute <= tolerance)),
+        "shape": list(candidate_array.shape),
+        "max_abs": float(absolute.max(initial=0.0)),
+        "mean_abs": float(absolute.mean()) if absolute.size else 0.0,
+        "max_rel": float((absolute / denominator).max(initial=0.0)),
+        "atol": PARITY_ATOL,
+        "rtol": PARITY_RTOL,
+    }
+
+
+@contextmanager
+def controlled_environment():
+    keys = (
+        "SYNTHEFY_CACHE_MAX_GB",
+        "SYNTHEFY_DISABLE_CACHED_INFERENCE",
+        "SYNTHEFY_ENABLE_CACHED_INFERENCE",
+        "SYNTHEFY_DISABLE_PIPELINE_BATCHING",
+        "SYNTHEFY_MAX_ELEMENTS_BUDGET",
+    )
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        os.environ.pop("SYNTHEFY_CACHE_MAX_GB", None)
+        os.environ.pop("SYNTHEFY_DISABLE_CACHED_INFERENCE", None)
+        os.environ.pop("SYNTHEFY_DISABLE_PIPELINE_BATCHING", None)
+        os.environ.pop("SYNTHEFY_MAX_ELEMENTS_BUDGET", None)
+        os.environ["SYNTHEFY_ENABLE_CACHED_INFERENCE"] = "1"
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def set_pipeline_batching(enabled: bool) -> None:
+    if enabled:
+        os.environ.pop("SYNTHEFY_DISABLE_PIPELINE_BATCHING", None)
+    else:
+        os.environ["SYNTHEFY_DISABLE_PIPELINE_BATCHING"] = "1"
+
+
+def clear_context_cache(predictor) -> None:
+    cache = getattr(predictor, "_context_cache", None)
+    if cache is not None:
+        cache.clear()
+
+
+def context_cache_signature(predictor) -> dict:
+    """Bundle identities, used to prove a nominal hot call did not rebuild."""
+    cache = getattr(predictor, "_context_cache", None) or {}
+    return {
+        key: id(entry[3])
+        for key, entry in cache.items()
+    }
+
+
+def assert_hot_cache_reused(predictor, expected: dict, *, label: str) -> None:
+    actual = context_cache_signature(predictor)
+    if not expected:
+        raise RuntimeError(f"{label} warmup retained no context cache")
+    if actual != expected:
+        raise RuntimeError(
+            f"{label} rebuilt or replaced its context cache during the timed call: "
+            f"before={expected}, after={actual}"
+        )
+
+
+def one_predict(
+    regressor,
+    predictor,
+    x_test: np.ndarray,
+    *,
+    batching: bool,
+    hot_reuse: bool,
+):
+    set_pipeline_batching(batching)
+    clear_context_cache(predictor)
+    warm_signature = {}
+    if hot_reuse:
+        warm_predictions = regressor.predict(x_test, output_type="mean")
+        torch.cuda.synchronize()
+        del warm_predictions
+        warm_signature = context_cache_signature(predictor)
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    started = time.perf_counter()
+    predictions = regressor.predict(x_test, output_type="mean")
+    torch.cuda.synchronize()
+    elapsed_ms = (time.perf_counter() - started) * 1_000.0
+    peak_gib = torch.cuda.max_memory_allocated() / GIB
+    report = getattr(predictor, "memory_report_", None)
+    if hot_reuse:
+        assert_hot_cache_reused(
+            predictor,
+            warm_signature,
+            label="batching-on" if batching else "batching-off",
+        )
+    return elapsed_ms, peak_gib, predictions, report
+
+
+def distribution_predict(
+    regressor,
+    predictor,
+    x_test: np.ndarray,
+    *,
+    batching: bool,
+    hot_reuse: bool,
+) -> dict:
+    set_pipeline_batching(batching)
+    clear_context_cache(predictor)
+    warm_signature = {}
+    if hot_reuse:
+        warm_distribution = regressor.predict(x_test, output_type="full")
+        torch.cuda.synchronize()
+        del warm_distribution
+        warm_signature = context_cache_signature(predictor)
+    torch.cuda.synchronize()
+    result = regressor.predict(x_test, output_type="full")
+    torch.cuda.synchronize()
+    if hot_reuse:
+        assert_hot_cache_reused(
+            predictor,
+            warm_signature,
+            label="batching-on distribution" if batching else "batching-off distribution",
+        )
+    return result
+
+
+def summarize_arm(durations_ms: list[float], peaks_gib: list[float], report: dict | None) -> dict:
+    return {
+        "durations_ms": durations_ms,
+        "median_ms": statistics.median(durations_ms),
+        "p95_ms": percentile(durations_ms, 0.95),
+        "peak_vram_gib": max(peaks_gib),
+        "peak_vram_gib_samples": peaks_gib,
+        "memory_report": report,
+    }
+
+
+def benchmark_case(
+    regressor,
+    predictor,
+    *,
+    name: str,
+    x_test: np.ndarray,
+    memory_policy,
+    repeats: int,
+    warmup: int,
+    expected_rung: str,
+    expected_query_chunk: int | None = None,
+    hot_reuse: bool = False,
+) -> tuple[dict, list[dict]]:
+    regressor.memory_policy = memory_policy
+    arms = (("batching_on", True), ("batching_off", False))
+
+    for index in range(warmup):
+        order = arms if index % 2 == 0 else tuple(reversed(arms))
+        for _, enabled in order:
+            one_predict(
+                regressor,
+                predictor,
+                x_test,
+                batching=enabled,
+                hot_reuse=hot_reuse,
+            )
+
+    durations = {label: [] for label, _ in arms}
+    peaks = {label: [] for label, _ in arms}
+    point_outputs = {}
+    reports = {}
+    for index in range(repeats):
+        order = arms if index % 2 == 0 else tuple(reversed(arms))
+        for label, enabled in order:
+            elapsed_ms, peak_gib, predictions, report = one_predict(
+                regressor,
+                predictor,
+                x_test,
+                batching=enabled,
+                hot_reuse=hot_reuse,
+            )
+            if report is None or report.get("rung") != expected_rung:
+                actual = None if report is None else report.get("rung")
+                raise RuntimeError(
+                    f"{name}/{label} reached memory rung {actual!r}; "
+                    f"expected {expected_rung!r}"
+                )
+            if (
+                expected_query_chunk is not None
+                and report.get("query_chunk") != expected_query_chunk
+            ):
+                raise RuntimeError(
+                    f"{name}/{label} used query_chunk={report.get('query_chunk')!r}; "
+                    f"expected {expected_query_chunk}"
+                )
+            durations[label].append(elapsed_ms)
+            peaks[label].append(peak_gib)
+            point_outputs[label] = predictions
+            reports[label] = report
+
+    distributions = {
+        label: distribution_predict(
+            regressor,
+            predictor,
+            x_test,
+            batching=enabled,
+            hot_reuse=hot_reuse,
+        )
+        for label, enabled in arms
+    }
+    parity = [
+        delta(f"{name}-point", point_outputs["batching_on"], point_outputs["batching_off"]),
+        delta(
+            f"{name}-distribution-quantiles",
+            distributions["batching_on"]["quantiles"],
+            distributions["batching_off"]["quantiles"],
+        ),
+        delta(
+            f"{name}-distribution-mean",
+            distributions["batching_on"]["mean"],
+            distributions["batching_off"]["mean"],
+        ),
+        delta(
+            f"{name}-distribution-taus",
+            distributions["batching_on"]["taus"],
+            distributions["batching_off"]["taus"],
+        ),
+    ]
+    arm_results = {
+        label: summarize_arm(durations[label], peaks[label], reports[label])
+        for label, _ in arms
+    }
+    baseline_ms = arm_results["batching_off"]["median_ms"]
+    candidate_ms = arm_results["batching_on"]["median_ms"]
+    return (
+        {
+            "name": name,
+            "n_test": len(x_test),
+            "baseline_ms": baseline_ms,
+            "candidate_ms": candidate_ms,
+            "speedup": baseline_ms / candidate_ms,
+            "hot_context_reuse": hot_reuse,
+            "arms": arm_results,
+            "deltas": {
+                "point": parity[0],
+                "distribution_quantiles": parity[1],
+                "distribution_mean": parity[2],
+                "distribution_taus": parity[3],
+            },
+        },
+        parity,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument(
+        "--repeats",
+        type=at_least_two,
+        default=5,
+        help="Timed repetitions per arm (minimum 2; default: 5).",
+    )
+    parser.add_argument("--warmup", type=nonnegative_int, default=1)
+    parser.add_argument("--output", type=Path, help="Optional path for the JSON result.")
+    parser.add_argument(
+        "--include-resident-cache",
+        action="store_true",
+        help="Also benchmark the 600-query exact resident-bf16 hot-reuse case.",
+    )
+    parser.add_argument("--gpu-cache-cap-gb", type=nonnegative_float, default=40.0)
+    parser.add_argument("--host-cache-cap-gb", type=nonnegative_float, default=80.0)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        parser.error("this benchmark requires CUDA")
+    device = torch.device(args.device)
+    if device.type != "cuda":
+        parser.error("--device must be cuda[:INDEX]")
+    if device.index is None:
+        device = torch.device("cuda", torch.cuda.current_device())
+    torch.cuda.set_device(device)
+
+    from synthefy_nori import NoriRegressor
+
+    x_train, y_train, x_test = make_data()
+    regressor = NoriRegressor(
+        model="nori-6m",
+        device=device,
+        augmentations=(),
+    ).fit(x_train, y_train)
+    predictor = regressor._get_predictor()
+
+    cases = []
+    parity = []
+    plain_policy = {
+        "cache": False,
+        "elements_budget": ELEMENTS_BUDGET,
+    }
+    cached_policy = {
+        "elements_budget": ELEMENTS_BUDGET,
+        "cache_dtype": "bf16",
+        "allow_quantization": False,
+        "reuse_context_cache": True,
+        "gpu_budget_absolute_gb": args.gpu_cache_cap_gb,
+        "host_budget_absolute_gb": args.host_cache_cap_gb,
+    }
+
+    with controlled_environment():
+        case, checks = benchmark_case(
+            regressor,
+            predictor,
+            name="public-6m-plain-n512-q256-f48",
+            x_test=x_test[:N_PLAIN_TEST],
+            memory_policy=plain_policy,
+            repeats=args.repeats,
+            warmup=args.warmup,
+            expected_rung="no_cache",
+        )
+        cases.append(case)
+        parity.extend(checks)
+        if args.include_resident_cache:
+            case, checks = benchmark_case(
+                regressor,
+                predictor,
+                name="public-6m-resident-bf16-hot-reuse-n512-q600-f48",
+                x_test=x_test,
+                memory_policy=cached_policy,
+                repeats=args.repeats,
+                warmup=args.warmup,
+                expected_rung="resident_bf16",
+                expected_query_chunk=256,
+                hot_reuse=True,
+            )
+            cases.append(case)
+            parity.extend(checks)
+
+    speedups = [case["speedup"] for case in cases]
+    result = {
+        "status": "complete",
+        "benchmark": "nori-inference-pipeline-batching",
+        "model": "nori-6m",
+        "device": str(device),
+        "device_name": torch.cuda.get_device_name(device),
+        "torch_version": str(torch.__version__),
+        "seed": SEED,
+        "repeats": args.repeats,
+        "warmup": args.warmup,
+        "workload": {
+            "n_train": N_TRAIN,
+            "plain_n_test": N_PLAIN_TEST,
+            "cached_n_test": N_CACHED_TEST if args.include_resident_cache else None,
+            "raw_features": N_FEATURES,
+            "elements_budget": ELEMENTS_BUDGET,
+            "gpu_cache_cap_gb": args.gpu_cache_cap_gb,
+            "host_cache_cap_gb": args.host_cache_cap_gb,
+            "cached_measurement": "hot_context_reuse" if args.include_resident_cache else None,
+        },
+        "geomean_speedup": math.exp(
+            sum(math.log(speedup) for speedup in speedups) / len(speedups)
+        ),
+        "cases": cases,
+        "parity": parity,
+    }
+    rendered = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    print(rendered, end="")
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_pipeline_batching.py
+++ b/benchmarks/bench_pipeline_batching.py
@@ -149,10 +149,7 @@ def clear_context_cache(predictor) -> None:
 def context_cache_signature(predictor) -> dict:
     """Bundle identities, used to prove a nominal hot call did not rebuild."""
     cache = getattr(predictor, "_context_cache", None) or {}
-    return {
-        key: id(entry[3])
-        for key, entry in cache.items()
-    }
+    return {key: id(entry[3]) for key, entry in cache.items()}
 
 
 def assert_hot_cache_reused(predictor, expected: dict, *, label: str) -> None:
@@ -161,8 +158,7 @@ def assert_hot_cache_reused(predictor, expected: dict, *, label: str) -> None:
         raise RuntimeError(f"{label} warmup retained no context cache")
     if actual != expected:
         raise RuntimeError(
-            f"{label} rebuilt or replaced its context cache during the timed call: "
-            f"before={expected}, after={actual}"
+            f"{label} rebuilt or replaced its context cache during the timed call: before={expected}, after={actual}"
         )
 
 
@@ -281,17 +277,10 @@ def benchmark_case(
             )
             if report is None or report.get("rung") != expected_rung:
                 actual = None if report is None else report.get("rung")
+                raise RuntimeError(f"{name}/{label} reached memory rung {actual!r}; expected {expected_rung!r}")
+            if expected_query_chunk is not None and report.get("query_chunk") != expected_query_chunk:
                 raise RuntimeError(
-                    f"{name}/{label} reached memory rung {actual!r}; "
-                    f"expected {expected_rung!r}"
-                )
-            if (
-                expected_query_chunk is not None
-                and report.get("query_chunk") != expected_query_chunk
-            ):
-                raise RuntimeError(
-                    f"{name}/{label} used query_chunk={report.get('query_chunk')!r}; "
-                    f"expected {expected_query_chunk}"
+                    f"{name}/{label} used query_chunk={report.get('query_chunk')!r}; expected {expected_query_chunk}"
                 )
             durations[label].append(elapsed_ms)
             peaks[label].append(peak_gib)
@@ -326,10 +315,7 @@ def benchmark_case(
             distributions["batching_off"]["taus"],
         ),
     ]
-    arm_results = {
-        label: summarize_arm(durations[label], peaks[label], reports[label])
-        for label, _ in arms
-    }
+    arm_results = {label: summarize_arm(durations[label], peaks[label], reports[label]) for label, _ in arms}
     baseline_ms = arm_results["batching_off"]["median_ms"]
     candidate_ms = arm_results["batching_on"]["median_ms"]
     return (
@@ -456,9 +442,7 @@ def main() -> None:
             "host_cache_cap_gb": args.host_cache_cap_gb,
             "cached_measurement": "hot_context_reuse" if args.include_resident_cache else None,
         },
-        "geomean_speedup": math.exp(
-            sum(math.log(speedup) for speedup in speedups) / len(speedups)
-        ),
+        "geomean_speedup": math.exp(sum(math.log(speedup) for speedup in speedups) / len(speedups)),
         "cases": cases,
         "parity": parity,
     }

--- a/benchmarks/bench_training_compile.py
+++ b/benchmarks/bench_training_compile.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import torch
 
+import synthefy_nori.model.layer as model_layer
 from synthefy_nori.model.layer import RMSNorm
 from synthefy_nori.utils.loading import _safe_torch_load, build_model
 
@@ -150,6 +151,20 @@ def main():
     parser.add_argument("--compile-cache-limit", type=int, default=1024)
     parser.add_argument("--disable-ddp-optimizer", action="store_true")
     parser.add_argument(
+        "--sdpa-batch-head-limit",
+        type=int,
+        help="Override the model's SDPA batch/head chunk limit for an A/B benchmark.",
+    )
+    parser.add_argument(
+        "--allow-distributed-compile",
+        action="store_true",
+        help=(
+            "Allow a compiled benchmark under DDP. This is unsafe for cache "
+            "warmup because ranks can reach collectives while a peer is still "
+            "compiling; use a single process to populate compiler artifacts."
+        ),
+    )
+    parser.add_argument(
         "--shapes",
         type=parse_shapes,
         default=parse_shapes("256x64@0.5"),
@@ -165,6 +180,10 @@ def main():
     parser.add_argument("--checkpointing", choices=("auto", "on", "off"), default="auto")
     parser.add_argument("--output")
     args = parser.parse_args()
+    if args.sdpa_batch_head_limit is not None:
+        if args.sdpa_batch_head_limit <= 0:
+            parser.error("--sdpa-batch-head-limit must be positive")
+        model_layer.SDPA_BATCH_HEAD_LIMIT = args.sdpa_batch_head_limit
 
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
     distributed = world_size > 1
@@ -252,6 +271,7 @@ def main():
     steady = [record["seconds"] for record in records if record["cycle"] > 0]
     summary = {
         "strategy": args.strategy,
+        "sdpa_batch_head_limit": model_layer.SDPA_BATCH_HEAD_LIMIT,
         "native_rms_norm": args.native_rms_norm,
         "batch_size": args.batch_size,
         "shape_count": len(args.shapes),

--- a/benchmarks/check_acceleration.py
+++ b/benchmarks/check_acceleration.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Check a held-out performance result against Nori's acceleration gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--min-geomean-speedup", type=float, default=1.05)
+    parser.add_argument("--max-case-regression", type=float, default=0.01)
+    args = parser.parse_args()
+
+    result = json.loads(args.results.read_text())
+    if result.get("status") != "complete":
+        print(f"PENDING status={result.get('status', 'missing')}")
+        return 1
+
+    cases = result.get("cases", [])
+    parity = result.get("parity", [])
+    if not cases or not parity:
+        print("FAIL missing held-out cases or parity checks")
+        return 1
+
+    speedups = []
+    regressions = []
+    for case in cases:
+        baseline_ms = float(case["baseline_ms"])
+        candidate_ms = float(case["candidate_ms"])
+        if baseline_ms <= 0.0 or candidate_ms <= 0.0:
+            print(f"FAIL invalid timing for {case.get('name', '<unnamed>')}")
+            return 1
+        speedups.append(baseline_ms / candidate_ms)
+        regressions.append(candidate_ms / baseline_ms - 1.0)
+
+    geomean_speedup = math.exp(sum(math.log(value) for value in speedups) / len(speedups))
+    worst_regression = max(0.0, max(regressions))
+    parity_ok = all(bool(check.get("passed")) for check in parity)
+    passed = geomean_speedup >= args.min_geomean_speedup and worst_regression <= args.max_case_regression and parity_ok
+    verdict = "PASS" if passed else "FAIL"
+    print(
+        f"{verdict} geomean_speedup={geomean_speedup:.4f} "
+        f"worst_regression={worst_regression:.4%} parity={'ok' if parity_ok else 'failed'}"
+    )
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/libs/synthefy/README.md
+++ b/libs/synthefy/README.md
@@ -392,6 +392,8 @@ preds = client.predict(X_train, y_train, X_test, memory_policy="max_context")  #
 
 # ...individual fields...
 preds = client.predict(X_train, y_train, X_test, memory_policy={"cache_dtype": "int8"})
+preds = client.predict(X_train, y_train, X_test,
+                       memory_policy={"stream_context": True})  # bounded GPU staging
 
 # ...or the typed model, which ships with the client — no synthefy-nori needed. Validated
 # before the request goes out, so a typo or an out-of-range value costs no round trip.
@@ -408,26 +410,36 @@ request, so it is not knowable from your side.
 
 | field | meaning |
 |---|---|
-| `rung` | which fallback served it — `resident_bf16` → `resident_int8` → `offload_bf16` → `offload_int8` → `plain_loop` → `no_cache` |
-| `est_cache_gb` / `resident_gb` | the cache's full-precision size, and what stayed in GPU memory |
+| `rung` | which path served it — ordinary `resident_*` / `offload_*`, explicit `stream_bf16` / `stream_int8`, or a lower fallback |
+| `est_cache_gb` / `resident_gb` | the cache's full-precision size, and its footprint at the chosen precision |
 | `query_chunk` | query rows per forward pass |
-| `dropped_context_rows` | context rows discarded to fit — **the one accuracy loss worth checking**, `0` unless subsampling engaged |
+| `dropped_context_rows` | context rows discarded to fit, `0` unless subsampling engaged |
 | `clamped` | fields the server capped (host-RAM budgets only) |
 | `notes` | remarks about the policy you sent, e.g. a budget that cannot take effect |
 
-**Only the int8 rungs trade accuracy**, and they are reached only when full precision
-will not fit. `offload_*` moves bytes to host RAM rather than approximating, so it is
-bit-identical to staying resident. Set `memory_policy={"allow_subsample": False}` to turn a
-silently shortened context into an error instead.
+**Only the int8 rungs quantize the cache.** Ordinary `offload_*` moves bytes to host
+RAM rather than approximating, so BF16 offload is bit-identical to staying resident.
+Explicit streaming is numerically close but not bit-exact even at BF16 because bounded
+online attention changes floating-point reduction order.
+
+Use `memory_policy={"stream_context": True}` when context-attention GPU memory should
+stop scaling with context length. It keeps the full context/KV state on the host, reports
+`stream_bf16` or `stream_int8`, disables cross-call context reuse, and defaults to a
+maximum staged-row cap of 2048. Runtime may use smaller K/V blocks to honor its fixed
+FP32 workspace cap; fit-time OOMs retry a bounded 2048 → 1024 → 512 → 256 row ladder.
+If the full cache cannot fit the allowed host budget, the request fails clearly
+instead of silently switching to `plain_loop`. Set
+`memory_policy={"allow_subsample": False}` to turn ordinary element-budget context
+shortening into an error as well.
 
 One field behaves differently over the network: **`elements_budget`**. The cache is only
 built when the query set spans more than one chunk, and at default settings that needs
 far more query rows than the hosted request-body limit (~64 MiB) allows — so lowering
 `elements_budget` is what lets a hosted request reach the cached path at all.
 
-In `mode="local"` the same argument works, but needs `synthefy-nori >= 0.13.0`; older
-builds raise `ImportError` with an upgrade hint. `last_memory_report` stays `None`
-locally — use `NoriRegressor` and read `memory_report_` if you need it there.
+In `mode="local"` the same argument works when the installed `synthefy-nori` exposes
+the field. An older runtime raises `ImportError` with an upgrade hint before inference.
+`last_memory_report` exposes the resolved local report just as it does for hosted calls.
 
 ### Choosing Context on Large Tables (`large_context_policy=`)
 

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -54,6 +54,7 @@ from synthefy.nori_data_models import (
     MAX_MULTI_TARGET_COPULA_PIT_JITTER,
     MAX_MULTI_TARGET_DRAWS,
     MemoryPolicyInput,
+    MemoryReport,
     MultiTargetPredictionPolicy,
     MultiTargetPredictionStrategy,
 )
@@ -1223,18 +1224,16 @@ class SynthefyNoriClient:
             self.api_key = api_key  # unused in local mode; may be None
             self.client = None
 
-        #: What the server did about ``memory_policy=`` on the most recent :meth:`predict`, or
+        #: What the runtime did about ``memory_policy=`` on the most recent :meth:`predict`, or
         #: ``None`` if that call did not set one. Mirrors the local package's
         #: ``NoriRegressor.memory_report_``: which fallback rung ran, the estimated and
         #: resident cache sizes, the query chunk, any dropped context rows, plus which fields
-        #: the server clamped and any coherence notes about the policy sent.
+        #: hosted serving clamped, any coherence notes, and the chronological attempt history.
         #:
-        #: Worth reading, because the rung is decided by the replica's free VRAM rather than
-        #: by the request -- it is not knowable from the client side.
+        #: Worth reading, because the rung is decided by available VRAM rather than by the
+        #: request -- it is not knowable before the prediction runs.
         #:
-        #: **Hosted modes only (remote/AWS).** In local mode the policy is honoured by the
-        #: estimator owned by this client, but no report is copied here. Use ``NoriRegressor``
-        #: directly and read ``memory_report_`` if you need the local report.
+        #: Populated in local, remote, and AWS modes whenever a memory policy is requested.
         self.last_memory_report: Optional[Dict[str, Any]] = None
         # Per-internal-call reports for the most recent hosted multi-target
         # prediction that explicitly set memory_policy.
@@ -1942,6 +1941,16 @@ class SynthefyNoriClient:
                 == "autoregressive"
                 else None
             )
+            if request.memory_policy is not None:
+                report = getattr(regressor, "memory_report_", None)
+                if report is None:
+                    raise ValueError(
+                        "memory_policy= was sent to local synthefy-nori but no "
+                        "memory_report_ came back. The installed runtime predates "
+                        "this capability or ignored the policy; upgrade "
+                        "synthefy-nori or omit memory_policy=."
+                    )
+                self.last_memory_report = MemoryReport.model_validate(report).model_dump()
             if request.large_context_policy is not None:
                 self.last_large_context_report = _normalized_large_context_report(
                     request, getattr(regressor, "large_context_report_", None)
@@ -1992,7 +2001,11 @@ class SynthefyNoriClient:
         discretize: Optional[str] = None,
         categorical_levels: Optional[VectorLike] = None,
     ) -> List[float]:
-        if output_type != DEFAULT_OUTPUT_TYPE or request.large_context_policy is not None:
+        if (
+            output_type != DEFAULT_OUTPUT_TYPE
+            or request.large_context_policy is not None
+            or request.memory_policy is not None
+        ):
             # "median" is a point output but still needs the estimator API
             # (see _local_regressor_predict). Discretization cannot reach here:
             # _validate_output_type rejects that combination up front.

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -633,6 +633,36 @@ def _local_memory_policy_available() -> bool:
         return False
 
 
+def _local_stream_context_available() -> bool:
+    """Whether the installed local policy understands ``stream_context``.
+
+    The lightweight client can be newer than the separately installed model package.
+    A runtime that has the original ``memory_policy=`` surface therefore passes the
+    module-presence check above but would reject this newer field deep inside fit().
+    Inspect the authoritative local model only on the local execution path so remote
+    clients still do not import the heavyweight optional package.
+    """
+    from synthefy_nori.inference.memory_policy import MemoryPolicy as LocalMemoryPolicy
+
+    return "stream_context" in LocalMemoryPolicy.model_fields
+
+
+def _require_local_memory_policy_capabilities(memory_policy: MemoryPolicyInput) -> None:
+    """Fail with an upgrade hint before forwarding an unsupported local policy."""
+    if not _local_memory_policy_available():
+        raise ImportError(
+            "memory_policy= requires synthefy-nori >= 0.13.0 (the serving-memory policy). "
+            "Upgrade with: pip install -U synthefy-nori."
+        )
+    stream_context_was_sent = not isinstance(memory_policy, str) and "stream_context" in memory_policy.model_fields_set
+    if stream_context_was_sent and not _local_stream_context_available():
+        raise ImportError(
+            "memory_policy.stream_context requires a newer synthefy-nori; the "
+            "installed runtime's MemoryPolicy does not include the stream_context "
+            "field. Upgrade with: pip install -U synthefy-nori."
+        )
+
+
 def _local_large_context_available() -> bool:
     """Return ``True`` if the installed ``synthefy-nori`` accepts ``large_context_policy=``.
 
@@ -1835,11 +1865,7 @@ class SynthefyNoriClient:
             init_kwargs["model"] = self._local_variant
         is_multi_target = np.asarray(request.y_train, dtype=float).ndim == 2
         if request.memory_policy is not None:
-            if not _local_memory_policy_available():
-                raise ImportError(
-                    "memory_policy= requires synthefy-nori >= 0.13.0 (the serving-memory policy). "
-                    "Upgrade with: pip install -U synthefy-nori."
-                )
+            _require_local_memory_policy_capabilities(request.memory_policy)
             # NoriRegressor belongs to another package and expects its own MemoryPolicy
             # class (or a plain input), not this client's equivalent pydantic class.
             init_kwargs["memory_policy"] = (
@@ -2038,11 +2064,7 @@ class SynthefyNoriClient:
             if categorical_levels is not None:
                 extra["categorical_levels"] = categorical_levels
         if request.memory_policy is not None:
-            if not _local_memory_policy_available():
-                raise ImportError(
-                    "memory_policy= requires synthefy-nori >= 0.13.0 (the serving-memory policy). "
-                    "Upgrade with: pip install -U synthefy-nori."
-                )
+            _require_local_memory_policy_capabilities(request.memory_policy)
             # A dict, not our MemoryPolicy instance: the library's coerce() accepts its OWN
             # class, a dict, a preset name or None -- a same-named class from this package is
             # none of those and would raise. exclude_unset for the same reason as the wire

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -270,10 +270,10 @@ class MemoryPolicy(BaseModel):
         None,
         gt=0,
         description=(
-            "Bound the fit-time build working set to this many context rows (bit-exact). "
-            "None = off, with 2048 engaged automatically after an OOM. Pinning a value "
-            "uses it from the first attempt — which also costs you that escalation, since "
-            "there is then nothing left to escalate to. "
+            "Bound prefill to this many context rows (deterministic, with small "
+            "floating-point reassociation differences). None = off, with 2048, 1024, "
+            "then 512 tried after OOMs. An explicit value is a first-attempt cap; retries "
+            "stay at or below it. "
         ),
     )
 
@@ -304,6 +304,27 @@ class MemoryPolicy(BaseModel):
             "makes that an error instead of a silent accuracy loss. "
         ),
     )
+
+
+class MemoryAttempt(BaseModel):
+    """One execution attempt contributing to a prediction's memory outcome."""
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+
+    pipeline_ids: List[int] = Field(default_factory=list)
+    path: Literal["pipeline_batch", "cached", "plain_loop"]
+    rung: str
+    cache_dtype: Literal["bf16", "int8"]
+    offload_to_host: bool
+    context_row_chunk: Optional[int] = Field(None, gt=0)
+    outcome: Literal["success", "oom", "unsupported"]
+    reason: Literal[
+        "resolved",
+        "oom_retry",
+        "fallback_after_oom",
+        "fallback_after_unsupported",
+    ]
+    dropped_context_rows: int = Field(0, ge=0)
 
 
 class MemoryReport(BaseModel):
@@ -359,10 +380,16 @@ class MemoryReport(BaseModel):
         0,
         ge=0,
         description=(
-            "Context rows the caller had to subsample away to fit. Non-zero only on the "
-            "plain_loop rung; recorded so a shrunk context is visible in memory_report_ "
+            "Context rows subsampled before cache resolution to fit the element budget; "
+            "recorded on cached and plain-loop outcomes so a shrunk context is visible "
             "rather than inferred from the score. "
         ),
+    )
+
+    attempt_history: List[MemoryAttempt] = Field(
+        default_factory=list,
+        description="Chronological memory execution attempts, including runtime OOMs, "
+                    "fit-row retries, and the successful fallback.",
     )
 
     clamped: List[str] = Field(

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -51,6 +51,8 @@ MEMORY_RUNGS = (
     "resident_int8",
     "offload_bf16",
     "offload_int8",
+    "stream_bf16",
+    "stream_int8",
     "context_row_chunk",
     "plain_loop",
 )
@@ -266,13 +268,26 @@ class MemoryPolicy(BaseModel):
         ),
     )
 
+    stream_context: bool = Field(
+        False,
+        description=(
+            "Keep the full context and K/V cache in host RAM and stage only bounded "
+            "row slices on the GPU. This forces the host-only stream_bf16/stream_int8 "
+            "path, disables cross-call context reuse, and uses "
+            "context_row_chunk=2048 as the maximum staged-row cap when no cap is "
+            "supplied. Runtime may split K/V blocks smaller to honor its fixed FP32 "
+            "online-attention workspace ceiling. Streaming never silently falls back "
+            "to plain_loop."
+        ),
+    )
+
     context_row_chunk: Optional[int] = Field(
         None,
         gt=0,
         description=(
             "Bound prefill to this many context rows (deterministic, with small "
-            "floating-point reassociation differences). None = off, with 2048, 1024, "
-            "then 512 tried after OOMs. An explicit value is a first-attempt cap; retries "
+            "floating-point reassociation differences). None = off, with 2048, 1024, 512, "
+            "then 256 tried after OOMs. An explicit value is a first-attempt cap; retries "
             "stay at or below it. "
         ),
     )
@@ -317,6 +332,7 @@ class MemoryAttempt(BaseModel):
     cache_dtype: Literal["bf16", "int8"]
     offload_to_host: bool
     context_row_chunk: Optional[int] = Field(None, gt=0)
+    query_chunk: Optional[int] = Field(None, gt=0)
     outcome: Literal["success", "oom", "unsupported"]
     reason: Literal[
         "resolved",
@@ -348,9 +364,10 @@ class MemoryReport(BaseModel):
             "Which fallback the server used, in decreasing memory cost: resident_bf16 "
             "(cache in GPU memory, exact), resident_int8 (quantized), offload_bf16 / "
             "offload_int8 (cache in host RAM, streamed back per layer, exact transport), "
-            "context_row_chunk (cache built in row chunks), plain_loop (no cache; the "
-            "context re-read per query batch), no_cache (the cached path did not apply). "
-            "Decided per request, not requestable. "
+            "stream_bf16 / stream_int8 (explicit bounded host-only context streaming; "
+            "not bit-exact), context_row_chunk (cache built in row chunks), plain_loop "
+            "(no cache; the context re-read per query batch), no_cache (the cached path "
+            "did not apply). Decided per request, not requestable. "
         ),
     )
 
@@ -370,9 +387,10 @@ class MemoryReport(BaseModel):
     query_chunk: Optional[int] = Field(
         None,
         description=(
-            "Query rows per decode forward, as the cached path was entered with. "
-            "Reported, not set. NOTE: a decode OOM may halve this further inside the "
-            "model, and that further reduction is not currently reported here. "
+            "Effective query rows per decode forward on the successful cached path. "
+            "If decoding exhausted its retries and raised, this is the last attempted "
+            "size. Every adaptive reduction is also recorded in attempt_history. "
+            "Reported, not set. "
         ),
     )
 
@@ -388,8 +406,9 @@ class MemoryReport(BaseModel):
 
     attempt_history: List[MemoryAttempt] = Field(
         default_factory=list,
-        description="Chronological memory execution attempts, including runtime OOMs, "
-                    "fit-row retries, and the successful fallback.",
+        description="Chronological memory execution attempts, including cache-build "
+        "OOMs, decode query-chunk retries, fit-row retries, and the "
+        "successful fallback.",
     )
 
     clamped: List[str] = Field(

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -2625,13 +2625,12 @@ def test_local_mode_uses_estimator_and_surfaces_memory_report(monkeypatch):
     monkeypatch.setattr(module, "_local_memory_policy_available", lambda: True)
     monkeypatch.setattr(module, "_load_local_regressor", lambda: FakeRegressor)
     monkeypatch.setattr(
-        module, "_load_local_predict",
+        module,
+        "_load_local_predict",
         lambda: (_ for _ in ()).throw(AssertionError("functional path used")),
     )
     client = SynthefyNoriClient(model="nori-30m", mode="local")
-    predictions = client.predict(
-        _X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache_dtype": "int8"}
-    )
+    predictions = client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache_dtype": "int8"})
 
     assert predictions == [0.1, 0.2]
     assert seen["model"] == "nori-30m"

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -2359,17 +2359,20 @@ _REPORT = {
     "resident_gb": 0.0065,
     "query_chunk": 256,
     "dropped_context_rows": 0,
-    "attempt_history": [{
-        "pipeline_ids": [0],
-        "path": "cached",
-        "rung": "resident_int8",
-        "cache_dtype": "int8",
-        "offload_to_host": False,
-        "context_row_chunk": None,
-        "outcome": "success",
-        "reason": "resolved",
-        "dropped_context_rows": 0,
-    }],
+    "attempt_history": [
+        {
+            "pipeline_ids": [0],
+            "path": "cached",
+            "rung": "resident_int8",
+            "cache_dtype": "int8",
+            "offload_to_host": False,
+            "context_row_chunk": None,
+            "query_chunk": None,
+            "outcome": "success",
+            "reason": "resolved",
+            "dropped_context_rows": 0,
+        }
+    ],
     "clamped": [],
     "notes": [],
 }
@@ -2401,8 +2404,15 @@ def test_a_request_without_memory_does_not_send_the_field():
 
 @pytest.mark.parametrize(
     "policy",
-    ["exact", "max_context", "off", {"cache_dtype": "int8"}, {"elements_budget": 4000}],
-    ids=["exact", "max_context", "off", "dict", "elements_budget"],
+    [
+        "exact",
+        "max_context",
+        "off",
+        {"cache_dtype": "int8"},
+        {"elements_budget": 4000},
+        {"stream_context": True},
+    ],
+    ids=["exact", "max_context", "off", "dict", "elements_budget", "stream_context"],
 )
 def test_a_policy_is_sent_verbatim(policy):
     capture: Dict = {}
@@ -2520,6 +2530,76 @@ def test_local_mode_refuses_memory_on_an_old_synthefy_nori(monkeypatch):
     client = SynthefyNoriClient(model="nori-30m", mode="local")
     with pytest.raises(ImportError, match="0.13.0"):
         client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy="exact")
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_local_mode_refuses_stream_field_when_installed_policy_lacks_it(monkeypatch, enabled):
+    """Even explicit False is forwarded, so an older policy would reject either value."""
+    from synthefy import nori_client as module
+
+    initialized = []
+
+    class PreStreamingRegressor:
+        def __init__(self, model=None, memory_policy=None):
+            initialized.append((model, memory_policy))
+
+        def predict(self, X, *, output_type="mean"):
+            return [0.0] * len(X)
+
+    monkeypatch.setattr(module, "_local_memory_policy_available", lambda: True)
+    monkeypatch.setattr(module, "_local_stream_context_available", lambda: False)
+    monkeypatch.setattr(module, "_load_local_regressor", lambda: PreStreamingRegressor)
+
+    client = SynthefyNoriClient(model="nori-30m", mode="local")
+    with pytest.raises(ImportError, match="MemoryPolicy does not include.*stream_context"):
+        client.predict(
+            _X_TRAIN,
+            _Y_TRAIN,
+            _X_TEST,
+            memory_policy={"stream_context": enabled},
+        )
+    assert initialized == [], "capability guard must run before estimator construction"
+
+
+def test_local_mode_forwards_stream_context_when_installed_policy_supports_it(monkeypatch):
+    from synthefy import nori_client as module
+
+    seen: Dict = {}
+
+    class StreamingRegressor:
+        def __init__(self, model=None, memory_policy=None):
+            seen["memory_policy"] = memory_policy
+            self.memory_policy = memory_policy
+            self.memory_report_ = None
+
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X, *, output_type="mean", quantiles=None):
+            self.memory_report_ = {
+                **_REPORT,
+                "rung": "stream_bf16",
+                "stream_context": True,
+                "context_row_chunk": 2048,
+                "reuse_context_cache": False,
+            }
+            return [0.1] * len(X)
+
+    monkeypatch.setattr(module, "_local_memory_policy_available", lambda: True)
+    monkeypatch.setattr(module, "_local_stream_context_available", lambda: True)
+    monkeypatch.setattr(module, "_load_local_regressor", lambda: StreamingRegressor)
+
+    client = SynthefyNoriClient(model="nori-30m", mode="local")
+    client.predict(
+        _X_TRAIN,
+        _Y_TRAIN,
+        _X_TEST,
+        memory_policy={"stream_context": True},
+    )
+
+    assert seen["memory_policy"] == {"stream_context": True}
+    assert client.last_memory_report["rung"] == "stream_bf16"
+    assert client.last_memory_report["context_row_chunk"] == 2048
 
 
 def test_local_mode_uses_estimator_and_surfaces_memory_report(monkeypatch):

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -2359,6 +2359,17 @@ _REPORT = {
     "resident_gb": 0.0065,
     "query_chunk": 256,
     "dropped_context_rows": 0,
+    "attempt_history": [{
+        "pipeline_ids": [0],
+        "path": "cached",
+        "rung": "resident_int8",
+        "cache_dtype": "int8",
+        "offload_to_host": False,
+        "context_row_chunk": None,
+        "outcome": "success",
+        "reason": "resolved",
+        "dropped_context_rows": 0,
+    }],
     "clamped": [],
     "notes": [],
 }
@@ -2497,35 +2508,56 @@ def test_local_mode_refuses_memory_on_an_old_synthefy_nori(monkeypatch):
     """An opaque TypeError from deep inside the library is not an acceptable answer."""
     from synthefy import nori_client as module
 
+    class OldRegressor:
+        def __init__(self, model=None):
+            self.model = model
+
+        def predict(self, X, *, output_type="mean"):
+            return [0.0] * len(X)
+
     monkeypatch.setattr(module, "_local_memory_policy_available", lambda: False)
-    monkeypatch.setattr(module, "_load_local_predict", lambda: lambda *a, **k: [0.0, 0.0])
+    monkeypatch.setattr(module, "_load_local_regressor", lambda: OldRegressor)
     client = SynthefyNoriClient(model="nori-30m", mode="local")
     with pytest.raises(ImportError, match="0.13.0"):
         client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy="exact")
 
 
-def test_local_mode_forwards_the_policy_when_supported(monkeypatch):
+def test_local_mode_uses_estimator_and_surfaces_memory_report(monkeypatch):
     from synthefy import nori_client as module
 
     seen: Dict = {}
 
-    def fake_predict(X_train, y_train, X_test, *, model=None, **kwargs):
-        # `model` is explicit because the client gates the local variant on
-        # signature(local_predict).parameters, exactly as synthefy_nori.predict declares it.
-        seen["model"] = model
-        seen.update(kwargs)
-        return [0.1, 0.2]
+    class FakeRegressor:
+        def __init__(self, model=None, memory_policy=None):
+            seen["model"] = model
+            seen["memory_policy"] = memory_policy
+            self.memory_policy = memory_policy
+            self.memory_report_ = None
+
+        def fit(self, X, y):
+            seen["fit"] = (X, y)
+            return self
+
+        def predict(self, X, *, output_type="mean", quantiles=None, **_kwargs):
+            self.memory_report_ = dict(_REPORT)
+            return [0.1, 0.2]
 
     monkeypatch.setattr(module, "_local_memory_policy_available", lambda: True)
-    monkeypatch.setattr(module, "_load_local_predict", lambda: fake_predict)
+    monkeypatch.setattr(module, "_load_local_regressor", lambda: FakeRegressor)
+    monkeypatch.setattr(
+        module, "_load_local_predict",
+        lambda: (_ for _ in ()).throw(AssertionError("functional path used")),
+    )
     client = SynthefyNoriClient(model="nori-30m", mode="local")
-    client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache_dtype": "int8"})
-    # Forwarded as a DICT, not our MemoryPolicy class: the library's coerce() accepts its own
-    # class, a dict, a preset or None, and a same-named class from this package is none of them.
+    predictions = client.predict(
+        _X_TRAIN, _Y_TRAIN, _X_TEST, memory_policy={"cache_dtype": "int8"}
+    )
+
+    assert predictions == [0.1, 0.2]
+    assert seen["model"] == "nori-30m"
     assert seen["memory_policy"] == {"cache_dtype": "int8"}
-    # Documented asymmetry: the functional local path discards the estimator that holds the
-    # report, so there is nothing to surface.
-    assert client.last_memory_report is None
+    assert client.last_memory_report["rung"] == "resident_int8"
+    assert client.last_memory_report["attempt_history"][0]["outcome"] == "success"
 
 
 # --------------------------------- the model in synthefy-nori IS the schema
@@ -3432,11 +3464,13 @@ def _fake_regressor_class(seen: Dict, *, with_model=True, with_output_type=True)
             seen["init_model"] = model
             seen["init_memory_policy"] = memory_policy
             self.memory_policy = memory_policy
+            self.memory_report_ = None
     else:
 
         def __init__(self):  # noqa: E306 - old build: no model= selector
             seen["init_count"] = seen.get("init_count", 0) + 1
             seen["init_model"] = "<absent>"
+            self.memory_report_ = None
 
     def fit(self, X, y):
         seen["fit"] = (X, y)
@@ -3450,6 +3484,8 @@ def _fake_regressor_class(seen: Dict, *, with_model=True, with_output_type=True)
                 "output_type": output_type,
                 "quantiles": quantiles,
             }
+            if getattr(self, "memory_policy", None) is not None:
+                self.memory_report_ = dict(_REPORT)
             n = len(X)
             if output_type == "quantiles":
                 # (n_levels, n_query), the shape NoriRegressor returns.

--- a/libs/synthefy/tests/test_nori_data_models.py
+++ b/libs/synthefy/tests/test_nori_data_models.py
@@ -54,8 +54,12 @@ requires_library = pytest.mark.skipif(
 #: Fields the server DECIDES; they belong to the report, not the policy. Mirrors the split in
 #: the library's openapi generator, which is the one place that split is written down.
 DECIDED_FIELDS = {
-    "rung", "est_cache_gb", "resident_gb", "query_chunk",
-    "dropped_context_rows", "attempt_history",
+    "rung",
+    "est_cache_gb",
+    "resident_gb",
+    "query_chunk",
+    "dropped_context_rows",
+    "attempt_history",
 }
 
 
@@ -124,7 +128,6 @@ def test_attempt_history_keeps_newer_server_fields():
     )
     assert report.model_dump()["attempt_history"][0]["new_attempt_detail"] == "kept"
     assert report.model_dump()["attempt_history"][0]["query_chunk"] == 128
-
 
 
 def test_defaults_match_the_documented_behaviour():
@@ -220,8 +223,7 @@ def test_each_memory_attempt_field_matches_the_library_on_type_bounds_and_defaul
     theirs = Authoritative.model_json_schema()["properties"][field]
     for key in ("type", "enum", "default", "exclusiveMinimum", "minimum", "maximum", "anyOf"):
         assert mine.get(key) == theirs.get(key), (
-            f"MemoryAttempt.{field}.{key}: client has {mine.get(key)!r}, "
-            f"library has {theirs.get(key)!r}"
+            f"MemoryAttempt.{field}.{key}: client has {mine.get(key)!r}, library has {theirs.get(key)!r}"
         )
 
 

--- a/libs/synthefy/tests/test_nori_data_models.py
+++ b/libs/synthefy/tests/test_nori_data_models.py
@@ -19,7 +19,13 @@ import importlib.util
 
 import pytest
 
-from synthefy.nori_data_models import MEMORY_PRESETS, MEMORY_RUNGS, MemoryPolicy, MemoryReport
+from synthefy.nori_data_models import (
+    MEMORY_PRESETS,
+    MEMORY_RUNGS,
+    MemoryAttempt,
+    MemoryPolicy,
+    MemoryReport,
+)
 
 
 def _library_available() -> bool:
@@ -47,7 +53,10 @@ requires_library = pytest.mark.skipif(
 
 #: Fields the server DECIDES; they belong to the report, not the policy. Mirrors the split in
 #: the library's openapi generator, which is the one place that split is written down.
-DECIDED_FIELDS = {"rung", "est_cache_gb", "resident_gb", "query_chunk", "dropped_context_rows"}
+DECIDED_FIELDS = {
+    "rung", "est_cache_gb", "resident_gb", "query_chunk",
+    "dropped_context_rows", "attempt_history",
+}
 
 
 # ------------------------------------------------- the mirror stands on its own
@@ -79,6 +88,25 @@ def test_the_report_keeps_fields_this_version_does_not_know():
     report = MemoryReport(rung="resident_int8", something_new=17)
     assert report.rung == "resident_int8"
     assert report.model_dump()["something_new"] == 17
+
+
+def test_attempt_history_keeps_newer_server_fields():
+    report = MemoryReport(
+        attempt_history=[{
+            "pipeline_ids": [0],
+            "path": "cached",
+            "rung": "resident_bf16",
+            "cache_dtype": "bf16",
+            "offload_to_host": False,
+            "context_row_chunk": None,
+            "outcome": "success",
+            "reason": "resolved",
+            "dropped_context_rows": 0,
+            "new_attempt_detail": "kept",
+        }]
+    )
+    assert report.model_dump()["attempt_history"][0]["new_attempt_detail"] == "kept"
+
 
 
 def test_defaults_match_the_documented_behaviour():
@@ -124,6 +152,51 @@ def test_each_field_matches_the_library_on_type_bounds_and_default(field):
     for key in ("type", "enum", "default", "exclusiveMinimum", "minimum", "maximum", "anyOf"):
         assert mine.get(key) == theirs.get(key), (
             f"{field}.{key}: client has {mine.get(key)!r}, library has {theirs.get(key)!r}"
+        )
+
+
+#: `rung` is deliberately looser on the client (bare `str`) than the library's Literal, so a
+#: server that adds a new rung still parses -- same forward-compat reasoning as
+#: `test_attempt_history_keeps_newer_server_fields`. Excluded from the per-field type/bounds
+#: comparison below; still covered by the field-NAME comparison, since the field itself must
+#: still exist under the same name.
+_MEMORY_ATTEMPT_LOOSENED_FIELDS = {"rung"}
+
+
+@requires_library
+def test_the_memory_attempt_fields_match_the_library_exactly():
+    """Field-name parity for the nested type the other mirror tests never touch.
+
+    `MemoryPolicy`/`MemoryReport` parity checks only ever key off `MemoryPolicy.model_fields`,
+    so a drift in the nested `MemoryAttempt` type (a rename, a new required field) would pass
+    every one of them silently -- `extra="allow"` on the client's `MemoryAttempt` means an
+    unrecognised field is carried through rather than rejected, not caught.
+    """
+    from synthefy_nori.inference.memory_policy import MemoryAttempt as Authoritative
+
+    ours = set(MemoryAttempt.model_fields)
+    theirs = set(Authoritative.model_fields)
+    assert ours == theirs, (
+        f"the client's MemoryAttempt drifted: missing={sorted(theirs - ours)}, "
+        f"stale={sorted(ours - theirs)}. Update src/synthefy/nori_data_models.py."
+    )
+
+
+@requires_library
+@pytest.mark.parametrize(
+    "field",
+    sorted(set(MemoryAttempt.model_fields) - _MEMORY_ATTEMPT_LOOSENED_FIELDS),
+)
+def test_each_memory_attempt_field_matches_the_library_on_type_bounds_and_default(field):
+    """Per-field, mirroring test_each_field_matches_the_library_on_type_bounds_and_default."""
+    from synthefy_nori.inference.memory_policy import MemoryAttempt as Authoritative
+
+    mine = MemoryAttempt.model_json_schema()["properties"][field]
+    theirs = Authoritative.model_json_schema()["properties"][field]
+    for key in ("type", "enum", "default", "exclusiveMinimum", "minimum", "maximum", "anyOf"):
+        assert mine.get(key) == theirs.get(key), (
+            f"MemoryAttempt.{field}.{key}: client has {mine.get(key)!r}, "
+            f"library has {theirs.get(key)!r}"
         )
 
 

--- a/libs/synthefy/tests/test_nori_data_models.py
+++ b/libs/synthefy/tests/test_nori_data_models.py
@@ -90,22 +90,40 @@ def test_the_report_keeps_fields_this_version_does_not_know():
     assert report.model_dump()["something_new"] == 17
 
 
+def test_streaming_report_keeps_the_resolved_policy_details():
+    report = MemoryReport(
+        rung="stream_bf16",
+        stream_context=True,
+        context_row_chunk=2048,
+        reuse_context_cache=False,
+    )
+    dumped = report.model_dump()
+    assert dumped["rung"] == "stream_bf16"
+    assert dumped["stream_context"] is True
+    assert dumped["context_row_chunk"] == 2048
+    assert dumped["reuse_context_cache"] is False
+
+
 def test_attempt_history_keeps_newer_server_fields():
     report = MemoryReport(
-        attempt_history=[{
-            "pipeline_ids": [0],
-            "path": "cached",
-            "rung": "resident_bf16",
-            "cache_dtype": "bf16",
-            "offload_to_host": False,
-            "context_row_chunk": None,
-            "outcome": "success",
-            "reason": "resolved",
-            "dropped_context_rows": 0,
-            "new_attempt_detail": "kept",
-        }]
+        attempt_history=[
+            {
+                "pipeline_ids": [0],
+                "path": "cached",
+                "rung": "resident_bf16",
+                "cache_dtype": "bf16",
+                "offload_to_host": False,
+                "context_row_chunk": None,
+                "query_chunk": 128,
+                "outcome": "success",
+                "reason": "resolved",
+                "dropped_context_rows": 0,
+                "new_attempt_detail": "kept",
+            }
+        ]
     )
     assert report.model_dump()["attempt_history"][0]["new_attempt_detail"] == "kept"
+    assert report.model_dump()["attempt_history"][0]["query_chunk"] == 128
 
 
 
@@ -115,7 +133,14 @@ def test_defaults_match_the_documented_behaviour():
     assert policy.cache_dtype == "bf16"
     assert policy.allow_quantization is True and policy.offload_to_host is True
     assert policy.gpu_budget_frac == 0.4 and policy.host_budget_frac == 0.25
+    assert policy.stream_context is False
     assert policy.allow_subsample is True
+
+
+def test_stream_context_remains_a_partial_wire_policy():
+    policy = MemoryPolicy(stream_context=True)
+    assert policy.model_dump(exclude_unset=True) == {"stream_context": True}
+    assert {"stream_bf16", "stream_int8"} <= set(MEMORY_RUNGS)
 
 
 # ------------------------------------------------- and matches the authority

--- a/src/synthefy_nori/inference/degradation.py
+++ b/src/synthefy_nori/inference/degradation.py
@@ -70,6 +70,18 @@ class ContextSubsampledWarning(DegradedPipelineWarning):
     """
 
 
+class CacheQuantizedWarning(DegradedPipelineWarning):
+    """The context key/value cache was quantized to int8 to keep it resident (or
+    offloadable) under the configured memory budget.
+
+    Measured cost is small (``|dR2| ~ 6e-6``), but it is a real, requested-then-
+    silently-granted-anyway fidelity loss, not merely a slowdown -- unlike
+    ``offload_to_host``, which moves bytes without changing them. The
+    declarative way to refuse this is ``memory_policy={"allow_quantization": False}``,
+    which keeps every rung bit-exact and offloads to host RAM sooner instead.
+    """
+
+
 @contextmanager
 def strict_pipeline(*categories: type[Warning]):
     """Make degradation warnings fatal for the duration of the block.

--- a/src/synthefy_nori/inference/memory_policy.py
+++ b/src/synthefy_nori/inference/memory_policy.py
@@ -29,12 +29,14 @@ resident_int8      bf16 would not fit but int8 does, so the cache stays on the
                    fast on-GPU path instead of paying PCIe streaming. Costs
                    |dR2| ~ 6e-6 (per-(row, head) absmax quantization).
                    Requires ``allow_quantization``.
-offload_bf16       cannot stay resident and quantizing is not allowed -> the
-                   full-precision cache lives in host RAM. Bit-exact, slower.
+offload_bf16       cannot stay resident (or resident attempts OOM) -> the
+                   full-precision cache lives in host RAM. Bit-exact, slower;
+                   may follow resident_int8 to recover precision while moving host-side.
 offload_int8       cannot stay resident at any precision -> quantized cache in
                    host RAM, each layer's slice streamed back on demand.
 context_row_chunk  an actual OOM happened -> re-run bounding the prefill
-                   working set too (bit-exact; see layer.py).
+                   working set too (deterministic, with small floating-point
+                   reassociation differences; see layer.py).
 plain_loop         nothing above worked. **No cache at all: every query chunk
                    recomputes the context K/V, so this is several times slower,
                    and if the context alone exceeds the element budget the
@@ -126,6 +128,11 @@ DEFAULT_HOST_BUDGET_FRAC = 0.25
 
 #: Fit-time row chunk engaged automatically after an OOM on the cached path.
 FIT_ROW_CHUNK_ON_OOM = 2048
+
+#: Bounded, deterministic prefill retries before abandoning the cache. Keeping the
+#: floor explicit prevents an OOM from turning into an unbounded retry loop while
+#: still giving large contexts two materially smaller working sets after 2048.
+FIT_ROW_CHUNK_RETRY_LADDER: tuple[int, ...] = (2048, 1024, 512)
 
 #: Fields that only mean anything while the cached path is in use. Asking for any of
 #: them with ``cache=False`` is incoherent, so it is rejected rather than silently
@@ -414,6 +421,54 @@ def total_host_ram_gb() -> float:
     return limit or physical
 
 
+MemoryAttemptOutcome = Literal["success", "oom", "unsupported"]
+MemoryAttemptPath = Literal["pipeline_batch", "cached", "plain_loop"]
+MemoryAttemptReason = Literal[
+    "resolved",
+    "oom_retry",
+    "fallback_after_oom",
+    "fallback_after_unsupported",
+]
+
+
+class MemoryAttempt(BaseModel):
+    """One execution attempt contributing to a prediction's memory outcome."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    pipeline_ids: list[int] = Field(
+        default_factory=list,
+        description="Preprocessing-pipeline members covered by this attempt. More than "
+                    "one means the pipeline-batched fast path was used.",
+    )
+    path: MemoryAttemptPath = Field(
+        description="Execution path attempted: batched cache, per-pipeline cache, or plain loop.",
+    )
+    rung: MemoryRung = Field(description="Memory ladder rung used for this attempt.")
+    cache_dtype: CacheDtype = Field(
+        description="Cache precision used by this attempt.",
+    )
+    offload_to_host: bool = Field(
+        description="Whether this attempt streamed its cache from host RAM.",
+    )
+    context_row_chunk: int | None = Field(
+        None,
+        gt=0,
+        description="Context rows per prefill chunk for this attempt; null means unchunked prefill.",
+    )
+    outcome: MemoryAttemptOutcome = Field(
+        description="Whether the attempt succeeded, OOMed, or lacked checkpoint support.",
+    )
+    reason: MemoryAttemptReason = Field(
+        description="Why this attempt ran: initial resolution, an OOM retry, or a plain-loop fallback.",
+    )
+    dropped_context_rows: int = Field(
+        0,
+        ge=0,
+        description="Context rows already removed before this attempt. Non-zero is always explicit.",
+    )
+
+
 class MemoryPolicy(BaseModel):
     """What inference may spend on memory, and where the K/V cache goes.
 
@@ -513,10 +568,10 @@ class MemoryPolicy(BaseModel):
         None,
         gt=0,
         description="Bound the fit-time build working set to this many context rows "
-        f"(bit-exact). None = off, with {FIT_ROW_CHUNK_ON_OOM} engaged "
-        "automatically after an OOM. Pinning a value uses it from the "
-        "first attempt — which also costs you that escalation, since "
-        "there is then nothing left to escalate to.",
+                    f"(deterministic, with small floating-point reassociation differences). "
+                    f"None = off, with {FIT_ROW_CHUNK_ON_OOM}, 1024, "
+                    "then 512 tried automatically after OOMs. An explicit value is "
+                    "a first-attempt cap, then retries step through smaller safe rungs.",
     )
     adaptive_query_chunk: bool = Field(
         True,
@@ -569,12 +624,26 @@ class MemoryPolicy(BaseModel):
         "currently reported here.",
     )
     dropped_context_rows: int = Field(
-        0,
-        ge=0,
-        description="Context rows the caller had to subsample away to fit. Non-zero "
-        "only on the plain_loop rung; recorded so a shrunk context is "
-        "visible in memory_report_ rather than inferred from the score.",
+        0, ge=0,
+        json_schema_extra={"readOnly": True},
+        description="Context rows the caller had to subsample away before cache "
+                    "resolution to fit the element budget. Recorded on cached and "
+                    "plain-loop outcomes alike so a shrunk context is "
+                    "visible in memory_report_ rather than inferred from the score.")
+    attempt_history: list[MemoryAttempt] = Field(
+        default_factory=list,
+        json_schema_extra={"readOnly": True},
+        description="Chronological execution attempts across every preprocessing "
+                    "pipeline in this predict call, including OOMs, fit-row retries, "
+                    "unsupported cached paths, and the successful fallback. This "
+                    "distinguishes a requested cached mechanism that recovered via "
+                    "plain_loop from a request that selected plain_loop initially.",
     )
+
+    def __hash__(self) -> int:
+        # Every other field is a scalar; this one is the sole list, so it is the sole
+        # field pydantic's frozen-model hash (which hashes every field) cannot handle.
+        return hash(tuple(v for k, v in self.__dict__.items() if k != "attempt_history"))
 
     @model_validator(mode="after")
     def _check_rung(self) -> "MemoryPolicy":
@@ -888,6 +957,60 @@ class MemoryPolicy(BaseModel):
             return self.host_budget_absolute_gb
         return self.host_budget_frac * total_ram_gb
 
+    def _precision_candidates(
+        self,
+        *,
+        est_cache_gb: float,
+        bytes_per_element: int,
+        head_dim: int,
+    ) -> list[tuple[CacheDtype, float]]:
+        """Return allowed cache precisions and footprints, best accuracy first."""
+        int8_gb = int8_footprint_gb(
+            est_cache_gb,
+            bytes_per_element=bytes_per_element,
+            head_dim=head_dim,
+        )
+        if self.cache_dtype == "int8":
+            return [("int8", int8_gb)]
+        if self.allow_quantization:
+            return [("bf16", est_cache_gb), ("int8", int8_gb)]
+        return [("bf16", est_cache_gb)]
+
+    def _placement_candidates(
+        self,
+        *,
+        est_cache_gb: float,
+        bytes_per_element: int,
+        head_dim: int,
+        gpu_budget_gb: float,
+        host_budget_gb: float,
+    ) -> list[tuple[str, CacheDtype, bool, float]]:
+        """Return every allowed, budget-feasible cache placement in ladder order.
+
+        Both opening-rung resolution and runtime OOM retries consume this exact list.
+        Keeping candidate construction here prevents the two paths from drifting on
+        precision permissions, budget checks, or placement order.
+        """
+        precisions = self._precision_candidates(
+            est_cache_gb=est_cache_gb,
+            bytes_per_element=bytes_per_element,
+            head_dim=head_dim,
+        )
+
+        candidates: list[tuple[str, CacheDtype, bool, float]] = []
+        candidates.extend(
+            (f"resident_{dtype}", dtype, False, footprint)
+            for dtype, footprint in precisions
+            if footprint <= gpu_budget_gb
+        )
+        if self.offload_to_host:
+            candidates.extend(
+                (f"offload_{dtype}", dtype, True, footprint)
+                for dtype, footprint in precisions
+                if footprint <= host_budget_gb
+            )
+        return candidates
+
     @property
     def is_resolved(self) -> bool:
         """Whether a rung has been chosen for a specific request."""
@@ -944,8 +1067,6 @@ class MemoryPolicy(BaseModel):
         ram = total_host_ram_gb() if total_ram_gb is None else total_ram_gb
         gpu_budget_gb = self.gpu_budget(vram)
         host_budget_gb = self.host_budget(ram)
-        bf16_gb = est_cache_gb
-        int8_gb = int8_footprint_gb(est_cache_gb, bytes_per_element=bytes_per_element, head_dim=head_dim)
 
         def decided(
             rung: str, dtype: str, offload: bool, resident: float, cache: bool, budgets: bool = True
@@ -969,30 +1090,16 @@ class MemoryPolicy(BaseModel):
             # "budget 9.6 GiB" on an 80 GB card is worse than one that says nothing.
             return decided("no_cache", self.cache_dtype, False, 0.0, cache=False, budgets=False)
 
-        # Precisions this request may use, cheapest-accuracy-cost first. Starting at
-        # int8 means bf16 is not a candidate at all — the caller asked for the smaller
-        # cache; allow_quantization only governs DOWNGRADING from bf16.
-        if self.cache_dtype == "int8":
-            candidates = [("int8", int8_gb)]
-        elif self.allow_quantization:
-            candidates = [("bf16", bf16_gb), ("int8", int8_gb)]
-        else:
-            candidates = [("bf16", bf16_gb)]
-
-        for dtype, footprint in candidates:
-            if footprint <= gpu_budget_gb:
-                return decided(f"resident_{dtype}", dtype, False, footprint, cache=True)
-
-        if self.offload_to_host:
-            # Offload the LARGEST (i.e. most precise) candidate host RAM can hold, not
-            # the smallest. Offload transport is bit-exact at either precision, so
-            # quantizing here buys only PCIe bandwidth -- and spending accuracy for
-            # speed is exactly what this ladder exists not to do. int8 is used only
-            # when bf16 will not fit host either. Callers who would rather have the
-            # faster stream ask for it: cache_dtype="int8" or memory_policy="max_context".
-            for dtype, footprint in candidates:
-                if footprint <= host_budget_gb:
-                    return decided(f"offload_{dtype}", dtype, True, footprint, cache=True)
+        placements = self._placement_candidates(
+            est_cache_gb=est_cache_gb,
+            bytes_per_element=bytes_per_element,
+            head_dim=head_dim,
+            gpu_budget_gb=gpu_budget_gb,
+            host_budget_gb=host_budget_gb,
+        )
+        if placements:
+            rung, dtype, offload, footprint = placements[0]
+            return decided(rung, dtype, offload, footprint, cache=True)
 
         # Rule 6: we needed a fallback and offload could not provide one. Warn HERE
         # rather than up-front: a host budget below the GPU budget makes offload
@@ -1014,17 +1121,64 @@ class MemoryPolicy(BaseModel):
                 f"loop. Raise host_budget_frac / host_budget_absolute_gb above the GPU "
                 f"budget to make offload reachable.",
             )
-        worst_dtype, worst_footprint = candidates[-1]
+        worst_dtype, worst_footprint = self._precision_candidates(
+            est_cache_gb=est_cache_gb,
+            bytes_per_element=bytes_per_element,
+            head_dim=head_dim,
+        )[-1]
         return decided("plain_loop", worst_dtype, False, worst_footprint, cache=False)
 
-    def escalated(
+    def runtime_fallbacks(
         self,
-        rung: str,
+        resolved: "MemoryPolicy",
         *,
-        context_row_chunk: int | None = None,
-        dropped_context_rows: int | None = None,
-        query_chunk: int | None = None,
-    ) -> "MemoryPolicy":
+        bytes_per_element: int,
+        head_dim: int,
+    ) -> list["MemoryPolicy"]:
+        """Ordered budget-feasible precision/placement attempts after resolution.
+
+        Recomputes ``_placement_candidates()`` from ``resolved``'s own stored
+        est_cache_gb/budget fields rather than reusing whatever list ``resolve()``
+        built moments earlier, so this stays callable on its own with just a
+        resolved policy and fresh measurements -- exactly how the tests above use
+        it, independent of any particular ``resolve()`` call. Passing
+        ``bytes_per_element``/``head_dim`` that do not match the ones ``resolved``
+        was actually resolved with is a caller error, not something this method
+        can detect; the ``resolved.rung not in labels`` fallback below exists for
+        exactly that mismatch.
+        """
+        if resolved.rung not in {
+            "resident_bf16", "resident_int8", "offload_bf16", "offload_int8"
+        }:
+            return []
+
+        placements = self._placement_candidates(
+            est_cache_gb=resolved.est_cache_gb or 0.0,
+            bytes_per_element=bytes_per_element,
+            head_dim=head_dim,
+            gpu_budget_gb=resolved.gpu_budget_absolute_gb or 0.0,
+            host_budget_gb=resolved.host_budget_absolute_gb or 0.0,
+        )
+        attempts = [
+            resolved._revalidated_copy(
+                cache=True,
+                reuse_context_cache=self.reuse_context_cache,
+                cache_dtype=dtype,
+                offload_to_host=offload,
+                rung=rung,
+                resident_gb=footprint,
+                context_row_chunk=self.context_row_chunk,
+            )
+            for rung, dtype, offload, footprint in placements
+        ]
+        labels = [attempt.rung for attempt in attempts]
+        if resolved.rung not in labels:
+            return [resolved]
+        return attempts[labels.index(resolved.rung):]
+
+    def escalated(self, rung: str, *, context_row_chunk: int | None = None,
+                  dropped_context_rows: int | None = None,
+                  query_chunk: int | None = None) -> "MemoryPolicy":
         """Return a copy recording an escalation the caller made after an OOM.
 
         Args:
@@ -1045,6 +1199,8 @@ class MemoryPolicy(BaseModel):
             updates["query_chunk"] = query_chunk
         if rung == "plain_loop":
             updates["cache"] = False
+            updates["reuse_context_cache"] = False
+            updates["offload_to_host"] = False
         return self._revalidated_copy(**updates)
 
     def describe(self) -> str:

--- a/src/synthefy_nori/inference/memory_policy.py
+++ b/src/synthefy_nori/inference/memory_policy.py
@@ -76,9 +76,9 @@ import contextlib
 import os
 import threading
 import warnings
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
 
 #: Named starting points, for callers who do not want to set fields individually.
 #: Each one CHANGES something. There is deliberately no "auto"/"default" preset:
@@ -99,6 +99,14 @@ RUNGS: tuple[str, ...] = (
     "context_row_chunk",
     "plain_loop",
 )
+
+#: A rung name, carrying the closed set into any generated JSON schema. Internal
+#: introduced this alongside its serving wire-contract check; the field
+#: annotations promoted with #516 reference it, so it is defined here too.
+MemoryRung = Annotated[
+    str,
+    WithJsonSchema({"type": "string", "enum": list(RUNGS)}),
+]
 
 # --- unit + shape constants (no bare numbers in the arithmetic below) ---------
 

--- a/src/synthefy_nori/inference/memory_policy.py
+++ b/src/synthefy_nori/inference/memory_policy.py
@@ -34,6 +34,11 @@ offload_bf16       cannot stay resident (or resident attempts OOM) -> the
                    may follow resident_int8 to recover precision while moving host-side.
 offload_int8       cannot stay resident at any precision -> quantized cache in
                    host RAM, each layer's slice streamed back on demand.
+stream_bf16        caller-requested bounded streaming: context activations and
+                   K/V stay in host RAM while at most ``context_row_chunk`` rows
+                   are staged on the GPU. Never falls through to ``plain_loop``.
+                   Not bit-exact because online attention changes reduction order.
+stream_int8        the same bounded host-only path with an int8 K/V cache.
 context_row_chunk  an actual OOM happened -> re-run bounding the prefill
                    working set too (deterministic, with small floating-point
                    reassociation differences; see layer.py).
@@ -46,16 +51,19 @@ plain_loop         nothing above worked. **No cache at all: every query chunk
                    dropped, how many.
 =================  ========================================================
 
-**Only the int8 rungs are lossy, and ``resident_int8`` is reached only when the
-full-precision cache does not fit.** That ordering is the point: a table that serves
-correctly today keeps bit-exact predictions, and accuracy is spent only to avoid a
-fallback that would otherwise be slower or fatal. A measured cost for int8
-(|dR2| = 5.8e-6) is not a licence to charge it to requests that had no memory
-problem in the first place.
+**Only the int8 rungs quantize the cache.** The explicitly requested streaming rungs
+are also not bit-exact, including ``stream_bf16``, because bounded online attention
+reassociates floating-point reductions. The measured CUDA difference for BF16 streaming
+is small rather than zero (max prediction delta 2.93e-3, mean 7.44e-4). Outside
+streaming, ``resident_int8`` is reached only when the full-precision cache does not fit.
+That ordering is the point: a table that serves correctly today keeps bit-exact
+predictions, and accuracy is spent only to avoid a fallback that would otherwise be
+slower or fatal.
 
-``context_row_chunk`` and ``plain_loop`` are *reactions* to an OutOfMemoryError, so the
-caller escalates into them via :meth:`MemoryPolicy.escalated`; :meth:`resolve` picks
-the opening rung.
+Outside explicit ``stream_context=True``, ``context_row_chunk`` and ``plain_loop`` are
+*reactions* to an OutOfMemoryError, so the caller escalates into them via
+:meth:`MemoryPolicy.escalated`; :meth:`resolve` picks the opening rung. Streaming starts
+with a concrete row cap instead and raises if its host-only contract cannot be honoured.
 
 Budgets are **fractions of the hardware** rather than absolute GB so one setting is
 portable from a 24 GB laptop card to a 143 GB H200. The ``*_absolute_gb`` overrides
@@ -96,9 +104,13 @@ RUNGS: tuple[str, ...] = (
     "resident_int8",
     "offload_bf16",
     "offload_int8",
+    "stream_bf16",
+    "stream_int8",
     "context_row_chunk",
     "plain_loop",
 )
+
+STREAM_RUNGS: tuple[str, ...] = ("stream_bf16", "stream_int8")
 
 #: A rung name, carrying the closed set into any generated JSON schema. Internal
 #: introduced this alongside its serving wire-contract check; the field
@@ -137,10 +149,23 @@ DEFAULT_HOST_BUDGET_FRAC = 0.25
 #: Fit-time row chunk engaged automatically after an OOM on the cached path.
 FIT_ROW_CHUNK_ON_OOM = 2048
 
+#: Conservative maximum context rows staged at once by the explicitly requested
+#: host-streaming path when accelerator capacity is unknown or below 40 GiB.
+#: Larger accelerators select a larger default in
+#: :func:`default_stream_context_row_chunk`; an explicit caller value always wins.
+DEFAULT_STREAM_CONTEXT_ROW_CHUNK = 2048
+
+#: Hardware-adaptive streamed-context row chunks. Bigger chunks amortize the
+#: block-attention launch/transfer overhead; they do not change the O(1)-in-context
+#: GPU-memory contract because the staged row count remains a fixed hardware choice.
+STREAM_CONTEXT_ROW_CHUNK_40_GIB = 8192
+STREAM_CONTEXT_ROW_CHUNK_80_GIB = 16384
+
 #: Bounded, deterministic prefill retries before abandoning the cache. Keeping the
-#: floor explicit prevents an OOM from turning into an unbounded retry loop while
-#: still giving large contexts two materially smaller working sets after 2048.
-FIT_ROW_CHUNK_RETRY_LADDER: tuple[int, ...] = (2048, 1024, 512)
+#: floor explicit prevents an OOM from turning into an unbounded retry loop. The
+#: final 256-row halving materially lowers the workspace after a 512-row OOM; 128 is
+#: left as an explicit caller override rather than another costly automatic rebuild.
+FIT_ROW_CHUNK_RETRY_LADDER: tuple[int, ...] = (2048, 1024, 512, 256)
 
 #: Fields that only mean anything while the cached path is in use. Asking for any of
 #: them with ``cache=False`` is incoherent, so it is rejected rather than silently
@@ -150,6 +175,7 @@ CACHE_ONLY_FIELDS: tuple[str, ...] = (
     "cache_dtype",
     "allow_quantization",
     "offload_to_host",
+    "stream_context",
     "context_row_chunk",
     # adaptive_query_chunk is passed only to forward_cached_regression, so it is
     # inert on the plain loop as well -- it belongs here for the same reason.
@@ -166,6 +192,22 @@ CACHE_ONLY_FIELDS: tuple[str, ...] = (
 #: torch will not describe). Conservative on purpose; the OOM fallback is the real
 #: safety net regardless of how good this estimate is.
 ASSUMED_VRAM_GB = 24.0
+
+
+def default_stream_context_row_chunk(total_vram_gb: float | None) -> int:
+    """Choose the omitted streamed-context row cap from accelerator capacity.
+
+    Explicit ``context_row_chunk`` values never pass through this helper. Unknown
+    devices use :data:`ASSUMED_VRAM_GB`, deliberately selecting the conservative
+    2,048-row tier; runtime OOM recovery may only retry smaller chunks.
+    """
+    vram = ASSUMED_VRAM_GB if total_vram_gb is None else total_vram_gb
+    if vram >= 80.0:
+        return STREAM_CONTEXT_ROW_CHUNK_80_GIB
+    if vram >= 40.0:
+        return STREAM_CONTEXT_ROW_CHUNK_40_GIB
+    return DEFAULT_STREAM_CONTEXT_ROW_CHUNK
+
 
 #: Config warnings already emitted this process. These describe a *configuration*, not
 #: a request, so saying it once is enough -- and the alternative is genuine spam:
@@ -192,12 +234,12 @@ def warn_once(message: str) -> None:
 
 
 class ContextTooLargeError(RuntimeError):
-    """The context does not fit the element budget and may not be subsampled.
+    """The context cannot fit without a fallback the caller's policy forbids.
 
-    A **caller** condition, not a server fault: the context size, ``elements_budget`` and
-    ``allow_subsample`` are all things the caller chose, and changing any one of them
-    makes the same request work. The message names which setting forbade the shrink and
-    what to raise.
+    A **caller** condition, not a server fault. This covers both a context that exceeds
+    ``elements_budget`` while ``allow_subsample=False`` and an explicitly streamed
+    context whose cache exceeds the permitted host budget. In each case the message
+    names which caller-controlled setting to change.
 
     Typed so that a server can tell it apart from the other ``RuntimeError`` that reaches
     the same place -- a CUDA OOM, which really is a server condition. Without the
@@ -447,7 +489,7 @@ class MemoryAttempt(BaseModel):
     pipeline_ids: list[int] = Field(
         default_factory=list,
         description="Preprocessing-pipeline members covered by this attempt. More than "
-                    "one means the pipeline-batched fast path was used.",
+        "one means the pipeline-batched fast path was used.",
     )
     path: MemoryAttemptPath = Field(
         description="Execution path attempted: batched cache, per-pipeline cache, or plain loop.",
@@ -463,6 +505,13 @@ class MemoryAttempt(BaseModel):
         None,
         gt=0,
         description="Context rows per prefill chunk for this attempt; null means unchunked prefill.",
+    )
+    query_chunk: int | None = Field(
+        None,
+        gt=0,
+        description="Query-chunk limit attempted by this decode step. A cached decode "
+        "OOM is followed by another history entry with the smaller retry "
+        "limit; null means the attempt failed before query decoding began.",
     )
     outcome: MemoryAttemptOutcome = Field(
         description="Whether the attempt succeeded, OOMed, or lacked checkpoint support.",
@@ -572,14 +621,25 @@ class MemoryPolicy(BaseModel):
         "resolves to, and that case has to degrade to 'no offload' rather "
         "than fail.",
     )
+    stream_context: bool = Field(
+        False,
+        description="Keep the full context and K/V cache in host RAM and stage only "
+        "bounded row slices on the GPU. This forces the host-only "
+        "stream_bf16/stream_int8 path, disables cross-call context reuse, "
+        "and chooses an omitted context_row_chunk from accelerator VRAM "
+        "as the maximum staged-row cap (2048 below 40 GiB, 8192 from "
+        "40 GiB, 16384 from 80 GiB). Runtime "
+        "may split K/V blocks smaller to honor its fixed FP32 online-attention "
+        "workspace ceiling. Streaming never silently falls back to plain_loop.",
+    )
     context_row_chunk: int | None = Field(
         None,
         gt=0,
         description="Bound the fit-time build working set to this many context rows "
-                    f"(deterministic, with small floating-point reassociation differences). "
-                    f"None = off, with {FIT_ROW_CHUNK_ON_OOM}, 1024, "
-                    "then 512 tried automatically after OOMs. An explicit value is "
-                    "a first-attempt cap, then retries step through smaller safe rungs.",
+        f"(deterministic, with small floating-point reassociation differences). "
+        f"None = off, with {FIT_ROW_CHUNK_ON_OOM}, 1024, 512, "
+        "then 256 tried automatically after OOMs. An explicit value is "
+        "a first-attempt cap, then retries step through smaller safe rungs.",
     )
     adaptive_query_chunk: bool = Field(
         True,
@@ -610,7 +670,8 @@ class MemoryPolicy(BaseModel):
         description="Which fallback the server used, in decreasing memory cost: "
         "resident_bf16 (cache in GPU memory, exact), resident_int8 (quantized), "
         "offload_bf16 / offload_int8 (cache in host RAM, streamed back per layer, "
-        "exact transport), context_row_chunk (cache built in row chunks), "
+        "exact transport), stream_bf16 / stream_int8 (explicit bounded host-only "
+        "context streaming; not bit-exact), context_row_chunk (cache built in row chunks), "
         "plain_loop (no cache; the context re-read per query batch), no_cache "
         "(the cached path did not apply). Decided per request, not requestable.",
     )
@@ -626,26 +687,29 @@ class MemoryPolicy(BaseModel):
     query_chunk: int | None = Field(
         None,
         gt=0,
-        description="Query rows per decode forward, as the cached path was entered "
-        "with. Reported, not set. NOTE: a decode OOM may halve this "
-        "further inside the model, and that further reduction is not "
-        "currently reported here.",
+        json_schema_extra={"readOnly": True},
+        description="Effective query rows per decode forward on the successful cached "
+        "path. If decoding exhausted its retries and raised, this is the "
+        "last attempted size. Every adaptive reduction is also recorded in "
+        "attempt_history. Reported, not set.",
     )
     dropped_context_rows: int = Field(
-        0, ge=0,
+        0,
+        ge=0,
         json_schema_extra={"readOnly": True},
         description="Context rows the caller had to subsample away before cache "
-                    "resolution to fit the element budget. Recorded on cached and "
-                    "plain-loop outcomes alike so a shrunk context is "
-                    "visible in memory_report_ rather than inferred from the score.")
+        "resolution to fit the element budget. Recorded on cached and "
+        "plain-loop outcomes alike so a shrunk context is "
+        "visible in memory_report_ rather than inferred from the score.",
+    )
     attempt_history: list[MemoryAttempt] = Field(
         default_factory=list,
         json_schema_extra={"readOnly": True},
         description="Chronological execution attempts across every preprocessing "
-                    "pipeline in this predict call, including OOMs, fit-row retries, "
-                    "unsupported cached paths, and the successful fallback. This "
-                    "distinguishes a requested cached mechanism that recovered via "
-                    "plain_loop from a request that selected plain_loop initially.",
+        "pipeline in this predict call, including OOMs, fit-row retries, "
+        "unsupported cached paths, and the successful fallback. This "
+        "distinguishes a requested cached mechanism that recovered via "
+        "plain_loop from a request that selected plain_loop initially.",
     )
 
     def __hash__(self) -> int:
@@ -658,6 +722,52 @@ class MemoryPolicy(BaseModel):
         """Reject an unrecognised rung so a typo cannot masquerade as a decision."""
         if self.rung is not None and self.rung not in RUNGS:
             raise ValueError(f"rung must be one of {RUNGS}, got {self.rung!r}")
+        return self
+
+    @model_validator(mode="after")
+    def _check_streaming_contract(self) -> "MemoryPolicy":
+        """Keep explicit context streaming host-only, bounded, and observable."""
+        if self.rung in STREAM_RUNGS and not self.stream_context:
+            raise ValueError(
+                f"rung={self.rung!r} requires stream_context=True; streaming rungs "
+                "cannot describe an ordinary cache request."
+            )
+        if not self.stream_context:
+            return self
+
+        if not self.cache:
+            raise ValueError(
+                "stream_context=True requires cache=True: the bounded path streams "
+                "the context K/V cache and has no silent plain_loop fallback."
+            )
+        if not self.offload_to_host:
+            raise ValueError(
+                "stream_context=True requires offload_to_host=True: streamed context "
+                "activations and K/V are host-resident by contract."
+            )
+        if self.rung is None:
+            if "reuse_context_cache" in self.model_fields_set and self.reuse_context_cache:
+                raise ValueError(
+                    "stream_context=True cannot be combined with "
+                    "reuse_context_cache=True: streaming owns one request-scoped "
+                    "host context and never retains it across predict() calls."
+                )
+            return self
+
+        if self.rung not in STREAM_RUNGS:
+            raise ValueError(
+                f"stream_context=True must resolve to one of {STREAM_RUNGS}, got "
+                f"rung={self.rung!r}; it never silently falls back to plain_loop."
+            )
+        if self.rung != f"stream_{self.cache_dtype}":
+            raise ValueError(
+                f"rung={self.rung!r} contradicts cache_dtype={self.cache_dtype!r}; "
+                f"the resolved streaming rung must be stream_{self.cache_dtype}."
+            )
+        if self.context_row_chunk is None:
+            raise ValueError("a resolved stream_context policy requires a concrete context_row_chunk maximum")
+        if self.reuse_context_cache:
+            raise ValueError("a resolved stream_context policy requires reuse_context_cache=False")
         return self
 
     @model_validator(mode="after")
@@ -759,6 +869,7 @@ class MemoryPolicy(BaseModel):
         # box, so resolve() carries the same check for it.
         if (
             self.offload_to_host
+            and not self.stream_context
             and self.gpu_budget_absolute_gb is not None
             and self.host_budget_absolute_gb is not None
             and self.host_budget_absolute_gb <= self.gpu_budget_absolute_gb
@@ -1028,9 +1139,10 @@ class MemoryPolicy(BaseModel):
     def is_bit_exact(self) -> bool:
         """Whether the cache is stored losslessly.
 
-        Offload moves bytes without changing them, so only precision decides this.
+        Ordinary offload moves bytes without changing them. Streaming also changes
+        floating-point reduction order, so both streaming rungs are non-bit-exact.
         """
-        return self.cache_dtype != "int8"
+        return self.cache_dtype != "int8" and not self.stream_context
 
     @property
     def is_degraded(self) -> bool:
@@ -1039,7 +1151,14 @@ class MemoryPolicy(BaseModel):
         ``no_cache`` is not degraded — it means the request never needed a cache.
         Used by the predictor to decide whether to log at warning level.
         """
-        return self.rung in ("offload_bf16", "offload_int8", "context_row_chunk", "plain_loop")
+        return self.rung in (
+            "offload_bf16",
+            "offload_int8",
+            "stream_bf16",
+            "stream_int8",
+            "context_row_chunk",
+            "plain_loop",
+        )
 
     def resolve(
         self,
@@ -1079,16 +1198,52 @@ class MemoryPolicy(BaseModel):
         def decided(
             rung: str, dtype: str, offload: bool, resident: float, cache: bool, budgets: bool = True
         ) -> "MemoryPolicy":
+            streaming = rung in STREAM_RUNGS
             return self._revalidated_copy(
                 cache=cache,
                 cache_dtype=dtype,
                 offload_to_host=offload,
-                reuse_context_cache=bool(cache and self.reuse_context_cache),
-                gpu_budget_absolute_gb=gpu_budget_gb if budgets else None,
+                reuse_context_cache=False if streaming else bool(cache and self.reuse_context_cache),
+                gpu_budget_absolute_gb=0.0 if streaming else (gpu_budget_gb if budgets else None),
                 host_budget_absolute_gb=host_budget_gb if budgets else None,
+                context_row_chunk=(
+                    (self.context_row_chunk or default_stream_context_row_chunk(vram))
+                    if streaming
+                    else self.context_row_chunk
+                ),
                 rung=rung,
                 est_cache_gb=est_cache_gb,
                 resident_gb=resident,
+            )
+
+        if self.stream_context:
+            if not cache_eligible:
+                raise ValueError(
+                    "stream_context=True requires a cache-eligible regression path; "
+                    "it cannot resolve to no_cache or plain_loop."
+                )
+            precisions = self._precision_candidates(
+                est_cache_gb=est_cache_gb,
+                bytes_per_element=bytes_per_element,
+                head_dim=head_dim,
+            )
+            for dtype, footprint in precisions:
+                if footprint <= host_budget_gb:
+                    return decided(
+                        f"stream_{dtype}",
+                        dtype,
+                        True,
+                        footprint,
+                        cache=True,
+                    )
+            smallest_dtype, smallest_footprint = precisions[-1]
+            raise ContextTooLargeError(
+                "stream_context=True requires a host-resident context cache, but "
+                f"even the smallest allowed {smallest_dtype} cache "
+                f"({smallest_footprint:.1f} GiB) exceeds the host budget "
+                f"({host_budget_gb:.1f} GiB). Raise host_budget_frac / "
+                "host_budget_absolute_gb, allow int8 quantization, or disable "
+                "stream_context explicitly; Nori will not silently use plain_loop."
             )
 
         if not self.cache or not cache_eligible:
@@ -1155,9 +1310,28 @@ class MemoryPolicy(BaseModel):
         can detect; the ``resolved.rung not in labels`` fallback below exists for
         exactly that mismatch.
         """
-        if resolved.rung not in {
-            "resident_bf16", "resident_int8", "offload_bf16", "offload_int8"
-        }:
+        if resolved.rung in STREAM_RUNGS:
+            attempts = [
+                resolved._revalidated_copy(
+                    cache=True,
+                    reuse_context_cache=False,
+                    cache_dtype=dtype,
+                    offload_to_host=True,
+                    rung=f"stream_{dtype}",
+                    resident_gb=footprint,
+                    context_row_chunk=(resolved.context_row_chunk or DEFAULT_STREAM_CONTEXT_ROW_CHUNK),
+                )
+                for dtype, footprint in self._precision_candidates(
+                    est_cache_gb=resolved.est_cache_gb or 0.0,
+                    bytes_per_element=bytes_per_element,
+                    head_dim=head_dim,
+                )
+                if footprint <= (resolved.host_budget_absolute_gb or 0.0)
+            ]
+            labels = [attempt.rung for attempt in attempts]
+            return attempts[labels.index(resolved.rung) :]
+
+        if resolved.rung not in {"resident_bf16", "resident_int8", "offload_bf16", "offload_int8"}:
             return []
 
         placements = self._placement_candidates(
@@ -1182,11 +1356,16 @@ class MemoryPolicy(BaseModel):
         labels = [attempt.rung for attempt in attempts]
         if resolved.rung not in labels:
             return [resolved]
-        return attempts[labels.index(resolved.rung):]
+        return attempts[labels.index(resolved.rung) :]
 
-    def escalated(self, rung: str, *, context_row_chunk: int | None = None,
-                  dropped_context_rows: int | None = None,
-                  query_chunk: int | None = None) -> "MemoryPolicy":
+    def escalated(
+        self,
+        rung: str,
+        *,
+        context_row_chunk: int | None = None,
+        dropped_context_rows: int | None = None,
+        query_chunk: int | None = None,
+    ) -> "MemoryPolicy":
         """Return a copy recording an escalation the caller made after an OOM.
 
         Args:
@@ -1198,6 +1377,12 @@ class MemoryPolicy(BaseModel):
         Returns:
             The updated policy.
         """
+        if self.stream_context and rung not in STREAM_RUNGS:
+            raise ValueError(
+                f"stream_context=True cannot escalate to rung={rung!r}; it remains "
+                f"on one of {STREAM_RUNGS} or raises instead of silently using "
+                "plain_loop."
+            )
         updates: dict[str, object] = {"rung": rung}
         if context_row_chunk is not None:
             updates["context_row_chunk"] = context_row_chunk
@@ -1221,6 +1406,14 @@ class MemoryPolicy(BaseModel):
         if not self.is_resolved:
             return "unresolved"
         parts = [self.rung]
+        if self.rung in STREAM_RUNGS:
+            parts.append(
+                f"(host-streamed cache {self.est_cache_gb:.1f} GiB -> "
+                f"{self.resident_gb:.1f} GiB {self.cache_dtype}, host budget "
+                f"{self.host_budget_absolute_gb:.1f} GiB)"
+            )
+            parts.append(f"maximum staged context rows={self.context_row_chunk}")
+            return " ".join(parts)
         if self.est_cache_gb and self.gpu_budget_absolute_gb is not None:
             parts.append(
                 f"(cache {self.est_cache_gb:.1f} GiB -> {self.resident_gb:.1f} GiB "
@@ -1232,3 +1425,30 @@ class MemoryPolicy(BaseModel):
         if self.dropped_context_rows:
             parts.append(f"DROPPED {self.dropped_context_rows} context rows")
         return " ".join(parts)
+
+
+def _require_every_report_field(schema: dict) -> None:
+    """Mark every field that ``model_dump()`` emits as required in the response schema."""
+    schema["required"] = list(schema["properties"])
+
+
+class MemoryReport(MemoryPolicy):
+    """Reports how Nori applied the requested memory policy."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        json_schema_extra=_require_every_report_field,
+    )
+
+    attempt_history: list[MemoryAttempt] = Field(
+        default_factory=list,
+        description="Chronological execution attempts across every preprocessing "
+        "pipeline in this predict call, including cache-build OOMs, decode "
+        "query-chunk retries, fit-row retries, unsupported cached paths, "
+        "and the successful fallback. This "
+        "distinguishes a requested cached mechanism that recovered via "
+        "plain_loop from a request that selected plain_loop initially.",
+    )
+    clamped: list[str]
+    notes: list[str]

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -10,7 +10,8 @@ from synthefy_nori.inference.preprocess import (
     HighDimFeatureSelector,
     MaxFeatureSubsampler,
     MADWinsorizer,
-    PolynomialInteractionGenerator)
+    PolynomialInteractionGenerator,
+)
 from synthefy_nori.inference.degradation import (
     CacheQuantizedWarning,
     ContextSubsampledWarning,
@@ -201,9 +202,7 @@ class NoriPredictor:
         self.native_rms_norm = None if native_rms_norm is None else bool(native_rms_norm)
         self.inference_with_DDP = inference_with_DDP
         if self.inference_with_DDP and self.mask_prediction:
-            raise ValueError(
-                "inference_with_DDP does not support mask_prediction"
-            )
+            raise ValueError("inference_with_DDP does not support mask_prediction")
         if self.inference_with_DDP and memory_policy is not None:
             # The DDP branch of predict() never resolves a MemoryPolicy or
             # populates memory_report_ -- it is a structurally separate path, not
@@ -1216,10 +1215,7 @@ class NoriPredictor:
         """Return the smaller-than-`pinned` retry ladder (the pinned/None value
         itself is never a new attempt: it is already the first cache_attempts entry
         built from the placement ladder)."""
-        return [
-            chunk for chunk in FIT_ROW_CHUNK_RETRY_LADDER
-            if pinned is None or chunk < pinned
-        ]
+        return [chunk for chunk in FIT_ROW_CHUNK_RETRY_LADDER if pinned is None or chunk < pinned]
 
     def _evict_pipe_cache(self, id_pipe) -> None:
         """Drop only this pipe's own retained context-cache entry.
@@ -1232,17 +1228,29 @@ class NoriPredictor:
         if isinstance(cache, dict):
             cache.pop(id_pipe, None)
 
-    def _memory_rung_sort_key(self, policy: MemoryPolicy) -> tuple[int, float]:
-        """Comparable "how bad is this outcome" key: rank first, then chunk size.
+    def _memory_rung_sort_key(self, policy: MemoryPolicy) -> tuple[int, float, float]:
+        """Comparable "how bad/complete is this outcome" key: rank, then
+        context_row_chunk degradation, then query_chunk degradation.
 
         A smaller ``context_row_chunk`` is a more degraded outcome within that one
         rung (a harder-won escalation), so it sorts worse than a larger one. Every
-        other rung always has ``context_row_chunk is None``, which sorts lowest, so
-        rank alone decides ties there.
+        other rung always has ``context_row_chunk is None``, which ties there and
+        falls through to the query_chunk component.
+
+        query_chunk breaks what would otherwise be a remaining tie, and does so by
+        VALUE, not just presence: the opening ``resolve()`` publishes a policy
+        before any attempt has run, so it has no query_chunk yet, and a later
+        attempt at the same rank that DID run must win that tie. But adaptive
+        decode can also halve its chunk mid-attempt after an internal OOM, so
+        among attempts that ran, the smaller (more degraded) query_chunk must win
+        too, or the published report understates how hard-won the recovery was.
         """
         rank = self._MEMORY_RUNG_SEVERITY.get(policy.rung or "no_cache", -1)
         chunk = policy.context_row_chunk
-        return rank, (-chunk if chunk is not None else float("-inf"))
+        chunk_component = -chunk if chunk is not None else float("-inf")
+        query_chunk = policy.query_chunk
+        query_component = -query_chunk if query_chunk is not None else float("-inf")
+        return rank, chunk_component, query_component
 
     def _publish_memory_policy(self, policy: MemoryPolicy) -> None:
         """Publish the worst successful/selected rung seen in this predict call."""
@@ -1269,6 +1277,7 @@ class NoriPredictor:
         outcome: str,
         reason: str,
         dropped_context_rows: int,
+        query_chunk: int | None = None,
     ) -> None:
         """Append one validated attempt and refresh the public report."""
         attempt = MemoryAttempt(
@@ -1278,6 +1287,7 @@ class NoriPredictor:
             cache_dtype=policy.cache_dtype,
             offload_to_host=policy.offload_to_host,
             context_row_chunk=context_row_chunk,
+            query_chunk=query_chunk,
             outcome=outcome,
             reason=reason,
             dropped_context_rows=dropped_context_rows,
@@ -1289,6 +1299,41 @@ class NoriPredictor:
         current = getattr(self, "_memory_outcome_policy", None)
         if current is not None:
             self._publish_memory_policy(current)
+
+    def _record_cached_query_trace(
+        self,
+        policy: MemoryPolicy,
+        events: list[tuple[int, Literal["success", "oom"]]],
+        *,
+        pipeline_ids: list[int],
+        path: Literal["pipeline_batch", "cached"],
+        context_row_chunk: int | None,
+        reason: str,
+        dropped_context_rows: int,
+    ) -> MemoryPolicy:
+        """Append one row per adaptive decode event and return its final policy."""
+        if not events:
+            raise ValueError("cached query trace must contain at least one event")
+        final_policy = policy
+        for index, (query_chunk, outcome) in enumerate(events):
+            final_policy = policy.escalated(
+                policy.rung,
+                dropped_context_rows=dropped_context_rows,
+                query_chunk=query_chunk,
+            )
+            self._record_memory_attempt(
+                final_policy,
+                pipeline_ids=pipeline_ids,
+                path=path,
+                rung=final_policy.rung,
+                context_row_chunk=context_row_chunk,
+                query_chunk=query_chunk,
+                outcome=outcome,
+                reason=(reason if index == 0 else "oom_retry"),
+                dropped_context_rows=dropped_context_rows,
+            )
+            self._publish_memory_policy(final_policy)
+        return final_policy
 
     def _coerced_memory_policy(self) -> MemoryPolicy:
         """This predictor's :class:`MemoryPolicy`.
@@ -1304,11 +1349,11 @@ class NoriPredictor:
             The still-unresolved policy for this predictor.
 
         Raises:
-            RuntimeError: if ``SYNTHEFY_CACHE_MAX_GB`` is set. That variable shipped
-                on main with a *different* meaning (skip the cache above this size,
-                measured against the full-precision footprint) and no longer has an
-                equivalent. Silently ignoring a memory-safety knob could turn a
-                working job into an OOM, so this fails loudly instead.
+            RuntimeError: if an explicit streamed-context request conflicts with
+                a cache kill switch, or if ``SYNTHEFY_CACHE_MAX_GB`` is set. The
+                latter shipped with a different meaning (skip the cache above a
+                full-precision footprint), so silently translating it could turn a
+                working job into an OOM.
         """
         if os.environ.get("SYNTHEFY_CACHE_MAX_GB") is not None:
             raise RuntimeError(
@@ -1325,6 +1370,14 @@ class NoriPredictor:
             os.environ.get("SYNTHEFY_DISABLE_CACHED_INFERENCE", "0") == "1"
             or os.environ.get("SYNTHEFY_ENABLE_CACHED_INFERENCE", "1") != "1"
         )
+        if disabled and policy.stream_context:
+            raise RuntimeError(
+                "stream_context=True cannot run while cached inference is disabled "
+                "by SYNTHEFY_DISABLE_CACHED_INFERENCE=1 or "
+                "SYNTHEFY_ENABLE_CACHED_INFERENCE!=1. Remove the kill switch or "
+                "disable stream_context explicitly; Nori will not silently use "
+                "no_cache/plain_loop or subsample rows."
+            )
         if disabled and policy.cache:
             logger.info("Nori KV cache disabled by environment kill switch")
             # Rebuild rather than model_copy(cache=False): flipping cache off while the
@@ -1877,6 +1930,8 @@ class NoriPredictor:
         fit_row_chunk,
         reuse_context_cache,
         cache_entries=1,
+        stream_context=False,
+        _hybrid_resident_int8_prefill=False,
     ):
         """Build the per-pipe context (train) K/V cache, reusing it across predict()
         calls whose context and cache params are unchanged.
@@ -1912,13 +1967,18 @@ class NoriPredictor:
         """
 
         def _build():
-            return bare_model.build_context_cache(
-                x_train_t,
-                y_train_t,
-                cache_dtype=cache_dtype,
-                offload_kv_cache=offload_kv_cache,
-                fit_row_chunk=fit_row_chunk,
-            )
+            build_kwargs = {
+                "cache_dtype": cache_dtype,
+                "offload_kv_cache": offload_kv_cache,
+                "fit_row_chunk": fit_row_chunk,
+            }
+            # Preserve compatibility with older/custom cache builders that do not
+            # accept the new keyword unless streaming was explicitly requested.
+            if stream_context:
+                build_kwargs["stream_context"] = True
+            if _hybrid_resident_int8_prefill:
+                build_kwargs["_hybrid_resident_int8_prefill"] = True
+            return bare_model.build_context_cache(x_train_t, y_train_t, **build_kwargs)
 
         if not reuse_context_cache:
             # A policy can change between calls (the shared engine re-declares one
@@ -1929,7 +1989,13 @@ class NoriPredictor:
             if cache is not None:
                 cache.clear()
             return _build()
-        key = self._context_cache_key(cache_dtype, offload_kv_cache, fit_row_chunk)
+        key = self._context_cache_key(
+            cache_dtype,
+            offload_kv_cache,
+            fit_row_chunk,
+            stream_context,
+            _hybrid_resident_int8_prefill,
+        )
         cache = getattr(self, "_context_cache", None)
         if cache is None:
             cache = self._context_cache = {}
@@ -2110,7 +2176,9 @@ class NoriPredictor:
                 break
         return True
 
-    def _context_cache_key(self, cache_dtype, offload_kv_cache, fit_row_chunk) -> tuple:
+    def _context_cache_key(
+        self, cache_dtype, offload_kv_cache, fit_row_chunk, stream_context=False, _hybrid_resident_int8_prefill=False
+    ) -> tuple:
         """The non-tensor half of the cache key: everything OUTSIDE the context table
         that changes what ``build_context_cache`` produces.
 
@@ -2121,7 +2189,14 @@ class NoriPredictor:
         drawing the SAME random feature positional embedding, which only holds while
         the seed the predictor reseeds with is unchanged.
         """
-        return (str(cache_dtype), bool(offload_kv_cache), fit_row_chunk, self.seed)
+        return (
+            str(cache_dtype),
+            bool(offload_kv_cache),
+            fit_row_chunk,
+            bool(stream_context),
+            bool(_hybrid_resident_int8_prefill),
+            self.seed,
+        )
 
     @staticmethod
     def _same_context(cached: torch.Tensor, candidate: torch.Tensor) -> bool:
@@ -2174,47 +2249,38 @@ class NoriPredictor:
         for item in prepared:
             _, x_train, y_train, x_test = item
             key = (
-                x_train.shape, y_train.shape, x_test.shape,
-                x_train.dtype, y_train.dtype, x_test.dtype,
-                x_train.device, y_train.device, x_test.device,
+                x_train.shape,
+                y_train.shape,
+                x_test.shape,
+                x_train.dtype,
+                y_train.dtype,
+                x_test.dtype,
+                x_train.device,
+                y_train.device,
+                x_test.device,
             )
             grouped.setdefault(key, []).append(item)
         result = []
         for group in grouped.values():
             width = group[0][1].shape[-1]
-            batch_size = (
-                PIPELINE_BATCH_MAX
-                if width <= PIPELINE_BATCH_MAX_FEATURES
-                else 1
-            )
-            result.extend(
-                group[start:start + batch_size]
-                for start in range(0, len(group), batch_size)
-            )
+            batch_size = PIPELINE_BATCH_MAX if width <= PIPELINE_BATCH_MAX_FEATURES else 1
+            result.extend(group[start : start + batch_size] for start in range(0, len(group), batch_size))
         if result:
             final_pipe_id = max(item[0] for item in prepared)
             final_group_index = next(
-                index
-                for index, group in enumerate(result)
-                if any(item[0] == final_pipe_id for item in group)
+                index for index, group in enumerate(result) if any(item[0] == final_pipe_id for item in group)
             )
             result.append(result.pop(final_group_index))
         return result
 
-    def _clear_pipeline_batch_contexts(
-            self, keep: set[tuple] | None = None) -> None:
+    def _clear_pipeline_batch_contexts(self, keep: set[tuple] | None = None) -> None:
         """Release grouped caches that cannot serve the current execution mode."""
         cache = getattr(self, "_context_cache", None)
         if not isinstance(cache, dict):
             return
         keep = keep or set()
         for slot in list(cache):
-            if (
-                isinstance(slot, tuple)
-                and len(slot) == 2
-                and slot[0] == "pipeline_batch"
-                and slot not in keep
-            ):
+            if isinstance(slot, tuple) and len(slot) == 2 and slot[0] == "pipeline_batch" and slot not in keep:
                 cache.pop(slot, None)
 
     def _clear_pipeline_member_contexts(self, batch_slots: set[tuple]) -> None:
@@ -2222,11 +2288,7 @@ class NoriPredictor:
         cache = getattr(self, "_context_cache", None)
         if not isinstance(cache, dict):
             return
-        grouped_ids = {
-            id_pipe
-            for _, ids in batch_slots
-            for id_pipe in ids
-        }
+        grouped_ids = {id_pipe for _, ids in batch_slots for id_pipe in ids}
         for id_pipe in grouped_ids:
             cache.pop(id_pipe, None)
 
@@ -2336,9 +2398,18 @@ class NoriPredictor:
             return bare_model.apply_context_cache(x_test, context, **kwargs)
 
     def _try_batched_ordinary_regression(
-            self, bare_model, *, x_train_base, x_test_base, y_train,
-            categorical_idx, n_samples_train, n_samples_test,
-            budget_n_features, max_elements_budget, dropped_context_rows,
+        self,
+        bare_model,
+        *,
+        x_train_base,
+        x_test_base,
+        y_train,
+        categorical_idx,
+        n_samples_train,
+        n_samples_test,
+        budget_n_features,
+        max_elements_budget,
+        dropped_context_rows,
     ) -> list[torch.Tensor] | None:
         """Execute prepared ordinary members in bounded same-shape groups.
 
@@ -2351,6 +2422,13 @@ class NoriPredictor:
         production mileage. Batching preserves the model math, although mixed-
         precision GEMMs may reassociate at the last few bits versus B=1 execution.
         """
+        requested = self._coerced_memory_policy()
+        if requested.stream_context:
+            # Each preprocessing pipeline owns a separate CPU-resident context and
+            # bounded K/V stream. Stacking them would multiply the host retention
+            # and defeat the deliberately one-pipeline-at-a-time schedule.
+            self._clear_pipeline_batch_contexts()
+            return None
         try:
             device = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
         except (TypeError, RuntimeError):
@@ -2370,13 +2448,9 @@ class NoriPredictor:
             self._clear_pipeline_batch_contexts()
             return None
 
-        chunk_size = self._chunk_size(
-            max_elements_budget, budget_n_features, n_samples_train)
-        requested = self._coerced_memory_policy()
+        chunk_size = self._chunk_size(max_elements_budget, budget_n_features, n_samples_train)
         cache_eligible = (
-            hasattr(bare_model, "forward_cached_regression")
-            and n_samples_test > chunk_size
-            and requested.cache
+            hasattr(bare_model, "forward_cached_regression") and n_samples_test > chunk_size and requested.cache
         )
         if cache_eligible:
             fpg = max(int(getattr(bare_model, "features_per_group", 2)), 1)
@@ -2399,7 +2473,9 @@ class NoriPredictor:
             )
         else:
             policy = requested.resolve(
-                est_cache_gb=0.0, bytes_per_element=1, head_dim=1,
+                est_cache_gb=0.0,
+                bytes_per_element=1,
+                head_dim=1,
                 cache_eligible=False,
             )
         if (
@@ -2425,33 +2501,28 @@ class NoriPredictor:
             # contain one and the check would be dead code.
             for id_step, step in enumerate(pipe):
                 x_train_, x_test_, categorical_idx_ = self._fit_transform_step_inductive(
-                    step, x_train_, x_test_, categorical_idx_,
+                    step,
+                    x_train_,
+                    x_test_,
+                    categorical_idx_,
                     self.seeds[id_pipe * self.preprocess_num + self._seed_step_index(pipe, id_step)],
                     y_train=y_,
                 )
-            prospective_host_bytes = (
-                x_train_.size + x_test_.size + y_.size
-            ) * np.dtype(np.float32).itemsize
-            if (
-                retained_host_bytes + prospective_host_bytes
-                > PIPELINE_BATCH_HOST_BUDGET_BYTES
-            ):
+            prospective_host_bytes = (x_train_.size + x_test_.size + y_.size) * np.dtype(np.float32).itemsize
+            if retained_host_bytes + prospective_host_bytes > PIPELINE_BATCH_HOST_BUDGET_BYTES:
                 self._clear_pipeline_batch_contexts()
                 return None
-            x_all = torch.from_numpy(
-                np.concatenate([x_train_, x_test_], axis=0)
-            ).float()
+            x_all = torch.from_numpy(np.concatenate([x_train_, x_test_], axis=0)).float()
             y_tensor = torch.from_numpy(y_).float()
-            prepared.append((
-                id_pipe,
-                x_all[:len(y_)],
-                y_tensor,
-                x_all[len(y_):],
-            ))
-            retained_host_bytes += (
-                x_all.numel() * x_all.element_size()
-                + y_tensor.numel() * y_tensor.element_size()
+            prepared.append(
+                (
+                    id_pipe,
+                    x_all[: len(y_)],
+                    y_tensor,
+                    x_all[len(y_) :],
+                )
             )
+            retained_host_bytes += x_all.numel() * x_all.element_size() + y_tensor.numel() * y_tensor.element_size()
 
         groups = self._group_ordinary_pipes(prepared)
         if policy.rung == "resident_bf16":
@@ -2466,14 +2537,11 @@ class NoriPredictor:
                     nlayers=nlayers,
                     embed_dim=embed_dim,
                     bytes_per_element=bytes_per,
-                ) * len(group)
+                )
+                * len(group)
                 for group in groups
             ]
-            batched_cache_gb = (
-                sum(group_cache_sizes)
-                if requested.reuse_context_cache
-                else max(group_cache_sizes)
-            )
+            batched_cache_gb = sum(group_cache_sizes) if requested.reuse_context_cache else max(group_cache_sizes)
             policy = requested.resolve(
                 est_cache_gb=batched_cache_gb,
                 bytes_per_element=bytes_per,
@@ -2485,20 +2553,27 @@ class NoriPredictor:
                 self._clear_pipeline_batch_contexts()
                 return None
 
-        active_batch_slots = {
-            ("pipeline_batch", tuple(item[0] for item in group))
-            for group in groups
-            if len(group) > 1
-        } if policy.rung == "resident_bf16" and policy.reuse_context_cache else set()
+        active_batch_slots = (
+            {("pipeline_batch", tuple(item[0] for item in group)) for group in groups if len(group) > 1}
+            if policy.rung == "resident_bf16" and policy.reuse_context_cache
+            else set()
+        )
         self._clear_pipeline_batch_contexts(keep=active_batch_slots)
         self._clear_pipeline_member_contexts(active_batch_slots)
 
         self._publish_memory_policy(policy)
         outputs: list[torch.Tensor | None] = [None] * len(prepared)
         ids: tuple[int, ...] = ()
+        query_events: list[tuple[int, Literal["success", "oom"]]] | None = None
         try:
             for group in groups:
                 ids = tuple(item[0] for item in group)
+                query_events = [] if policy.rung == "resident_bf16" else None
+
+                def observe_query_attempt(query_chunk: int, outcome: Literal["success", "oom"]) -> None:
+                    assert query_events is not None
+                    query_events.append((query_chunk, outcome))
+
                 x_train_t = torch.stack([item[1] for item in group]).to(self.device)
                 y_train_t = torch.stack([item[2] for item in group]).to(self.device)
                 x_test_t = torch.stack([item[3] for item in group]).to(self.device)
@@ -2509,17 +2584,23 @@ class NoriPredictor:
                     if policy.rung == "resident_bf16":
                         slot = ids[0] if len(ids) == 1 else ("pipeline_batch", ids)
                         context = self._get_or_build_context(
-                            bare_model, slot,
-                            x_train_t=x_train_t, y_train_t=y_train_t,
-                            cache_dtype="bf16", offload_kv_cache=False,
+                            bare_model,
+                            slot,
+                            x_train_t=x_train_t,
+                            y_train_t=y_train_t,
+                            cache_dtype="bf16",
+                            offload_kv_cache=False,
                             fit_row_chunk=None,
                             reuse_context_cache=policy.reuse_context_cache,
                         )
                         try:
                             group_output = self._unwrap_model_output(
                                 bare_model.apply_context_cache(
-                                    x_test_t, context, row_chunk_size=chunk_size,
+                                    x_test_t,
+                                    context,
+                                    row_chunk_size=chunk_size,
                                     adaptive_query_chunk=policy.adaptive_query_chunk,
+                                    query_chunk_attempt_callback=observe_query_attempt,
                                 ),
                                 task_type="reg",
                             )
@@ -2533,14 +2614,19 @@ class NoriPredictor:
                         for start in range(0, n_samples_test, chunk_size):
                             end = min(start + chunk_size, n_samples_test)
                             x_in = torch.cat([x_train_t, x_test_t[:, start:end]], dim=1)
-                            y_in = torch.cat([
-                                y_train_t,
-                                y_train_t.new_zeros(len(group), end - start),
-                            ], dim=1)
-                            chunks.append(self._unwrap_model_output(
-                                self.model(x=x_in, y=y_in, eval_pos=n_samples_train, task_type="reg"),
-                                task_type="reg",
-                            ))
+                            y_in = torch.cat(
+                                [
+                                    y_train_t,
+                                    y_train_t.new_zeros(len(group), end - start),
+                                ],
+                                dim=1,
+                            )
+                            chunks.append(
+                                self._unwrap_model_output(
+                                    self.model(x=x_in, y=y_in, eval_pos=n_samples_train, task_type="reg"),
+                                    task_type="reg",
+                                )
+                            )
                         group_output = torch.cat(chunks, dim=1)
                 if (
                     not isinstance(group_output, torch.Tensor)
@@ -2548,37 +2634,76 @@ class NoriPredictor:
                     or group_output.shape[0] != len(group)
                     or group_output.shape[1] != n_samples_test
                 ):
-                    raise NotImplementedError(
-                        "pipeline-batched model output must be [B, n_test, ...]"
-                    )
+                    raise NotImplementedError("pipeline-batched model output must be [B, n_test, ...]")
                 group_output = self._reject_nonfinite_output(
-                    group_output, path=f"pipeline-batched ({policy.rung})",
-                    n_train=n_samples_train, n_test=n_samples_test,
+                    group_output,
+                    path=f"pipeline-batched ({policy.rung})",
+                    n_train=n_samples_train,
+                    n_test=n_samples_test,
                 )
                 for (id_pipe, *_), member_output in zip(group, group_output.unbind(0)):
                     outputs[id_pipe] = member_output
+                if query_events is not None:
+                    if not query_events:
+                        query_events.append((chunk_size, "success"))
+                    self._record_cached_query_trace(
+                        policy,
+                        query_events,
+                        pipeline_ids=list(ids),
+                        path="pipeline_batch",
+                        context_row_chunk=None,
+                        reason="resolved",
+                        dropped_context_rows=dropped_context_rows,
+                    )
+                else:
+                    self._record_memory_attempt(
+                        policy,
+                        pipeline_ids=list(ids),
+                        path="pipeline_batch",
+                        rung=policy.rung,
+                        context_row_chunk=None,
+                        outcome="success",
+                        reason="resolved",
+                        dropped_context_rows=dropped_context_rows,
+                    )
+        except (NotImplementedError, torch.cuda.OutOfMemoryError) as exc:
+            is_oom = isinstance(exc, torch.cuda.OutOfMemoryError)
+            if is_oom and query_events:
+                failed_events = list(query_events)
+                if failed_events[-1][1] == "success":
+                    failed_events[-1] = (failed_events[-1][0], "oom")
+                self._record_cached_query_trace(
+                    policy,
+                    failed_events,
+                    pipeline_ids=list(ids),
+                    path="pipeline_batch",
+                    context_row_chunk=None,
+                    reason="resolved",
+                    dropped_context_rows=dropped_context_rows,
+                )
+            else:
+                if query_events:
+                    oom_events = [event for event in query_events if event[1] == "oom"]
+                    if oom_events:
+                        self._record_cached_query_trace(
+                            policy,
+                            oom_events,
+                            pipeline_ids=list(ids),
+                            path="pipeline_batch",
+                            context_row_chunk=None,
+                            reason="resolved",
+                            dropped_context_rows=dropped_context_rows,
+                        )
                 self._record_memory_attempt(
                     policy,
                     pipeline_ids=list(ids),
                     path="pipeline_batch",
                     rung=policy.rung,
                     context_row_chunk=None,
-                    outcome="success",
+                    outcome=("oom" if is_oom else "unsupported"),
                     reason="resolved",
                     dropped_context_rows=dropped_context_rows,
                 )
-        except (NotImplementedError, torch.cuda.OutOfMemoryError) as exc:
-            self._record_memory_attempt(
-                policy,
-                pipeline_ids=list(ids),
-                path="pipeline_batch",
-                rung=policy.rung,
-                context_row_chunk=None,
-                outcome=("oom" if isinstance(exc, torch.cuda.OutOfMemoryError)
-                         else "unsupported"),
-                reason="resolved",
-                dropped_context_rows=dropped_context_rows,
-            )
             cache = getattr(self, "_context_cache", None)
             if isinstance(cache, dict):
                 # The failed attempt may already have built singleton groups.
@@ -2594,13 +2719,13 @@ class NoriPredictor:
         )
         self._publish_memory_policy(used)
         self._log_once_per_call(
-            "rung", logging.INFO,
+            "rung",
+            logging.INFO,
             f"Nori serving-memory rung: {used.describe()}",
         )
         if any(output is None for output in outputs):
             raise AssertionError("pipeline batching lost an ensemble member")
         return [output for output in outputs if output is not None]
-
 
     def _predict_reg_single(
         self,
@@ -2642,6 +2767,12 @@ class NoriPredictor:
         n_features = x_train.shape[1] if x_train.ndim > 1 else 1
         n_samples_train = x_train.shape[0]
         n_samples_test = x_test.shape[0]
+        requested_policy = self._coerced_memory_policy()
+        if requested_policy.stream_context and self.inference_with_DDP:
+            raise NotImplementedError(
+                "stream_context is not supported by distributed_inference; run one "
+                "streamed context per model replica instead"
+            )
 
         # If the number of elements is too large, we must chunk the test set to avoid OOM.
         # The default is VRAM-aware: anchored at 2M elements for a ~24GB GPU (the
@@ -2657,12 +2788,12 @@ class NoriPredictor:
         budget_n_features = self._effective_budget_n_features(n_features, x_train)
         base_elements = (n_samples_train + 1) * budget_n_features
         dropped_context_rows = 0
-        if base_elements > MAX_ELEMENTS_BUDGET:
+        if base_elements > MAX_ELEMENTS_BUDGET and not requested_policy.stream_context:
             # Guard: SYNTHEFY_FORBID_SUBSAMPLE=1 makes context subsampling FAIL LOUDLY
             # instead of silently shrinking the training set. Use for full-context
             # evaluation where any subsampling must be visible, never silent.
             _forbid_env = os.environ.get("SYNTHEFY_FORBID_SUBSAMPLE") == "1"
-            if not self._coerced_memory_policy().allow_subsample or _forbid_env:
+            if not requested_policy.allow_subsample or _forbid_env:
                 # Name whichever setting actually forbade it. Reporting the env var to
                 # someone who set memory_policy={"allow_subsample": False} sends them hunting
                 # a variable they never set.
@@ -2747,7 +2878,6 @@ class NoriPredictor:
                     return output
                 return self._collapse_regression_output(output)
 
-
         outputs = []
         mask_predictions = []
         for id_pipe, pipe in enumerate(self.preprocess_pipelines):
@@ -2766,17 +2896,49 @@ class NoriPredictor:
                     y_train=y_,
                 )
 
-            x_ = np.concatenate([x_train_, x_test_], axis=0)
-            x_ = torch.from_numpy(x_[:, :]).float().to(self.device)
-            y_ = torch.from_numpy(y_).float().to(self.device)
+            bounded_cpu_prefill = not self.inference_with_DDP and (
+                requested_policy.stream_context or requested_policy.context_row_chunk is not None
+            )
+            if bounded_cpu_prefill:
+                # Both explicit streaming and the private resident-INT8 hybrid
+                # start from host tensors. The latter is selected only after policy
+                # resolution below; retain these originals across fallback attempts.
+                x_ = None
+                x_train_t = torch.from_numpy(x_train_).float()
+                x_test_t = torch.from_numpy(x_test_).float()
+                y_ = torch.from_numpy(y_).float()
+            else:
+                x_ = torch.from_numpy(np.concatenate([x_train_, x_test_], axis=0)).float().to(self.device)
+                x_train_t = x_[: len(y_train)]
+                x_test_t = x_[len(y_train) :]
+                y_ = torch.from_numpy(y_).float().to(self.device)
+
+            device_pipeline_inputs = None
+
+            def _device_pipeline_inputs():
+                nonlocal device_pipeline_inputs
+                if device_pipeline_inputs is None:
+                    if x_ is not None:
+                        device_pipeline_inputs = (x_, x_train_t, x_test_t, y_)
+                    else:
+                        x_device = torch.cat([x_train_t, x_test_t], dim=0).to(self.device)
+                        y_device = y_.to(self.device)
+                        device_pipeline_inputs = (
+                            x_device,
+                            x_device[: len(y_train)],
+                            x_device[len(y_train) :],
+                            y_device,
+                        )
+                return device_pipeline_inputs
+
             torch.manual_seed(self.seed)
             torch.cuda.manual_seed_all(self.seed)
             if self.inference_with_DDP:
                 assert distributed_inference is not None
                 output = distributed_inference.inference(
-                    x_[: len(y_train)],
+                    x_train_t,
                     y_,
-                    x_[len(y_train) :],
+                    x_test_t,
                 )
                 outputs.append(output)
             if not self.inference_with_DDP:
@@ -2821,17 +2983,26 @@ class NoriPredictor:
                 # defaults, or pass a preset name ("exact", "max_context", "off"), a
                 # dict, or a MemoryPolicy. No env var configures this; only the
                 # SYNTHEFY_DISABLE_CACHED_INFERENCE kill switch is honoured.
-                requested_policy = self._coerced_memory_policy()
                 policy = requested_policy
+                if policy.stream_context and (
+                    model_mask_pred
+                    or not hasattr(bare_model, "build_context_cache")
+                    or not hasattr(bare_model, "apply_context_cache")
+                ):
+                    raise NotImplementedError(
+                        "stream_context requires a regression checkpoint with the "
+                        "split context-cache interface and mask_prediction=False"
+                    )
                 use_cached = (
                     hasattr(bare_model, "forward_cached_regression")
-                    and not self.mask_prediction
-                    and n_samples_test > chunk_size
+                    and not model_mask_pred
+                    and (policy.stream_context or n_samples_test > chunk_size)
                     and policy.cache
                 )
                 if use_cached:
                     fpg = max(int(getattr(bare_model, "features_per_group", 2)), 1)
-                    n_groups = (x_train_.shape[-1] + fpg - 1) // fpg
+                    transformed_features = int(x_train_t.shape[-1])
+                    n_groups = (transformed_features + fpg - 1) // fpg
                     embed_dim = int(getattr(bare_model, "embed_dim", 128))
                     nlayers = int(getattr(bare_model, "nlayers", 16))
                     nhead = max(int(getattr(bare_model, "nhead", 2)), 1)
@@ -2851,6 +3022,10 @@ class NoriPredictor:
                         total_ram_gb=total_host_ram_gb(),
                     )
                     use_cached = policy.cache
+                    if policy.stream_context:
+                        if policy.context_row_chunk is None:
+                            raise AssertionError("stream_context resolver did not concretize context_row_chunk")
+                        chunk_size = min(n_samples_test, policy.context_row_chunk)
                 else:
                     policy = policy.resolve(
                         est_cache_gb=0.0,
@@ -2874,9 +3049,9 @@ class NoriPredictor:
                 if use_cached:
                     self.model.to(self.device)
                     # Walk every allowed, budget-feasible precision/placement rung,
-                    # then bound the final rung's prefill working set at 2048, 1024,
-                    # and 512 rows before giving up on the cache. An explicit chunk is
-                    # the first-attempt cap; no retry can exceed it.
+                    # then bound the final rung with the shared prefill retry ladder.
+                    # Streaming starts with the concrete cap chosen by resolve(); an
+                    # explicit cap remains the maximum and retries only get smaller.
                     #
                     # Chunking is tried LAST, combined only with the worst placement,
                     # not first against the bit-exact rung: it only bounds the
@@ -2887,16 +3062,15 @@ class NoriPredictor:
                     # raises NotImplementedError). RUNGS already ranks
                     # context_row_chunk below offload_int8, so this matches that.
                     pinned = requested_policy.context_row_chunk
+                    initial_fit_chunk = policy.context_row_chunk if policy.stream_context else pinned
                     placement_policies = requested_policy.runtime_fallbacks(
                         policy,
                         bytes_per_element=bytes_per,
                         head_dim=head_dim,
                     )
-                    cache_attempts = [
-                        (candidate, pinned) for candidate in placement_policies
-                    ]
+                    cache_attempts = [(candidate, initial_fit_chunk) for candidate in placement_policies]
                     final_policy = placement_policies[-1]
-                    for retry_chunk in self._fit_row_chunk_attempts(pinned):
+                    for retry_chunk in self._fit_row_chunk_attempts(initial_fit_chunk):
                         cache_attempts.append((final_policy, retry_chunk))
                     fallback_reason = "fallback_after_oom"
                     for attempt_index, (attempt_policy, attempt_fit_chunk) in enumerate(cache_attempts):
@@ -2904,6 +3078,42 @@ class NoriPredictor:
                         attempt_reason = "resolved" if attempt_index == 0 else "oom_retry"
                         ctx_bundle = None
                         output = None
+                        execution_policy = attempt_policy
+                        if attempt_fit_chunk is not None and attempt_fit_chunk != initial_fit_chunk:
+                            recovered_rung = (
+                                attempt_policy.rung if attempt_policy.stream_context else "context_row_chunk"
+                            )
+                            execution_policy = attempt_policy.escalated(
+                                recovered_rung,
+                                context_row_chunk=attempt_fit_chunk,
+                            )
+                        query_events: list[tuple[int, Literal["success", "oom"]]] = []
+
+                        def observe_query_attempt(
+                            query_chunk: int,
+                            outcome: Literal["success", "oom"],
+                        ) -> None:
+                            query_events.append((query_chunk, outcome))
+
+                        hybrid_resident_int8_prefill = (
+                            attempt_policy.rung == "resident_int8"
+                            and attempt_policy.cache_dtype == "int8"
+                            and not attempt_policy.offload_to_host
+                            and not attempt_policy.stream_context
+                            and attempt_fit_chunk is not None
+                        )
+                        if policy.stream_context or hybrid_resident_int8_prefill:
+                            attempt_x_train = x_train_t
+                            attempt_x_test = x_test_t
+                            attempt_y_train = y_
+                        else:
+                            (
+                                _attempt_x_all,
+                                attempt_x_train,
+                                attempt_x_test,
+                                attempt_y_train,
+                            ) = _device_pipeline_inputs()
+
                         try:
                             with (
                                 torch.autocast(
@@ -2920,23 +3130,27 @@ class NoriPredictor:
                                 # the fit-once / serve-many pattern -- instead of
                                 # rebuilding it per query batch. This splits the former
                                 # forward_cached_regression(full) into its build+apply
-                                # halves (bit-identical: that method is now exactly this
-                                # pair) and memoizes the build. See _get_or_build_context.
-                                n_ctx = len(y_train)
+                                # build/apply halves and memoizes the build. Streamed BF16
+                                # keeps every row but may differ at the last bits from
+                                # chunked GEMM and online-softmax reassociation. See
+                                # _get_or_build_context.
                                 ctx_bundle = self._get_or_build_context(
                                     bare_model,
                                     id_pipe,
-                                    x_train_t=x_[:n_ctx].unsqueeze(0),
-                                    y_train_t=y_[:n_ctx].unsqueeze(0),
+                                    x_train_t=attempt_x_train.unsqueeze(0),
+                                    y_train_t=attempt_y_train.unsqueeze(0),
                                     cache_dtype=policy.cache_dtype,
                                     offload_kv_cache=policy.offload_to_host,
                                     fit_row_chunk=attempt_fit_chunk,
-                                    reuse_context_cache=policy.reuse_context_cache,
+                                    reuse_context_cache=(policy.reuse_context_cache and not policy.stream_context),
                                     cache_entries=self.context_cache_entries,
+                                    stream_context=policy.stream_context,
+                                    _hybrid_resident_int8_prefill=(hybrid_resident_int8_prefill),
                                 )
                                 apply_kwargs = {
                                     "row_chunk_size": chunk_size,
                                     "adaptive_query_chunk": policy.adaptive_query_chunk,
+                                    "query_chunk_attempt_callback": observe_query_attempt,
                                 }
                                 if (
                                     policy.rung == "resident_bf16"
@@ -2946,17 +3160,15 @@ class NoriPredictor:
                                 ):
                                     output = self._apply_context_cache_exact_safe(
                                         bare_model,
-                                        x_[n_ctx:].unsqueeze(0),
+                                        attempt_x_test.unsqueeze(0),
                                         ctx_bundle,
                                         **apply_kwargs,
                                     )
                                 else:
-                                    if getattr(
-                                        bare_model, "_exact_cudagraphs_enabled", False
-                                    ):
+                                    if getattr(bare_model, "_exact_cudagraphs_enabled", False):
                                         self._disable_exact_cached_cudagraphs(bare_model)
                                     output = bare_model.apply_context_cache(
-                                        x_[n_ctx:].unsqueeze(0),
+                                        attempt_x_test.unsqueeze(0),
                                         ctx_bundle,
                                         **apply_kwargs,
                                     )
@@ -2969,13 +3181,14 @@ class NoriPredictor:
                             )
                             outputs.append(output)
                             cached_done = True
-                            self._record_memory_attempt(
-                                attempt_policy,
+                            if not query_events:
+                                query_events.append((chunk_size, "success"))
+                            policy = self._record_cached_query_trace(
+                                execution_policy,
+                                query_events,
                                 pipeline_ids=[id_pipe],
                                 path="cached",
-                                rung=attempt_policy.rung,
                                 context_row_chunk=attempt_fit_chunk,
-                                outcome="success",
                                 reason=attempt_reason,
                                 dropped_context_rows=dropped_context_rows,
                             )
@@ -2997,27 +3210,24 @@ class NoriPredictor:
                                     "instead).",
                                     CacheQuantizedWarning,
                                 )
-                            if (
-                                attempt_fit_chunk is not None
-                                and (pinned is None or attempt_fit_chunk < pinned)
-                            ):
-                                policy = attempt_policy.escalated(
-                                    "context_row_chunk",
-                                    context_row_chunk=attempt_fit_chunk)
-                            else:
-                                policy = attempt_policy
+                            # `policy` already carries recovered_rung/context_row_chunk
+                            # (via execution_policy) and the true achieved query_chunk
+                            # (via _record_cached_query_trace's last event) -- both were
+                            # already offered to _publish_memory_policy internally, so
+                            # there is nothing left to re-escalate or re-publish here.
                             if attempt_index > 0:
                                 # Recovered after at least one earlier attempt failed --
                                 # whether via a smaller chunk (above) or precision/
                                 # placement alone. Log it either way, or a lossy/slow
                                 # recovery that never touched context_row_chunk is
                                 # invisible in the logs.
+                                logger.warning("Nori recovered on rung %s", policy.describe())
+                            effective_query_chunk = query_events[-1][0]
+                            if effective_query_chunk != chunk_size:
                                 logger.warning(
-                                    "Nori recovered on rung %s", policy.describe())
-                            policy = policy.escalated(
-                                policy.rung, dropped_context_rows=dropped_context_rows,
-                                query_chunk=chunk_size)
-                            self._publish_memory_policy(policy)
+                                    "Nori recovered with query_chunk=%s after decode OOM",
+                                    effective_query_chunk,
+                                )
                             break
                         except NotImplementedError as exc:
                             self._record_memory_attempt(
@@ -3037,7 +3247,7 @@ class NoriPredictor:
                             # as an OOM escalation, degrade quietly to the next rung.
                             self._evict_pipe_cache(id_pipe)
                             del ctx_bundle, output
-                            if pinned is not None:
+                            if policy.stream_context or pinned is not None:
                                 raise
                             logger.warning(
                                 "Nori cannot escalate to context_row_chunk on this "
@@ -3047,16 +3257,35 @@ class NoriPredictor:
                             cached_done = False
                             break
                         except torch.cuda.OutOfMemoryError:
-                            self._record_memory_attempt(
-                                attempt_policy,
-                                pipeline_ids=[id_pipe],
-                                path="cached",
-                                rung=attempt_policy.rung,
-                                context_row_chunk=attempt_fit_chunk,
-                                outcome="oom",
-                                reason=attempt_reason,
-                                dropped_context_rows=dropped_context_rows,
-                            )
+                            if query_events or ctx_bundle is not None:
+                                failed_events = list(query_events)
+                                if not failed_events:
+                                    failed_events.append((chunk_size, "oom"))
+                                elif failed_events[-1][1] == "success":
+                                    # Decode itself returned, but validation or
+                                    # post-processing OOMed before the attempt
+                                    # could be considered successful.
+                                    failed_events[-1] = (failed_events[-1][0], "oom")
+                                self._record_cached_query_trace(
+                                    execution_policy,
+                                    failed_events,
+                                    pipeline_ids=[id_pipe],
+                                    path="cached",
+                                    context_row_chunk=attempt_fit_chunk,
+                                    reason=attempt_reason,
+                                    dropped_context_rows=dropped_context_rows,
+                                )
+                            else:
+                                self._record_memory_attempt(
+                                    attempt_policy,
+                                    pipeline_ids=[id_pipe],
+                                    path="cached",
+                                    rung=attempt_policy.rung,
+                                    context_row_chunk=attempt_fit_chunk,
+                                    outcome="oom",
+                                    reason=attempt_reason,
+                                    dropped_context_rows=dropped_context_rows,
+                                )
                             self._evict_pipe_cache(id_pipe)
                             del ctx_bundle, output
                             torch.cuda.empty_cache()
@@ -3065,16 +3294,26 @@ class NoriPredictor:
                             # invisible in the logs and a slow run looks inexplicable.
                             if attempt_index + 1 < len(cache_attempts):
                                 next_policy, next_chunk = cache_attempts[attempt_index + 1]
-                                next_step = (
-                                    f"retrying rung {next_policy.rung} "
-                                    f"with context_row_chunk={next_chunk}"
+                                next_step = f"retrying rung {next_policy.rung} with context_row_chunk={next_chunk}"
+                            elif policy.stream_context:
+                                logger.error(
+                                    "Nori streamed context exhausted bounded cache attempts; refusing plain_loop"
                                 )
+                                raise
                             else:
                                 next_step = "falling back to the plain chunked loop"
                             logger.warning(
                                 "Nori OOM on rung %s (context_row_chunk=%s); %s",
-                                policy.rung, attempt_fit_chunk, next_step,
+                                policy.rung,
+                                attempt_fit_chunk,
+                                next_step,
                             )
+                if not cached_done and policy.stream_context:
+                    raise RuntimeError(
+                        "stream_context did not complete its cached path; refusing "
+                        "the plain_loop fallback because it would violate full-context "
+                        "streaming"
+                    )
                 if not cached_done:
                     # Every cached rung failed, or the policy never chose one. This
                     # is the plain chunked loop: much slower, and the only rung that
@@ -3099,44 +3338,53 @@ class NoriPredictor:
                         self._log_once_per_call("plain_loop", logging.WARNING, msg)
                         self._warn_once_per_call("plain_loop", msg, RuntimeWarning)
                     else:
-                        policy = policy.escalated(
-                            policy.rung, dropped_context_rows=dropped_context_rows)
+                        policy = policy.escalated(policy.rung, dropped_context_rows=dropped_context_rows)
                     self._publish_memory_policy(policy)
 
                 # Chunk the test data (skipped entirely if the cached path ran)
                 try:
                     all_outputs = []
-                    for i in ([] if cached_done else range(0, n_samples_test, chunk_size)):
+                    if not cached_done:
+                        plain_x, _plain_train, _plain_test, plain_y = _device_pipeline_inputs()
+                    for i in [] if cached_done else range(0, n_samples_test, chunk_size):
                         end_idx = min(i + chunk_size, n_samples_test)
-                        x_chunk_test = x_[len(y_train) + i : len(y_train) + end_idx]
-                    
+                        x_chunk_test = plain_x[len(y_train) + i : len(y_train) + end_idx]
+
                         # Recombine train + test chunk
-                        x_chunk_combined = torch.cat([x_[:len(y_train)], x_chunk_test], dim=0)
-                    
+                        x_chunk_combined = torch.cat([plain_x[: len(y_train)], x_chunk_test], dim=0)
+
                         # Create dummy y for test chunk
-                        y_chunk_test = torch.zeros(end_idx - i, dtype=y_.dtype, device=y_.device)
-                        y_chunk_combined = torch.cat([y_[:len(y_train)], y_chunk_test], dim=0)
+                        y_chunk_test = torch.zeros(end_idx - i, dtype=plain_y.dtype, device=plain_y.device)
+                        y_chunk_combined = torch.cat([plain_y[: len(y_train)], y_chunk_test], dim=0)
 
                         self.model.to(self.device)
-                        with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
+                        with (
+                            torch.autocast(
+                                device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
+                                enabled=self.mix_precision,
+                            ),
+                            torch.inference_mode(),
+                        ):
                             x_in = x_chunk_combined.unsqueeze(0)
                             y_in = y_chunk_combined.unsqueeze(0)
 
-                            chunk_output = self.model(
-                                x=x_in, y=y_in, eval_pos=len(y_train), task_type='reg'
-                            )
+                            chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type="reg")
 
                         if self.mask_prediction:
-                            process_config = chunk_output['process_config']
-                            chunk_output_feature_pred = self.PostProcessInModel(chunk_output['feature_pred'], process_config)
-                            source_row_indices = np.concatenate((
-                                np.arange(len(y_train), dtype=np.int64),
-                                np.arange(
-                                    len(y_train) + i,
-                                    len(y_train) + end_idx,
-                                    dtype=np.int64,
-                                ),
-                            ))
+                            process_config = chunk_output["process_config"]
+                            chunk_output_feature_pred = self.PostProcessInModel(
+                                chunk_output["feature_pred"], process_config
+                            )
+                            source_row_indices = np.concatenate(
+                                (
+                                    np.arange(len(y_train), dtype=np.int64),
+                                    np.arange(
+                                        len(y_train) + i,
+                                        len(y_train) + end_idx,
+                                        dtype=np.int64,
+                                    ),
+                                )
+                            )
                             chunk_output_feature_pred = self.PostProcess(
                                 chunk_output_feature_pred,
                                 pipe,
@@ -3144,14 +3392,12 @@ class NoriPredictor:
                                 source_row_indices=source_row_indices,
                             )
                             pipeline_mask_chunks.append(chunk_output_feature_pred)
-                            chunk_output = chunk_output['reg_output']
+                            chunk_output = chunk_output["reg_output"]
 
-                        chunk_output = self._unwrap_model_output(
-                            chunk_output, task_type="reg"
-                        ).squeeze(0)
+                        chunk_output = self._unwrap_model_output(chunk_output, task_type="reg").squeeze(0)
                         chunk_output = self._reject_nonfinite_output(
-                            chunk_output, path="plain chunked loop",
-                            n_train=n_samples_train, n_test=end_idx - i)
+                            chunk_output, path="plain chunked loop", n_train=n_samples_train, n_test=end_idx - i
+                        )
                         all_outputs.append(chunk_output)
 
                     # Concatenate all test chunks (cached path already appended above)
@@ -3190,7 +3436,7 @@ class NoriPredictor:
                     self._evict_pipe_cache(id_pipe)
                     torch.cuda.empty_cache()
                     raise
-            
+
         output = torch.stack(outputs).mean(dim=0)
         if return_distribution:
             # Return the ensemble-averaged decoder output BEFORE collapse: the

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -2205,10 +2205,12 @@ class NoriPredictor:
             x_test_ = x_test_base.copy()
             y_ = y_train.copy()
             categorical_idx_ = categorical_idx.copy()
+            # Internal bails out here on retrieval steps (InferenceAttentionMap,
+            # SubSampleData), which reshape the context between pipelines and so
+            # break the identical-shape grouping this path depends on. Neither
+            # class exists in this tier's inference_method, so no pipeline can
+            # contain one and the check would be dead code.
             for id_step, step in enumerate(pipe):
-                if isinstance(step, (InferenceAttentionMap, SubSampleData)):
-                    self._clear_pipeline_batch_contexts()
-                    return None
                 x_train_, x_test_, categorical_idx_ = self._fit_transform_step_inductive(
                     step, x_train_, x_test_, categorical_idx_,
                     self.seeds[id_pipe * self.preprocess_num + self._seed_step_index(pipe, id_step)],
@@ -2303,7 +2305,8 @@ class NoriPredictor:
                                 bare_model.apply_context_cache(
                                     x_test_t, context, row_chunk_size=chunk_size,
                                     adaptive_query_chunk=policy.adaptive_query_chunk,
-                                )
+                                ),
+                                task_type="reg",
                             )
                         finally:
                             if not policy.reuse_context_cache:
@@ -2320,7 +2323,8 @@ class NoriPredictor:
                                 y_train_t.new_zeros(len(group), end - start),
                             ], dim=1)
                             chunks.append(self._unwrap_model_output(
-                                self.model(x=x_in, y=y_in, eval_pos=n_samples_train)
+                                self.model(x=x_in, y=y_in, eval_pos=n_samples_train, task_type="reg"),
+                                task_type="reg",
                             ))
                         group_output = torch.cat(chunks, dim=1)
                 if (

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -2443,7 +2443,11 @@ class NoriPredictor:
             or self.mask_prediction
             or bool(getattr(bare_model, "mask_prediction", False))
             or not self._model_supports_pipeline_batching(bare_model)
-            or any(config["retrieval_config"]["use_retrieval"] for config in self.inference_config)
+            # Internal also excludes retrieval-enabled configs here, for the same
+            # reason it excludes retrieval preprocessing steps below: they reshape
+            # the context per pipeline and break the identical-shape grouping.
+            # This tier has no retrieval, so its inference configs carry no
+            # "retrieval_config" key at all and reading one raises KeyError.
         ):
             self._clear_pipeline_batch_contexts()
             return None

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -28,7 +28,9 @@ from synthefy_nori.inference.memory_policy import (
 from synthefy_nori.model.layer import RMSNorm
 from synthefy_nori.utils.loading import load_model
 import contextlib
+import importlib.util
 import torch
+import types
 from typing import List, Literal
 import random
 from sklearn.utils.validation import check_X_y, check_array
@@ -60,6 +62,13 @@ PIPELINE_BATCH_MAX_FEATURES = 256
 # partners. The legacy path streams one transformed table at a time; falling
 # back above this cap preserves that behavior for very large query sets.
 PIPELINE_BATCH_HOST_BUDGET_BYTES = 512 * 1024**2
+# Opt-in exact-serving mode: keep every ensemble member at B=1, but replay the
+# cached per-layer eager kernels through CUDA graphs. This preserves B=1
+# arithmetic while removing most Python/kernel-launch overhead on repeated,
+# fixed-shape resident-cache queries. It is deliberately not the default:
+# graph capture has a cold-start and persistent-memory cost, and is intended
+# for fit-once/serve-many workloads.
+EXACT_CACHED_CUDAGRAPHS_ENV = "SYNTHEFY_EXACT_CACHED_CUDAGRAPHS"
 
 
 class NoriPredictor:
@@ -2235,6 +2244,97 @@ class NoriPredictor:
                 return False
         return True
 
+    @staticmethod
+    def _exact_cached_cudagraphs_requested() -> bool:
+        return os.environ.get(EXACT_CACHED_CUDAGRAPHS_ENV, "0") == "1"
+
+    def _maybe_enable_exact_cached_cudagraphs(self, bare_model) -> bool:
+        """Compile cached B=1 encoder layers with the eager CUDA-graph backend.
+
+        Unlike Inductor, the ``cudagraphs`` backend replays the original eager
+        kernels and therefore preserves B=1 output bits. The compiled unbound
+        method is shared by every encoder layer, mirroring training's regional
+        compilation pattern without compiling one graph per layer instance.
+        """
+        if not self._exact_cached_cudagraphs_requested():
+            return False
+        attempted = getattr(bare_model, "_exact_cudagraphs_attempted", False)
+        if attempted:
+            return bool(getattr(bare_model, "_exact_cudagraphs_enabled", False))
+        bare_model._exact_cudagraphs_attempted = True
+
+        try:
+            device = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
+        except (TypeError, RuntimeError):
+            return False
+        layers = getattr(getattr(bare_model, "transformer_encoder", None), "layers", None)
+        if device.type != "cuda" or not layers or not hasattr(torch, "compile"):
+            return False
+        # Torch's backend discovery imports setuptools through its CPU ISA probe.
+        # Serving-minimal environments may intentionally omit it; exact mode must
+        # then remain a safe eager B=1 fallback instead of failing a request.
+        if importlib.util.find_spec("setuptools") is None:
+            self._log_once_per_call(
+                "exact_cudagraphs_unavailable",
+                logging.WARNING,
+                f"{EXACT_CACHED_CUDAGRAPHS_ENV}=1 requested, but setuptools is "
+                "unavailable; using exact eager B=1 inference.",
+            )
+            return False
+        try:
+            original = type(layers[0]).forward_test_with_cache
+            compiled = torch.compile(
+                original,
+                backend="cudagraphs",
+                dynamic=False,
+                fullgraph=False,
+            )
+        except Exception as exc:  # pragma: no cover - backend availability varies
+            self._log_once_per_call(
+                "exact_cudagraphs_unavailable",
+                logging.WARNING,
+                f"Could not initialize exact cached CUDA graphs "
+                f"({type(exc).__name__}: {exc}); using eager B=1 inference.",
+            )
+            return False
+        for layer in layers:
+            layer.forward_test_with_cache = types.MethodType(compiled, layer)
+        bare_model._exact_cudagraphs_original = original
+        bare_model._exact_cudagraphs_enabled = True
+        return True
+
+    @staticmethod
+    def _is_torch_compiler_failure(exc: Exception) -> bool:
+        module = type(exc).__module__
+        return module.startswith(("torch._dynamo", "torch._inductor"))
+
+    def _disable_exact_cached_cudagraphs(self, bare_model) -> None:
+        original = getattr(bare_model, "_exact_cudagraphs_original", None)
+        layers = getattr(getattr(bare_model, "transformer_encoder", None), "layers", ())
+        if original is not None:
+            for layer in layers:
+                layer.forward_test_with_cache = types.MethodType(original, layer)
+        bare_model._exact_cudagraphs_enabled = False
+
+    def _apply_context_cache_exact_safe(self, bare_model, x_test, context, **kwargs):
+        enabled = self._maybe_enable_exact_cached_cudagraphs(bare_model)
+        if enabled and not getattr(self, "_exact_cudagraph_step_marked", False):
+            torch.compiler.cudagraph_mark_step_begin()
+            self._exact_cudagraph_step_marked = True
+        try:
+            return bare_model.apply_context_cache(x_test, context, **kwargs)
+        except Exception as exc:
+            if not enabled or not self._is_torch_compiler_failure(exc):
+                raise
+            self._disable_exact_cached_cudagraphs(bare_model)
+            self._log_once_per_call(
+                "exact_cudagraphs_runtime_fallback",
+                logging.WARNING,
+                f"Exact cached CUDA-graph compilation failed at runtime "
+                f"({type(exc).__name__}: {exc}); retrying with eager B=1 inference.",
+            )
+            return bare_model.apply_context_cache(x_test, context, **kwargs)
+
     def _try_batched_ordinary_regression(
             self, bare_model, *, x_train_base, x_test_base, y_train,
             categorical_idx, n_samples_train, n_samples_test,
@@ -2259,6 +2359,7 @@ class NoriPredictor:
         if (
             device.type != "cuda"
             or os.environ.get("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "0") == "1"
+            or self._exact_cached_cudagraphs_requested()
             or len(self.preprocess_pipelines) < 2
             or self.inference_with_DDP
             or self.mask_prediction
@@ -2833,13 +2934,36 @@ class NoriPredictor:
                                     reuse_context_cache=policy.reuse_context_cache,
                                     cache_entries=self.context_cache_entries,
                                 )
-                                output = bare_model.apply_context_cache(
-                                    x_[n_ctx:].unsqueeze(0),
-                                    ctx_bundle,
-                                    row_chunk_size=chunk_size,
-                                    adaptive_query_chunk=policy.adaptive_query_chunk,
-                                )
-                            output = self._unwrap_model_output(output, task_type="reg").squeeze(0)
+                                apply_kwargs = {
+                                    "row_chunk_size": chunk_size,
+                                    "adaptive_query_chunk": policy.adaptive_query_chunk,
+                                }
+                                if (
+                                    policy.rung == "resident_bf16"
+                                    and policy.cache_dtype == "bf16"
+                                    and not policy.offload_to_host
+                                    and attempt_fit_chunk is None
+                                ):
+                                    output = self._apply_context_cache_exact_safe(
+                                        bare_model,
+                                        x_[n_ctx:].unsqueeze(0),
+                                        ctx_bundle,
+                                        **apply_kwargs,
+                                    )
+                                else:
+                                    if getattr(
+                                        bare_model, "_exact_cudagraphs_enabled", False
+                                    ):
+                                        self._disable_exact_cached_cudagraphs(bare_model)
+                                    output = bare_model.apply_context_cache(
+                                        x_[n_ctx:].unsqueeze(0),
+                                        ctx_bundle,
+                                        **apply_kwargs,
+                                    )
+                            output = self._unwrap_model_output(
+                                output,
+                                task_type="reg",
+                            ).squeeze(0)
                             output = self._reject_nonfinite_output(
                                 output, path=f"cached ({policy.rung})", n_train=n_samples_train, n_test=n_samples_test
                             )

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -42,6 +42,19 @@ import warnings
 logger = logging.getLogger(__name__)
 
 NA_PLACEHOLDER = "__MISSING__"
+# The default eight-member ensemble naturally forms two shape groups of four.
+# Cap custom configs at that measured sweet spot so batching cannot multiply
+# activation/context-cache memory without bound.
+PIPELINE_BATCH_MAX = 4
+# Batched GEMMs are launch-bound and much faster on narrow/medium tables, but
+# the gain disappears on very wide transformed tables while memory rises. The
+# H200 crossover was between 146 and 352 processed features, so keep the first
+# rollout on the conservative side and leave wide members at B=1.
+PIPELINE_BATCH_MAX_FEATURES = 256
+# Bound the extra host copies retained while pipelines wait for same-shape
+# partners. The legacy path streams one transformed table at a time; falling
+# back above this cap preserves that behavior for very large query sets.
+PIPELINE_BATCH_HOST_BUDGET_BYTES = 512 * 1024**2
 
 
 class NoriPredictor:
@@ -2028,6 +2041,327 @@ class NoriPredictor:
             )
         )
 
+    @staticmethod
+    def _group_ordinary_pipes(prepared: list[tuple]) -> list[list[tuple]]:
+        """Stable groups whose context/query tensors have identical shapes.
+
+        The group containing the final pipeline executes last. Each model call
+        reseeds first, so this preserves the legacy loop's post-call RNG state
+        when different transformed widths consume different amounts of RNG.
+        """
+        grouped = {}
+        for item in prepared:
+            _, x_train, y_train, x_test = item
+            key = (
+                x_train.shape, y_train.shape, x_test.shape,
+                x_train.dtype, y_train.dtype, x_test.dtype,
+                x_train.device, y_train.device, x_test.device,
+            )
+            grouped.setdefault(key, []).append(item)
+        result = []
+        for group in grouped.values():
+            width = group[0][1].shape[-1]
+            batch_size = (
+                PIPELINE_BATCH_MAX
+                if width <= PIPELINE_BATCH_MAX_FEATURES
+                else 1
+            )
+            result.extend(
+                group[start:start + batch_size]
+                for start in range(0, len(group), batch_size)
+            )
+        if result:
+            final_pipe_id = max(item[0] for item in prepared)
+            final_group_index = next(
+                index
+                for index, group in enumerate(result)
+                if any(item[0] == final_pipe_id for item in group)
+            )
+            result.append(result.pop(final_group_index))
+        return result
+
+    def _clear_pipeline_batch_contexts(
+            self, keep: set[tuple] | None = None) -> None:
+        """Release grouped caches that cannot serve the current execution mode."""
+        cache = getattr(self, "_context_cache", None)
+        if not isinstance(cache, dict):
+            return
+        keep = keep or set()
+        for slot in list(cache):
+            if (
+                isinstance(slot, tuple)
+                and len(slot) == 2
+                and slot[0] == "pipeline_batch"
+                and slot not in keep
+            ):
+                cache.pop(slot, None)
+
+    def _clear_pipeline_member_contexts(self, batch_slots: set[tuple]) -> None:
+        """Release B=1 caches superseded by retained grouped cache slots."""
+        cache = getattr(self, "_context_cache", None)
+        if not isinstance(cache, dict):
+            return
+        grouped_ids = {
+            id_pipe
+            for _, ids in batch_slots
+            for id_pipe in ids
+        }
+        for id_pipe in grouped_ids:
+            cache.pop(id_pipe, None)
+
+    @staticmethod
+    def _model_supports_pipeline_batching(bare_model) -> bool:
+        """Whether one RNG seed is equivalent to reseeding every B=1 member."""
+        if bool(getattr(bare_model, "training", False)):
+            return False
+        modules = bare_model.modules() if hasattr(bare_model, "modules") else (bare_model,)
+        for module in modules:
+            dropout = getattr(module, "dropout", 0.0)
+            if isinstance(dropout, (int, float)) and float(dropout) != 0.0:
+                # MultiheadAttention passes its numeric dropout directly to SDPA,
+                # which applies it even when the enclosing module is in eval mode.
+                return False
+        return True
+
+    def _try_batched_ordinary_regression(
+            self, bare_model, *, x_train_base, x_test_base, y_train,
+            categorical_idx, n_samples_train, n_samples_test,
+            budget_n_features, max_elements_budget, dropped_context_rows,
+    ) -> list[torch.Tensor] | None:
+        """Execute prepared ordinary members in bounded same-shape groups.
+
+        This deliberately covers only the two full-precision, on-device execution
+        modes: an ordinary model forward (``no_cache``) and a resident bf16 context
+        cache.
+        Retrieval, DDP, imputation, int8, host offload, pinned prefill chunking, and
+        every OOM/unsupported case use the established loop below. The environment
+        kill switch gives operators a no-code rollback while this optimization gains
+        production mileage. Batching preserves the model math, although mixed-
+        precision GEMMs may reassociate at the last few bits versus B=1 execution.
+        """
+        try:
+            device = self.device if isinstance(self.device, torch.device) else torch.device(self.device)
+        except (TypeError, RuntimeError):
+            self._clear_pipeline_batch_contexts()
+            return None
+        if (
+            device.type != "cuda"
+            or os.environ.get("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "0") == "1"
+            or len(self.preprocess_pipelines) < 2
+            or self.inference_with_DDP
+            or self.mask_prediction
+            or bool(getattr(bare_model, "mask_prediction", False))
+            or not self._model_supports_pipeline_batching(bare_model)
+            or any(config["retrieval_config"]["use_retrieval"] for config in self.inference_config)
+        ):
+            self._clear_pipeline_batch_contexts()
+            return None
+
+        chunk_size = self._chunk_size(
+            max_elements_budget, budget_n_features, n_samples_train)
+        requested = self._coerced_memory_policy()
+        cache_eligible = (
+            hasattr(bare_model, "forward_cached_regression")
+            and n_samples_test > chunk_size
+            and requested.cache
+        )
+        if cache_eligible:
+            fpg = max(int(getattr(bare_model, "features_per_group", 2)), 1)
+            embed_dim = int(getattr(bare_model, "embed_dim", 128))
+            nlayers = int(getattr(bare_model, "nlayers", 16))
+            nhead = max(int(getattr(bare_model, "nhead", 2)), 1)
+            bytes_per = 2 if self.mix_precision else 4
+            policy = requested.resolve(
+                est_cache_gb=estimate_cache_gb(
+                    n_context_rows=n_samples_train,
+                    n_groups=(budget_n_features + fpg - 1) // fpg,
+                    nlayers=nlayers,
+                    embed_dim=embed_dim,
+                    bytes_per_element=bytes_per,
+                ),
+                bytes_per_element=bytes_per,
+                head_dim=max(embed_dim // nhead, 1),
+                total_vram_gb=self._total_vram_gb(),
+                total_ram_gb=total_host_ram_gb(),
+            )
+        else:
+            policy = requested.resolve(
+                est_cache_gb=0.0, bytes_per_element=1, head_dim=1,
+                cache_eligible=False,
+            )
+        if (
+            policy.rung not in ("no_cache", "resident_bf16")
+            or policy.cache_dtype != "bf16"
+            or policy.offload_to_host
+            or policy.context_row_chunk is not None
+        ):
+            self._clear_pipeline_batch_contexts()
+            return None
+
+        prepared = []
+        retained_host_bytes = 0
+        for id_pipe, pipe in enumerate(self.preprocess_pipelines):
+            x_train_ = x_train_base.copy()
+            x_test_ = x_test_base.copy()
+            y_ = y_train.copy()
+            categorical_idx_ = categorical_idx.copy()
+            for id_step, step in enumerate(pipe):
+                if isinstance(step, (InferenceAttentionMap, SubSampleData)):
+                    self._clear_pipeline_batch_contexts()
+                    return None
+                x_train_, x_test_, categorical_idx_ = self._fit_transform_step_inductive(
+                    step, x_train_, x_test_, categorical_idx_,
+                    self.seeds[id_pipe * self.preprocess_num + self._seed_step_index(pipe, id_step)],
+                    y_train=y_,
+                )
+            prospective_host_bytes = (
+                x_train_.size + x_test_.size + y_.size
+            ) * np.dtype(np.float32).itemsize
+            if (
+                retained_host_bytes + prospective_host_bytes
+                > PIPELINE_BATCH_HOST_BUDGET_BYTES
+            ):
+                self._clear_pipeline_batch_contexts()
+                return None
+            x_all = torch.from_numpy(
+                np.concatenate([x_train_, x_test_], axis=0)
+            ).float()
+            y_tensor = torch.from_numpy(y_).float()
+            prepared.append((
+                id_pipe,
+                x_all[:len(y_)],
+                y_tensor,
+                x_all[len(y_):],
+            ))
+            retained_host_bytes += (
+                x_all.numel() * x_all.element_size()
+                + y_tensor.numel() * y_tensor.element_size()
+            )
+
+        groups = self._group_ordinary_pipes(prepared)
+        if policy.rung == "resident_bf16":
+            # Resolve again from the actual post-transform widths and the total
+            # retained ensemble cache. The earlier lower-bound resolution uses the
+            # raw/effective input width only to avoid preprocessing modes that could
+            # never stay resident; it must not under-report a wider prepared group.
+            group_cache_sizes = [
+                estimate_cache_gb(
+                    n_context_rows=n_samples_train,
+                    n_groups=(group[0][1].shape[-1] + fpg - 1) // fpg,
+                    nlayers=nlayers,
+                    embed_dim=embed_dim,
+                    bytes_per_element=bytes_per,
+                ) * len(group)
+                for group in groups
+            ]
+            batched_cache_gb = (
+                sum(group_cache_sizes)
+                if requested.reuse_context_cache
+                else max(group_cache_sizes)
+            )
+            policy = requested.resolve(
+                est_cache_gb=batched_cache_gb,
+                bytes_per_element=bytes_per,
+                head_dim=max(embed_dim // nhead, 1),
+                total_vram_gb=self._total_vram_gb(),
+                total_ram_gb=total_host_ram_gb(),
+            )
+            if policy.rung != "resident_bf16":
+                self._clear_pipeline_batch_contexts()
+                return None
+
+        active_batch_slots = {
+            ("pipeline_batch", tuple(item[0] for item in group))
+            for group in groups
+            if len(group) > 1
+        } if policy.rung == "resident_bf16" and policy.reuse_context_cache else set()
+        self._clear_pipeline_batch_contexts(keep=active_batch_slots)
+        self._clear_pipeline_member_contexts(active_batch_slots)
+
+        outputs: list[torch.Tensor | None] = [None] * len(prepared)
+        try:
+            for group in groups:
+                ids = tuple(item[0] for item in group)
+                x_train_t = torch.stack([item[1] for item in group]).to(self.device)
+                y_train_t = torch.stack([item[2] for item in group]).to(self.device)
+                x_test_t = torch.stack([item[3] for item in group]).to(self.device)
+                torch.manual_seed(self.seed)
+                torch.cuda.manual_seed_all(self.seed)
+                self.model.to(self.device)
+                with torch.autocast(device_type=device.type, enabled=self.mix_precision), torch.inference_mode():
+                    if policy.rung == "resident_bf16":
+                        slot = ids[0] if len(ids) == 1 else ("pipeline_batch", ids)
+                        context = self._get_or_build_context(
+                            bare_model, slot,
+                            x_train_t=x_train_t, y_train_t=y_train_t,
+                            cache_dtype="bf16", offload_kv_cache=False,
+                            fit_row_chunk=None,
+                            reuse_context_cache=policy.reuse_context_cache,
+                        )
+                        try:
+                            group_output = self._unwrap_model_output(
+                                bare_model.apply_context_cache(
+                                    x_test_t, context, row_chunk_size=chunk_size,
+                                    adaptive_query_chunk=policy.adaptive_query_chunk,
+                                )
+                            )
+                        finally:
+                            if not policy.reuse_context_cache:
+                                # Without reuse only one group's full K/V bundle is
+                                # budgeted. Drop it before the next group is built.
+                                del context
+                    else:
+                        chunks = []
+                        for start in range(0, n_samples_test, chunk_size):
+                            end = min(start + chunk_size, n_samples_test)
+                            x_in = torch.cat([x_train_t, x_test_t[:, start:end]], dim=1)
+                            y_in = torch.cat([
+                                y_train_t,
+                                y_train_t.new_zeros(len(group), end - start),
+                            ], dim=1)
+                            chunks.append(self._unwrap_model_output(
+                                self.model(x=x_in, y=y_in, eval_pos=n_samples_train)
+                            ))
+                        group_output = torch.cat(chunks, dim=1)
+                if (
+                    not isinstance(group_output, torch.Tensor)
+                    or group_output.ndim < 2
+                    or group_output.shape[0] != len(group)
+                    or group_output.shape[1] != n_samples_test
+                ):
+                    raise NotImplementedError(
+                        "pipeline-batched model output must be [B, n_test, ...]"
+                    )
+                group_output = self._reject_nonfinite_output(
+                    group_output, path=f"pipeline-batched ({policy.rung})",
+                    n_train=n_samples_train, n_test=n_samples_test,
+                )
+                for (id_pipe, *_), member_output in zip(group, group_output.unbind(0)):
+                    outputs[id_pipe] = member_output
+        except (NotImplementedError, torch.cuda.OutOfMemoryError):
+            cache = getattr(self, "_context_cache", None)
+            if isinstance(cache, dict):
+                # The failed attempt may already have built singleton groups.
+                # Legacy retry must start without any partial grouped-run state.
+                cache.clear()
+            torch.cuda.empty_cache()
+            return None
+
+        used = policy.escalated(
+            policy.rung,
+            dropped_context_rows=dropped_context_rows,
+            **({"query_chunk": chunk_size} if policy.rung == "resident_bf16" else {}),
+        )
+        self.memory_report_ = used.model_dump()
+        self._log_once_per_call(
+            "rung", logging.INFO,
+            f"Nori serving-memory rung: {used.describe()}",
+        )
+        if any(output is None for output in outputs):
+            raise AssertionError("pipeline batching lost an ensemble member")
+        return [output for output in outputs if output is not None]
+
+
     def _predict_reg_single(
         self,
         x_train: np.ndarray,
@@ -2148,6 +2482,31 @@ class NoriPredictor:
             x_train,
             x_test,
         )
+
+        # The batched path calls the bare model directly, so it cannot honour a
+        # DistributedInference session. Internal has no DDP inference and so no
+        # equivalent guard; skip the fast path rather than silently dropping the
+        # caller's distributed context.
+        if distributed_inference is None:
+            bare_model = self._bare_model()
+            batched_outputs = self._try_batched_ordinary_regression(
+                bare_model,
+                x_train_base=x_train_base,
+                x_test_base=x_test_base,
+                y_train=y_train,
+                categorical_idx=categorical_idx,
+                n_samples_train=n_samples_train,
+                n_samples_test=n_samples_test,
+                budget_n_features=budget_n_features,
+                max_elements_budget=MAX_ELEMENTS_BUDGET,
+                dropped_context_rows=dropped_context_rows,
+            )
+            if batched_outputs is not None:
+                output = torch.stack(batched_outputs).mean(dim=0)
+                if return_distribution:
+                    return output
+                return self._collapse_regression_output(output)
+
 
         outputs = []
         mask_predictions = []

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -1228,9 +1228,19 @@ class NoriPredictor:
         if isinstance(cache, dict):
             cache.pop(id_pipe, None)
 
-    def _memory_rung_sort_key(self, policy: MemoryPolicy) -> tuple[int, float, float]:
-        """Comparable "how bad/complete is this outcome" key: rank, then
-        context_row_chunk degradation, then query_chunk degradation.
+    def _memory_rung_sort_key(self, policy: MemoryPolicy) -> tuple[int, int, float, float]:
+        """Comparable "how bad/complete is this outcome" key: rank, then dropped
+        context rows, then context_row_chunk degradation, then query_chunk
+        degradation.
+
+        dropped_context_rows ranks directly under the rung because losing context
+        rows is the most severe thing that can happen within one: a subsampled
+        answer used less data than the caller supplied. It is computed once per
+        predict() call, so it never oscillates — it only separates the opening
+        ``resolve()`` policy, published before subsampling is known and therefore
+        carrying 0, from the later outcome policy that carries the real count.
+        Without it those two tie and the strict ``>`` below keeps the opening one,
+        which reports dropped_context_rows=0 for a call that did drop rows.
 
         A smaller ``context_row_chunk`` is a more degraded outcome within that one
         rung (a harder-won escalation), so it sorts worse than a larger one. Every
@@ -1246,11 +1256,12 @@ class NoriPredictor:
         too, or the published report understates how hard-won the recovery was.
         """
         rank = self._MEMORY_RUNG_SEVERITY.get(policy.rung or "no_cache", -1)
+        dropped_component = int(policy.dropped_context_rows or 0)
         chunk = policy.context_row_chunk
         chunk_component = -chunk if chunk is not None else float("-inf")
         query_chunk = policy.query_chunk
         query_component = -query_chunk if query_chunk is not None else float("-inf")
-        return rank, chunk_component, query_component
+        return rank, dropped_component, chunk_component, query_component
 
     def _publish_memory_policy(self, policy: MemoryPolicy) -> None:
         """Publish the worst successful/selected rung seen in this predict call."""

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -10,12 +10,17 @@ from synthefy_nori.inference.preprocess import (
     HighDimFeatureSelector,
     MaxFeatureSubsampler,
     MADWinsorizer,
-    PolynomialInteractionGenerator,
+    PolynomialInteractionGenerator)
+from synthefy_nori.inference.degradation import (
+    CacheQuantizedWarning,
+    ContextSubsampledWarning,
+    DegradedPipelineWarning,
 )
-from synthefy_nori.inference.degradation import ContextSubsampledWarning, DegradedPipelineWarning
 from synthefy_nori.inference.memory_policy import (
-    FIT_ROW_CHUNK_ON_OOM,
+    FIT_ROW_CHUNK_RETRY_LADDER,
+    RUNGS,
     ContextTooLargeError,
+    MemoryAttempt,
     MemoryPolicy,
     estimate_cache_gb,
     total_host_ram_gb,
@@ -187,7 +192,23 @@ class NoriPredictor:
         self.native_rms_norm = None if native_rms_norm is None else bool(native_rms_norm)
         self.inference_with_DDP = inference_with_DDP
         if self.inference_with_DDP and self.mask_prediction:
-            raise ValueError("inference_with_DDP does not support mask_prediction")
+            raise ValueError(
+                "inference_with_DDP does not support mask_prediction"
+            )
+        if self.inference_with_DDP and memory_policy is not None:
+            # The DDP branch of predict() never resolves a MemoryPolicy or
+            # populates memory_report_ -- it is a structurally separate path, not
+            # a missing feature. Reject this combination here, loudly and at
+            # construction time, rather than silently leaving memory_report_ at
+            # None and letting a caller downstream (e.g. the client) misdiagnose
+            # it as an out-of-date runtime.
+            raise ValueError(
+                "inference_with_DDP does not support memory_policy: the DDP "
+                "path never resolves a memory policy, so memory_report_ would "
+                "stay None regardless of what was requested. Pass "
+                "memory_policy=None with inference_with_DDP=True, or drop "
+                "inference_with_DDP to use the memory-policy-aware path."
+            )
         # Optional inference-time augmentations. Currently supports:
         #   'yj': Yeo-Johnson target transform ensemble — fit PowerTransformer
         #         on y_train, predict in transformed space, inverse-transform,
@@ -588,6 +609,14 @@ class NoriPredictor:
         # config); these make them once per user-visible predict instead.
         self._warned_this_call = set()
         self._logged_this_call = set()
+        self._exact_cudagraph_step_marked = False
+        self.memory_report_ = None
+        self._memory_attempt_history = []
+        self._memory_outcome_policy = None
+        if not self._exact_cached_cudagraphs_requested():
+            bare_model = self._bare_model()
+            if getattr(bare_model, "_exact_cudagraphs_enabled", False):
+                self._disable_exact_cached_cudagraphs(bare_model)
         with self._execution_overrides():
             if return_distribution:
                 return self._predict_reg(x_train, y_train, x_test, return_distribution=True)
@@ -1168,6 +1197,89 @@ class NoriPredictor:
     #: quietly dropped to ``plain_loop``, the one rung that may subsample the context,
     #: is indistinguishable from a fast one except by its numbers.
     memory_report_: dict | None = None
+
+    # Derived from RUNGS (not hand-duplicated) so a rung added there cannot silently
+    # fall back to severity -1 here and be treated as never-worse-than-anything.
+    _MEMORY_RUNG_SEVERITY = {rung: index for index, rung in enumerate(RUNGS)}
+
+    @staticmethod
+    def _fit_row_chunk_attempts(pinned: int | None) -> list[int]:
+        """Return the smaller-than-`pinned` retry ladder (the pinned/None value
+        itself is never a new attempt: it is already the first cache_attempts entry
+        built from the placement ladder)."""
+        return [
+            chunk for chunk in FIT_ROW_CHUNK_RETRY_LADDER
+            if pinned is None or chunk < pinned
+        ]
+
+    def _evict_pipe_cache(self, id_pipe) -> None:
+        """Drop only this pipe's own retained context-cache entry.
+
+        Used by the per-pipe cached-retry loop's OOM/unsupported handlers: a bad
+        attempt for ONE pipe must not evict every OTHER pipe's already-built,
+        reusable K/V cache.
+        """
+        cache = getattr(self, "_context_cache", None)
+        if isinstance(cache, dict):
+            cache.pop(id_pipe, None)
+
+    def _memory_rung_sort_key(self, policy: MemoryPolicy) -> tuple[int, float]:
+        """Comparable "how bad is this outcome" key: rank first, then chunk size.
+
+        A smaller ``context_row_chunk`` is a more degraded outcome within that one
+        rung (a harder-won escalation), so it sorts worse than a larger one. Every
+        other rung always has ``context_row_chunk is None``, which sorts lowest, so
+        rank alone decides ties there.
+        """
+        rank = self._MEMORY_RUNG_SEVERITY.get(policy.rung or "no_cache", -1)
+        chunk = policy.context_row_chunk
+        return rank, (-chunk if chunk is not None else float("-inf"))
+
+    def _publish_memory_policy(self, policy: MemoryPolicy) -> None:
+        """Publish the worst successful/selected rung seen in this predict call."""
+        current = getattr(self, "_memory_outcome_policy", None)
+        if current is None or self._memory_rung_sort_key(policy) > self._memory_rung_sort_key(current):
+            self._memory_outcome_policy = policy
+            current = policy
+        report = current.model_dump()
+        # Reference, not copy: ``_memory_attempt_history`` is reassigned to a fresh
+        # list at the start of every predict() call (never appended-to across
+        # calls), so sharing this call's list is safe and avoids an O(attempts^2)
+        # copy across a multi-attempt OOM-retry sequence.
+        report["attempt_history"] = getattr(self, "_memory_attempt_history", [])
+        self.memory_report_ = report
+
+    def _record_memory_attempt(
+        self,
+        policy: MemoryPolicy,
+        *,
+        pipeline_ids: list[int],
+        path: str,
+        rung: str,
+        context_row_chunk: int | None,
+        outcome: str,
+        reason: str,
+        dropped_context_rows: int,
+    ) -> None:
+        """Append one validated attempt and refresh the public report."""
+        attempt = MemoryAttempt(
+            pipeline_ids=pipeline_ids,
+            path=path,
+            rung=rung,
+            cache_dtype=policy.cache_dtype,
+            offload_to_host=policy.offload_to_host,
+            context_row_chunk=context_row_chunk,
+            outcome=outcome,
+            reason=reason,
+            dropped_context_rows=dropped_context_rows,
+        ).model_dump()
+        history = getattr(self, "_memory_attempt_history", None)
+        if history is None:
+            history = self._memory_attempt_history = []
+        history.append(attempt)
+        current = getattr(self, "_memory_outcome_policy", None)
+        if current is not None:
+            self._publish_memory_policy(current)
 
     def _coerced_memory_policy(self) -> MemoryPolicy:
         """This predictor's :class:`MemoryPolicy`.
@@ -2280,7 +2392,9 @@ class NoriPredictor:
         self._clear_pipeline_batch_contexts(keep=active_batch_slots)
         self._clear_pipeline_member_contexts(active_batch_slots)
 
+        self._publish_memory_policy(policy)
         outputs: list[torch.Tensor | None] = [None] * len(prepared)
+        ids: tuple[int, ...] = ()
         try:
             for group in groups:
                 ids = tuple(item[0] for item in group)
@@ -2342,7 +2456,28 @@ class NoriPredictor:
                 )
                 for (id_pipe, *_), member_output in zip(group, group_output.unbind(0)):
                     outputs[id_pipe] = member_output
-        except (NotImplementedError, torch.cuda.OutOfMemoryError):
+                self._record_memory_attempt(
+                    policy,
+                    pipeline_ids=list(ids),
+                    path="pipeline_batch",
+                    rung=policy.rung,
+                    context_row_chunk=None,
+                    outcome="success",
+                    reason="resolved",
+                    dropped_context_rows=dropped_context_rows,
+                )
+        except (NotImplementedError, torch.cuda.OutOfMemoryError) as exc:
+            self._record_memory_attempt(
+                policy,
+                pipeline_ids=list(ids),
+                path="pipeline_batch",
+                rung=policy.rung,
+                context_row_chunk=None,
+                outcome=("oom" if isinstance(exc, torch.cuda.OutOfMemoryError)
+                         else "unsupported"),
+                reason="resolved",
+                dropped_context_rows=dropped_context_rows,
+            )
             cache = getattr(self, "_context_cache", None)
             if isinstance(cache, dict):
                 # The failed attempt may already have built singleton groups.
@@ -2356,7 +2491,7 @@ class NoriPredictor:
             dropped_context_rows=dropped_context_rows,
             **({"query_chunk": chunk_size} if policy.rung == "resident_bf16" else {}),
         )
-        self.memory_report_ = used.model_dump()
+        self._publish_memory_policy(used)
         self._log_once_per_call(
             "rung", logging.INFO,
             f"Nori serving-memory rung: {used.describe()}",
@@ -2585,7 +2720,8 @@ class NoriPredictor:
                 # defaults, or pass a preset name ("exact", "max_context", "off"), a
                 # dict, or a MemoryPolicy. No env var configures this; only the
                 # SYNTHEFY_DISABLE_CACHED_INFERENCE kill switch is honoured.
-                policy = self._coerced_memory_policy()
+                requested_policy = self._coerced_memory_policy()
+                policy = requested_policy
                 use_cached = (
                     hasattr(bare_model, "forward_cached_regression")
                     and not self.mask_prediction
@@ -2594,11 +2730,12 @@ class NoriPredictor:
                 )
                 if use_cached:
                     fpg = max(int(getattr(bare_model, "features_per_group", 2)), 1)
-                    n_groups = (budget_n_features + fpg - 1) // fpg
+                    n_groups = (x_train_.shape[-1] + fpg - 1) // fpg
                     embed_dim = int(getattr(bare_model, "embed_dim", 128))
                     nlayers = int(getattr(bare_model, "nlayers", 16))
                     nhead = max(int(getattr(bare_model, "nhead", 2)), 1)
                     bytes_per = 2 if self.mix_precision else 4
+                    head_dim = max(embed_dim // nhead, 1)
                     policy = policy.resolve(
                         est_cache_gb=estimate_cache_gb(
                             n_context_rows=n_samples_train,
@@ -2608,7 +2745,7 @@ class NoriPredictor:
                             bytes_per_element=bytes_per,
                         ),
                         bytes_per_element=bytes_per,
-                        head_dim=max(embed_dim // nhead, 1),
+                        head_dim=head_dim,
                         total_vram_gb=self._total_vram_gb(),
                         total_ram_gb=total_host_ram_gb(),
                     )
@@ -2620,6 +2757,7 @@ class NoriPredictor:
                         head_dim=1,
                         cache_eligible=False,
                     )
+                self._publish_memory_policy(policy)
                 # Announce the opening rung. WARNING when it is already a fallback
                 # (offload / plain loop), because that is a real slowdown the caller
                 # should see by default; INFO on the fast rungs so a normal run stays
@@ -2631,21 +2769,40 @@ class NoriPredictor:
                 )
 
                 cached_done = False
+                fallback_reason = "resolved"
                 if use_cached:
                     self.model.to(self.device)
-                    # Sequential fallback. Attempt 1 uses the resolved rung; on an
-                    # OOM, escalate to fit-time row chunking (bit-exact — it bounds
-                    # the O(N*groups) build working set, which offload alone cannot)
-                    # before dropping to the plain loop.
+                    # Walk every allowed, budget-feasible precision/placement rung,
+                    # then bound the final rung's prefill working set at 2048, 1024,
+                    # and 512 rows before giving up on the cache. An explicit chunk is
+                    # the first-attempt cap; no retry can exceed it.
                     #
-                    # A policy that PINS context_row_chunk uses it from attempt 1, which
-                    # also means there is nothing left to escalate to. That is the
-                    # documented cost of pinning it.
-                    pinned = policy.context_row_chunk
-                    fit_chunk_attempts = [pinned]
-                    if pinned is None:
-                        fit_chunk_attempts.append(FIT_ROW_CHUNK_ON_OOM)
-                    for attempt_fit_chunk in fit_chunk_attempts:
+                    # Chunking is tried LAST, combined only with the worst placement,
+                    # not first against the bit-exact rung: it only bounds the
+                    # transient BUILD peak, not the finished cache's resident size,
+                    # so it cannot rescue an OOM caused by the cache itself being too
+                    # big to fit -- only the placement ladder above can. It also is
+                    # not supported on every checkpoint (serial sequence attention
+                    # raises NotImplementedError). RUNGS already ranks
+                    # context_row_chunk below offload_int8, so this matches that.
+                    pinned = requested_policy.context_row_chunk
+                    placement_policies = requested_policy.runtime_fallbacks(
+                        policy,
+                        bytes_per_element=bytes_per,
+                        head_dim=head_dim,
+                    )
+                    cache_attempts = [
+                        (candidate, pinned) for candidate in placement_policies
+                    ]
+                    final_policy = placement_policies[-1]
+                    for retry_chunk in self._fit_row_chunk_attempts(pinned):
+                        cache_attempts.append((final_policy, retry_chunk))
+                    fallback_reason = "fallback_after_oom"
+                    for attempt_index, (attempt_policy, attempt_fit_chunk) in enumerate(cache_attempts):
+                        policy = attempt_policy
+                        attempt_reason = "resolved" if attempt_index == 0 else "oom_retry"
+                        ctx_bundle = None
+                        output = None
                         try:
                             with (
                                 torch.autocast(
@@ -2688,19 +2845,74 @@ class NoriPredictor:
                             )
                             outputs.append(output)
                             cached_done = True
-                            if attempt_fit_chunk is not None and pinned is None:
-                                policy = policy.escalated("context_row_chunk", context_row_chunk=attempt_fit_chunk)
-                                logger.warning("Nori recovered on rung %s", policy.describe())
-                            policy = policy.escalated(
-                                policy.rung, dropped_context_rows=dropped_context_rows, query_chunk=chunk_size
+                            self._record_memory_attempt(
+                                attempt_policy,
+                                pipeline_ids=[id_pipe],
+                                path="cached",
+                                rung=attempt_policy.rung,
+                                context_row_chunk=attempt_fit_chunk,
+                                outcome="success",
+                                reason=attempt_reason,
+                                dropped_context_rows=dropped_context_rows,
                             )
-                            self.memory_report_ = policy.model_dump()
+                            if attempt_policy.cache_dtype == "int8":
+                                # Unlike offload (moves bytes unchanged) or chunking
+                                # (bit-exact by design), quantizing the cache is a
+                                # real fidelity loss -- the DegradedPipelineWarning
+                                # family exists so a scored caller (strict_pipeline())
+                                # can catch exactly this, not just see it in the logs.
+                                self._warn_once_per_call(
+                                    "cache_quantized",
+                                    "Nori quantized the context cache to int8: "
+                                    f"{attempt_policy.describe()}. Predictions carry "
+                                    "a small numerical difference from bf16 (|dR2| ~ "
+                                    "6e-6 measured). Raise memory_policy={'gpu_budget_frac': "
+                                    "...} / 'host_budget_frac' / 'elements_budget' for more "
+                                    "headroom, or set memory_policy={'allow_quantization': "
+                                    "False} to keep every rung bit-exact (offloads sooner "
+                                    "instead).",
+                                    CacheQuantizedWarning,
+                                )
+                            if (
+                                attempt_fit_chunk is not None
+                                and (pinned is None or attempt_fit_chunk < pinned)
+                            ):
+                                policy = attempt_policy.escalated(
+                                    "context_row_chunk",
+                                    context_row_chunk=attempt_fit_chunk)
+                            else:
+                                policy = attempt_policy
+                            if attempt_index > 0:
+                                # Recovered after at least one earlier attempt failed --
+                                # whether via a smaller chunk (above) or precision/
+                                # placement alone. Log it either way, or a lossy/slow
+                                # recovery that never touched context_row_chunk is
+                                # invisible in the logs.
+                                logger.warning(
+                                    "Nori recovered on rung %s", policy.describe())
+                            policy = policy.escalated(
+                                policy.rung, dropped_context_rows=dropped_context_rows,
+                                query_chunk=chunk_size)
+                            self._publish_memory_policy(policy)
                             break
                         except NotImplementedError as exc:
+                            self._record_memory_attempt(
+                                attempt_policy,
+                                pipeline_ids=[id_pipe],
+                                path="cached",
+                                rung=attempt_policy.rung,
+                                context_row_chunk=attempt_fit_chunk,
+                                outcome="unsupported",
+                                reason=attempt_reason,
+                                dropped_context_rows=dropped_context_rows,
+                            )
+                            fallback_reason = "fallback_after_unsupported"
                             # This checkpoint cannot do context-row chunking (serial
                             # sequence attention). If the CALLER pinned it, that is
                             # their error and it propagates. If we chose it ourselves
                             # as an OOM escalation, degrade quietly to the next rung.
+                            self._evict_pipe_cache(id_pipe)
+                            del ctx_bundle, output
                             if pinned is not None:
                                 raise
                             logger.warning(
@@ -2711,20 +2923,33 @@ class NoriPredictor:
                             cached_done = False
                             break
                         except torch.cuda.OutOfMemoryError:
+                            self._record_memory_attempt(
+                                attempt_policy,
+                                pipeline_ids=[id_pipe],
+                                path="cached",
+                                rung=attempt_policy.rung,
+                                context_row_chunk=attempt_fit_chunk,
+                                outcome="oom",
+                                reason=attempt_reason,
+                                dropped_context_rows=dropped_context_rows,
+                            )
+                            self._evict_pipe_cache(id_pipe)
+                            del ctx_bundle, output
                             torch.cuda.empty_cache()
                             cached_done = False
                             # Name the OOM and what happens next, or the escalation is
                             # invisible in the logs and a slow run looks inexplicable.
-                            next_step = (
-                                f"retrying with fit_row_chunk={FIT_ROW_CHUNK_ON_OOM}"
-                                if attempt_fit_chunk is None and pinned is None
-                                else "falling back to the plain chunked loop"
-                            )
+                            if attempt_index + 1 < len(cache_attempts):
+                                next_policy, next_chunk = cache_attempts[attempt_index + 1]
+                                next_step = (
+                                    f"retrying rung {next_policy.rung} "
+                                    f"with context_row_chunk={next_chunk}"
+                                )
+                            else:
+                                next_step = "falling back to the plain chunked loop"
                             logger.warning(
-                                "Nori OOM on rung %s (fit_row_chunk=%s); %s",
-                                policy.rung,
-                                attempt_fit_chunk,
-                                next_step,
+                                "Nori OOM on rung %s (context_row_chunk=%s); %s",
+                                policy.rung, attempt_fit_chunk, next_step,
                             )
                 if not cached_done:
                     # Every cached rung failed, or the policy never chose one. This
@@ -2750,77 +2975,98 @@ class NoriPredictor:
                         self._log_once_per_call("plain_loop", logging.WARNING, msg)
                         self._warn_once_per_call("plain_loop", msg, RuntimeWarning)
                     else:
-                        policy = policy.escalated(policy.rung, dropped_context_rows=dropped_context_rows)
-                    self.memory_report_ = policy.model_dump()
+                        policy = policy.escalated(
+                            policy.rung, dropped_context_rows=dropped_context_rows)
+                    self._publish_memory_policy(policy)
 
                 # Chunk the test data (skipped entirely if the cached path ran)
-                all_outputs = []
-                for i in [] if cached_done else range(0, n_samples_test, chunk_size):
-                    end_idx = min(i + chunk_size, n_samples_test)
-                    x_chunk_test = x_[len(y_train) + i : len(y_train) + end_idx]
+                try:
+                    all_outputs = []
+                    for i in ([] if cached_done else range(0, n_samples_test, chunk_size)):
+                        end_idx = min(i + chunk_size, n_samples_test)
+                        x_chunk_test = x_[len(y_train) + i : len(y_train) + end_idx]
+                    
+                        # Recombine train + test chunk
+                        x_chunk_combined = torch.cat([x_[:len(y_train)], x_chunk_test], dim=0)
+                    
+                        # Create dummy y for test chunk
+                        y_chunk_test = torch.zeros(end_idx - i, dtype=y_.dtype, device=y_.device)
+                        y_chunk_combined = torch.cat([y_[:len(y_train)], y_chunk_test], dim=0)
 
-                    # Recombine train + test chunk
-                    x_chunk_combined = torch.cat([x_[: len(y_train)], x_chunk_test], dim=0)
+                        self.model.to(self.device)
+                        with torch.autocast(device_type=self.device.type if isinstance(self.device, torch.device) else self.device, enabled=self.mix_precision), torch.inference_mode():
+                            x_in = x_chunk_combined.unsqueeze(0)
+                            y_in = y_chunk_combined.unsqueeze(0)
 
-                    # Create dummy y for test chunk
-                    y_chunk_test = torch.zeros(end_idx - i, dtype=y_.dtype, device=y_.device)
-                    y_chunk_combined = torch.cat([y_[: len(y_train)], y_chunk_test], dim=0)
+                            chunk_output = self.model(
+                                x=x_in, y=y_in, eval_pos=len(y_train), task_type='reg'
+                            )
 
-                    self.model.to(self.device)
-                    with (
-                        torch.autocast(
-                            device_type=self.device.type if isinstance(self.device, torch.device) else self.device,
-                            enabled=self.mix_precision,
-                        ),
-                        torch.inference_mode(),
-                    ):
-                        x_in = x_chunk_combined.unsqueeze(0)
-                        y_in = y_chunk_combined.unsqueeze(0)
-
-                        chunk_output = self.model(x=x_in, y=y_in, eval_pos=len(y_train), task_type="reg")
-
-                    if self.mask_prediction:
-                        process_config = chunk_output["process_config"]
-                        chunk_output_feature_pred = self.PostProcessInModel(
-                            chunk_output["feature_pred"], process_config
-                        )
-                        source_row_indices = np.concatenate(
-                            (
+                        if self.mask_prediction:
+                            process_config = chunk_output['process_config']
+                            chunk_output_feature_pred = self.PostProcessInModel(chunk_output['feature_pred'], process_config)
+                            source_row_indices = np.concatenate((
                                 np.arange(len(y_train), dtype=np.int64),
                                 np.arange(
                                     len(y_train) + i,
                                     len(y_train) + end_idx,
                                     dtype=np.int64,
                                 ),
+                            ))
+                            chunk_output_feature_pred = self.PostProcess(
+                                chunk_output_feature_pred,
+                                pipe,
+                                process_config,
+                                source_row_indices=source_row_indices,
+                            )
+                            pipeline_mask_chunks.append(chunk_output_feature_pred)
+                            chunk_output = chunk_output['reg_output']
+
+                        chunk_output = self._unwrap_model_output(
+                            chunk_output, task_type="reg"
+                        ).squeeze(0)
+                        chunk_output = self._reject_nonfinite_output(
+                            chunk_output, path="plain chunked loop",
+                            n_train=n_samples_train, n_test=end_idx - i)
+                        all_outputs.append(chunk_output)
+
+                    # Concatenate all test chunks (cached path already appended above)
+                    if not cached_done:
+                        output = torch.cat(all_outputs, dim=0)
+                        outputs.append(output)
+                    if pipeline_mask_chunks:
+                        mask_predictions.append(
+                            self._aggregate_feature_reconstruction_chunks(
+                                pipeline_mask_chunks,
+                                len(y_train),
                             )
                         )
-                        chunk_output_feature_pred = self.PostProcess(
-                            chunk_output_feature_pred,
-                            pipe,
-                            process_config,
-                            source_row_indices=source_row_indices,
+                    if not cached_done:
+                        self._record_memory_attempt(
+                            policy,
+                            pipeline_ids=[id_pipe],
+                            path="plain_loop",
+                            rung=policy.rung,
+                            context_row_chunk=None,
+                            outcome="success",
+                            reason=fallback_reason,
+                            dropped_context_rows=dropped_context_rows,
                         )
-                        pipeline_mask_chunks.append(chunk_output_feature_pred)
-                        chunk_output = chunk_output["reg_output"]
-
-                    chunk_output = self._unwrap_model_output(chunk_output, task_type="reg").squeeze(0)
-                    chunk_output = self._reject_nonfinite_output(
-                        chunk_output, path="plain chunked loop", n_train=n_samples_train, n_test=end_idx - i
+                except torch.cuda.OutOfMemoryError:
+                    self._record_memory_attempt(
+                        policy,
+                        pipeline_ids=[id_pipe],
+                        path="plain_loop",
+                        rung=policy.rung,
+                        context_row_chunk=None,
+                        outcome="oom",
+                        reason=fallback_reason,
+                        dropped_context_rows=dropped_context_rows,
                     )
-                    all_outputs.append(chunk_output)
-
-                # Concatenate all test chunks (cached path already appended above)
-                if not cached_done:
-                    output = torch.cat(all_outputs, dim=0)
-                    outputs.append(output)
-                if pipeline_mask_chunks:
-                    mask_predictions.append(
-                        self._aggregate_feature_reconstruction_chunks(
-                            pipeline_mask_chunks,
-                            len(y_train),
-                        )
-                    )
-
+                    self._evict_pipe_cache(id_pipe)
+                    torch.cuda.empty_cache()
+                    raise
+            
         output = torch.stack(outputs).mean(dim=0)
         if return_distribution:
             # Return the ensemble-averaged decoder output BEFORE collapse: the

--- a/src/synthefy_nori/model/kv_cache_scaling.py
+++ b/src/synthefy_nori/model/kv_cache_scaling.py
@@ -12,10 +12,11 @@ module lets that cache be:
 dequantizing + staging to the compute device lazily when the attention code reads
 ``cache["kv"]`` — so it is transparent to ``MultiheadAttention.forward_with_kv_cache``.
 
-This mirrors TabPFN-3's serving recipe (int8 KV + host offload + chunked prefill):
-GPU high-water-mark stays ~flat in N (weights + per-chunk activations + a staged
-slice), while the O(N) cache lives in host RAM. Compute is unchanged; this is a
-memory lever only.
+This follows the int8/offload/chunked-prefill serving recipe: the O(N) stored
+cache may live in host RAM and fit-time chunk-local transients are bounded. The
+current layer path still keeps O(N) input/self-KV tensors on GPU and stages a
+full layer during decode, so total GPU high-water can still grow with N.
+
 """
 
 from __future__ import annotations

--- a/src/synthefy_nori/model/kv_cache_scaling.py
+++ b/src/synthefy_nori/model/kv_cache_scaling.py
@@ -12,10 +12,12 @@ module lets that cache be:
 dequantizing + staging to the compute device lazily when the attention code reads
 ``cache["kv"]`` — so it is transparent to ``MultiheadAttention.forward_with_kv_cache``.
 
-This follows the int8/offload/chunked-prefill serving recipe: the O(N) stored
-cache may live in host RAM and fit-time chunk-local transients are bounded. The
-current layer path still keeps O(N) input/self-KV tensors on GPU and stages a
-full layer during decode, so total GPU high-water can still grow with N.
+``ScalableSeqKV`` implements the legacy int8/offload recipe and may still stage a
+full layer during decode. ``BlockwiseSeqKV`` is the fail-closed representation
+for bounded prefill: full-N activations and self-attention K/V blocks stay in host RAM, and online-softmax
+attention stages only a bounded row slice on the compute device. Explicit context
+streaming also keeps the reusable cross-cache on the host; the private hybrid
+prefill keeps that cache resident in directly preallocated INT8 storage.
 
 """
 
@@ -176,6 +178,208 @@ class ScalableSeqKV:
         return self._kv.numel() * self._kv.element_size()
 
 
+class BlockwiseSeqKV:
+    """Blockwise K/V storage for genuinely bounded-device attention.
+
+    ``ScalableSeqKV`` lowers *resident* GPU memory, but ``cache["kv"]`` still
+    reconstructs one complete layer on the compute device before SDPA runs. This
+    representation has no full-tensor accessor: consumers must iterate bounded
+    blocks through :meth:`iter_kv_blocks`.
+
+    Explicit context streaming stores the blocks on the host. The hybrid resident
+    INT8 prefill stores one directly preallocated quantized payload on the compute
+    device and exposes disjoint row views of it. Both avoid a full-layer BF16/FP32
+    reconstruction, and an accidental ``cache["kv"]`` read fails loudly.
+    """
+
+    def __init__(
+        self,
+        blocks: list[tuple[torch.Tensor, torch.Tensor | None]],
+        batch: int,
+        groups: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        quantized: bool,
+        offloaded: bool = True,
+    ):
+        if not blocks:
+            raise ValueError("BlockwiseSeqKV requires at least one K/V block")
+        self.batch = int(batch)
+        self.groups = int(groups)
+        self.device = torch.device(device)
+        self.dtype = dtype
+        self.quantized = bool(quantized)
+        self.offloaded = bool(offloaded)
+        self._blocks = blocks
+        self.n_rows = sum(int(payload.shape[1]) for payload, _ in blocks)
+        self.max_block_rows = max(int(payload.shape[1]) for payload, _ in blocks)
+        # Diagnostic used by reports/tests. It is reset at the start of each scan.
+        self.max_staged_rows = 0
+
+    def __getitem__(self, key: str):
+        if key == "batch":
+            return self.batch
+        if key == "groups":
+            return self.groups
+        if key == "kv":
+            raise RuntimeError(
+                "BlockwiseSeqKV cannot materialize a full layer on the compute "
+                "device; consume iter_kv_blocks() with online-softmax attention"
+            )
+        raise KeyError(key)
+
+    @classmethod
+    def from_row_slices(
+        cls,
+        slices,
+        batch: int,
+        groups: int,
+        *,
+        quantize: bool,
+        device: torch.device,
+        dtype: torch.dtype | None = None,
+        offload: bool = True,
+        n_rows: int | None = None,
+    ) -> "BlockwiseSeqKV":
+        """Consume projected row slices without a concatenation peak.
+
+        Host-offloaded caches retain separate CPU blocks. Resident INT8 caches
+        preallocate their final payload and scale tensors once, then copy each
+        quantized row slice directly into its destination. The exposed blocks are
+        disjoint views of that storage, so online attention never reconstructs a
+        full BF16 or FP32 layer.
+        """
+        if not offload:
+            if not quantize:
+                raise ValueError("resident blockwise K/V requires quantize=True")
+            if n_rows is None or n_rows <= 0:
+                raise ValueError("resident blockwise K/V requires a positive n_rows")
+            iterator = iter(slices)
+            try:
+                first_slice = next(iterator)
+            except StopIteration as exc:
+                raise ValueError("from_row_slices got no slices; nothing to cache") from exc
+            if dtype is None:
+                dtype = first_slice.dtype
+            target_device = torch.device(device)
+            first_payload, first_scale = quantize_int8(first_slice)
+            payload_shape = (*first_payload.shape[:1], n_rows, *first_payload.shape[2:])
+            scale_shape = (*first_scale.shape[:1], n_rows, *first_scale.shape[2:])
+            payload_storage = torch.empty(payload_shape, dtype=first_payload.dtype, device=target_device)
+            scale_storage = torch.empty(scale_shape, dtype=first_scale.dtype, device=target_device)
+            blocks: list[tuple[torch.Tensor, torch.Tensor | None]] = []
+            offset = 0
+
+            def store(payload: torch.Tensor, scale: torch.Tensor) -> None:
+                nonlocal offset
+                width = int(payload.shape[1])
+                end = offset + width
+                if end > n_rows:
+                    raise ValueError(f"row slices exceed declared n_rows={n_rows}")
+                payload_view = payload_storage[:, offset:end]
+                scale_view = scale_storage[:, offset:end]
+                payload_view.copy_(payload)
+                scale_view.copy_(scale)
+                blocks.append((payload_view, scale_view))
+                offset = end
+
+            store(first_payload, first_scale)
+            del first_slice, first_payload, first_scale
+            for kv_slice in iterator:
+                payload, scale = quantize_int8(kv_slice)
+                store(payload, scale)
+                del kv_slice, payload, scale
+            if offset != n_rows:
+                raise ValueError(f"row slices covered {offset} rows, expected n_rows={n_rows}")
+            return cls(
+                blocks,
+                batch,
+                groups,
+                device=target_device,
+                dtype=dtype,
+                quantized=True,
+                offloaded=False,
+            )
+
+        blocks: list[tuple[torch.Tensor, torch.Tensor | None]] = []
+        for kv_slice in slices:
+            if dtype is None:
+                dtype = kv_slice.dtype
+            if quantize:
+                payload, scale = quantize_int8(kv_slice)
+                host_payload = payload.detach().to("cpu")
+                host_scale = scale.detach().to("cpu")
+                blocks.append((host_payload, host_scale))
+                del payload, scale, host_payload, host_scale
+            else:
+                host_payload = kv_slice.detach().to("cpu")
+                blocks.append((host_payload, None))
+                del host_payload
+            del kv_slice
+        if dtype is None:
+            raise ValueError("from_row_slices got no slices; nothing to cache")
+        return cls(
+            blocks,
+            batch,
+            groups,
+            device=device,
+            dtype=dtype,
+            quantized=quantize,
+            offloaded=True,
+        )
+
+    def iter_kv_blocks(self, block_rows: int | None = None):
+        """Yield full-precision K/V blocks on the compute device, in row order."""
+        if block_rows is not None and block_rows <= 0:
+            raise ValueError("block_rows must be positive")
+        self.max_staged_rows = 0
+        for payload, stored_scale in self._blocks:
+            stored_rows = int(payload.shape[1])
+            step = stored_rows if block_rows is None else min(block_rows, stored_rows)
+            for start in range(0, stored_rows, step):
+                end = min(start + step, stored_rows)
+                # Slice while still on CPU. Transferring then slicing would recreate
+                # the full-layer staging allocation this path promises not to make.
+                staged_payload = payload[:, start:end].to(self.device, non_blocking=True)
+                if self.quantized:
+                    assert stored_scale is not None
+                    staged_scale = stored_scale[:, start:end].to(self.device, non_blocking=True)
+                    kv = dequantize_int8(staged_payload, staged_scale, self.dtype)
+                else:
+                    kv = staged_payload
+                self.max_staged_rows = max(self.max_staged_rows, end - start)
+                yield kv
+                # A generator retains locals across ``yield``. Release the staged
+                # block before the next host slice is transferred so peak staging is
+                # one block, not the previous and current block together.
+                del kv, staged_payload
+                if self.quantized:
+                    del staged_scale
+
+    def resident_gpu_bytes(self) -> int:
+        """Bytes retained on the compute device between iterator steps."""
+        if self.offloaded:
+            return 0
+        total = 0
+        for payload, scale in self._blocks:
+            total += payload.numel() * payload.element_size()
+            if scale is not None:
+                total += scale.numel() * scale.element_size()
+        return total
+
+    def host_bytes(self) -> int:
+        """Bytes retained by the host block list."""
+        if not self.offloaded:
+            return 0
+        total = 0
+        for payload, scale in self._blocks:
+            total += payload.numel() * payload.element_size()
+            if scale is not None:
+                total += scale.numel() * scale.element_size()
+        return total
+
+
 def scale_caches(
     caches: list[dict], *, quantize: bool = False, offload: bool = False, device: torch.device | None = None
 ) -> list[dict]:
@@ -185,7 +389,7 @@ def scale_caches(
         return caches
     for layer_cache in caches:
         skv = layer_cache.get("seq_kv")
-        if skv is None or isinstance(skv, ScalableSeqKV):
+        if skv is None or isinstance(skv, (ScalableSeqKV, BlockwiseSeqKV)):
             continue
         if "kv" not in skv:  # delta/isab cache is the O(M) landmark memory, already tiny
             continue

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -1,17 +1,85 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from typing import Callable, Literal, Optional
 import functools
+import inspect
+from typing import Callable, Literal, Optional
 import math
 import os
 
 import torch
 import torch.nn as nn
 from torch.nn.attention import SDPBackend, sdpa_kernel
+import torch.nn.attention.flex_attention as flex_attention_module
 from torch.utils.checkpoint import checkpoint
+from synthefy_nori.model.kv_cache_scaling import BlockwiseSeqKV, ScalableSeqKV, scale_caches
 from functools import partial
 from torch.amp import autocast
+
+# Hard ceiling for the only block-local tensor whose width is Q x K: the FP32
+# attention score/weight workspace. The row cap below derives K from the actual
+# [batch*groups, heads, query_rows] shape, so a caller may request a larger
+# context_row_chunk without making this tensor grow past 256 MiB.
+BLOCKWISE_SCORE_WORKSPACE_BYTES = 256 * 1024**2
+FP32_ELEMENT_BYTES = 4
+
+flex_attention = flex_attention_module.flex_attention
+_FLEX_SUPPORTS_RETURN_AUX = "return_aux" in inspect.signature(flex_attention).parameters
+_FLEX_AUX_REQUEST = getattr(flex_attention_module, "AuxRequest", None)
+if _FLEX_SUPPORTS_RETURN_AUX and _FLEX_AUX_REQUEST is None:
+    raise RuntimeError("FlexAttention exposes return_aux without AuxRequest")
+_FLEX_LSE_REQUEST = _FLEX_AUX_REQUEST(lse=True) if _FLEX_SUPPORTS_RETURN_AUX else None
+
+
+@functools.lru_cache(maxsize=1)
+def _compiled_flex_attention():
+    """Compile FlexAttention once for streamed CUDA K/V blocks."""
+    return torch.compile(flex_attention)
+
+
+def _flex_attention_with_lse(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    scale: float,
+    enable_gqa: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run fused exact attention and retain each block's softmax normalizer."""
+    compiled = _compiled_flex_attention()
+    if _FLEX_LSE_REQUEST is not None:
+        out, aux = compiled(
+            q,
+            k,
+            v,
+            scale=scale,
+            enable_gqa=enable_gqa,
+            return_aux=_FLEX_LSE_REQUEST,
+        )
+        if aux.lse is None:
+            raise RuntimeError("FlexAttention did not return the requested LSE")
+        return out, aux.lse
+    out, lse = compiled(
+        q,
+        k,
+        v,
+        scale=scale,
+        enable_gqa=enable_gqa,
+        return_lse=True,
+    )
+    return out, lse
+
+
+# Internal defines HAVE_FLASH_ATTN / HAVE_FLASH_ATTN_4 here and dispatches
+# cached attention to flash-attn when present. This tier has no flash path, so
+# the probes are omitted rather than left as unread constants. It also disables
+# cuDNN SDPA process-wide at import; the per-call sdpa_kernel guard below does
+# the same job without mutating global torch state, so that block is omitted too.
+
+#: Working dtype for the FlexAttention blockwise kernel. Named for the flash
+#: kernels it was introduced alongside; the blockwise path uses it whether or
+#: not flash-attn is installed.
+FLASH_ATTN_DTYPE = torch.bfloat16
 
 from typing_extensions import override
 
@@ -442,18 +510,14 @@ class MultiheadAttention(torch.nn.Module):
         else:
             kv = torch.nn.functional.linear(
                 x_kv_flat,
-                kv_proj_weight.reshape(
-                    2 * self.num_heads * self.head_dim, self.embed_dim
-                ),
-            ).view(
-                *x_kv_flat.shape[:-1], 2, self.num_heads, self.head_dim
-            )
+                kv_proj_weight.reshape(2 * self.num_heads * self.head_dim, self.embed_dim),
+            ).view(*x_kv_flat.shape[:-1], 2, self.num_heads, self.head_dim)
         return {"kv": kv.contiguous(), "batch": B, "groups": S}
 
     def forward_with_kv_cache(
         self,
         x: torch.Tensor,
-        kv_cache: dict[str, torch.Tensor | int],
+        kv_cache: dict[str, torch.Tensor | int] | BlockwiseSeqKV,
         *,
         calculate_sample_attention: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -472,17 +536,37 @@ class MultiheadAttention(torch.nn.Module):
             x_flat,
             q_proj_weight.reshape(self.num_heads * self.head_dim, self.embed_dim),
         ).view(*x_flat.shape[:-1], self.num_heads, self.head_dim)
-        kv = kv_cache["kv"]
-        assert isinstance(kv, torch.Tensor)
+        blockwise = isinstance(kv_cache, BlockwiseSeqKV)
+        kv = None if blockwise else kv_cache["kv"]
+        if kv is not None:
+            assert isinstance(kv, torch.Tensor)
+        n_keys = kv_cache.n_rows if blockwise else int(kv.shape[1])
         if self.use_qassmax:
-            q = self.apply_qassmax(q, kv.shape[1])
+            q = self.apply_qassmax(q, n_keys)
 
-        kv_perhead = self._kv_for_kernel(kv, needs_explicit_heads=False)
-        atten_out = self.compute_attention_by_torch(None, q, kv_perhead, None)
+        if blockwise:
+            if calculate_sample_attention:
+                raise NotImplementedError("sample-attention diagnostics are not available for streamed K/V")
+            if self._attention_dropout_p() != 0.0:
+                raise RuntimeError("blockwise K/V attention is inference-only (dropout must be zero)")
+            # ``compute_attention_by_torch`` applies the logN / learnable
+            # temperature to q itself, which the blockwise path does not go
+            # through — so apply it here to give both paths the same effective
+            # query. Internal instead folds that factor into an ``sdpa_scale``
+            # argument; passing None keeps this tier's already-scaled q on the
+            # blockwise kernel's default 1/sqrt(head_dim).
+            q = self._apply_extra_attn_scale(q, n_keys)
+            atten_out = self.compute_attention_blockwise(q, kv_cache, sdpa_scale=None)
+        else:
+            kv_perhead = self._kv_for_kernel(kv, needs_explicit_heads=False)
+            atten_out = self.compute_attention_by_torch(None, q, kv_perhead, None)
 
         atten_out = atten_out.reshape(x_flat.shape[0], x_flat.shape[1], self.num_heads, self.head_dim)
         sample_attention = None
         if calculate_sample_attention:
+            # Broadcast a single-head (MQA) cache so the diagnostic score has
+            # the same per-head shape it had when the cache was materialized.
+            assert kv is not None
             k, _ = self._kv_for_kernel(kv, needs_explicit_heads=True).unbind(dim=2)
             sample_attention = self.caculate_attention_score(q[-1], k[-1])
         out = torch.einsum(
@@ -491,6 +575,170 @@ class MultiheadAttention(torch.nn.Module):
             self.out_proj_weight,
         )
         return out.reshape(B, S, *out.shape[1:]), sample_attention
+
+    def compute_attention_blockwise(
+        self,
+        q: torch.Tensor,
+        kv_cache: BlockwiseSeqKV,
+        *,
+        sdpa_scale: float | None = None,
+    ) -> torch.Tensor:
+        """Exact-context attention with a stable online softmax over CPU K/V blocks.
+
+        ``q`` is ``[BG, Q, H, D]`` and every yielded K/V block is
+        ``[BG, Kb, 2, Hkv, D]`` (``Hkv`` is either ``H`` or one for MQA). The
+        accumulator is FP32 and has no key-length dimension, so GPU working memory
+        is O(Q * H * D + block_rows * Hkv * D), independent of total context rows.
+        The total key count was already used for QASS/log-N/temperature before this
+        method is called; block size never changes model scaling.
+        """
+        if self._attention_dropout_p() != 0.0:
+            raise RuntimeError("blockwise K/V attention is inference-only (dropout must be zero)")
+
+        if kv_cache.device != q.device:
+            raise RuntimeError(
+                "streamed K/V cache device does not match the query/model device: "
+                f"cache={kv_cache.device}, query={q.device}; rebuild the context cache"
+            )
+        if q.device.type == "cuda":
+            return self._compute_attention_blockwise_flex(
+                q,
+                kv_cache,
+                sdpa_scale=sdpa_scale,
+            )
+        batch_groups, n_query, n_heads, head_dim = q.shape
+        score_bytes_per_key_row = batch_groups * n_heads * n_query * FP32_ELEMENT_BYTES
+        # At least one key row must be processed. If even one row exceeds the
+        # workspace target, adaptive query chunking is the remaining lever.
+        score_limited_rows = max(
+            1,
+            BLOCKWISE_SCORE_WORKSPACE_BYTES // max(score_bytes_per_key_row, 1),
+        )
+        block_rows = min(kv_cache.max_block_rows, score_limited_rows)
+        running_max = torch.full(
+            (batch_groups, n_heads, n_query, 1),
+            float("-inf"),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        denominator = torch.zeros_like(running_max)
+        numerator = torch.zeros(
+            (batch_groups, n_heads, n_query, head_dim),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        scale = (1.0 / math.sqrt(float(head_dim))) if sdpa_scale is None else sdpa_scale
+        q_fp32 = q.to(torch.float32)
+
+        for kv_block in kv_cache.iter_kv_blocks(block_rows=block_rows):
+            if kv_block.ndim != 5 or kv_block.shape[0] != batch_groups:
+                raise ValueError(f"streamed K/V block must be [BG, K, 2, Hkv, D], got {tuple(kv_block.shape)}")
+            k, v = kv_block.unbind(dim=2)
+            k_fp32 = k.to(torch.float32)
+            v_fp32 = v.to(torch.float32)
+            logits = torch.einsum("bqhd,bkhd->bhqk", q_fp32, k_fp32) * scale
+            block_max = logits.amax(dim=-1, keepdim=True)
+            new_max = torch.maximum(running_max, block_max)
+            old_scale = torch.where(
+                denominator > 0,
+                torch.exp(running_max - new_max),
+                torch.zeros_like(new_max),
+            )
+            # Reuse the score allocation as softmax weights. Keeping both FP32
+            # [BG,H,Q,K] tensors doubled the very workspace this path bounds.
+            logits.sub_(new_max).exp_()
+            block_denominator = logits.sum(dim=-1, keepdim=True)
+            block_numerator = torch.einsum("bhqk,bkhd->bhqd", logits, v_fp32)
+            numerator = numerator * old_scale + block_numerator
+            denominator = denominator * old_scale + block_denominator
+            running_max = new_max
+            del (
+                kv_block,
+                k,
+                v,
+                k_fp32,
+                v_fp32,
+                logits,
+                block_max,
+                new_max,
+                old_scale,
+                block_denominator,
+                block_numerator,
+            )
+
+        # BlockwiseSeqKV rejects an empty cache and this path has no attention mask,
+        # so every query has positive mass. Avoid a device sync just to re-prove it.
+        return (numerator / denominator).to(q.dtype).permute(0, 2, 1, 3)
+
+    def _compute_attention_blockwise_flex(
+        self,
+        q: torch.Tensor,
+        kv_cache: BlockwiseSeqKV,
+        *,
+        sdpa_scale: float | None = None,
+    ) -> torch.Tensor:
+        """Fuse each K/V block and merge its normalized output by exact LSE.
+
+        FlexAttention never materializes ``[BG, H, Q, K]`` scores. Each call
+        returns the block-local normalized output and log-sum-exp; combining
+        those pairs in FP32 is algebraically identical to one softmax over all
+        context rows while retaining only O(BG * H * Q * D) accumulators.
+        """
+        batch_groups, n_query, n_heads, head_dim = q.shape
+        scale = (1.0 / math.sqrt(float(head_dim))) if sdpa_scale is None else sdpa_scale
+        q_flex = q.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
+        running_lse = torch.full(
+            (batch_groups, n_heads, n_query),
+            float("-inf"),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        running_output = torch.zeros(
+            (batch_groups, n_heads, n_query, head_dim),
+            device=q.device,
+            dtype=torch.float32,
+        )
+
+        for kv_block in kv_cache.iter_kv_blocks():
+            if kv_block.ndim != 5 or kv_block.shape[0] != batch_groups:
+                raise ValueError(f"streamed K/V block must be [BG, K, 2, Hkv, D], got {tuple(kv_block.shape)}")
+            k, v = kv_block.unbind(dim=2)
+            k_flex = k.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
+            v_flex = v.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
+            block_output, block_lse = _flex_attention_with_lse(
+                q_flex,
+                k_flex,
+                v_flex,
+                scale=scale,
+                enable_gqa=k_flex.shape[1] != n_heads,
+            )
+            if block_lse.shape != running_lse.shape:
+                raise RuntimeError(
+                    "FlexAttention returned an unexpected LSE shape: "
+                    f"expected {tuple(running_lse.shape)}, "
+                    f"got {tuple(block_lse.shape)}"
+                )
+            block_lse = block_lse.to(torch.float32)
+            new_lse = torch.logaddexp(running_lse, block_lse)
+            old_weight = torch.exp(running_lse - new_lse).unsqueeze(-1)
+            block_weight = torch.exp(block_lse - new_lse).unsqueeze(-1)
+            running_output.mul_(old_weight)
+            running_output.add_(block_output.to(torch.float32) * block_weight)
+            running_lse = new_lse
+            del (
+                kv_block,
+                k,
+                v,
+                k_flex,
+                v_flex,
+                block_output,
+                block_lse,
+                new_lse,
+                old_weight,
+                block_weight,
+            )
+
+        return running_output.to(q.dtype).permute(0, 2, 1, 3)
 
     def compute_attention_by_torch(
         self, qkv: torch.Tensor | None, q: torch.Tensor | None, kv: torch.Tensor | None, attn_mask: torch.Tensor | None
@@ -965,7 +1213,17 @@ class EncoderBaseLayer(nn.Module):
         return layer_norm(out + residual)
 
     def _project_kv_cache_rowchunked(
-        self, attn_mod, x_kv_src, copy_kv, row_chunk, *, norm=None, offload=False, quantize=False, device=None
+        self,
+        attn_mod,
+        x_kv_src,
+        copy_kv,
+        row_chunk,
+        *,
+        norm=None,
+        offload=False,
+        quantize=False,
+        device=None,
+        streaming=False,
     ):
         """Build attn_mod's K/V cache over the row axis in chunks.
 
@@ -992,15 +1250,15 @@ class EncoderBaseLayer(nn.Module):
             offload: store the finished cache on host RAM.
             quantize: store the finished cache int8.
             device: compute device reads are staged back to.
+            streaming: retain separate blocks and forbid full-device staging.
 
         Returns:
-            A ``ScalableSeqKV`` when quantizing/offloading, else the plain
-            ``{"kv", "batch", "groups"}`` dict.
+            A blockwise cache when streaming, ``ScalableSeqKV`` when merely
+            quantizing/offloading, else the plain cache dict.
         """
-        from synthefy_nori.model.kv_cache_scaling import ScalableSeqKV
-
         N = x_kv_src.shape[1]
         B, groups = x_kv_src.shape[0], x_kv_src.shape[2]
+        compute_device = torch.device(device) if device is not None else attn_mod.qkv_proj_weight.device
 
         def _row_slices():
             """Yield each row-slice's projected K/V, one at a time.
@@ -1011,10 +1269,26 @@ class EncoderBaseLayer(nn.Module):
             for r0 in range(0, N, row_chunk):
                 sl = slice(r0, min(r0 + row_chunk, N))
                 rows = x_kv_src[:, sl]
+                if rows.device != compute_device:
+                    rows = rows.to(compute_device)
                 if norm is not None:
                     rows = norm(rows)
-                yield attn_mod.project_kv_cache(rows.transpose(1, 2), copy_first_head_kv=copy_kv)["kv"]
+                projected = attn_mod.project_kv_cache(rows.transpose(1, 2), copy_first_head_kv=copy_kv)["kv"]
+                del rows
+                yield projected
+                del projected
 
+        if streaming:
+            return BlockwiseSeqKV.from_row_slices(
+                _row_slices(),
+                B,
+                groups,
+                quantize=quantize,
+                device=compute_device,
+                dtype=x_kv_src.dtype,
+                offload=offload,
+                n_rows=N,
+            )
         if not (quantize or offload):
             # Nothing to fold in; the plain dict is what the uninstrumented path uses.
             return {"kv": torch.cat(list(_row_slices()), dim=1), "batch": B, "groups": groups}
@@ -1024,9 +1298,129 @@ class EncoderBaseLayer(nn.Module):
             groups,
             quantize=quantize,
             offload=offload,
-            device=device or x_kv_src.device,
+            device=compute_device,
             dtype=x_kv_src.dtype,
         )
+
+    def _forward_train_cache_streaming(
+        self,
+        x_train,
+        feature_atten_mask,
+        pre_seq_steps,
+        seq_step,
+        post_seq_steps,
+        index1,
+        index2,
+        row_chunk,
+        quantize,
+        device,
+        *,
+        cross_cache_offload=True,
+    ):
+        """Run one context layer with only row-bounded tensors on the GPU.
+
+        The complete layer input/output and self-attention K/V representation live
+        on CPU. Each row block is staged for row-local work; self-attention scans
+        CPU K/V blocks with FP32 online softmax, so neither an N-row activation nor
+        a full layer's BF16 K/V is ever materialized on the GPU. Explicit context
+        streaming also offloads the reusable cross-cache. The private hybrid path
+        instead writes that cache directly into preallocated resident INT8 storage.
+
+        Sequence-serial layers are rejected by the caller: their cross-cache source
+        is the complete self-attention output, which needs a different two-pass
+        schedule to preserve the same semantics.
+        """
+        compute_device = torch.device(device) if device is not None else next(self.parameters()).device
+        if feature_atten_mask is not None:
+            raise NotImplementedError(
+                "stream_context does not yet support feature_atten_mask; staging "
+                "a full mask would violate the bounded-GPU-memory contract"
+            )
+        if x_train.device.type != "cpu":
+            raise ValueError(
+                "stream_context requires CPU-resident context activations; the "
+                "predictor must not upload the full training matrix"
+            )
+        seq_attn_train = self.sequence_attentions[index1]
+        seq_attn_test = self.sequence_attentions[index2]
+        seq_norm = self.layer_norms[seq_step]
+        n_rows = x_train.shape[1]
+
+        def _write_host(source, transform):
+            if n_rows <= 0:
+                raise ValueError("stream_context received an empty context")
+            for row_start in range(0, n_rows, row_chunk):
+                row_end = min(row_start + row_chunk, n_rows)
+                row_slice = slice(row_start, row_end)
+                staged = source[:, row_slice].to(compute_device)
+                staged = transform(staged)
+                host = staged.detach().to("cpu")
+                source[:, row_slice].copy_(host)
+                del staged, host
+            return source
+
+        def _run_steps(staged, steps):
+            for step_idx in steps:
+                staged = self._run_non_sequence_step(
+                    staged,
+                    step_idx=step_idx,
+                    feature_atten_mask=feature_atten_mask,
+                    eval_pos=staged.shape[1],
+                )
+            return staged
+
+        # FMFMSM's feature/MLP steps are row-local, but every row must reach the
+        # sequence-attention input before any K/V is projected.
+        prepared = _write_host(x_train, lambda rows: _run_steps(rows, pre_seq_steps)) if pre_seq_steps else x_train
+        del x_train
+        norm = seq_norm if self.pre_norm else None
+
+        def _project(module, copy_first_head, *, quantize_cache, offload_cache):
+            return self._project_kv_cache_rowchunked(
+                module,
+                prepared,
+                copy_first_head,
+                row_chunk,
+                norm=norm,
+                quantize=quantize_cache,
+                offload=offload_cache,
+                device=compute_device,
+                streaming=True,
+            )
+
+        # Prefill self-attention remains full precision. Only the reusable cross
+        # cache follows cache_dtype=int8, matching the existing cached path.
+        train_cache = _project(
+            seq_attn_train,
+            self.self_share_all_kv_heads,
+            quantize_cache=False,
+            offload_cache=True,
+        )
+        test_cache = _project(
+            seq_attn_test,
+            self.cross_share_all_kv_heads,
+            quantize_cache=quantize,
+            offload_cache=cross_cache_offload,
+        )
+
+        def _self_attention_and_post(rows):
+            residual = rows
+            if self.pre_norm:
+                attention = seq_attn_train.forward_with_kv_cache(
+                    seq_norm(rows).transpose(1, 2),
+                    train_cache,
+                )[0].transpose(1, 2)
+                rows = self._residual_add(residual, attention)
+            else:
+                attention = seq_attn_train.forward_with_kv_cache(
+                    rows.transpose(1, 2),
+                    train_cache,
+                )[0].transpose(1, 2)
+                rows = seq_norm(attention + residual)
+            return _run_steps(rows, post_seq_steps)
+
+        output = _write_host(prepared, _self_attention_and_post)
+        return output, {"seq_kv": test_cache}
 
     def _forward_train_cache_memsaving(
         self,
@@ -1113,6 +1507,8 @@ class EncoderBaseLayer(nn.Module):
         quantize_kv_cache: bool = False,
         offload_kv_cache: bool = False,
         device=None,
+        stream_context: bool = False,
+        _hybrid_resident_int8_prefill: bool = False,
     ) -> tuple[torch.Tensor, dict[str, dict[str, torch.Tensor | int]]]:
         """Run the train rows through one layer and cache train K/V for tests.
 
@@ -1124,7 +1520,10 @@ class EncoderBaseLayer(nn.Module):
         memory-bounded build (TabPFN-3-style: chunked queries + in-place
         residual + chunked/offloaded cache projection) that keeps only the
         resident K/V tensor full-size. Supported for non-serial seq attention;
-        serial falls back to the standard monolithic path.
+        serial raises rather than silently ignoring the requested memory cap.
+
+        stream_context additionally keeps full-N activations and every K/V layer
+        on CPU; only ``fit_row_chunk`` rows are staged on the compute device.
         """
 
         if self.layer_arch == "fmfmsm":
@@ -1151,12 +1550,39 @@ class EncoderBaseLayer(nn.Module):
         # requested memory lever is how a caller ends up believing the cap applied
         # while the build still peaks at O(N); the predictor catches this to decide
         # whether to escalate elsewhere.
-        if fit_row_chunk and self.seq_attn_serial:
+        bounded_prefill = stream_context or _hybrid_resident_int8_prefill
+        if (fit_row_chunk or bounded_prefill) and self.seq_attn_serial:
+            requested = "stream_context" if stream_context else "context_row_chunk"
             raise NotImplementedError(
-                "context_row_chunk is not supported for serial sequence attention: "
+                f"{requested} is not supported for serial sequence attention: "
                 "the serial variant's test cache reads the self-attention output, so "
-                "the chunked build would have to materialise all rows anyway. Use "
-                "memory={'context_row_chunk': None} on this checkpoint."
+                "the bounded build needs a different two-pass schedule. Use a "
+                "non-serial checkpoint for streaming, or disable context_row_chunk "
+                "only when the full context safely fits."
+            )
+        if bounded_prefill:
+            if not fit_row_chunk:
+                requested = "stream_context" if stream_context else "hybrid resident INT8 prefill"
+                raise ValueError(f"{requested} requires a concrete context_row_chunk")
+            if stream_context and not offload_kv_cache:
+                raise ValueError("stream_context requires offload_kv_cache=True")
+            if _hybrid_resident_int8_prefill and (stream_context or offload_kv_cache or not quantize_kv_cache):
+                raise ValueError(
+                    "hybrid resident INT8 prefill requires stream_context=False, "
+                    "offload_kv_cache=False, and quantize_kv_cache=True"
+                )
+            return self._forward_train_cache_streaming(
+                x_train,
+                feature_atten_mask,
+                pre_seq_steps,
+                seq_step,
+                post_seq_steps,
+                index1,
+                index2,
+                fit_row_chunk,
+                quantize_kv_cache,
+                device,
+                cross_cache_offload=not _hybrid_resident_int8_prefill,
             )
         if fit_row_chunk:
             return self._forward_train_cache_memsaving(
@@ -1377,8 +1803,8 @@ class LayerStack(nn.Module):
         offload = kwargs.get("offload_kv_cache", False)
         device = kwargs.get("device", None)
         fit_row_chunk = kwargs.get("fit_row_chunk", None)
-        if quantize or offload:
-            from synthefy_nori.model.kv_cache_scaling import scale_caches
+        stream_context = kwargs.get("stream_context", False)
+        hybrid_resident_int8_prefill = kwargs.get("_hybrid_resident_int8_prefill", False)
         for layer in self.layers:
             x_train, layer_cache = layer.forward_train_cache(
                 x_train,
@@ -1387,8 +1813,10 @@ class LayerStack(nn.Module):
                 quantize_kv_cache=quantize,
                 offload_kv_cache=offload,
                 device=device,
+                stream_context=stream_context,
+                _hybrid_resident_int8_prefill=hybrid_resident_int8_prefill,
             )
-            if quantize or offload:
+            if (quantize or offload) and not stream_context and not hybrid_resident_int8_prefill:
                 # Scale in place, per layer: the full-precision GPU tensor is
                 # dropped as soon as the CPU/int8 copy is stored, so the next
                 # layer builds against a freed allocator slot. (No-op if the

--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -24,6 +24,11 @@ _SDPA_BACKENDS_WITHOUT_CUDNN = [
     SDPBackend.MATH,
 ]
 
+# PyTorch SDPA grids one CUDA dimension over batch/head pairs. Keep each
+# launch within that dimension's portable limit; larger independent batches
+# are split in ``compute_attention_by_torch``.
+SDPA_BATCH_HEAD_LIMIT = 65_535
+
 ACTIVATION_FN: dict[str, Callable[[torch.Tensor], torch.Tensor]] = {
     "gelu": nn.GELU(),
     "relu": nn.ReLU(),
@@ -430,9 +435,19 @@ class MultiheadAttention(torch.nn.Module):
             # below materializes num_heads identical K/V copies and defeats
             # the memory-saving purpose of MQA.
             kv_weights = kv_proj_weight[:, :1]
+            # This head slice is strided in the packed [Q,K,V] parameter.
+            # Reshaping it for F.linear copies the weights on every cache
+            # build, which is slower than einsum for this MQA-only branch.
             kv = torch.einsum("... s, j h d s -> ... j h d", x_kv_flat, kv_weights)
         else:
-            kv = torch.einsum("... s, j h d s -> ... j h d", x_kv_flat, kv_proj_weight)
+            kv = torch.nn.functional.linear(
+                x_kv_flat,
+                kv_proj_weight.reshape(
+                    2 * self.num_heads * self.head_dim, self.embed_dim
+                ),
+            ).view(
+                *x_kv_flat.shape[:-1], 2, self.num_heads, self.head_dim
+            )
         return {"kv": kv.contiguous(), "batch": B, "groups": S}
 
     def forward_with_kv_cache(
@@ -453,7 +468,10 @@ class MultiheadAttention(torch.nn.Module):
             )
         x_flat = x.reshape(-1, *x.shape[-2:])
         q_proj_weight = self.qkv_proj_weight[0]
-        q = torch.einsum("... s, h d s -> ... h d", x_flat, q_proj_weight)
+        q = torch.nn.functional.linear(
+            x_flat,
+            q_proj_weight.reshape(self.num_heads * self.head_dim, self.embed_dim),
+        ).view(*x_flat.shape[:-1], self.num_heads, self.head_dim)
         kv = kv_cache["kv"]
         assert isinstance(kv, torch.Tensor)
         if self.use_qassmax:
@@ -502,12 +520,45 @@ class MultiheadAttention(torch.nn.Module):
         # mutating process-wide torch backend state at import time.
         backend_context = nullcontext() if _ALLOW_CUDNN_SDP else sdpa_kernel(_SDPA_BACKENDS_WITHOUT_CUDNN)
         with backend_context:
+            # q/k/v: [B, seq, num_heads, head_dim]. SDPA grids over (B * num_heads);
+            # above CUDA's 65535 grid-dimension limit it raises "invalid
+            # configuration argument". Feature/sample attention is independent
+            # across the batch dimension, so chunking B and concatenating is
+            # mathematically exact. Keep every legal launch whole: a lower 32768
+            # cutoff needlessly split production shapes such as batch=20,
+            # rows=1536, heads=2 (61440), adding a second SDPA launch and
+            # concatenation in every encoder layer.
+            #
+            # The QASS temperature is already folded into q by
+            # ``_apply_extra_attn_scale`` above, so no explicit ``scale=`` is
+            # passed here — internal instead threads an ``sdpa_scale`` argument,
+            # which is the same quantity applied one step later.
+            B = q.size(0)
+            dropout_p = self._attention_dropout_p()
+            if B * self.num_heads > SDPA_BATCH_HEAD_LIMIT:
+                chunk = max(1, SDPA_BATCH_HEAD_LIMIT // max(self.num_heads, 1))
+                mask_batched = attn_mask is not None and attn_mask.dim() >= 1 and attn_mask.size(0) == B
+                outs = []
+                for s in range(0, B, chunk):
+                    e = min(s + chunk, B)
+                    m = attn_mask[s:e] if mask_batched else attn_mask
+                    o = torch.nn.functional.scaled_dot_product_attention(
+                        q[s:e].transpose(1, 2),
+                        k[s:e].transpose(1, 2),
+                        v[s:e].transpose(1, 2),
+                        attn_mask=m,
+                        dropout_p=dropout_p,
+                        enable_gqa=enable_gqa,
+                    )
+                    outs.append(o.transpose(1, 2))
+                return torch.cat(outs, dim=0)
+
             attention_outputs = torch.nn.functional.scaled_dot_product_attention(
                 q.transpose(1, 2),
                 k.transpose(1, 2),
                 v.transpose(1, 2),
                 attn_mask=attn_mask,
-                dropout_p=self._attention_dropout_p(),
+                dropout_p=dropout_p,
                 enable_gqa=enable_gqa,
             )
         attention_outputs = attention_outputs.transpose(1, 2)

--- a/src/synthefy_nori/model/transformer.py
+++ b/src/synthefy_nori/model/transformer.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from dataclasses import dataclass
 from synthefy_nori.model.layer import EncoderBaseLayer, MLP, LayerStack, RMSNorm
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 
 @dataclass
@@ -31,6 +31,9 @@ class ContextCache:
     - ``valid_feature_num``: the context-only count used by
       ``ValidFeatureEncoder`` to keep feature-group scaling independent of the
       query rows presented in a particular call.
+    - ``query_y_embedding``: the context-derived embedding of one NaN query
+      target. Streaming expands this one row per query chunk instead of encoding
+      ``N_context + N_query`` targets during decode.
     - ``y_train``: context targets, to reconstruct the query y-placeholder embedding
       exactly as the transductive path does (query rows are NaN-masked anyway).
     - ``eval_pos``: number of context rows (``n_train``).
@@ -41,8 +44,11 @@ class ContextCache:
     or query rows get stats derived from THEMSELVES instead of the context: a silent,
     data-dependent divergence rather than an error. With them, the cached
     path stays within float-reassociation distance of the transductive forward (~3e-05
-    on nori-6m) for finite, NaN- and Inf-bearing tables alike; it is bit-identical to
-    ``forward_cached_regression``, which is literally this build/apply pair.
+    on nori-6m) for finite, NaN- and Inf-bearing tables alike. The legacy cached pair
+    is bit-identical to ``forward_cached_regression``, which is literally that
+    build/apply pair. Streamed BF16 preserves the same rows and statistics, but its
+    chunked GEMMs and FP32 online-softmax reduction are only numerically close, not
+    bit-exact.
     """
 
     caches: list
@@ -52,6 +58,7 @@ class ContextCache:
     eval_pos: int
     nan_mean: torch.Tensor | None = None
     valid_feature_num: torch.Tensor | None = None
+    query_y_embedding: torch.Tensor | None = None
 
 
 from synthefy_nori.model.encoders import get_x_encoder, get_cls_y_encoder, get_reg_y_encoder, preprocesss_4_x
@@ -642,7 +649,7 @@ class FeaturesTransformer(nn.Module):
                 which ``NoriPredictor.predict`` resolves before calling here.
             offload_kv_cache: keep the cache in host RAM, streaming slices back.
             fit_row_chunk: bound the fit-time build working set to this many
-                context rows (bit-exact). ``None`` = off.
+                context rows (deterministic, with small floating-point reassociation differences). ``None`` = off.
             adaptive_query_chunk: on a decode OOM, halve the query chunk and
                 retry rather than raising.
             quantize_kv_cache: alias for ``cache_dtype``, accepted so the WS1
@@ -712,6 +719,8 @@ class FeaturesTransformer(nn.Module):
         offload_kv_cache: bool = False,
         fit_row_chunk: int | None = None,
         quantize_kv_cache: bool | None = None,
+        stream_context: bool = False,
+        _hybrid_resident_int8_prefill: bool = False,
     ) -> ContextCache:
         """Encode a fixed context (train) table once into a reusable ``ContextCache``.
 
@@ -723,6 +732,9 @@ class FeaturesTransformer(nn.Module):
 
         ``cache_dtype`` / ``offload_kv_cache`` / ``fit_row_chunk`` behave exactly as
         in :meth:`forward_cached_regression` (which is now a wrapper over this pair).
+        ``stream_context=True`` additionally requires CPU inputs, host offload, and a
+        concrete row cap; it never materializes a full-N activation or K/V layer on
+        the compute device.
         """
         if quantize_kv_cache is not None and cache_dtype == "bf16":
             cache_dtype = "int8" if quantize_kv_cache else "bf16"
@@ -752,6 +764,27 @@ class FeaturesTransformer(nn.Module):
             raise AssertionError("x_train must have at least one context row")
         if y_train.shape[1] < eval_pos:
             raise AssertionError("y_train must cover all context rows")
+        if _hybrid_resident_int8_prefill and (
+            stream_context or offload_kv_cache or cache_dtype != "int8" or fit_row_chunk is None
+        ):
+            raise ValueError(
+                "hybrid resident INT8 prefill requires cache_dtype='int8', "
+                "offload_kv_cache=False, stream_context=False, and a concrete "
+                "context_row_chunk"
+            )
+        if stream_context or _hybrid_resident_int8_prefill:
+            if stream_context and not offload_kv_cache:
+                raise ValueError("stream_context requires offload_kv_cache=True")
+            if fit_row_chunk is None:
+                requested = "stream_context" if stream_context else "hybrid resident INT8 prefill"
+                raise ValueError(f"{requested} requires a concrete context_row_chunk")
+            return self._build_context_cache_streaming(
+                x_train,
+                y_train[:, :eval_pos],
+                cache_dtype=cache_dtype,
+                fit_row_chunk=fit_row_chunk,
+                _hybrid_resident_int8_prefill=_hybrid_resident_int8_prefill,
+            )
 
         x_dict, _feature_to_add = self._build_x_preprocess_inputs(x_train, eval_pos)
         preprocessed_x = self.x_preprocess(x_dict)
@@ -830,6 +863,7 @@ class FeaturesTransformer(nn.Module):
         *,
         row_chunk_size: int | None = None,
         adaptive_query_chunk: bool = True,
+        query_chunk_attempt_callback: (Callable[[int, Literal["success", "oom"]], None] | None) = None,
     ) -> torch.Tensor:
         """Score query rows against a prebuilt :class:`ContextCache`.
 
@@ -837,6 +871,11 @@ class FeaturesTransformer(nn.Module):
         query) pair, but the context forward is skipped: only the query rows stream
         through the cached per-layer K/V. Safe to call repeatedly with different
         query batches for the same context -- it mutates nothing on ``context``.
+
+        ``query_chunk_attempt_callback`` is an internal observability hook. It is
+        called for every decode OOM with the chunk limit that failed, then once
+        with the effective chunk limit after the full query batch succeeds. If
+        retries are exhausted, the final event is the OOM at chunk size one.
         """
         if self.mask_prediction:
             raise NotImplementedError("apply_context_cache requires mask_prediction=False")
@@ -852,36 +891,59 @@ class FeaturesTransformer(nn.Module):
         # eval_pos here only feeds the (overridden) NormalizationEncoder split point.
         x_dict, _feature_to_add = self._build_x_preprocess_inputs(x_test, n_test)
         if context.norm_stats is not None:
-            x_dict["_frozen_norm_stats"] = context.norm_stats
+            x_dict["_frozen_norm_stats"] = {key: value.to(x_test.device) for key, value in context.norm_stats.items()}
         if context.nan_mean is not None:
-            x_dict["_frozen_nan_mean"] = context.nan_mean
+            x_dict["_frozen_nan_mean"] = context.nan_mean.to(x_test.device)
         if context.valid_feature_num is not None:
-            x_dict["_frozen_valid_feature_num"] = context.valid_feature_num
+            x_dict["_frozen_valid_feature_num"] = context.valid_feature_num.to(x_test.device)
         preprocessed_x = self.x_preprocess(x_dict)
         preprocessed_x = self.process_4_x(preprocessed_x)
 
-        # Query-row y is NaN-masked in the transductive path regardless of its value;
-        # reconstruct the SAME query embedding by encoding [context y ; NaN query]
-        # and slicing the query tail, so the y-encoder's context normalization matches.
-        _, embedded_y_full = self._encode_y_full(
-            context.y_train,
-            total_rows=eval_pos + n_test,
-            eval_pos=eval_pos,
-            task_type="reg",
-        )
-        embedded_y_query = embedded_y_full[:, eval_pos:]
+        streaming_context = context.query_y_embedding is not None
+        if not streaming_context:
+            # Legacy bundles retain context y. Query-row y is NaN-masked in the
+            # transductive path regardless of its value, so reconstruct the SAME
+            # query embedding by encoding [context y ; NaN query] and slicing the
+            # tail, keeping the y-encoder's context normalization matched.
+            _, embedded_y_full = self._encode_y_full(
+                context.y_train,
+                total_rows=eval_pos + n_test,
+                eval_pos=eval_pos,
+                task_type="reg",
+            )
+            embedded_y_query = embedded_y_full[:, eval_pos:]
 
         if row_chunk_size is None or row_chunk_size <= 0:
             row_chunk_size = n_test
 
         def _run_chunk(start: int, end: int) -> torch.Tensor:
-            x_q = self._encode_x_rows(
-                preprocessed_x,
-                slice(start, end),
-                total_rows=n_test,
-                feature_pos_emb=context.feature_pos_emb,
-            )
-            test_tokens = torch.cat((x_q, embedded_y_query[:, start:end].unsqueeze(2)), dim=2)
+            if streaming_context:
+                # Keep the raw query matrix and its parameter-free preprocessing
+                # on the host. Only this query slice and its one-row y placeholder
+                # are resident on the compute device.
+                width = end - start
+                host_chunk = self._slice_preprocessed_x(preprocessed_x, slice(start, end), n_test)
+                compute_device = next(self.parameters()).device
+                staged = {
+                    key: value.to(compute_device) if isinstance(value, torch.Tensor) else value
+                    for key, value in host_chunk.items()
+                }
+                x_q = self._encode_x_rows(
+                    staged,
+                    slice(0, width),
+                    total_rows=width,
+                    feature_pos_emb=context.feature_pos_emb,
+                )
+                y_q = context.query_y_embedding.to(compute_device).expand(-1, width, -1)
+            else:
+                x_q = self._encode_x_rows(
+                    preprocessed_x,
+                    slice(start, end),
+                    total_rows=n_test,
+                    feature_pos_emb=context.feature_pos_emb,
+                )
+                y_q = embedded_y_query[:, start:end]
+            test_tokens = torch.cat((x_q, y_q.unsqueeze(2)), dim=2)
             test_out = self.transformer_encoder.forward_test_with_cache(
                 test_tokens,
                 context.caches,
@@ -899,6 +961,8 @@ class FeaturesTransformer(nn.Module):
                 outputs.append(_run_chunk(start, end))
                 start = end
             except torch.cuda.OutOfMemoryError:
+                if query_chunk_attempt_callback is not None:
+                    query_chunk_attempt_callback(chunk, "oom")
                 # Adaptive halving: degrade the query chunk instead of dying. The
                 # reduced chunk is deliberately NOT restored for later chunks --
                 # whatever made this one not fit is a property of the request, so
@@ -907,6 +971,8 @@ class FeaturesTransformer(nn.Module):
                     raise
                 torch.cuda.empty_cache()
                 chunk = max(1, chunk // 2)
+        if query_chunk_attempt_callback is not None:
+            query_chunk_attempt_callback(chunk, "success")
         return torch.cat(outputs, dim=1)
 
     def apply_target_aware_embedding(
@@ -997,3 +1063,137 @@ class FeaturesTransformer(nn.Module):
         else:
             raise ValueError(f"Unknown feature_positional_embedding_type={self.feature_positional_embedding_type}")
         return x
+
+    def _build_context_cache_streaming(
+        self,
+        x_train: torch.Tensor,
+        y_train: torch.Tensor,
+        *,
+        cache_dtype: str,
+        fit_row_chunk: int,
+        _hybrid_resident_int8_prefill: bool = False,
+    ) -> ContextCache:
+        """Build a context cache without a full-N tensor on the compute device."""
+        if x_train.device.type != "cpu" or y_train.device.type != "cpu":
+            mode = "hybrid resident INT8 prefill" if _hybrid_resident_int8_prefill else "stream_context"
+            raise ValueError(
+                f"{mode} requires CPU x_train/y_train; upload only row chunks, not the full training matrix"
+            )
+        compute_device = next(self.parameters()).device
+        eval_pos = x_train.shape[1]
+
+        # Preprocessing reductions are context-wide but parameter-free, so keep
+        # their small raw-feature representation and derived stats on CPU.
+        x_dict, _feature_to_add = self._build_x_preprocess_inputs(x_train, eval_pos)
+        preprocessed_x = self.x_preprocess(x_dict)
+        captured = preprocessed_x.get("_norm_stats") or {}
+        norm_stats = {k: v.detach() for k, v in captured.items()} if captured else None
+        captured_nan_mean = preprocessed_x.get("_nan_mean")
+        nan_mean = captured_nan_mean.detach() if isinstance(captured_nan_mean, torch.Tensor) else None
+        captured_valid_feature_num = preprocessed_x.get("_valid_feature_num")
+        valid_feature_num = (
+            captured_valid_feature_num.detach() if isinstance(captured_valid_feature_num, torch.Tensor) else None
+        )
+        n_groups = (x_train.shape[2] + self.features_per_group - 1) // self.features_per_group
+        feature_pos_emb = self.make_feature_positional_embeddings(
+            int(n_groups),
+            device=compute_device,
+            dtype=x_train.dtype,
+        )
+        # The full pass above exists only to derive context-wide frozen stats.
+        # Re-run the parameter-free preprocessing per row chunk below so it does
+        # not overlap a full preprocessed table with the O(N) token buffer.
+        del x_dict, preprocessed_x, captured, captured_nan_mean
+        del captured_valid_feature_num
+
+        # Query y is always NaN-masked. Cache its one-row embedding, derived from
+        # the full context mean, rather than recreating an N_context+N_query y
+        # activation at decode time.
+        y_values = y_train.unsqueeze(-1)
+        y_finite = torch.isfinite(y_values)
+        y_count = y_finite.sum(dim=1).clamp_min(1)
+        y_nan_mean = torch.where(y_finite, y_values, torch.zeros_like(y_values)).sum(dim=1) / y_count
+        y_nan_mean_device = y_nan_mean.to(compute_device)
+        query_y_input = {
+            "data": torch.full(
+                (y_train.shape[0], 1, 1),
+                float("nan"),
+                device=compute_device,
+                dtype=y_train.dtype,
+            ),
+            "eval_pos": 1,
+            "_frozen_nan_mean": y_nan_mean_device,
+        }
+        query_y_embedding = self.reg_y_encoder(query_y_input)["data"].squeeze(2).detach()
+
+        train_tokens = None
+        for row_start in range(0, eval_pos, fit_row_chunk):
+            row_end = min(row_start + fit_row_chunk, eval_pos)
+            width = row_end - row_start
+            chunk, _ = self._build_x_preprocess_inputs(x_train[:, row_start:row_end], width)
+            if norm_stats is not None:
+                chunk["_frozen_norm_stats"] = norm_stats
+            if nan_mean is not None:
+                chunk["_frozen_nan_mean"] = nan_mean
+            if valid_feature_num is not None:
+                chunk["_frozen_valid_feature_num"] = valid_feature_num
+            chunk = self.x_preprocess(chunk)
+            chunk = self.process_4_x(chunk)
+            staged = {
+                key: value.to(compute_device) if isinstance(value, torch.Tensor) else value
+                for key, value in chunk.items()
+            }
+            x_encoded = self._encode_x_rows(
+                staged,
+                slice(0, width),
+                total_rows=width,
+                feature_pos_emb=feature_pos_emb,
+            )
+            y_rows = y_train[:, row_start:row_end].to(compute_device)
+            # Streaming is a cached-inference path and so always regression;
+            # internal's model dropped task_type entirely, this tier's has not.
+            x_encoded = self.apply_target_aware_embedding(x_encoded, y_rows, eval_pos=width, task_type="reg")
+            y_input = {
+                "data": y_rows.unsqueeze(-1),
+                "eval_pos": width,
+                "_frozen_nan_mean": y_nan_mean_device,
+            }
+            y_encoded = self.reg_y_encoder(y_input)["data"].squeeze(2)
+            tokens = torch.cat((x_encoded, y_encoded.unsqueeze(2)), dim=2)
+            host_tokens = tokens.detach().to("cpu")
+            if train_tokens is None:
+                train_tokens = torch.empty(
+                    (x_train.shape[0], eval_pos, *host_tokens.shape[2:]),
+                    dtype=host_tokens.dtype,
+                    device="cpu",
+                )
+            train_tokens[:, row_start:row_end].copy_(host_tokens)
+            del chunk, staged, x_encoded, y_rows, y_encoded, tokens, host_tokens
+        if train_tokens is None:
+            raise ValueError("stream_context received an empty context")
+
+        empty_y_train = y_train[:, :0].detach()
+        del x_train, y_train, y_values, y_finite, y_count, y_nan_mean
+        del y_nan_mean_device, query_y_input
+
+        final_tokens, caches = self.transformer_encoder.build_train_cache(
+            train_tokens,
+            feature_atten_mask=None,
+            quantize_kv_cache=cache_dtype == "int8",
+            offload_kv_cache=not _hybrid_resident_int8_prefill,
+            fit_row_chunk=fit_row_chunk,
+            device=compute_device,
+            stream_context=not _hybrid_resident_int8_prefill,
+            _hybrid_resident_int8_prefill=_hybrid_resident_int8_prefill,
+        )
+        del train_tokens, final_tokens
+        return ContextCache(
+            caches=caches,
+            feature_pos_emb=feature_pos_emb,
+            norm_stats=norm_stats,
+            y_train=empty_y_train,
+            eval_pos=eval_pos,
+            nan_mean=nan_mean,
+            valid_feature_num=valid_feature_num,
+            query_y_embedding=query_y_embedding,
+        )

--- a/tests/test_attention_fast_paths.py
+++ b/tests/test_attention_fast_paths.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+import synthefy_nori.model.layer as layer_module
+from synthefy_nori.model.layer import MultiheadAttention
+
+
+@pytest.mark.parametrize("copy_first_head_kv", [False, True])
+def test_cached_kv_projection_matches_einsum(copy_first_head_kv):
+    torch.manual_seed(0)
+    attention = MultiheadAttention(
+        embed_dim=8,
+        num_heads=2,
+        qkv_combined=False,
+    )
+    x_kv = torch.randn(2, 3, 5, 8)
+    x_kv_flat = x_kv.reshape(-1, *x_kv.shape[-2:])
+    weights = attention.qkv_proj_weight[1:]
+    if copy_first_head_kv:
+        weights = weights[:, :1]
+    expected = torch.einsum("... s, j h d s -> ... j h d", x_kv_flat, weights)
+
+    cache = attention.project_kv_cache(
+        x_kv,
+        copy_first_head_kv=copy_first_head_kv,
+    )
+
+    assert torch.equal(cache["kv"], expected)
+
+
+def test_cached_q_linear_projection_matches_einsum(monkeypatch):
+    torch.manual_seed(1)
+    attention = MultiheadAttention(
+        embed_dim=8,
+        num_heads=2,
+        qkv_combined=False,
+    )
+    x = torch.randn(2, 3, 7, 8)
+    x_flat = x.reshape(-1, *x.shape[-2:])
+    expected = torch.einsum(
+        "... s, h d s -> ... h d",
+        x_flat,
+        attention.qkv_proj_weight[0],
+    )
+    captured = {}
+
+    def capture_attention(qkv, q, kv, attn_mask, sdpa_scale=None):
+        captured["q"] = q
+        return q
+
+    monkeypatch.setattr(attention, "compute_attention_by_torch", capture_attention)
+    cache = {
+        "kv": torch.zeros(6, 5, 2, 2, 4),
+        "batch": 2,
+        "groups": 3,
+    }
+
+    attention.forward_with_kv_cache(x, cache)
+
+    assert torch.equal(captured["q"], expected)
+
+
+@pytest.mark.parametrize(
+    ("batch", "expected_calls"),
+    [
+        pytest.param(2, 1, id="within-limit"),
+        pytest.param(3, 2, id="above-limit"),
+    ],
+)
+def test_sdpa_chunks_only_above_cuda_batch_head_limit(monkeypatch, batch, expected_calls):
+    attention = MultiheadAttention(
+        embed_dim=2,
+        num_heads=2,
+        qkv_combined=False,
+    )
+    q = torch.zeros(batch, 1, 2, 1)
+    kv = torch.zeros(batch, 1, 2, 2, 1)
+    calls = []
+
+    def fake_sdpa(query, key, value, **kwargs):
+        calls.append(query.shape)
+        return query
+
+    monkeypatch.setattr(layer_module, "SDPA_BATCH_HEAD_LIMIT", 5)
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", fake_sdpa)
+
+    output = attention.compute_attention_by_torch(None, q, kv, None)
+
+    assert output.shape == q.shape
+    assert len(calls) == expected_calls
+
+
+def test_sdpa_batch_head_limit_uses_full_cuda_grid_capacity():
+    assert layer_module.SDPA_BATCH_HEAD_LIMIT == 65_535

--- a/tests/test_blockwise_context_attention.py
+++ b/tests/test_blockwise_context_attention.py
@@ -1,0 +1,394 @@
+"""CPU tests for bounded-GPU context/KV streaming.
+
+These tests exercise the math and storage contract without requiring CUDA. Device
+transfer is still traversed (CPU -> CPU), so a future implementation that asks the
+cache for a full ``["kv"]`` tensor fails the same spy on every backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import synthefy_nori.model.kv_cache_scaling as kv_cache_scaling
+import synthefy_nori.model.layer as layer_module
+
+from synthefy_nori.model.kv_cache_scaling import (
+    BlockwiseSeqKV,
+    ScalableSeqKV,
+)
+from synthefy_nori.model.layer import MultiheadAttention
+
+
+def _row_slices(kv: torch.Tensor, rows: tuple[int, ...]):
+    start = 0
+    for width in rows:
+        yield kv[:, start : start + width]
+        start += width
+    assert start == kv.shape[1]
+
+
+def test_resident_int8_preallocates_without_cat(monkeypatch):
+    torch.manual_seed(17)
+    kv = torch.randn(2, 13, 2, 1, 8)
+
+    def forbid_cat(*args, **kwargs):
+        raise AssertionError("resident blockwise construction must not call torch.cat")
+
+    monkeypatch.setattr(kv_cache_scaling.torch, "cat", forbid_cat)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (4, 6, 3)),
+        1,
+        2,
+        quantize=True,
+        device=torch.device("cpu"),
+        dtype=kv.dtype,
+        offload=False,
+        n_rows=13,
+    )
+    assert cache.quantized is True
+    assert cache.offloaded is False
+    assert cache.n_rows == 13
+    assert cache.max_block_rows == 6
+    assert cache.host_bytes() == 0
+    assert cache.resident_gpu_bytes() > 0
+    assert len({payload.untyped_storage().data_ptr() for payload, _ in cache._blocks}) == 1
+    assert len({scale.untyped_storage().data_ptr() for _, scale in cache._blocks}) == 1
+
+    monkeypatch.undo()
+    expected = ScalableSeqKV(kv, 1, 2, quantize=True, offload=False, device=torch.device("cpu"))["kv"]
+    actual = torch.cat(list(cache.iter_kv_blocks()), dim=1)
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_blockwise_bf16_transport_reassembles_original(dtype):
+    torch.manual_seed(0)
+    kv = torch.randn(2, 11, 2, 3, 4, dtype=dtype)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (3, 5, 3)),
+        1,
+        2,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=dtype,
+    )
+    got = torch.cat(list(cache.iter_kv_blocks()), dim=1)
+    assert torch.equal(got, kv)
+    assert cache.resident_gpu_bytes() == 0
+    assert cache.host_bytes() == kv.numel() * kv.element_size()
+    with pytest.raises(RuntimeError, match="cannot materialize a full layer"):
+        cache["kv"]
+
+
+def test_blockwise_int8_matches_full_cache_dequantization_exactly():
+    torch.manual_seed(1)
+    kv = torch.randn(2, 13, 2, 1, 8)
+    full = ScalableSeqKV(kv, 1, 2, quantize=True, offload=True, device=torch.device("cpu"))["kv"]
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (4, 6, 3)),
+        1,
+        2,
+        quantize=True,
+        device=torch.device("cpu"),
+        dtype=kv.dtype,
+    )
+    got = torch.cat(list(cache.iter_kv_blocks()), dim=1)
+    # Quantization is per row/head vector, so slice-wise and whole-cache paths
+    # must produce exactly the same payload/scales and dequantized values.
+    assert torch.equal(got, full)
+
+
+def test_ragged_stored_blocks_are_resliced_before_staging():
+    torch.manual_seed(2)
+    kv = torch.randn(1, 17, 2, 2, 4)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (5, 7, 5)),
+        1,
+        1,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=kv.dtype,
+    )
+    blocks = list(cache.iter_kv_blocks(block_rows=3))
+    assert max(block.shape[1] for block in blocks) <= 3
+    assert cache.max_staged_rows == 3
+    assert torch.equal(torch.cat(blocks, dim=1), kv)
+
+
+def _attention_pair(
+    *, n_heads: int, copy_first_head: bool, dtype: torch.dtype, key_rows: int, stored_rows: tuple[int, ...]
+):
+    torch.manual_seed(3)
+    embed_dim = n_heads * 4
+    attn = MultiheadAttention(
+        embed_dim=embed_dim,
+        num_heads=n_heads,
+        qkv_combined=False,
+        dropout=0.0,
+        dtype=dtype,
+        use_logn_attention=True,
+        use_learnable_attn_temperature=True,
+    ).eval()
+    x_kv = torch.randn(1, 2, key_rows, embed_dim, dtype=dtype)
+    x_q = torch.randn(1, 2, 5, embed_dim, dtype=dtype)
+    full = attn.project_kv_cache(x_kv, copy_first_head_kv=copy_first_head)
+    projected = full["kv"]
+    streamed = BlockwiseSeqKV.from_row_slices(
+        _row_slices(projected, stored_rows),
+        1,
+        2,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=dtype,
+    )
+    with torch.inference_mode():
+        expected = attn.forward_with_kv_cache(x_q, full)[0]
+        got = attn.forward_with_kv_cache(x_q, streamed)[0]
+    return expected.float(), got.float(), streamed
+
+
+@pytest.mark.parametrize(
+    "n_heads,copy_first_head",
+    [pytest.param(2, False, id="mha"), pytest.param(4, True, id="mqa")],
+)
+@pytest.mark.parametrize(
+    "key_rows,stored_rows",
+    [
+        pytest.param(7, (1, 1, 1, 1, 1, 1, 1), id="block-1"),
+        pytest.param(11, (3, 5, 3), id="odd-ragged"),
+        pytest.param(5, (5,), id="block-ge-n"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_online_softmax_matches_full_attention(n_heads, copy_first_head, key_rows, stored_rows, dtype):
+    expected, got, streamed = _attention_pair(
+        n_heads=n_heads,
+        copy_first_head=copy_first_head,
+        dtype=dtype,
+        key_rows=key_rows,
+        stored_rows=stored_rows,
+    )
+    tolerance = 2e-2 if dtype == torch.bfloat16 else 2e-5
+    torch.testing.assert_close(got, expected, rtol=tolerance, atol=tolerance)
+    assert streamed.max_staged_rows == max(stored_rows)
+
+
+def test_int8_online_attention_uses_sliced_dequantization():
+    torch.manual_seed(4)
+    attn = MultiheadAttention(
+        embed_dim=8,
+        num_heads=2,
+        qkv_combined=False,
+        dropout=0.0,
+    ).eval()
+    x_kv = torch.randn(1, 1, 9, 8)
+    x_q = torch.randn(1, 1, 3, 8)
+    projected = attn.project_kv_cache(x_kv)["kv"]
+    full = ScalableSeqKV(projected, 1, 1, quantize=True, offload=True, device=torch.device("cpu"))
+    streamed = BlockwiseSeqKV.from_row_slices(
+        _row_slices(projected, (4, 3, 2)),
+        1,
+        1,
+        quantize=True,
+        device=torch.device("cpu"),
+        dtype=projected.dtype,
+    )
+    with torch.inference_mode():
+        expected = attn.forward_with_kv_cache(x_q, full)[0]
+        got = attn.forward_with_kv_cache(x_q, streamed)[0]
+    torch.testing.assert_close(got, expected, rtol=2e-5, atol=2e-5)
+    assert streamed.max_staged_rows == 4
+
+
+def test_score_workspace_reslices_stored_blocks(monkeypatch):
+    torch.manual_seed(5)
+    attn = MultiheadAttention(
+        embed_dim=8,
+        num_heads=2,
+        qkv_combined=False,
+        dropout=0.0,
+    ).eval()
+    x_kv = torch.randn(1, 2, 11, 8)
+    x_q = torch.randn(1, 2, 5, 8)
+    full = attn.project_kv_cache(x_kv)
+    streamed = BlockwiseSeqKV.from_row_slices(
+        _row_slices(full["kv"], (11,)),
+        1,
+        2,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=x_kv.dtype,
+    )
+    score_bytes_per_key_row = 2 * 2 * 5 * 4
+    monkeypatch.setattr(
+        layer_module,
+        "BLOCKWISE_SCORE_WORKSPACE_BYTES",
+        2 * score_bytes_per_key_row,
+    )
+    with torch.inference_mode():
+        expected = attn.forward_with_kv_cache(x_q, full)[0]
+        got = attn.forward_with_kv_cache(x_q, streamed)[0]
+    torch.testing.assert_close(got, expected, rtol=2e-5, atol=2e-5)
+    assert streamed.max_staged_rows == 2
+
+
+def test_blockwise_cache_device_mismatch_is_actionable():
+    attn = MultiheadAttention(
+        embed_dim=8,
+        num_heads=2,
+        qkv_combined=False,
+        dropout=0.0,
+    ).eval()
+    x_kv = torch.randn(1, 1, 3, 8)
+    streamed = BlockwiseSeqKV.from_row_slices(
+        _row_slices(attn.project_kv_cache(x_kv)["kv"], (3,)),
+        1,
+        1,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=x_kv.dtype,
+    )
+    streamed.device = torch.device("meta")
+    with pytest.raises(RuntimeError, match="cache device does not match"):
+        attn.forward_with_kv_cache(torch.randn(1, 1, 1, 8), streamed)
+
+
+@pytest.mark.parametrize("kv_heads", [1, 4])
+def test_flex_block_lse_merge_matches_one_full_softmax(monkeypatch, kv_heads):
+    torch.manual_seed(6)
+    n_heads = 4
+    head_dim = 8
+    q = torch.randn(2, 7, n_heads, head_dim)
+    kv = torch.randn(2, 13, 2, kv_heads, head_dim)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (4, 6, 3)),
+        1,
+        2,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=kv.dtype,
+    )
+    calls = []
+
+    def fake_flex(q_block, k_block, v_block, *, scale, enable_gqa):
+        calls.append((k_block.shape[2], enable_gqa))
+        if enable_gqa:
+            repeats = q_block.shape[1] // k_block.shape[1]
+            k_block = k_block.repeat_interleave(repeats, dim=1)
+            v_block = v_block.repeat_interleave(repeats, dim=1)
+        logits = torch.einsum("bhqd,bhkd->bhqk", q_block.float(), k_block.float()) * scale
+        lse = torch.logsumexp(logits, dim=-1)
+        output = torch.einsum("bhqk,bhkd->bhqd", torch.softmax(logits, dim=-1), v_block.float())
+        return output, lse
+
+    monkeypatch.setattr(layer_module, "_flex_attention_with_lse", fake_flex)
+    attn = MultiheadAttention(
+        embed_dim=n_heads * head_dim,
+        num_heads=n_heads,
+        qkv_combined=False,
+        dropout=0.0,
+    ).eval()
+    with torch.inference_mode():
+        got = attn._compute_attention_blockwise_flex(q, cache)
+
+    q_full = q.to(torch.bfloat16).permute(0, 2, 1, 3)
+    k_full, v_full = kv.to(torch.bfloat16).unbind(dim=2)
+    k_full = k_full.permute(0, 2, 1, 3)
+    v_full = v_full.permute(0, 2, 1, 3)
+    expected, _ = fake_flex(
+        q_full,
+        k_full,
+        v_full,
+        scale=head_dim**-0.5,
+        enable_gqa=kv_heads != n_heads,
+    )
+    expected = expected.permute(0, 2, 1, 3)
+    torch.testing.assert_close(got, expected, rtol=2e-5, atol=2e-5)
+    assert calls[:-1] == [
+        (4, kv_heads != n_heads),
+        (6, kv_heads != n_heads),
+        (3, kv_heads != n_heads),
+    ]
+    assert cache.max_staged_rows == 6
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("kv_heads", [1, 4])
+def test_cuda_flex_blockwise_matches_full_sdpa(kv_heads):
+    torch.manual_seed(7)
+    device = torch.device("cuda", torch.cuda.current_device())
+    n_heads = 4
+    head_dim = 16
+    q = torch.randn(2, 137, n_heads, head_dim, device=device, dtype=torch.bfloat16)
+    kv = torch.randn(2, 385, 2, kv_heads, head_dim, dtype=torch.bfloat16)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (128, 128, 129)),
+        1,
+        2,
+        quantize=False,
+        device=device,
+        dtype=kv.dtype,
+    )
+    k_full, v_full = kv.to(device).unbind(dim=2)
+    with torch.inference_mode():
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            q.permute(0, 2, 1, 3),
+            k_full.permute(0, 2, 1, 3),
+            v_full.permute(0, 2, 1, 3),
+            enable_gqa=kv_heads != n_heads,
+        ).permute(0, 2, 1, 3)
+        got = (
+            MultiheadAttention(
+                embed_dim=n_heads * head_dim,
+                num_heads=n_heads,
+                qkv_combined=False,
+                dropout=0.0,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            .eval()
+            .compute_attention_blockwise(q, cache)
+        )
+    torch.testing.assert_close(got.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    assert cache.max_staged_rows == 129
+
+
+@pytest.mark.parametrize("uses_aux_api", [False, True])
+def test_flex_lse_adapter_supports_both_torch_apis(monkeypatch, uses_aux_api):
+    q = torch.zeros(1, 2, 3, 4)
+    k = torch.zeros(1, 2, 5, 4)
+    v = torch.zeros_like(k)
+    expected_output = torch.ones_like(q)
+    expected_lse = torch.full(q.shape[:-1], 2.0)
+    request = object() if uses_aux_api else None
+    seen_kwargs = {}
+
+    class FakeAux:
+        lse = expected_lse
+
+    def fake_compiled(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        if uses_aux_api:
+            return expected_output, FakeAux()
+        return expected_output, expected_lse
+
+    monkeypatch.setattr(layer_module, "_FLEX_LSE_REQUEST", request)
+    monkeypatch.setattr(layer_module, "_compiled_flex_attention", lambda: fake_compiled)
+    output, lse = layer_module._flex_attention_with_lse(
+        q,
+        k,
+        v,
+        scale=0.5,
+        enable_gqa=True,
+    )
+    assert output is expected_output
+    assert lse is expected_lse
+    assert seen_kwargs["scale"] == 0.5
+    assert seen_kwargs["enable_gqa"] is True
+    if uses_aux_api:
+        assert seen_kwargs["return_aux"] is request
+        assert "return_lse" not in seen_kwargs
+    else:
+        assert seen_kwargs["return_lse"] is True
+        assert "return_aux" not in seen_kwargs

--- a/tests/test_context_cache.py
+++ b/tests/test_context_cache.py
@@ -40,6 +40,8 @@ import numpy as np
 import pytest
 import torch
 
+from synthefy_nori.model.transformer import ContextCache, FeaturesTransformer
+
 N_TRAIN, N_TEST, N_FEATURES = 300, 120, 8
 
 
@@ -76,6 +78,96 @@ def _split(model, xt, yt, eval_pos, seed=0):
     with torch.no_grad():
         bundle = model.build_context_cache(xt[:, :eval_pos], yt[:, :eval_pos])
         return model.apply_context_cache(xt[:, eval_pos:], bundle, row_chunk_size=0)
+
+
+class _DecodeOOMEncoder:
+    def __init__(self, fits_at: int | None):
+        self.fits_at = fits_at
+        self.widths = []
+
+    def forward_test_with_cache(self, test_tokens, _caches, feature_atten_mask=None):
+        del feature_atten_mask
+        width = test_tokens.shape[1]
+        self.widths.append(width)
+        if self.fits_at is None or width > self.fits_at:
+            raise torch.cuda.OutOfMemoryError("synthetic decode OOM")
+        return test_tokens
+
+
+class _ApplyContextHarness:
+    """Minimum protocol needed to drive apply_context_cache without weights."""
+
+    mask_prediction = False
+
+    def __init__(self, fits_at: int | None):
+        self.transformer_encoder = _DecodeOOMEncoder(fits_at)
+        self.encoder_out_norm = lambda value: value
+        self.reg_y_decoder = lambda value: value
+
+    def _build_x_preprocess_inputs(self, x_test, _eval_pos):
+        return {"data": x_test}, None
+
+    def x_preprocess(self, values):
+        return values
+
+    def process_4_x(self, values):
+        return values
+
+    def _encode_y_full(self, _y_train, *, total_rows, eval_pos, task_type="reg"):
+        del eval_pos
+        target = torch.zeros(1, total_rows)
+        embedded = torch.zeros(1, total_rows, 1)
+        return target, embedded
+
+    def _encode_x_rows(self, values, row_slice, *, total_rows, feature_pos_emb):
+        del total_rows, feature_pos_emb
+        start = row_slice.start or 0
+        stop = row_slice.stop
+        return values["data"].new_zeros(values["data"].shape[0], stop - start, 1, 1)
+
+
+def _empty_context():
+    return ContextCache(
+        caches=[],
+        feature_pos_emb=None,
+        norm_stats=None,
+        y_train=torch.zeros(1, 2),
+        eval_pos=2,
+    )
+
+
+def test_apply_context_cache_observes_oom_halving_and_effective_success():
+    model = _ApplyContextHarness(fits_at=2)
+    events = []
+
+    output = FeaturesTransformer.apply_context_cache(
+        model,
+        torch.zeros(1, 5, 1),
+        _empty_context(),
+        row_chunk_size=5,
+        query_chunk_attempt_callback=lambda chunk, outcome: events.append((chunk, outcome)),
+    )
+
+    assert model.transformer_encoder.widths == [5, 2, 2, 1]
+    assert events == [(5, "oom"), (2, "success")]
+    assert output.shape == (1, 5, 1)
+
+
+def test_apply_context_cache_observes_every_oom_when_retries_exhaust():
+    model = _ApplyContextHarness(fits_at=None)
+    events = []
+
+    with pytest.raises(torch.cuda.OutOfMemoryError, match="synthetic decode OOM"):
+        FeaturesTransformer.apply_context_cache(
+            model,
+            torch.zeros(1, 4, 1),
+            _empty_context(),
+            row_chunk_size=4,
+            query_chunk_attempt_callback=lambda chunk, outcome: events.append((chunk, outcome)),
+        )
+
+    assert model.transformer_encoder.widths == [4, 2, 1]
+    assert events == [(4, "oom"), (2, "oom"), (1, "oom")]
 
 
 @pytest.mark.slow

--- a/tests/test_encoder_stats.py
+++ b/tests/test_encoder_stats.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from synthefy_nori.model.encoders import calc_mean, calc_std
+
+
+@pytest.mark.parametrize("dim", [0, 1, 2])
+def test_calc_std_broadcast_matches_materialized_mean(dim):
+    torch.manual_seed(0)
+    actual_input = torch.randn(3, 5, 4, requires_grad=True)
+    with torch.no_grad():
+        actual_input[1, 2, 3] = torch.nan
+    expected_input = actual_input.detach().clone().requires_grad_(True)
+
+    expected_mean, expected_count = calc_mean(expected_input, dim)
+    materialized_mean = torch.repeat_interleave(
+        expected_mean.unsqueeze(dim),
+        expected_input.shape[dim],
+        dim=dim,
+    )
+    expected = torch.sqrt(
+        torch.nansum(torch.square(materialized_mean - expected_input), dim=dim) / (expected_count - 1)
+    )
+    actual = calc_std(actual_input, dim)
+
+    assert torch.equal(actual, expected)
+    actual.nansum().backward()
+    expected.nansum().backward()
+    torch.testing.assert_close(
+        actual_input.grad,
+        expected_input.grad,
+        rtol=0,
+        atol=0,
+        equal_nan=True,
+    )

--- a/tests/test_inference_output_fixes.py
+++ b/tests/test_inference_output_fixes.py
@@ -161,6 +161,23 @@ def test_distributed_imputation_fails_explicitly():
         )
 
 
+def test_distributed_memory_policy_fails_explicitly():
+    """DDP inference never resolves a MemoryPolicy or populates memory_report_,
+    so requesting one must fail at construction, not surface later as an empty
+    report a caller could mistake for a stale runtime."""
+    with pytest.raises(
+        ValueError,
+        match="inference_with_DDP does not support memory_policy",
+    ):
+        NoriPredictor(
+            device=torch.device("cpu"),
+            model=object(),
+            inference_config=[{}],
+            inference_with_DDP=True,
+            memory_policy={"cache_dtype": "int8"},
+        )
+
+
 @pytest.mark.parametrize("owns_process_group", [False, True])
 def test_distributed_runner_only_closes_owned_process_group(
     monkeypatch,

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -24,7 +24,7 @@ class _PlainModel:
     def to(self, _device):
         return self
 
-    def __call__(self, *, x, y, eval_pos):
+    def __call__(self, *, x, y, eval_pos, task_type="reg"):
         del y
         self.calls.append(x.shape[0])
         if self.oom_above is not None and x.shape[0] > self.oom_above:
@@ -37,7 +37,7 @@ class _QuantileModel(_PlainModel):
 
     num_reg_quantiles = 5
 
-    def __call__(self, *, x, y, eval_pos):
+    def __call__(self, *, x, y, eval_pos, task_type="reg"):
         del y
         self.calls.append(x.shape[0])
         base = x[:, eval_pos:, 0]
@@ -56,7 +56,7 @@ class _QuantileModel(_PlainModel):
 class _BatchSqueezingModel(_PlainModel):
     """A custom wrapper that violates the required batched output contract."""
 
-    def __call__(self, *, x, y, eval_pos):
+    def __call__(self, *, x, y, eval_pos, task_type="reg"):
         del y
         self.calls.append(x.shape[0])
         output = x[:, eval_pos:, :1]
@@ -66,7 +66,7 @@ class _BatchSqueezingModel(_PlainModel):
 class _RNGModel(_PlainModel):
     """Consume RNG by feature width, as feature positional embeddings do."""
 
-    def __call__(self, *, x, y, eval_pos):
+    def __call__(self, *, x, y, eval_pos, task_type="reg"):
         del y
         self.calls.append((x.shape[0], x.shape[-1]))
         torch.rand(x.shape[-1])

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import warnings
 import weakref
 
 import numpy as np
@@ -9,8 +11,12 @@ import pytest
 import torch
 
 import synthefy_nori.inference.predictor as predictor_module
-from synthefy_nori.inference.predictor import NoriPredictor
-from synthefy_nori.inference.memory_policy import estimate_cache_gb
+from synthefy_nori.inference.predictor import (
+    EXACT_CACHED_CUDAGRAPHS_ENV,
+    NoriPredictor,
+)
+from synthefy_nori.inference.degradation import CacheQuantizedWarning
+from synthefy_nori.inference.memory_policy import MemoryPolicy, estimate_cache_gb
 
 
 class _PlainModel:
@@ -142,6 +148,57 @@ class _FailingCachedApplyModel(_CachedModel):
             raise self.error_type("synthetic grouped-cache failure")
         x_train, _ = context
         return x_test[:, :, :1] + 0.0 * x_train[:, :1, :1]
+
+
+class _RetryingCachedModel(_CachedModel):
+    """Synthetic cache builder that succeeds only on one exact fallback rung."""
+
+    def __init__(self, success_at):
+        super().__init__()
+        self.success_at = success_at
+        self.cache_attempts = []
+
+    def build_context_cache(
+        self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk
+    ):
+        attempt = (cache_dtype, offload_kv_cache, fit_row_chunk)
+        self.cache_attempts.append(attempt)
+        if attempt != self.success_at:
+            raise torch.cuda.OutOfMemoryError("synthetic cache-build OOM")
+        return x_train, y_train
+
+
+
+class _RowChunkUnsupportedModel(_CachedModel):
+    """Raise NotImplementedError whenever asked to row-chunk the build, as a
+    checkpoint with serial sequence attention would."""
+
+    def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
+        if fit_row_chunk is not None:
+            raise NotImplementedError(
+                "context_row_chunk is not supported for serial sequence attention"
+            )
+        self.build_batches.append(x_train.shape[0])
+        return x_train, y_train
+
+
+class _CountedOOMCachedModel(_CachedModel):
+    """Raise a synthetic OOM on exactly the Nth build_context_cache call; every
+    other call succeeds. Used to make one specific attempt -- and only that
+    attempt -- fail, regardless of which pipeline or which rung it belongs to.
+    """
+
+    def __init__(self, oom_on_call):
+        super().__init__()
+        self.oom_on_call = oom_on_call
+        self.build_calls = 0
+
+    def build_context_cache(self, x_train, y_train, **_kwargs):
+        self.build_calls += 1
+        if self.build_calls == self.oom_on_call:
+            raise torch.cuda.OutOfMemoryError("synthetic cross-pipe OOM")
+        self.build_batches.append(x_train.shape[0])
+        return x_train, y_train
 
 
 class _PipeTransform:
@@ -437,6 +494,304 @@ def test_resident_cache_batches_build_and_apply(fake_cuda_tensors):
     assert list(predictor._context_cache) == [("pipeline_batch", (0, 1, 2))]
     torch.testing.assert_close(first, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
     torch.testing.assert_close(second, torch.from_numpy(second_x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+def test_worst_pipeline_report_and_history_survive_later_resident_success():
+    predictor = _predictor(_PlainModel())
+    predictor._memory_attempt_history = []
+    predictor._memory_outcome_policy = None
+    requested = MemoryPolicy(
+        gpu_budget_absolute_gb=1.0, host_budget_absolute_gb=2.0
+    )
+    resident = requested.resolve(
+        est_cache_gb=0.1,
+        bytes_per_element=2,
+        head_dim=4,
+        total_vram_gb=8.0,
+        total_ram_gb=16.0,
+    )
+    plain = resident.escalated("plain_loop")
+
+    predictor._publish_memory_policy(plain)
+    predictor._record_memory_attempt(
+        plain, pipeline_ids=[0], path="plain_loop", rung="plain_loop",
+        context_row_chunk=None, outcome="success",
+        reason="fallback_after_oom", dropped_context_rows=0,
+    )
+    predictor._publish_memory_policy(resident)
+    predictor._record_memory_attempt(
+        resident, pipeline_ids=[1], path="cached", rung="resident_bf16",
+        context_row_chunk=None, outcome="success", reason="resolved",
+        dropped_context_rows=0,
+    )
+
+    assert predictor.memory_report_["rung"] == "plain_loop"
+    assert [
+        attempt["pipeline_ids"] for attempt in predictor.memory_report_["attempt_history"]
+    ] == [[0], [1]]
+
+
+
+def test_explicit_fit_row_chunk_is_a_retry_cap():
+    assert NoriPredictor._fit_row_chunk_attempts(None) == [2048, 1024, 512]
+    assert NoriPredictor._fit_row_chunk_attempts(4096) == [2048, 1024, 512]
+    assert NoriPredictor._fit_row_chunk_attempts(1024) == [512]
+    assert NoriPredictor._fit_row_chunk_attempts(256) == []
+
+
+
+def test_apply_oom_releases_retained_context_and_output_before_retry(
+    fake_cuda_tensors, monkeypatch
+):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+
+    class Context:
+        def __init__(self, x_train):
+            self.x_train = x_train
+
+    class ApplyOOMModel(_CachedModel):
+        def __init__(self):
+            super().__init__()
+            self.cache_attempts = []
+            self.context_refs = []
+
+        def build_context_cache(
+            self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk
+        ):
+            del y_train
+            self.cache_attempts.append(
+                (cache_dtype, offload_kv_cache, fit_row_chunk)
+            )
+            context = Context(x_train)
+            self.context_refs.append(weakref.ref(context))
+            return context
+
+        def apply_context_cache(self, x_test, context, **_kwargs):
+            return x_test[:, :, :1] + 0.0 * context.x_train[:, :1, :1]
+
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = ApplyOOMModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+    real_unwrap = predictor._unwrap_model_output
+    output_refs = []
+
+    def oom_after_apply(value, *args, **kwargs):
+        if not output_refs:
+            output_refs.append(weakref.ref(value))
+            del value
+            raise torch.cuda.OutOfMemoryError("synthetic post-apply OOM")
+        return real_unwrap(value, *args, **kwargs)
+
+    predictor._unwrap_model_output = oom_after_apply
+    cleanup_checks = []
+
+    def assert_released_before_empty_cache():
+        cleanup_checks.append(True)
+        assert predictor._context_cache == {}
+        assert model.context_refs[0]() is None
+        assert output_refs[0]() is None
+
+    monkeypatch.setattr(torch.cuda, "empty_cache", assert_released_before_empty_cache)
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert cleanup_checks == [True]
+    assert model.cache_attempts[:2] == [
+        ("bf16", False, None),
+        ("int8", False, None),
+    ]
+    assert [
+        attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]
+    ] == ["oom", "success"]
+    torch.testing.assert_close(
+        output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5
+    )
+
+
+
+def test_runtime_oom_walks_every_allowed_rung_then_bounded_fit_chunks(
+    fake_cuda_tensors, monkeypatch
+):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _RetryingCachedModel(("int8", True, 512))
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    expected = [
+        ("bf16", False, None),
+        ("int8", False, None),
+        ("bf16", True, None),
+        ("int8", True, None),
+        ("int8", True, 2048),
+        ("int8", True, 1024),
+        ("int8", True, 512),
+    ]
+    assert model.cache_attempts == expected
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+    report = predictor.memory_report_
+    assert report["rung"] == "context_row_chunk"
+    assert report["context_row_chunk"] == 512
+    history = report["attempt_history"]
+    assert [attempt["outcome"] for attempt in history] == ["oom"] * 6 + ["success"]
+    assert [
+        (attempt["cache_dtype"], attempt["offload_to_host"], attempt["context_row_chunk"])
+        for attempt in history
+    ] == expected
+    assert all(attempt["dropped_context_rows"] == 0 for attempt in history)
+
+
+
+def test_oom_on_one_pipe_does_not_evict_a_sibling_pipes_cache(fake_cuda_tensors, monkeypatch):
+    """An OOM while building pipe 1's context cache must evict only pipe 1's own
+    (failed) cache entry -- never pipe 0's already-built, reusable one.
+
+    Regression coverage for the _evict_pipe_cache scope fix: the pre-fix code
+    called cache.clear() on the whole shared _context_cache dict from every
+    OOM/unsupported handler in this loop, which would have wiped pipe 0's entry
+    here even though pipe 0 never touched the failing build.
+    """
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    # Call 1: pipe 0's only attempt (bf16) -> succeeds, gets cached under id_pipe=0.
+    # Call 2: pipe 1's first attempt (bf16) -> OOMs.
+    # Call 3: pipe 1's retry (int8) -> succeeds, gets cached under id_pipe=1.
+    model = _CountedOOMCachedModel(oom_on_call=2)
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[], []]
+    predictor.inference_config = [{}, {}]
+
+    predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.build_calls == 3
+    assert set(predictor._context_cache) == {0, 1}
+    assert len(predictor._context_cache[0]) == 1
+    assert len(predictor._context_cache[1]) == 1
+    assert [
+        attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]
+    ] == ["success", "oom", "success"]
+
+
+
+def test_pinned_context_row_chunk_on_unsupported_checkpoint_raises(fake_cuda_tensors, monkeypatch):
+    """A caller who explicitly pins context_row_chunk on a checkpoint that cannot
+    honor it must see the NotImplementedError, not a silent fallback to the plain
+    loop -- only a chunk WE chose ourselves as an OOM escalation may degrade
+    quietly. See the "if pinned is not None: raise" branch this pins.
+    """
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _RowChunkUnsupportedModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+            "context_row_chunk": 2048,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+
+    with pytest.raises(NotImplementedError, match="serial sequence attention"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+
+def test_precision_only_recovery_logs_regardless_of_chunk_change(
+    fake_cuda_tensors, monkeypatch, caplog
+):
+    """A recovery via precision/placement alone (no context_row_chunk change) must
+    still log "Nori recovered on rung", not only chunk-based recoveries.
+    """
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    # Attempt 1 (bf16, unoffloaded, no chunk) OOMs; attempt 2 (int8, unoffloaded,
+    # no chunk) succeeds -- a pure precision recovery, attempt_fit_chunk is None
+    # throughout.
+    model = _RetryingCachedModel(("int8", False, None))
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+
+    with caplog.at_level(logging.WARNING, logger="synthefy_nori.inference.predictor"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.cache_attempts == [("bf16", False, None), ("int8", False, None)]
+    assert any("Nori recovered on rung" in record.message for record in caplog.records)
+    assert predictor.memory_report_["rung"] == "resident_int8"
+
+
+def test_int8_cache_warns_but_bf16_cache_does_not(fake_cuda_tensors, monkeypatch):
+    """Landing on an int8 rung must raise CacheQuantizedWarning (a real, catchable
+    fidelity-loss signal for strict_pipeline()/scored callers), not just a log
+    line -- and a bit-exact bf16 rung must NOT raise it.
+    """
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+
+    int8_model = _RetryingCachedModel(("int8", False, None))
+    int8_predictor = _predictor(
+        int8_model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    int8_predictor.preprocess_pipelines = [[]]
+    int8_predictor.inference_config = [{}]
+    with pytest.warns(CacheQuantizedWarning):
+        int8_predictor._predict_reg_single(x_train, y_train, x_test)
+
+    bf16_model = _CachedModel()
+    bf16_predictor = _predictor(
+        bf16_model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    bf16_predictor.preprocess_pipelines = [[]]
+    bf16_predictor.inference_config = [{}]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", CacheQuantizedWarning)
+        bf16_predictor._predict_reg_single(x_train, y_train, x_test)
+    assert bf16_predictor.memory_report_["rung"] == "resident_bf16"
+
 
 
 def test_nonreused_group_context_is_released_before_next_build(fake_cuda_tensors):

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -317,6 +317,89 @@ def test_plain_path_batches_and_kill_switch_restores_b1(fake_cuda_tensors, monke
     torch.testing.assert_close(batched, legacy, rtol=0, atol=0)
 
 
+def test_exact_cached_cudagraph_mode_preserves_b1_execution(
+    fake_cuda_tensors, monkeypatch,
+):
+    monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
+    x_train, y_train, x_test = _table()
+    model = _PlainModel()
+    predictor = _predictor(model)
+    predictor._predict_reg_single(x_train, y_train, x_test)
+    assert model.calls == [1, 1, 1]
+
+
+def test_exact_cached_cudagraphs_compile_one_unbound_layer_method(monkeypatch):
+    class Layer:
+        def forward_test_with_cache(self, x_test, cache, feature_atten_mask=None):
+            del self, cache, feature_atten_mask
+            return x_test
+
+    class Encoder:
+        layers = [Layer(), Layer(), Layer()]
+
+    class Model:
+        transformer_encoder = Encoder()
+
+    predictor = NoriPredictor.__new__(NoriPredictor)
+    predictor.device = torch.device("cuda")
+    predictor._logged_this_call = set()
+    monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
+    monkeypatch.setattr(
+        predictor_module.importlib.util, "find_spec", lambda _name: object(),
+    )
+    compile_calls = []
+
+    def compile_once(function, **kwargs):
+        compile_calls.append((function, kwargs))
+        return function
+
+    monkeypatch.setattr(torch, "compile", compile_once)
+    model = Model()
+    assert predictor._maybe_enable_exact_cached_cudagraphs(model)
+    assert predictor._maybe_enable_exact_cached_cudagraphs(model)
+    assert len(compile_calls) == 1
+    assert compile_calls[0][1] == {
+        "backend": "cudagraphs",
+        "dynamic": False,
+        "fullgraph": False,
+    }
+    for layer in model.transformer_encoder.layers:
+        assert layer.forward_test_with_cache("value", {}) == "value"
+
+    predictor._disable_exact_cached_cudagraphs(model)
+    assert not model._exact_cudagraphs_enabled
+
+
+def test_exact_cached_cudagraphs_fall_back_without_setuptools(monkeypatch):
+    class Layer:
+        def forward_test_with_cache(self, x_test, cache):
+            del self, cache
+            return x_test
+
+    class Encoder:
+        layers = [Layer()]
+
+    class Model:
+        transformer_encoder = Encoder()
+
+    predictor = NoriPredictor.__new__(NoriPredictor)
+    predictor.device = torch.device("cuda")
+    predictor._logged_this_call = set()
+    monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
+    monkeypatch.setattr(
+        predictor_module.importlib.util, "find_spec", lambda _name: None,
+    )
+    monkeypatch.setattr(
+        torch,
+        "compile",
+        lambda *_args, **_kwargs: pytest.fail("torch.compile must not run"),
+    )
+
+    model = Model()
+    assert not predictor._maybe_enable_exact_cached_cudagraphs(model)
+    assert model.transformer_encoder.layers[0].forward_test_with_cache("value", {}) == "value"
+
+
 def test_distribution_member_order_and_collapse_match_b1(fake_cuda_tensors, monkeypatch):
     x_train, y_train, x_test = _table()
     offsets = (30.0, 10.0, 60.0, 20.0, 50.0, 40.0)

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -158,15 +158,39 @@ class _RetryingCachedModel(_CachedModel):
         self.success_at = success_at
         self.cache_attempts = []
 
-    def build_context_cache(
-        self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk
-    ):
+    def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
         attempt = (cache_dtype, offload_kv_cache, fit_row_chunk)
         self.cache_attempts.append(attempt)
         if attempt != self.success_at:
             raise torch.cuda.OutOfMemoryError("synthetic cache-build OOM")
         return x_train, y_train
 
+
+class _AdaptiveDecodeModel(_CachedModel):
+    """Emit the model's adaptive query-chunk events without requiring CUDA."""
+
+    def __init__(self, succeed_at: int | None):
+        super().__init__()
+        self.succeed_at = succeed_at
+
+    def apply_context_cache(
+        self,
+        x_test,
+        context,
+        *,
+        row_chunk_size,
+        query_chunk_attempt_callback,
+        **_kwargs,
+    ):
+        chunk = row_chunk_size
+        while chunk != self.succeed_at:
+            query_chunk_attempt_callback(chunk, "oom")
+            if chunk <= 1:
+                raise torch.cuda.OutOfMemoryError("synthetic exhausted adaptive decode")
+            chunk = max(1, chunk // 2)
+        query_chunk_attempt_callback(chunk, "success")
+        x_train, _ = context
+        return x_test[:, :, :1] + 0.0 * x_train[:, :1, :1]
 
 
 class _RowChunkUnsupportedModel(_CachedModel):
@@ -175,9 +199,7 @@ class _RowChunkUnsupportedModel(_CachedModel):
 
     def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
         if fit_row_chunk is not None:
-            raise NotImplementedError(
-                "context_row_chunk is not supported for serial sequence attention"
-            )
+            raise NotImplementedError("context_row_chunk is not supported for serial sequence attention")
         self.build_batches.append(x_train.shape[0])
         return x_train, y_train
 
@@ -199,6 +221,44 @@ class _CountedOOMCachedModel(_CachedModel):
             raise torch.cuda.OutOfMemoryError("synthetic cross-pipe OOM")
         self.build_batches.append(x_train.shape[0])
         return x_train, y_train
+
+
+class _StreamingRetryModel(_CachedModel):
+    """Record the bounded host-streaming ladder and fail before one rung."""
+
+    def __init__(self, success_at=None, *, error_type=torch.cuda.OutOfMemoryError):
+        super().__init__()
+        self.success_at = success_at
+        self.error_type = error_type
+        self.cache_attempts = []
+        self.train_rows = []
+        self.build_devices = []
+        self.apply_devices = []
+        self.apply_kwargs = []
+
+    def build_context_cache(
+        self,
+        x_train,
+        y_train,
+        *,
+        cache_dtype,
+        offload_kv_cache,
+        fit_row_chunk,
+        stream_context,
+    ):
+        attempt = (cache_dtype, offload_kv_cache, fit_row_chunk, stream_context)
+        self.cache_attempts.append(attempt)
+        self.train_rows.append(x_train.shape[1])
+        self.build_devices.append((x_train.device.type, y_train.device.type))
+        if attempt != self.success_at:
+            raise self.error_type("synthetic streamed-cache failure")
+        return x_train, y_train
+
+    def apply_context_cache(self, x_test, context, **kwargs):
+        self.apply_devices.append(x_test.device.type)
+        self.apply_kwargs.append(kwargs)
+        x_train, _ = context
+        return x_test[:, :, :1] + 0.0 * x_train[:, :1, :1]
 
 
 class _PipeTransform:
@@ -318,7 +378,8 @@ def test_plain_path_batches_and_kill_switch_restores_b1(fake_cuda_tensors, monke
 
 
 def test_exact_cached_cudagraph_mode_preserves_b1_execution(
-    fake_cuda_tensors, monkeypatch,
+    fake_cuda_tensors,
+    monkeypatch,
 ):
     monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
     x_train, y_train, x_test = _table()
@@ -345,7 +406,9 @@ def test_exact_cached_cudagraphs_compile_one_unbound_layer_method(monkeypatch):
     predictor._logged_this_call = set()
     monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
     monkeypatch.setattr(
-        predictor_module.importlib.util, "find_spec", lambda _name: object(),
+        predictor_module.importlib.util,
+        "find_spec",
+        lambda _name: object(),
     )
     compile_calls = []
 
@@ -387,7 +450,9 @@ def test_exact_cached_cudagraphs_fall_back_without_setuptools(monkeypatch):
     predictor._logged_this_call = set()
     monkeypatch.setenv(EXACT_CACHED_CUDAGRAPHS_ENV, "1")
     monkeypatch.setattr(
-        predictor_module.importlib.util, "find_spec", lambda _name: None,
+        predictor_module.importlib.util,
+        "find_spec",
+        lambda _name: None,
     )
     monkeypatch.setattr(
         torch,
@@ -486,9 +551,7 @@ def test_wide_b1_groups_use_prepared_transforms_once(fake_cuda_tensors):
     )
 
 
-def test_mixed_width_groups_preserve_legacy_post_call_rng_state(
-    fake_cuda_tensors, monkeypatch
-):
+def test_mixed_width_groups_preserve_legacy_post_call_rng_state(fake_cuda_tensors, monkeypatch):
     x_train, y_train, x_test = _table()
 
     def mixed_predictor():
@@ -500,12 +563,9 @@ def test_mixed_width_groups_preserve_legacy_post_call_rng_state(
             [_PipeTransform(0.0)],
         ]
         predictor.inference_config = [
-            {"retrieval_config": {"use_retrieval": False}}
-            for _ in predictor.preprocess_pipelines
+            {"retrieval_config": {"use_retrieval": False}} for _ in predictor.preprocess_pipelines
         ]
-        predictor.seeds = [0] * (
-            len(predictor.preprocess_pipelines) * predictor.preprocess_num
-        )
+        predictor.seeds = [0] * (len(predictor.preprocess_pipelines) * predictor.preprocess_num)
         return predictor
 
     batched = mixed_predictor()
@@ -583,9 +643,7 @@ def test_worst_pipeline_report_and_history_survive_later_resident_success():
     predictor = _predictor(_PlainModel())
     predictor._memory_attempt_history = []
     predictor._memory_outcome_policy = None
-    requested = MemoryPolicy(
-        gpu_budget_absolute_gb=1.0, host_budget_absolute_gb=2.0
-    )
+    requested = MemoryPolicy(gpu_budget_absolute_gb=1.0, host_budget_absolute_gb=2.0)
     resident = requested.resolve(
         est_cache_gb=0.1,
         bytes_per_element=2,
@@ -597,35 +655,41 @@ def test_worst_pipeline_report_and_history_survive_later_resident_success():
 
     predictor._publish_memory_policy(plain)
     predictor._record_memory_attempt(
-        plain, pipeline_ids=[0], path="plain_loop", rung="plain_loop",
-        context_row_chunk=None, outcome="success",
-        reason="fallback_after_oom", dropped_context_rows=0,
+        plain,
+        pipeline_ids=[0],
+        path="plain_loop",
+        rung="plain_loop",
+        context_row_chunk=None,
+        outcome="success",
+        reason="fallback_after_oom",
+        dropped_context_rows=0,
     )
     predictor._publish_memory_policy(resident)
     predictor._record_memory_attempt(
-        resident, pipeline_ids=[1], path="cached", rung="resident_bf16",
-        context_row_chunk=None, outcome="success", reason="resolved",
+        resident,
+        pipeline_ids=[1],
+        path="cached",
+        rung="resident_bf16",
+        context_row_chunk=None,
+        outcome="success",
+        reason="resolved",
         dropped_context_rows=0,
     )
 
     assert predictor.memory_report_["rung"] == "plain_loop"
-    assert [
-        attempt["pipeline_ids"] for attempt in predictor.memory_report_["attempt_history"]
-    ] == [[0], [1]]
-
+    assert [attempt["pipeline_ids"] for attempt in predictor.memory_report_["attempt_history"]] == [[0], [1]]
 
 
 def test_explicit_fit_row_chunk_is_a_retry_cap():
-    assert NoriPredictor._fit_row_chunk_attempts(None) == [2048, 1024, 512]
-    assert NoriPredictor._fit_row_chunk_attempts(4096) == [2048, 1024, 512]
-    assert NoriPredictor._fit_row_chunk_attempts(1024) == [512]
+    assert NoriPredictor._fit_row_chunk_attempts(None) == [2048, 1024, 512, 256]
+    assert NoriPredictor._fit_row_chunk_attempts(16384) == [2048, 1024, 512, 256]
+    assert NoriPredictor._fit_row_chunk_attempts(4096) == [2048, 1024, 512, 256]
+    assert NoriPredictor._fit_row_chunk_attempts(1024) == [512, 256]
+    assert NoriPredictor._fit_row_chunk_attempts(512) == [256]
     assert NoriPredictor._fit_row_chunk_attempts(256) == []
 
 
-
-def test_apply_oom_releases_retained_context_and_output_before_retry(
-    fake_cuda_tensors, monkeypatch
-):
+def test_apply_oom_releases_retained_context_and_output_before_retry(fake_cuda_tensors, monkeypatch):
     monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
 
     class Context:
@@ -638,13 +702,9 @@ def test_apply_oom_releases_retained_context_and_output_before_retry(
             self.cache_attempts = []
             self.context_refs = []
 
-        def build_context_cache(
-            self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk
-        ):
+        def build_context_cache(self, x_train, y_train, *, cache_dtype, offload_kv_cache, fit_row_chunk):
             del y_train
-            self.cache_attempts.append(
-                (cache_dtype, offload_kv_cache, fit_row_chunk)
-            )
+            self.cache_attempts.append((cache_dtype, offload_kv_cache, fit_row_chunk))
             context = Context(x_train)
             self.context_refs.append(weakref.ref(context))
             return context
@@ -691,18 +751,11 @@ def test_apply_oom_releases_retained_context_and_output_before_retry(
         ("bf16", False, None),
         ("int8", False, None),
     ]
-    assert [
-        attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]
-    ] == ["oom", "success"]
-    torch.testing.assert_close(
-        output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5
-    )
+    assert [attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]] == ["oom", "success"]
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
 
 
-
-def test_runtime_oom_walks_every_allowed_rung_then_bounded_fit_chunks(
-    fake_cuda_tensors, monkeypatch
-):
+def test_runtime_oom_walks_every_allowed_rung_then_bounded_fit_chunks(fake_cuda_tensors, monkeypatch):
     monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
     x_train, y_train, x_test = _table(n_train=12, n_test=300)
     model = _RetryingCachedModel(("int8", True, 512))
@@ -736,11 +789,9 @@ def test_runtime_oom_walks_every_allowed_rung_then_bounded_fit_chunks(
     history = report["attempt_history"]
     assert [attempt["outcome"] for attempt in history] == ["oom"] * 6 + ["success"]
     assert [
-        (attempt["cache_dtype"], attempt["offload_to_host"], attempt["context_row_chunk"])
-        for attempt in history
+        (attempt["cache_dtype"], attempt["offload_to_host"], attempt["context_row_chunk"]) for attempt in history
     ] == expected
     assert all(attempt["dropped_context_rows"] == 0 for attempt in history)
-
 
 
 def test_oom_on_one_pipe_does_not_evict_a_sibling_pipes_cache(fake_cuda_tensors, monkeypatch):
@@ -775,10 +826,11 @@ def test_oom_on_one_pipe_does_not_evict_a_sibling_pipes_cache(fake_cuda_tensors,
     assert set(predictor._context_cache) == {0, 1}
     assert len(predictor._context_cache[0]) == 1
     assert len(predictor._context_cache[1]) == 1
-    assert [
-        attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]
-    ] == ["success", "oom", "success"]
-
+    assert [attempt["outcome"] for attempt in predictor.memory_report_["attempt_history"]] == [
+        "success",
+        "oom",
+        "success",
+    ]
 
 
 def test_pinned_context_row_chunk_on_unsupported_checkpoint_raises(fake_cuda_tensors, monkeypatch):
@@ -806,9 +858,7 @@ def test_pinned_context_row_chunk_on_unsupported_checkpoint_raises(fake_cuda_ten
         predictor._predict_reg_single(x_train, y_train, x_test)
 
 
-def test_precision_only_recovery_logs_regardless_of_chunk_change(
-    fake_cuda_tensors, monkeypatch, caplog
-):
+def test_precision_only_recovery_logs_regardless_of_chunk_change(fake_cuda_tensors, monkeypatch, caplog):
     """A recovery via precision/placement alone (no context_row_chunk change) must
     still log "Nori recovered on rung", not only chunk-based recoveries.
     """
@@ -876,6 +926,307 @@ def test_int8_cache_warns_but_bf16_cache_does_not(fake_cuda_tensors, monkeypatch
     assert bf16_predictor.memory_report_["rung"] == "resident_bf16"
 
 
+def test_resident_int8_row_chunk_uses_private_hybrid_without_changing_report(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+
+    class HybridModel(_CachedModel):
+        def __init__(self):
+            super().__init__()
+            self.builds = []
+
+        def build_context_cache(
+            self,
+            x_train,
+            y_train,
+            *,
+            cache_dtype,
+            offload_kv_cache,
+            fit_row_chunk,
+            stream_context=False,
+            _hybrid_resident_int8_prefill=False,
+        ):
+            self.builds.append(
+                {
+                    "cache_dtype": cache_dtype,
+                    "offload": offload_kv_cache,
+                    "fit_row_chunk": fit_row_chunk,
+                    "stream_context": stream_context,
+                    "hybrid": _hybrid_resident_int8_prefill,
+                    "devices": (x_train.device.type, y_train.device.type),
+                }
+            )
+            return x_train, y_train
+
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = HybridModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "cache_dtype": "int8",
+            "context_row_chunk": 4,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.builds == [
+        {
+            "cache_dtype": "int8",
+            "offload": False,
+            "fit_row_chunk": 4,
+            "stream_context": False,
+            "hybrid": True,
+            "devices": ("cpu", "cpu"),
+        }
+    ]
+    report = predictor.memory_report_
+    assert report["rung"] == "resident_int8"
+    assert report["stream_context"] is False
+    assert report["context_row_chunk"] == 4
+    assert report["attempt_history"][0]["rung"] == "resident_int8"
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+def _streaming_predictor(model, **policy_overrides):
+    policy = {
+        "stream_context": True,
+        "elements_budget": 8,
+        "allow_subsample": False,
+        "gpu_budget_absolute_gb": 0.0,
+        "host_budget_absolute_gb": 2.0,
+    }
+    policy.update(policy_overrides)
+    predictor = _predictor(model, memory_policy=policy)
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+    predictor.seeds = [0] * predictor.preprocess_num
+    return predictor
+
+
+def test_stream_context_keeps_all_rows_on_cpu_and_runs_for_one_query(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=1)
+    model = _StreamingRetryModel(("bf16", True, 8192, True))
+    predictor = _streaming_predictor(model, allow_subsample=True)
+    monkeypatch.setattr(predictor, "_total_vram_gb", lambda: 64.0)
+    monkeypatch.setattr(predictor, "_resolve_max_elements_budget", lambda: 8)
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.cache_attempts == [("bf16", True, 8192, True)]
+    assert model.train_rows == [len(x_train)]
+    assert model.build_devices == [("cpu", "cpu")]
+    assert model.apply_devices == ["cpu"]
+    assert model.calls == []
+    assert len(model.apply_kwargs) == 1
+    assert callable(model.apply_kwargs[0].pop("query_chunk_attempt_callback"))
+    assert model.apply_kwargs == [
+        {
+            "row_chunk_size": 1,
+            "adaptive_query_chunk": True,
+        }
+    ]
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+    report = predictor.memory_report_
+    assert report["rung"] == "stream_bf16"
+    assert report["context_row_chunk"] == 8192
+    assert report["query_chunk"] == 1
+    assert report["dropped_context_rows"] == 0
+    assert report["attempt_history"][0]["outcome"] == "success"
+
+
+def test_adaptive_decode_halving_is_reported_with_effective_query_chunk(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    predictor = _predictor(
+        _AdaptiveDecodeModel(succeed_at=128),
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [[]]
+    predictor.inference_config = [{}]
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+    report = predictor.memory_report_
+    assert report["query_chunk"] == 128
+    assert [
+        (attempt["query_chunk"], attempt["outcome"], attempt["reason"]) for attempt in report["attempt_history"]
+    ] == [
+        (256, "oom", "resolved"),
+        (128, "success", "oom_retry"),
+    ]
+
+
+def test_pipeline_batched_adaptive_decode_reports_the_same_trace(
+    fake_cuda_tensors,
+):
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    predictor = _predictor(
+        _AdaptiveDecodeModel(succeed_at=128),
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+
+    predictor._predict_reg_single(x_train, y_train, x_test)
+
+    report = predictor.memory_report_
+    assert report["query_chunk"] == 128
+    assert [
+        (
+            attempt["path"],
+            attempt["pipeline_ids"],
+            attempt["query_chunk"],
+            attempt["outcome"],
+        )
+        for attempt in report["attempt_history"]
+    ] == [
+        ("pipeline_batch", [0, 1, 2], 256, "oom"),
+        ("pipeline_batch", [0, 1, 2], 128, "success"),
+    ]
+
+
+def test_exhausted_adaptive_decode_reports_every_halving_and_reraises(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    predictor = _streaming_predictor(
+        _AdaptiveDecodeModel(succeed_at=None),
+        cache_dtype="int8",
+        context_row_chunk=256,
+    )
+    monkeypatch.setattr(predictor, "_total_vram_gb", lambda: 64.0)
+
+    with pytest.raises(torch.cuda.OutOfMemoryError, match="exhausted adaptive decode"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+    report = predictor.memory_report_
+    assert report["query_chunk"] == 1
+    assert [attempt["query_chunk"] for attempt in report["attempt_history"]] == [256, 128, 64, 32, 16, 8, 4, 2, 1]
+    assert all(attempt["outcome"] == "oom" for attempt in report["attempt_history"])
+    assert all(
+        attempt["path"] == "cached" and attempt["rung"] == "stream_int8" for attempt in report["attempt_history"]
+    )
+
+
+def test_stream_context_uses_shared_precision_then_row_chunk_ladder(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=1)
+    model = _StreamingRetryModel(("int8", True, 256, True))
+    predictor = _streaming_predictor(model)
+    monkeypatch.setattr(predictor, "_total_vram_gb", lambda: 64.0)
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    expected = [
+        ("bf16", True, 8192, True),
+        ("int8", True, 8192, True),
+        ("int8", True, 2048, True),
+        ("int8", True, 1024, True),
+        ("int8", True, 512, True),
+        ("int8", True, 256, True),
+    ]
+    assert model.cache_attempts == expected
+    assert model.train_rows == [len(x_train)] * len(expected)
+    assert model.calls == []
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+    report = predictor.memory_report_
+    assert report["rung"] == "stream_int8"
+    assert report["context_row_chunk"] == 256
+    assert report["query_chunk"] == 1
+    assert [attempt["outcome"] for attempt in report["attempt_history"]] == [
+        "oom",
+        "oom",
+        "oom",
+        "oom",
+        "oom",
+        "success",
+    ]
+    assert [
+        (
+            attempt["cache_dtype"],
+            attempt["offload_to_host"],
+            attempt["context_row_chunk"],
+        )
+        for attempt in report["attempt_history"]
+    ] == [attempt[:3] for attempt in expected]
+    assert all(attempt["path"] == "cached" and attempt["rung"] != "plain_loop" for attempt in report["attempt_history"])
+    assert all(attempt["dropped_context_rows"] == 0 for attempt in report["attempt_history"])
+
+
+def test_stream_context_exhaustion_reraises_without_plain_loop(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=1)
+    model = _StreamingRetryModel()
+    predictor = _streaming_predictor(model)
+    monkeypatch.setattr(predictor, "_total_vram_gb", lambda: 64.0)
+
+    with pytest.raises(torch.cuda.OutOfMemoryError, match="synthetic streamed-cache failure"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.cache_attempts == [
+        ("bf16", True, 8192, True),
+        ("int8", True, 8192, True),
+        ("int8", True, 2048, True),
+        ("int8", True, 1024, True),
+        ("int8", True, 512, True),
+        ("int8", True, 256, True),
+    ]
+    assert model.calls == []
+    history = predictor.memory_report_["attempt_history"]
+    assert [attempt["outcome"] for attempt in history] == ["oom"] * 6
+    assert all(attempt["path"] == "cached" for attempt in history)
+    assert all(attempt["rung"] != "plain_loop" for attempt in history)
+
+
+def test_stream_context_unsupported_reraises_without_retry_or_plain_loop(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    x_train, y_train, x_test = _table(n_train=12, n_test=1)
+    model = _StreamingRetryModel(error_type=NotImplementedError)
+    predictor = _streaming_predictor(model, context_row_chunk=256)
+
+    with pytest.raises(NotImplementedError, match="synthetic streamed-cache failure"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.cache_attempts == [("bf16", True, 256, True)]
+    assert model.calls == []
+    history = predictor.memory_report_["attempt_history"]
+    assert [attempt["outcome"] for attempt in history] == ["unsupported"]
+    assert history[0]["context_row_chunk"] == 256
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("SYNTHEFY_DISABLE_CACHED_INFERENCE", "1"),
+        ("SYNTHEFY_ENABLE_CACHED_INFERENCE", "0"),
+    ],
+)
+def test_stream_context_cache_kill_switch_fails_before_rows_or_model_call(fake_cuda_tensors, monkeypatch, name, value):
+    monkeypatch.setenv(name, value)
+    x_train, y_train, x_test = _table(n_train=12, n_test=1)
+    model = _StreamingRetryModel(("bf16", True, 2048, True))
+    predictor = _streaming_predictor(model)
+
+    with pytest.raises(RuntimeError, match="stream_context=True cannot run"):
+        predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.cache_attempts == []
+    assert model.train_rows == []
+    assert model.calls == []
+    assert predictor.memory_report_ is None
+
 
 def test_nonreused_group_context_is_released_before_next_build(fake_cuda_tensors):
     x_train, y_train, x_test = _table(n_train=12, n_test=300, n_features=5)
@@ -896,12 +1247,9 @@ def test_nonreused_group_context_is_released_before_next_build(fake_cuda_tensors
         [_PipeTransform(0.0, drop_last=True)],
     ]
     predictor.inference_config = [
-        {"retrieval_config": {"use_retrieval": False}}
-        for _ in predictor.preprocess_pipelines
+        {"retrieval_config": {"use_retrieval": False}} for _ in predictor.preprocess_pipelines
     ]
-    predictor.seeds = [0] * (
-        len(predictor.preprocess_pipelines) * predictor.preprocess_num
-    )
+    predictor.seeds = [0] * (len(predictor.preprocess_pipelines) * predictor.preprocess_num)
 
     predictor._predict_reg_single(x_train, y_train, x_test)
 

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -1,0 +1,640 @@
+"""Conservative batching of independent inference-pipeline model calls."""
+
+from __future__ import annotations
+
+import weakref
+
+import numpy as np
+import pytest
+import torch
+
+import synthefy_nori.inference.predictor as predictor_module
+from synthefy_nori.inference.predictor import NoriPredictor
+from synthefy_nori.inference.memory_policy import estimate_cache_gb
+
+
+class _PlainModel:
+    mask_prediction = False
+    num_reg_quantiles = 1
+
+    def __init__(self, *, oom_above: int | None = None):
+        self.calls = []
+        self.oom_above = oom_above
+
+    def to(self, _device):
+        return self
+
+    def __call__(self, *, x, y, eval_pos):
+        del y
+        self.calls.append(x.shape[0])
+        if self.oom_above is not None and x.shape[0] > self.oom_above:
+            raise torch.cuda.OutOfMemoryError("synthetic batched OOM")
+        return x[:, eval_pos:, :1]
+
+
+class _QuantileModel(_PlainModel):
+    """A nonlinear K>1 head so collapse-before-average is observably wrong."""
+
+    num_reg_quantiles = 5
+
+    def __call__(self, *, x, y, eval_pos):
+        del y
+        self.calls.append(x.shape[0])
+        base = x[:, eval_pos:, 0]
+        return torch.stack(
+            [
+                base - 10.0,
+                base - 1.0,
+                base,
+                base + base.square() / 10.0,
+                base + base.square(),
+            ],
+            dim=-1,
+        )
+
+
+class _BatchSqueezingModel(_PlainModel):
+    """A custom wrapper that violates the required batched output contract."""
+
+    def __call__(self, *, x, y, eval_pos):
+        del y
+        self.calls.append(x.shape[0])
+        output = x[:, eval_pos:, :1]
+        return output[0] if x.shape[0] > 1 else output
+
+
+class _RNGModel(_PlainModel):
+    """Consume RNG by feature width, as feature positional embeddings do."""
+
+    def __call__(self, *, x, y, eval_pos):
+        del y
+        self.calls.append((x.shape[0], x.shape[-1]))
+        torch.rand(x.shape[-1])
+        return x[:, eval_pos:, :1]
+
+
+class _CachedModel(_PlainModel):
+    features_per_group = 2
+    embed_dim = 8
+    nlayers = 1
+    nhead = 2
+
+    # Eligibility checks for the split cached API through this historical name.
+    forward_cached_regression = object()
+
+    def __init__(self):
+        super().__init__()
+        self.build_batches = []
+        self.apply_batches = []
+
+    def build_context_cache(self, x_train, y_train, **_kwargs):
+        self.build_batches.append(x_train.shape[0])
+        return x_train, y_train
+
+    def apply_context_cache(self, x_test, context, **_kwargs):
+        self.apply_batches.append(x_test.shape[0])
+        x_train, _ = context
+        return x_test[:, :, :1] + 0.0 * x_train[:, :1, :1]
+
+
+class _TrackedContext:
+    pass
+
+
+class _LifetimeCachedModel(_CachedModel):
+    """Track whether non-retained grouped contexts overlap in memory."""
+
+    def __init__(self):
+        super().__init__()
+        self.active_contexts = 0
+        self.active_before_build = []
+        self.build_shapes = []
+
+    def _release_context(self):
+        self.active_contexts -= 1
+
+    def build_context_cache(self, x_train, y_train, **_kwargs):
+        del y_train
+        self.active_before_build.append(self.active_contexts)
+        self.build_batches.append(x_train.shape[0])
+        self.build_shapes.append(tuple(x_train.shape))
+        self.active_contexts += 1
+        context = _TrackedContext()
+        weakref.finalize(context, self._release_context)
+        return context
+
+    def apply_context_cache(self, x_test, context, **_kwargs):
+        del context
+        self.apply_batches.append(x_test.shape[0])
+        return x_test[:, :, :1]
+
+
+class _FailingCachedApplyModel(_CachedModel):
+    """Fail only the grouped apply; the legacy B=1 retry remains healthy."""
+
+    def __init__(self, error_type):
+        super().__init__()
+        self.error_type = error_type
+
+    def apply_context_cache(self, x_test, context, **_kwargs):
+        self.apply_batches.append(x_test.shape[0])
+        if x_test.shape[0] > 1:
+            raise self.error_type("synthetic grouped-cache failure")
+        x_train, _ = context
+        return x_test[:, :, :1] + 0.0 * x_train[:, :1, :1]
+
+
+class _PipeTransform:
+    """Give each member distinct values and optionally a distinct feature width."""
+
+    def __init__(self, offset: float, *, drop_last: bool = False):
+        self.offset = offset
+        self.drop_last = drop_last
+        self.categorical_idx = []
+        self.fit_calls = 0
+        self.transform_calls = 0
+
+    def fit(self, _x, categorical_idx, _seed, **_kwargs):
+        self.fit_calls += 1
+        self.categorical_idx = list(categorical_idx)
+        return self.categorical_idx
+
+    def transform(self, x):
+        self.transform_calls += 1
+        transformed = x + self.offset
+        if self.drop_last:
+            transformed = transformed[:, :-1]
+        return transformed, self.categorical_idx
+
+
+def _predictor(model, *, memory_policy="off"):
+    predictor = NoriPredictor.__new__(NoriPredictor)
+    predictor.device = torch.device("cuda")
+    predictor.model = model
+    predictor.model_path = None
+    predictor.seed = 7
+    predictor.mix_precision = False
+    predictor.mask_prediction = False
+    predictor.inference_with_DDP = False
+    predictor.memory_policy = memory_policy
+    predictor.preprocess_pipelines = [[], [], []]
+    predictor.inference_config = [
+        {"retrieval_config": {"use_retrieval": False}} for _ in predictor.preprocess_pipelines
+    ]
+    predictor.preprocess_num = 10
+    predictor.seeds = [0] * 30
+    predictor.min_seq_len_for_category_infer = 100
+    predictor.min_unique_num_for_numerical_infer = 4
+    predictor.quantile_collapse = "mean"
+    predictor._warned_this_call = set()
+    predictor._logged_this_call = set()
+    return predictor
+
+
+@pytest.fixture
+def fake_cuda_tensors(monkeypatch):
+    """Exercise CUDA routing on a CPU-only CI worker without emulating kernels."""
+    original_to = torch.Tensor.to
+
+    def keep_cpu(tensor, *args, **kwargs):
+        if args and isinstance(args[0], torch.device) and args[0].type == "cuda":
+            return tensor
+        return original_to(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "to", keep_cpu)
+    monkeypatch.setattr(torch.cuda, "manual_seed_all", lambda _seed: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+
+
+def _table(n_train=12, n_test=7, n_features=4):
+    values = np.arange((n_train + n_test) * n_features, dtype=np.float32)
+    x = values.reshape(n_train + n_test, n_features) / 10.0
+    y = np.linspace(-1.0, 1.0, n_train, dtype=np.float32)
+    return x[:n_train], y, x[n_train:]
+
+
+def test_shape_grouping_is_stable_and_does_not_pad():
+    def item(id_pipe, features):
+        return (
+            id_pipe,
+            torch.zeros(4, features),
+            torch.zeros(4),
+            torch.zeros(2, features),
+        )
+
+    groups = NoriPredictor._group_ordinary_pipes(
+        [
+            item(2, 3),
+            item(0, 5),
+            item(1, 3),
+            item(3, 4),
+            item(4, 3),
+            item(5, 3),
+            item(6, 3),
+            item(7, 5),
+            item(8, 3),
+            item(9, 257),
+            item(10, 257),
+        ]
+    )
+    assert [[entry[0] for entry in group] for group in groups] == [
+        [2, 1, 4, 5],
+        [6, 8],
+        [0, 7],
+        [3],
+        [9],
+        [10],
+    ]
+
+
+def test_plain_path_batches_and_kill_switch_restores_b1(fake_cuda_tensors, monkeypatch):
+    x_train, y_train, x_test = _table()
+    batched_model = _PlainModel()
+    batched = _predictor(batched_model)._predict_reg_single(x_train, y_train, x_test)
+    assert batched_model.calls == [3]
+
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    legacy_model = _PlainModel()
+    legacy = _predictor(legacy_model)._predict_reg_single(x_train, y_train, x_test)
+    assert legacy_model.calls == [1, 1, 1]
+    torch.testing.assert_close(batched, legacy, rtol=0, atol=0)
+
+
+def test_distribution_member_order_and_collapse_match_b1(fake_cuda_tensors, monkeypatch):
+    x_train, y_train, x_test = _table()
+    offsets = (30.0, 10.0, 60.0, 20.0, 50.0, 40.0)
+
+    def distinct_predictor():
+        predictor = _predictor(_QuantileModel())
+        # More members than PIPELINE_BATCH_MAX forces execution groups [4, 2].
+        # Offsets are deliberately unsorted, so reconstructing results in group
+        # order instead of public pipeline-id order is observable.
+        predictor.preprocess_pipelines = [[_PipeTransform(offset)] for offset in offsets]
+        predictor.inference_config = [{"retrieval_config": {"use_retrieval": False}} for _ in offsets]
+        predictor.seeds = [0] * (len(offsets) * predictor.preprocess_num)
+        predictor.quantile_collapse = "huber_mean"
+        return predictor
+
+    ordered = distinct_predictor()
+    members = ordered._try_batched_ordinary_regression(
+        ordered._bare_model(),
+        x_train_base=x_train,
+        x_test_base=x_test,
+        y_train=y_train,
+        categorical_idx=[],
+        n_samples_train=len(x_train),
+        n_samples_test=len(x_test),
+        budget_n_features=x_train.shape[1],
+        max_elements_budget=1_000_000,
+        dropped_context_rows=0,
+    )
+    assert members is not None
+    assert ordered.model.calls == [4, 2]
+    base = torch.from_numpy(x_test[:, 0])
+    for member, offset in zip(members, offsets):
+        shifted = base + offset
+        expected = torch.stack(
+            [
+                shifted - 10.0,
+                shifted - 1.0,
+                shifted,
+                shifted + shifted.square() / 10.0,
+                shifted + shifted.square(),
+            ],
+            dim=-1,
+        )
+        torch.testing.assert_close(member, expected, rtol=0, atol=0)
+
+    expected_bank = torch.stack(members).mean(dim=0)
+    expected_point = ordered._collapse_regression_output(expected_bank)
+    collapse_first = torch.stack([ordered._collapse_regression_output(member) for member in members]).mean(dim=0)
+    assert not torch.allclose(expected_point, collapse_first), (
+        "fixture does not distinguish average-before-collapse from the wrong order"
+    )
+
+    batched = distinct_predictor()
+    batched_bank = batched._predict_reg_single(x_train, y_train, x_test, return_distribution=True)
+    batched_point = batched._predict_reg_single(x_train, y_train, x_test)
+
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    legacy = distinct_predictor()
+    legacy_bank = legacy._predict_reg_single(x_train, y_train, x_test, return_distribution=True)
+    legacy_point = legacy._predict_reg_single(x_train, y_train, x_test)
+
+    torch.testing.assert_close(batched_bank, expected_bank, rtol=0, atol=0)
+    torch.testing.assert_close(batched_bank, legacy_bank, rtol=0, atol=0)
+    torch.testing.assert_close(batched_point, expected_point, rtol=0, atol=0)
+    torch.testing.assert_close(batched_point, legacy_point, rtol=0, atol=0)
+
+
+def test_wide_b1_groups_use_prepared_transforms_once(fake_cuda_tensors):
+    x_train, y_train, x_test = _table(n_features=257)
+    model = _PlainModel()
+    predictor = _predictor(model)
+    steps = [_PipeTransform(float(id_pipe)) for id_pipe in range(3)]
+    predictor.preprocess_pipelines = [[step] for step in steps]
+
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.calls == [1, 1, 1]
+    assert [(step.fit_calls, step.transform_calls) for step in steps] == [(1, 2)] * 3
+    torch.testing.assert_close(
+        output,
+        torch.from_numpy(x_test[:, 0]) + 1.0,
+        rtol=0,
+        atol=5e-5,
+    )
+
+
+def test_mixed_width_groups_preserve_legacy_post_call_rng_state(
+    fake_cuda_tensors, monkeypatch
+):
+    x_train, y_train, x_test = _table()
+
+    def mixed_predictor():
+        predictor = _predictor(_RNGModel())
+        predictor.preprocess_pipelines = [
+            [_PipeTransform(0.0)],
+            [_PipeTransform(0.0, drop_last=True)],
+            [_PipeTransform(0.0, drop_last=True)],
+            [_PipeTransform(0.0)],
+        ]
+        predictor.inference_config = [
+            {"retrieval_config": {"use_retrieval": False}}
+            for _ in predictor.preprocess_pipelines
+        ]
+        predictor.seeds = [0] * (
+            len(predictor.preprocess_pipelines) * predictor.preprocess_num
+        )
+        return predictor
+
+    batched = mixed_predictor()
+    batched._predict_reg_single(x_train, y_train, x_test)
+    batched_rng_state = torch.get_rng_state()
+    assert batched.model.calls == [(2, 3), (2, 4)]
+
+    monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    legacy = mixed_predictor()
+    legacy._predict_reg_single(x_train, y_train, x_test)
+    legacy_rng_state = torch.get_rng_state()
+    assert legacy.model.calls == [(1, 4), (1, 3), (1, 3), (1, 4)]
+    assert torch.equal(batched_rng_state, legacy_rng_state)
+
+
+def test_batched_oom_restarts_the_untouched_b1_loop(fake_cuda_tensors):
+    x_train, y_train, x_test = _table()
+    model = _PlainModel(oom_above=1)
+    output = _predictor(model)._predict_reg_single(x_train, y_train, x_test)
+    assert model.calls == [3, 1, 1, 1]
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-6)
+
+
+def test_invalid_batched_output_shape_restarts_b1(fake_cuda_tensors):
+    x_train, y_train, x_test = _table()
+    model = _BatchSqueezingModel()
+    output = _predictor(model)._predict_reg_single(x_train, y_train, x_test)
+    assert model.calls == [3, 1, 1, 1]
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+def test_host_retention_guard_restarts_b1(fake_cuda_tensors, monkeypatch):
+    monkeypatch.setattr(predictor_module, "PIPELINE_BATCH_HOST_BUDGET_BYTES", 1)
+    x_train, y_train, x_test = _table()
+    model = _PlainModel()
+    output = _predictor(model)._predict_reg_single(x_train, y_train, x_test)
+    assert model.calls == [1, 1, 1]
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+def test_resident_cache_batches_build_and_apply(fake_cuda_tensors):
+    # n_test > the predictor's minimum query chunk (256) makes the cache eligible.
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _CachedModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    first = predictor._predict_reg_single(x_train, y_train, x_test)
+    second_x_test = x_test + 0.25
+    second = predictor._predict_reg_single(x_train, y_train, second_x_test)
+    assert model.build_batches == [3]
+    assert model.apply_batches == [3, 3]
+    assert predictor.memory_report_["rung"] == "resident_bf16"
+    assert predictor.memory_report_["est_cache_gb"] == pytest.approx(
+        3
+        * estimate_cache_gb(
+            n_context_rows=12,
+            n_groups=2,
+            nlayers=1,
+            embed_dim=8,
+            bytes_per_element=4,
+        )
+    )
+    assert list(predictor._context_cache) == [("pipeline_batch", (0, 1, 2))]
+    torch.testing.assert_close(first, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+    torch.testing.assert_close(second, torch.from_numpy(second_x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+def test_nonreused_group_context_is_released_before_next_build(fake_cuda_tensors):
+    x_train, y_train, x_test = _table(n_train=12, n_test=300, n_features=5)
+    model = _LifetimeCachedModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_280,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+            "reuse_context_cache": False,
+        },
+    )
+    predictor.preprocess_pipelines = [
+        [_PipeTransform(0.0)],
+        [_PipeTransform(0.0)],
+        [_PipeTransform(0.0, drop_last=True)],
+        [_PipeTransform(0.0, drop_last=True)],
+    ]
+    predictor.inference_config = [
+        {"retrieval_config": {"use_retrieval": False}}
+        for _ in predictor.preprocess_pipelines
+    ]
+    predictor.seeds = [0] * (
+        len(predictor.preprocess_pipelines) * predictor.preprocess_num
+    )
+
+    predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.build_shapes == [(2, 12, 5), (2, 12, 4)]
+    assert model.active_before_build == [0, 0]
+    assert model.active_contexts == 0
+    expected_peak_gb = 2 * estimate_cache_gb(
+        n_context_rows=12,
+        n_groups=3,
+        nlayers=1,
+        embed_dim=8,
+        bytes_per_element=4,
+    )
+    assert predictor.memory_report_["est_cache_gb"] == pytest.approx(expected_peak_gb)
+
+
+@pytest.mark.parametrize("transition", ["kill-switch", "int8"])
+def test_cache_slots_are_exclusive_across_batched_b1_transitions(fake_cuda_tensors, monkeypatch, transition):
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _CachedModel()
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor._predict_reg_single(x_train, y_train, x_test)
+    assert list(predictor._context_cache) == [("pipeline_batch", (0, 1, 2))]
+
+    if transition == "kill-switch":
+        monkeypatch.setenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING", "1")
+    else:
+        predictor.memory_policy = {
+            "elements_budget": 1_072,
+            "cache_dtype": "int8",
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        }
+    predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.build_batches == [3, 1, 1, 1]
+    assert set(predictor._context_cache) == {0, 1, 2}
+    assert not any(isinstance(slot, tuple) for slot in predictor._context_cache)
+
+    if transition == "kill-switch":
+        monkeypatch.delenv("SYNTHEFY_DISABLE_PIPELINE_BATCHING")
+    else:
+        predictor.memory_policy = {
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        }
+    predictor._predict_reg_single(x_train, y_train, x_test)
+
+    assert model.build_batches == [3, 1, 1, 1, 3]
+    assert list(predictor._context_cache) == [("pipeline_batch", (0, 1, 2))]
+
+
+@pytest.mark.parametrize("error_type", [torch.cuda.OutOfMemoryError, NotImplementedError])
+def test_cached_group_failure_clears_slot_and_restarts_b1(fake_cuda_tensors, error_type):
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _FailingCachedApplyModel(error_type)
+    predictor = _predictor(
+        model,
+        memory_policy={
+            "elements_budget": 1_072,
+            "gpu_budget_absolute_gb": 1.0,
+            "host_budget_absolute_gb": 2.0,
+        },
+    )
+    predictor.preprocess_pipelines = [
+        [_PipeTransform(0.0, drop_last=True)],
+        [_PipeTransform(0.0)],
+        [_PipeTransform(0.0)],
+    ]
+    output = predictor._predict_reg_single(x_train, y_train, x_test)
+    assert model.build_batches == [1, 2, 1, 1, 1]
+    assert model.apply_batches == [1, 2, 1, 1, 1]
+    assert set(predictor._context_cache) == {0, 1, 2}
+    assert not any(isinstance(slot, tuple) for slot in predictor._context_cache)
+    torch.testing.assert_close(output, torch.from_numpy(x_test[:, 0]), rtol=0, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "excluded",
+    [
+        "cpu",
+        "single-pipe",
+        "ddp",
+        "predictor-mask",
+        "model-mask",
+        "retrieval",
+        "training",
+        "dropout",
+    ],
+)
+def test_execution_mode_exclusions_do_not_enter_batching(fake_cuda_tensors, excluded):
+    x_train, y_train, x_test = _table()
+    model = _PlainModel()
+    predictor = _predictor(model)
+    if excluded == "cpu":
+        predictor.device = torch.device("cpu")
+    elif excluded == "single-pipe":
+        predictor.preprocess_pipelines = predictor.preprocess_pipelines[:1]
+        predictor.inference_config = predictor.inference_config[:1]
+    elif excluded == "ddp":
+        predictor.inference_with_DDP = True
+    elif excluded == "predictor-mask":
+        predictor.mask_prediction = True
+    elif excluded == "model-mask":
+        model.mask_prediction = True
+    elif excluded == "retrieval":
+        predictor.inference_config[0]["retrieval_config"]["use_retrieval"] = True
+    elif excluded == "training":
+        model.training = True
+    elif excluded == "dropout":
+        model.dropout = 0.1
+
+    result = predictor._try_batched_ordinary_regression(
+        predictor._bare_model(),
+        x_train_base=x_train,
+        x_test_base=x_test,
+        y_train=y_train,
+        categorical_idx=[],
+        n_samples_train=len(x_train),
+        n_samples_test=len(x_test),
+        budget_n_features=x_train.shape[1],
+        max_elements_budget=1_000_000,
+        dropped_context_rows=0,
+    )
+    assert result is None
+    assert model.calls == []
+
+
+@pytest.mark.parametrize(
+    "memory_policy",
+    [
+        pytest.param(
+            {
+                "elements_budget": 1_072,
+                "cache_dtype": "int8",
+                "gpu_budget_absolute_gb": 1.0,
+                "host_budget_absolute_gb": 2.0,
+            },
+            id="int8",
+        ),
+        pytest.param(
+            {
+                "elements_budget": 1_072,
+                "gpu_budget_absolute_gb": 0.0,
+                "host_budget_absolute_gb": 2.0,
+            },
+            id="host-offload",
+        ),
+        pytest.param(
+            {
+                "elements_budget": 1_072,
+                "context_row_chunk": 4,
+                "gpu_budget_absolute_gb": 1.0,
+                "host_budget_absolute_gb": 2.0,
+            },
+            id="pinned-context-row-chunk",
+        ),
+    ],
+)
+def test_memory_mode_exclusions_stay_on_the_legacy_loop(fake_cuda_tensors, memory_policy):
+    x_train, y_train, x_test = _table(n_train=12, n_test=300)
+    model = _CachedModel()
+    predictor = _predictor(model, memory_policy=memory_policy)
+    predictor._predict_reg_single(x_train, y_train, x_test)
+    assert model.build_batches == [1, 1, 1]
+    assert model.apply_batches == [1, 1, 1]

--- a/tests/test_inference_pipeline_batching.py
+++ b/tests/test_inference_pipeline_batching.py
@@ -1343,7 +1343,9 @@ def test_cached_group_failure_clears_slot_and_restarts_b1(fake_cuda_tensors, err
         "ddp",
         "predictor-mask",
         "model-mask",
-        "retrieval",
+        # Internal also parametrizes "retrieval" here. This tier has no
+        # retrieval: its inference configs carry no "retrieval_config" key, so
+        # there is no such execution mode to exclude.
         "training",
         "dropout",
     ],
@@ -1363,8 +1365,6 @@ def test_execution_mode_exclusions_do_not_enter_batching(fake_cuda_tensors, excl
         predictor.mask_prediction = True
     elif excluded == "model-mask":
         model.mask_prediction = True
-    elif excluded == "retrieval":
-        predictor.inference_config[0]["retrieval_config"]["use_retrieval"] = True
     elif excluded == "training":
         model.training = True
     elif excluded == "dropout":

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -218,6 +218,51 @@ class TestAutoLadder:
         assert isinstance(resolve(1.0), MemoryPolicy)
 
 
+    def test_runtime_fallbacks_reuse_resolve_candidate_order(self):
+        requested = MemoryPolicy(
+            gpu_budget_absolute_gb=100.0, host_budget_absolute_gb=200.0
+        )
+        resolved = requested.resolve(
+            est_cache_gb=1.0,
+            bytes_per_element=2,
+            head_dim=64,
+            total_vram_gb=80.0,
+            total_ram_gb=800.0,
+        )
+        assert [
+            policy.rung
+            for policy in requested.runtime_fallbacks(
+                resolved, bytes_per_element=2, head_dim=64
+            )
+        ] == [
+            "resident_bf16",
+            "resident_int8",
+            "offload_bf16",
+            "offload_int8",
+        ]
+
+    def test_runtime_fallbacks_respect_precision_and_offload_permissions(self):
+        requested = MemoryPolicy(
+            allow_quantization=False,
+            offload_to_host=False,
+            gpu_budget_absolute_gb=100.0,
+        )
+        resolved = requested.resolve(
+            est_cache_gb=1.0,
+            bytes_per_element=2,
+            head_dim=64,
+            total_vram_gb=80.0,
+            total_ram_gb=800.0,
+        )
+        assert [
+            policy.rung
+            for policy in requested.runtime_fallbacks(
+                resolved, bytes_per_element=2, head_dim=64
+            )
+        ] == ["resident_bf16"]
+
+
+
 class TestPinnedPrecision:
     def test_exact_preset_offloads_rather_than_quantizing(self):
         # "exact" must stay exact: when it will not fit the GPU the answer is host

--- a/tests/test_memory_policy.py
+++ b/tests/test_memory_policy.py
@@ -20,8 +20,10 @@ from pydantic import ValidationError
 
 from synthefy_nori.inference import memory_policy as _mp
 from synthefy_nori.inference.memory_policy import (
+    DEFAULT_STREAM_CONTEXT_ROW_CHUNK,
     DEFAULT_GPU_BUDGET_FRAC,
     MEMORY_PRESETS,
+    ContextTooLargeError,
     MemoryPolicy,
     estimate_cache_gb,
     int8_footprint_gb,
@@ -217,11 +219,8 @@ class TestAutoLadder:
         # left, which is why there is no separate decision object to keep straight.
         assert isinstance(resolve(1.0), MemoryPolicy)
 
-
     def test_runtime_fallbacks_reuse_resolve_candidate_order(self):
-        requested = MemoryPolicy(
-            gpu_budget_absolute_gb=100.0, host_budget_absolute_gb=200.0
-        )
+        requested = MemoryPolicy(gpu_budget_absolute_gb=100.0, host_budget_absolute_gb=200.0)
         resolved = requested.resolve(
             est_cache_gb=1.0,
             bytes_per_element=2,
@@ -229,12 +228,7 @@ class TestAutoLadder:
             total_vram_gb=80.0,
             total_ram_gb=800.0,
         )
-        assert [
-            policy.rung
-            for policy in requested.runtime_fallbacks(
-                resolved, bytes_per_element=2, head_dim=64
-            )
-        ] == [
+        assert [policy.rung for policy in requested.runtime_fallbacks(resolved, bytes_per_element=2, head_dim=64)] == [
             "resident_bf16",
             "resident_int8",
             "offload_bf16",
@@ -254,13 +248,129 @@ class TestAutoLadder:
             total_vram_gb=80.0,
             total_ram_gb=800.0,
         )
-        assert [
-            policy.rung
-            for policy in requested.runtime_fallbacks(
-                resolved, bytes_per_element=2, head_dim=64
-            )
-        ] == ["resident_bf16"]
+        assert [policy.rung for policy in requested.runtime_fallbacks(resolved, bytes_per_element=2, head_dim=64)] == [
+            "resident_bf16"
+        ]
 
+
+class TestExplicitContextStreaming:
+    """The opt-in path is host-only and bounded; it never becomes plain_loop."""
+
+    def test_default_policy_does_not_enable_streaming(self):
+        policy = MemoryPolicy()
+        assert policy.stream_context is False
+        assert policy.context_row_chunk is None
+
+        requested = MemoryPolicy(stream_context=True)
+        assert not requested.is_bit_exact
+
+    def test_streaming_forces_a_host_rung_and_uses_the_80gb_default(self):
+        policy = resolve(1.0, MemoryPolicy(stream_context=True))
+
+        assert policy.rung == "stream_bf16"
+        assert policy.cache and policy.offload_to_host
+        assert policy.gpu_budget_absolute_gb == 0.0
+        assert policy.reuse_context_cache is False
+        assert DEFAULT_STREAM_CONTEXT_ROW_CHUNK == 2048
+        assert policy.context_row_chunk == 8192
+
+    @pytest.mark.parametrize(
+        ("total_vram_gb", "expected_chunk"),
+        [
+            (None, 2048),
+            (39.9, 2048),
+            (40.0, 8192),
+            (79.9, 8192),
+            (80.0, 16384),
+            (139.8, 16384),
+        ],
+    )
+    def test_omitted_chunk_adapts_to_accelerator_vram(self, total_vram_gb, expected_chunk):
+        policy = MemoryPolicy(stream_context=True).resolve(
+            est_cache_gb=1.0,
+            bytes_per_element=2,
+            head_dim=HEAD_DIM,
+            total_vram_gb=total_vram_gb,
+            total_ram_gb=BIG_RAM,
+        )
+        assert policy.context_row_chunk == expected_chunk
+
+    def test_explicit_chunk_is_the_reported_maximum(self):
+        policy = MemoryPolicy(stream_context=True, context_row_chunk=4096).resolve(
+            est_cache_gb=1.0,
+            bytes_per_element=2,
+            head_dim=HEAD_DIM,
+            total_vram_gb=139.8,
+            total_ram_gb=BIG_RAM,
+        )
+
+        assert policy.context_row_chunk == 4096
+        assert "maximum staged context rows=4096" in policy.describe()
+
+    def test_streaming_quantizes_only_when_bf16_exceeds_host_capacity(self):
+        # 4 GiB bf16 exceeds the 2.5 GiB host budget; int8 is ~2.1 GiB and fits.
+        policy = resolve(
+            4.0,
+            MemoryPolicy(stream_context=True),
+            total_ram_gb=10.0,
+        )
+        assert policy.rung == "stream_int8"
+        assert policy.cache_dtype == "int8"
+
+    @pytest.mark.parametrize("dtype", ["bf16", "int8"])
+    def test_both_streaming_rungs_are_non_bit_exact_and_degraded(self, dtype):
+        policy = resolve(
+            1.0,
+            MemoryPolicy(stream_context=True, cache_dtype=dtype),
+        )
+        assert policy.rung == f"stream_{dtype}"
+        assert not policy.is_bit_exact
+        assert policy.is_degraded
+
+    def test_runtime_fallbacks_stay_on_streaming_rungs(self):
+        requested = MemoryPolicy(stream_context=True)
+        resolved = resolve(1.0, requested)
+        attempts = requested.runtime_fallbacks(
+            resolved,
+            bytes_per_element=2,
+            head_dim=HEAD_DIM,
+        )
+
+        assert [attempt.rung for attempt in attempts] == [
+            "stream_bf16",
+            "stream_int8",
+        ]
+        assert all(attempt.offload_to_host for attempt in attempts)
+        assert all(not attempt.reuse_context_cache for attempt in attempts)
+
+    def test_host_capacity_failure_raises_instead_of_selecting_plain_loop(self):
+        with pytest.raises(ContextTooLargeError, match="will not silently use plain_loop"):
+            resolve(
+                20.0,
+                MemoryPolicy(stream_context=True),
+                total_ram_gb=10.0,
+            )
+
+    def test_streaming_cannot_be_resolved_as_ineligible_or_escalated_to_plain_loop(self):
+        requested = MemoryPolicy(stream_context=True)
+        with pytest.raises(ValueError, match="cannot resolve to no_cache or plain_loop"):
+            resolve(0.0, requested, cache_eligible=False)
+
+        resolved = resolve(1.0, requested)
+        with pytest.raises(ValueError, match="instead of silently using plain_loop"):
+            resolved.escalated("plain_loop")
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"cache": False}, "requires cache=True"),
+            ({"offload_to_host": False}, "requires offload_to_host=True"),
+            ({"reuse_context_cache": True}, "reuse_context_cache=True"),
+        ],
+    )
+    def test_incoherent_streaming_requests_are_rejected(self, kwargs, message):
+        with pytest.raises(ValidationError, match=message):
+            MemoryPolicy(stream_context=True, **kwargs)
 
 
 class TestPinnedPrecision:
@@ -461,6 +571,24 @@ class TestPredictorEnvSurface:
         # Shipped and documented in public/README.md, so it keeps working.
         monkeypatch.setenv("SYNTHEFY_ENABLE_CACHED_INFERENCE", "0")
         assert self._policy_of().cache is False
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("SYNTHEFY_DISABLE_CACHED_INFERENCE", "1"),
+            ("SYNTHEFY_ENABLE_CACHED_INFERENCE", "0"),
+        ],
+    )
+    def test_stream_context_fails_closed_under_cache_kill_switch(self, monkeypatch, name, value):
+        monkeypatch.setenv(name, value)
+        with pytest.raises(RuntimeError, match="stream_context=True cannot run"):
+            self._policy_of(
+                {
+                    "stream_context": True,
+                    "elements_budget": 8,
+                    "allow_subsample": False,
+                }
+            )
 
     def test_removed_cache_max_gb_fails_loudly(self, monkeypatch):
         # It shipped with a DIFFERENT meaning (skip vs offload), so silently ignoring

--- a/tests/test_memory_policy_e2e.py
+++ b/tests/test_memory_policy_e2e.py
@@ -64,6 +64,13 @@ def _predict(regressor_cls, table, memory_policy):
     return np.asarray(model.predict(x_test), dtype=np.float64), model.memory_report_
 
 
+def _policy_from_report(report):
+    """Round-trip the reported dict straight back through MemoryPolicy."""
+    assert set(report) == set(MemoryPolicy().model_dump())
+    assert isinstance(report["attempt_history"], list)
+    return MemoryPolicy(**report)
+
+
 class TestPolicyReachesInference:
     def test_report_is_none_before_predicting(self, regressor_cls):
         model = regressor_cls(model="nori-6m", device="cpu")
@@ -75,13 +82,12 @@ class TestPolicyReachesInference:
         assert report["rung"] == "resident_bf16", (
             f"expected the cached path to engage; got {report['rung']}. If this is "
             f'"no_cache", SMALL_ELEMENTS_BUDGET is too large for this table and the '
-            f"rest of this suite is testing nothing."
-        )
-        assert MemoryPolicy(**report).is_bit_exact
+            f'rest of this suite is testing nothing.')
+        assert _policy_from_report(report).is_bit_exact
 
     def test_report_round_trips_into_the_policy_type(self, regressor_cls, table):
         _, report = _predict(regressor_cls, table, None)
-        assert MemoryPolicy(**report).rung == report["rung"]
+        assert _policy_from_report(report).rung == report["rung"]
 
     def test_requesting_int8_changes_the_reported_rung(self, regressor_cls, table):
         # The load-bearing assertion: a different memory_policy= must produce a different
@@ -89,7 +95,7 @@ class TestPolicyReachesInference:
         _, default_report = _predict(regressor_cls, table, None)
         _, int8_report = _predict(regressor_cls, table, {"cache_dtype": "int8"})
         assert int8_report["cache_dtype"] == "int8"
-        assert not MemoryPolicy(**int8_report).is_bit_exact
+        assert not _policy_from_report(int8_report).is_bit_exact
         assert default_report["rung"] == "resident_bf16"
         assert int8_report["rung"] == "resident_int8"
 

--- a/tests/test_memory_policy_e2e.py
+++ b/tests/test_memory_policy_e2e.py
@@ -82,7 +82,8 @@ class TestPolicyReachesInference:
         assert report["rung"] == "resident_bf16", (
             f"expected the cached path to engage; got {report['rung']}. If this is "
             f'"no_cache", SMALL_ELEMENTS_BUDGET is too large for this table and the '
-            f'rest of this suite is testing nothing.')
+            f"rest of this suite is testing nothing."
+        )
         assert _policy_from_report(report).is_bit_exact
 
     def test_report_round_trips_into_the_policy_type(self, regressor_cls, table):

--- a/tests/test_model_encoder_invariants.py
+++ b/tests/test_model_encoder_invariants.py
@@ -5,6 +5,7 @@ import json
 import pytest
 import torch
 
+from synthefy_nori.model.kv_cache_scaling import BlockwiseSeqKV
 from synthefy_nori.model.encoders import (
     MaskEmbEncoder,
     NanEncoder,
@@ -197,6 +198,106 @@ def test_nonfinite_values_are_missing_and_direct_matches_cache(
     assert torch.isfinite(direct).all()
     assert torch.isfinite(cached).all()
     torch.testing.assert_close(cached, direct, atol=1e-6, rtol=1e-6)
+
+
+@pytest.mark.parametrize("cache_dtype", ["bf16", "int8"])
+@pytest.mark.parametrize("target_case", ["finite", "mixed", "all_nonfinite"])
+def test_streamed_context_matches_legacy_cache_and_stays_host_blockwise(cache_dtype, target_case):
+    torch.manual_seed(123)
+    model = _tiny_model(features_per_group=3)
+    values = torch.arange(9 * 5, dtype=torch.float32).reshape(1, 9, 5) / 7
+    y_train = torch.tensor([[0.0, 1.0, -1.0, 2.0, 3.0, -2.0]])
+    if target_case == "mixed":
+        values[0, 1, 2] = float("nan")
+        values[0, 3, 4] = float("inf")
+        y_train[0, 2] = float("nan")
+    elif target_case == "all_nonfinite":
+        y_train.fill_(float("nan"))
+
+    with torch.no_grad():
+        legacy = model.build_context_cache(
+            values[:, :6],
+            y_train,
+            cache_dtype=cache_dtype,
+            offload_kv_cache=True,
+            fit_row_chunk=2,
+        )
+        expected = model.apply_context_cache(values[:, 6:], legacy, row_chunk_size=2)
+        streamed = model.build_context_cache(
+            values[:, :6].cpu(),
+            y_train.cpu(),
+            cache_dtype=cache_dtype,
+            offload_kv_cache=True,
+            fit_row_chunk=2,
+            stream_context=True,
+        )
+        actual = model.apply_context_cache(values[:, 6:].cpu(), streamed, row_chunk_size=2)
+
+    assert torch.isfinite(expected).all()
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, expected, atol=5e-3, rtol=5e-3)
+    assert streamed.eval_pos == 6
+    assert streamed.y_train.numel() == 0
+    assert streamed.query_y_embedding.shape[1] == 1
+    for layer_cache in streamed.caches:
+        seq_kv = layer_cache["seq_kv"]
+        assert isinstance(seq_kv, BlockwiseSeqKV)
+        assert seq_kv.n_rows == 6
+        assert seq_kv.max_block_rows <= 2
+        assert seq_kv.max_staged_rows <= 2
+        assert seq_kv.resident_gpu_bytes() == 0
+        assert seq_kv.host_bytes() > 0
+        assert all(
+            payload.device.type == "cpu" and (scale is None or scale.device.type == "cpu")
+            for payload, scale in seq_kv._blocks
+        )
+
+
+def test_hybrid_resident_int8_prefill_matches_legacy_cache():
+    torch.manual_seed(321)
+    model = _tiny_model(features_per_group=3)
+    values = torch.arange(9 * 5, dtype=torch.float32).reshape(1, 9, 5) / 7
+    values[0, 2, 1] = float("nan")
+    y_train = torch.tensor([[0.0, 1.0, -1.0, 2.0, 3.0, -2.0]])
+
+    with torch.no_grad():
+        legacy = model.build_context_cache(
+            values[:, :6],
+            y_train,
+            cache_dtype="int8",
+            offload_kv_cache=False,
+            fit_row_chunk=2,
+        )
+        expected = model.apply_context_cache(values[:, 6:], legacy, row_chunk_size=2)
+        hybrid = model.build_context_cache(
+            values[:, :6].cpu(),
+            y_train.cpu(),
+            cache_dtype="int8",
+            offload_kv_cache=False,
+            fit_row_chunk=2,
+            _hybrid_resident_int8_prefill=True,
+        )
+        actual = model.apply_context_cache(values[:, 6:].cpu(), hybrid, row_chunk_size=2)
+
+    torch.testing.assert_close(actual, expected, atol=5e-3, rtol=5e-3)
+    assert hybrid.eval_pos == 6
+    assert hybrid.y_train.numel() == 0
+    assert hybrid.query_y_embedding.shape[1] == 1
+    for layer_cache in hybrid.caches:
+        seq_kv = layer_cache["seq_kv"]
+        assert isinstance(seq_kv, BlockwiseSeqKV)
+        assert seq_kv.quantized is True
+        assert seq_kv.offloaded is False
+        assert seq_kv.n_rows == 6
+        assert seq_kv.max_block_rows <= 2
+        assert seq_kv.resident_gpu_bytes() > 0
+        assert seq_kv.host_bytes() == 0
+        assert all(
+            payload.device == next(model.parameters()).device
+            and scale is not None
+            and scale.device == next(model.parameters()).device
+            for payload, scale in seq_kv._blocks
+        )
 
 
 def test_rbf_centers_are_deterministic_and_reconstructed_from_config():


### PR DESCRIPTION
Replaces #142, which was closed unmerged after its GPU gate failed.

> **Opened ahead of the cascade, deliberately.** Synthefy/synthefy-nori-staging#39
> carries this exact commit set and is green but not yet merged. This PR exists to
> get public's CI signal early — particularly the GPU gate, which is the one thing
> staging structurally cannot run (see the bottom of this description). **Merge
> staging#39 first.**

The tree here is **byte-identical** to staging#39's (`82d33bbc`), cherry-picked
onto a public `main` whose tree is in turn identical to staging's base.

## Why #142 failed, and why this doesn't

#142's GPU gate died with:

```
python -m synthefy_nori.training.cli --device cuda:0 ...
  → KeyError: 'cls_output'

FAILED test_single_training_step_writes_checkpoint
FAILED test_logical_batch_runs_with_or_without_memory_plan[True-2]
FAILED test_logical_batch_runs_with_or_without_memory_plan[False-1]
FAILED test_prefetch_refill_survives_a_second_step
```

Not a GPU-specific bug. #142 took internal's file *versions* wholesale, which
carried internal's #392 removal of the classification head — while this tier's
`training/loss.py` still reads `model_output["cls_output"]`.

This PR promotes **commits**, not files, and stops at the ones the streaming work
actually needs. #392 is not among them, so the classification head stays.

## What's here

| | internal | why |
|---|---|---|
| perf: accelerate Nori inference and attention | #493 | #517's blockwise dispatch shares its call sites |
| perf: add exact cached CUDA graph mode | #495 | #516's tests import `EXACT_CACHED_CUDAGRAPHS_ENV` |
| Fix runtime memory fallback retries and reporting | **#516** | |
| Bound full-context GPU memory with streamed attention | **#517** | |

Plus three `fix(promote)`/`style` commits adapting the above to this tier.

**Not** promoted: #392 (classification-head removal), #475 (synthetic-pipeline
hardening), the MPS stride fix, #511. Each touches the same files but is a
separate change; #392/#475 would drag the training rewrite and seven
internal-only training modules with them.

## Surface area

**No new source modules.** `src/synthefy_nori/` gains zero files — every change
lands in a file that already exists. The seven added files are three benchmarks
and four test modules.

## Tier adaptations

Internal removed classification from the model in #392; this tier has it.
Everything below follows, and each is commented at the site.

1. **`task_type="reg"` at the new call sites** — this tier's `forward()` still
   defaults to `"cls"`, so internal's code omitting the argument silently selected
   the classification head. Affects the batched regression path, the streaming
   prefill's `apply_target_aware_embedding`, and `_encode_y_full`.
2. **`sdpa_scale=None` on the blockwise kernel** — internal folds the QASS log(n)
   factor into an `sdpa_scale` threaded through the `compute_attention_by_torch`
   it refactored in #475. This tier applies it to `q` via
   `_apply_extra_attn_scale`. The streaming path does not go through
   `compute_attention_by_torch`, so the scale is applied to `q` explicitly first.
   Same effective query, no #475 needed.
3. **Retrieval guards dropped** — #493 excludes retrieval configs and
   `InferenceAttentionMap`/`SubSampleData` steps from batching. Neither exists
   here; `config["retrieval_config"]` raises `KeyError`. See the testing note below.
4. **Flash-attn probes and the process-wide cuDNN disable omitted** — no flash
   dispatch here, and the per-call `sdpa_kernel` guard already excludes cuDNN
   without mutating global torch state. `FLASH_ATTN_DTYPE` is kept; the
   FlexAttention kernel uses it either way.
5. **Batched path skipped under `DistributedInference`** — it calls the bare model
   directly and cannot honour a distributed session. Internal has no DDP inference.
6. **`MemoryRung` defined locally** — internal added it in #347 beside its serving
   wire-contract check; #516's field annotations reference it.

Serving paths (`serving/`, its case-table and OpenAPI tests,
`libs/synthefy/SOURCE_SNAPSHOT.json`, `ci/sync_openapi.py`) were dropped from each
pick — internal-only.

## One real bug fixed along the way

`memory_report_["dropped_context_rows"]` reported **0** for a call that dropped
2875 rows. #516's `_publish_memory_policy` ranks outcomes by
`_memory_rung_sort_key`, which did not compare `dropped_context_rows`, so the real
outcome tied with the opening `resolve()` policy and the strict `>` kept the
latter.

Fixed here and, identically, in internal
(Synthefy/synthefy-nori-internal#537, merged). The two hunks are byte-identical,
so the cascade rebase 3-way merges them cleanly.

Caught by `TestSubsamplingIsNeverSilent`, which exists in this tier and in staging
but **not in internal** — which is why #516 merged there green. #537 ports the
class across so internal gains the coverage.

## Verification, run locally on an H100

```
pytest -q                                        888 passed, 21 skipped
ruff check src scripts tests                     All checks passed
ruff format --check .                            178 files already formatted

# the GPU gate's own selection, SYNTHEFY_NORI_SMOKE_DEVICE=cuda:0
pytest -m slow tests/test_inference_e2e.py tests/test_training_smoke.py
                                                 4 passed, 2 skipped
```

The two skips are `requires an MPS-capable macOS host`; they skip on Modal's Linux
A100 too.

The exact commands that raised `KeyError: 'cls_output'` on #142, re-run on cuda:0:

```
training.cli --device cuda:0 --task-type cls              → completes, checkpoint saved
same, prefetch on, 2 steps                                 → completes, checkpoint saved
```

End-to-end streaming, 4000x12 context, same table with and without:

```
baseline rung : no_cache
streamed rung : stream_bf16
streamed cap  : 512   (honoured verbatim)
max |delta|   : 1.181e-03
baseline R2   : 0.9987
streamed R2   : 0.9987
```

Not bit-exact by design — bounded online attention reassociates the reductions.
Inside the range internal documents (max 2.93e-3).

## Worth knowing before merging

**The retrieval `KeyError` in adaptation 3 passed all 888 unit tests.** They build
their own `inference_config` stubs, so nothing exercised the real config shape. It
surfaced only on an actual `NoriRegressor.predict()`. Unit-test green is not
sufficient evidence for a promotion of this shape.

**Staging's GPU gate has never run.** `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` are set
in this repo and in internal, but not in staging, so its `gpu-ci` job takes the
documented no-op branch and reports green in 13 seconds. That is why #142's GPU
failure was invisible one tier earlier. Adding those two secrets to staging is a
separate, one-time fix.

**Two pre-existing failures**, both verified against unmodified `main` and not
touched here:

- `test_pickle.py::test_fitted_regressor_pickles_and_predicts_identically`
  (`download_checkpoint requires model=`)
- internal's `test_the_serving_engine_walks_every_rung_a_caller_can_force`, which
  asserts `offload_bf16` is bit-exact; on an H100 it differs by `1.32e-3`

Docs for the feature: Synthefy/synthefy-docs#76 (open).
