### PR TITLE
chore(release): prepare 7.1.1 and 0.20.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.1.0';
-          assert synthefy_nori.__version__ == '0.20.0'"
+          assert synthefy.__version__ == '7.1.1';
+          assert synthefy_nori.__version__ == '0.20.1'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests
@@ -42,13 +42,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.1.0-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.1.1-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.1.0.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.1.1.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.1.0-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.1.1-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -72,7 +72,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.1.0"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.1.1"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.1.0] - Unreleased
+## [7.1.1] - 2026-08-29
+
+### Fixed
+
+- Preserved the one-row local `NoriRegressor.predict_point(...)` shape contract when the installed `synthefy-nori` package returns a single prediction. Local clients now receive a one-element prediction vector instead of a scalar for batch size 1, matching multi-row calls.
+
+## [7.1.0] - 2026-08-27
 
 ### Added
 

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.1.0"
+version = "7.1.1"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -17,7 +17,7 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.1.0"
+__version__ = "7.1.1"
 
 __all__ = [
     "DEFAULT_LARGE_CONTEXT_SEED",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.20.0"
+version = "0.20.1"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -24,7 +24,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -99,11 +99,11 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.20.0"
+    assert root["project"]["version"] == "0.20.1"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.1.0"
-    assert _declared_version() == "7.1.0"
+    assert client["project"]["version"] == "7.1.1"
+    assert _declared_version() == "7.1.1"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -343,7 +343,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.1.0"
+    assert client_entries[0]["version"] == "7.1.1"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6457,7 +6457,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.1.0"
+version = "7.1.1"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },
@@ -6540,7 +6540,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Summary
Prepare patch releases for the one-row prediction shape fix after the merged public promotion.

- Bump `synthefy` from `7.1.0` to `7.1.1`.
- Bump `synthefy-nori` from `0.20.0` to `0.20.1`.
- Add `synthefy` changelog notes for the fix.
- Update lockfile and release/version assertions.

## Release Notes
### synthefy 7.1.1
Fixed local single-row point prediction handling when using an installed `synthefy-nori`: local clients now receive a one-element prediction vector instead of a scalar for batch size 1, matching multi-row calls.

### synthefy-nori 0.20.1
Fixed `NoriRegressor.predict_point(...)` for single-row inputs by preserving the one-prediction-per-input-row return shape. The result is now a shape `(1,)` NumPy array instead of a zero-dimensional scalar when the predictor emits one value.

## Validation
```text
uv sync --locked --extra dev
python import/version check: synthefy 7.1.1, synthefy-nori 0.20.1
pytest -q tests/test_synthefy_workspace.py tests/test_api_smoke.py::test_single_query_point_prediction_returns_one_value_per_row
11 passed
ruff check src scripts tests ci libs/synthefy/src libs/synthefy/tests
All checks passed!
uv build --package synthefy --no-sources --out-dir dist/synthefy
twine check --strict dist/synthefy/*
PASSED
uv build --package synthefy-nori --no-sources --out-dir dist/synthefy-nori
twine check --strict dist/synthefy-nori/*
PASSED
```

## Compatibility
No checkpoint, dependency range, hosted API schema, deployment config, or weight changes. This release ships the already-merged local/API shape fix to package users.

## Rollback
PyPI uploads are immutable after publication. If either package fails post-publish verification, fix forward with the next patch version.
