### PR TITLE
fix(api): preserve one-row prediction shape

### DIFF
--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -1083,7 +1083,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             predictor.quantile_collapse, predictor.bar_point_estimator = saved
         if isinstance(pred, torch.Tensor):
             pred = pred.detach().cpu().numpy()
-        pred = np.asarray(pred, dtype=np.float64).squeeze()
+        pred = np.asarray(pred, dtype=np.float64).reshape(-1)
         return pred * self.y_std_ + self.y_mean_
 
     def _large_context_predict(self, predictor, X_test: np.ndarray, y_norm: np.ndarray, *, decoder: tuple):

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -158,6 +158,32 @@ def test_predict_rejects_unsupported_output_types():
         model.predict([[0.0, 1.0]], output_type="mean", quantiles=[0.5])
 
 
+def test_single_query_point_prediction_returns_one_value_per_row(monkeypatch):
+    class PredictorStub:
+        quantile_collapse = "mean"
+        bar_point_estimator = "mean"
+
+        def predict(self, X_train, y_train, X_test):
+            assert len(X_test) == 1
+            return np.array([0.25])
+
+    model = NoriRegressor(model_path="local.pt")
+    model.X_train_ = np.array([[0.0], [1.0]], dtype=np.float32)
+    model.y_train_ = np.array([1.0, 3.0], dtype=np.float64)
+    model.y_mean_ = 2.0
+    model.y_std_ = 2.0
+    model.large_context_policy = None
+    model.large_context_threshold = 50_000
+    monkeypatch.setattr(model, "_get_predictor", lambda: PredictorStub())
+    monkeypatch.setattr(model, "_prepare_query_features", lambda X: np.asarray(X, dtype=np.float32))
+
+    out = model.predict([[0.5]])
+
+    assert isinstance(out, np.ndarray)
+    assert out.shape == (1,)
+    np.testing.assert_allclose(out, [2.5])
+
+
 def test_distribution_outputs_require_fit_and_valid_levels():
     # 'quantiles'/'full' are supported but need fit() first; the fit guard and
     # the quantile-level validation both fire before any weights are loaded.


### PR DESCRIPTION
## Summary
Promotes the internal #544 fix to public so single-row `NoriRegressor.predict_point(...)` calls preserve the public API contract: one output value per input row.

This PR is intentionally narrow and reviewable: one bug fix commit, one focused regression test, and no unrelated cleanup.

## Root Cause
`NoriRegressor._predict_point()` converted predictor output with `np.asarray(pred, dtype=np.float64).squeeze()`. For a single query row, a normal one-element predictor output such as `np.array([0.25])` collapsed into a zero-dimensional `numpy.float64` scalar instead of a shape `(1,)` array.

## Affected Paths
- `src/synthefy_nori/api.py`
- `tests/test_api_smoke.py`

## Production Reachability
`NoriRegressor` is the exported sklearn-style inference API and is exercised by documented local prediction paths. The lightweight `synthefy` local client delegates to this path for point predictions, so the shape contract matters for downstream code that indexes, serializes, batches, or validates one prediction per row.

## Reproduction
Before the fix, a deterministic no-checkpoint probe with one query row and a stub predictor returning `np.array([0.25])` produced:

```text
<class numpy.float64> () np.float64(2.5)
```

After the fix, the same probe produces:

```text
<class numpy.ndarray> (1,) array([2.5])
```

The new regression test covers this exact edge case.

## Fix
Replaces the final `squeeze()` with `reshape(-1)` so scalar-like or one-element predictor outputs are normalized to a one-dimensional prediction vector while preserving multi-row behavior.

## Validation
On isolated public worktree from latest `origin/main`:

```text
uv sync --extra dev
uv run pytest -q tests/test_api_smoke.py::test_single_query_point_prediction_returns_one_value_per_row tests/test_api_smoke.py
18 passed in 23.06s

uv run ruff check src scripts tests ci
All checks passed!

uv run pytest -q
889 passed, 21 skipped, 56 deselected, 12 warnings in 97.70s
```

## Compatibility
Runtime/API: restores the expected array return shape for one-row point predictions. Multi-row predictions remain one-dimensional arrays.

Checkpoint/deployment: no checkpoint format, model artifact, dependency, packaging, or deployment configuration changes.

Risk: downstream code that accidentally depended on receiving a scalar for one-row predictions may need to handle the documented vector shape. That scalar behavior was inconsistent with the batch API contract and with multi-row calls.

## Rollback
Revert this commit to restore the previous `squeeze()` behavior. No data migration, checkpoint migration, release tag, deployment, or weight publication is involved.
