### PR TITLE
feat(inference): add target-rank context policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ NoriRegressor(model="nori-6m", large_context_policy="cluster_route")   # thresho
 | `safeboost` | one per shard | +0.015 mean, worst **0.000** — on 8 tables | the table is heterogeneous and you can afford the calls |
 | `boost` | one per shard | −0.019 mean, worst **−0.229** | never as a default; only gated or after measuring your own table |
 | `random` | 1 | the baseline | you want today's behavior, made explicit |
+| `target_rank[cap=N]` | 1 | 64k−32k: −0.0035 overall; +0.0040 IID, −0.0129 LaDe | compare context caps behind a holdout gate |
 
 Pass a **list** to gate: candidates are scored on a train holdout and the per-table
 winner is deployed. This is the only safe way to use `boost` — the gate declined it on
@@ -755,6 +756,29 @@ exactly the tables where it detonated:
 ```python
 NoriRegressor(large_context_policy=["random", "cluster_route", "safeboost"])
 ```
+
+For chronologically ordered rows, use a tail holdout so future rows never enter
+the candidate contexts. The measured 64k regression was concentrated in temporal
+LaDe tables, so do not use the default random holdout for this comparison:
+
+```python
+NoriRegressor(
+    large_context_policy=[
+        "target_rank[cap=32768]",
+        "target_rank[cap=65536]",
+    ],
+    large_context_holdout="tail",
+)
+```
+
+For IID rows, leave `large_context_holdout="random"`. A cap is a maximum: when
+the table is only slightly larger than the 50k activation threshold, the gate
+scores a candidate on the largest context left after its holdout rather than
+failing because 64k rows are unavailable.
+
+The direct 32k and 64k arms are measured. Tail-gate selection itself is a new
+safety mechanism and still needs a frozen temporal replay before it should
+become a default policy.
 
 Also accepted: `True` (the default policy), `"cluster_route[groups=16]"` to pass
 parameters, and `"pkg.mod:fn"` / `"path/to/file.py:fn"` / any callable for your own —

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Large-context policy lists now work in local, Baseten, and SageMaker modes.
+  `large_context_holdout="random"` scores IID rows, while `"tail"` keeps future
+  chronological rows out of validation contexts. The capability report echoes
+  the honored strategy. Lists are bounded to eight installed built-ins.
 - Added one-call multi-target regression to `SynthefyNoriClient.predict` in
   local, Baseten remote, and SageMaker modes. A matrix-valued `y_train` returns
   joint means or bounded joint samples, defaults to the copula strategy, and

--- a/libs/synthefy/README.md
+++ b/libs/synthefy/README.md
@@ -469,15 +469,39 @@ Here are some commonly used built-in policies:
 | `"cluster_route_g4"` | supported |
 | `"safeboost"` | supported |
 | `"boost"` | supported; prefer `safeboost` |
+| `"target_rank[cap=N]"` | supported; compare caps through a policy-list gate |
 
 Hosted and SageMaker support built-ins from the installed Nori version. See
 [`policies.py`](../../src/synthefy_nori/inference/policies.py) for the complete
-current list and configuration options. Hosted modes forward policy-name strings
-unchanged, including parameter strings such as `"safeboost[nu=0.25]"`. Custom
+current list and configuration options. Hosted modes forward one policy-name string
+or a list of up to eight names unchanged, including parameter strings such as
+`"safeboost[nu=0.25]"`. Custom
 callables and module/file policies remain local-only.
 `large_context_cache_entries` is also intentionally absent from the client:
 each client call is one-shot, fits the supplied `X_train` again, and hosted
 serving retains no customer context across requests.
+
+For the 32k/64k target-rank comparison, send a list and choose the split that
+matches row semantics:
+
+```python
+preds = client.predict(
+    X_train,
+    y_train,
+    X_test,
+    large_context_policy=[
+        "target_rank[cap=32768]",
+        "target_rank[cap=65536]",
+    ],
+    large_context_holdout="tail",  # chronological; use "random" for IID
+)
+```
+
+The response echoes `holdout_strategy`; the client rejects a response that did
+not honor it. The global 64k screen was 3.02x slower than 32k and lost 0.0129
+mean R² on four LaDe temporal tables, so 64k is not a default.
+The direct arms are measured; selecting between them with a tail gate still
+needs a frozen temporal replay before that gate should become a default.
 
 `last_large_context_report` is cleared before every call and works in all
 three modes. It records whether the policy engaged, the honored policy,

--- a/libs/synthefy/src/synthefy/data_models.py
+++ b/libs/synthefy/src/synthefy/data_models.py
@@ -4,9 +4,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from synthefy.nori_data_models import (
     LargeContextPolicy,
+    LargeContextHoldout,
     LargeContextReport,
     MAX_LARGE_CONTEXT_SEED,
     MAX_LARGE_CONTEXT_THRESHOLD,
+    MAX_LARGE_CONTEXT_CANDIDATES,
     MemoryPolicyInput,
     MemoryReport,
     MultiTargetMemoryReport,
@@ -57,6 +59,8 @@ class NoriPredictRequest(BaseModel):
         with ``large_context_policy``.
     large_context_seed : int or None, optional
         Deterministic selection/routing seed. Valid only with a policy.
+    large_context_holdout : {"random", "tail"} or None, optional
+        Validation split for a policy list. Tail is leak-safe for chronological rows.
     """
 
     # Coerce assignments just as construction does, so assigning a policy dict
@@ -73,15 +77,29 @@ class NoriPredictRequest(BaseModel):
     large_context_policy: Optional[LargeContextPolicy] = None
     large_context_threshold: Optional[int] = Field(default=None, strict=True, ge=1, le=MAX_LARGE_CONTEXT_THRESHOLD)
     large_context_seed: Optional[int] = Field(default=None, strict=True, ge=0, le=MAX_LARGE_CONTEXT_SEED)
+    large_context_holdout: Optional[LargeContextHoldout] = None
     multi_target_prediction_strategy: Optional[MultiTargetPredictionStrategy] = None
     multi_target_prediction_policy: Optional[MultiTargetPredictionPolicy] = None
 
     @model_validator(mode="after")
     def _large_context_parameters_need_a_policy(self):
         if self.large_context_policy is None and (
-            self.large_context_threshold is not None or self.large_context_seed is not None
+            self.large_context_threshold is not None
+            or self.large_context_seed is not None
+            or self.large_context_holdout is not None
         ):
-            raise ValueError("large_context_threshold/large_context_seed require large_context_policy")
+            raise ValueError(
+                "large_context_threshold/large_context_seed/large_context_holdout require large_context_policy"
+            )
+        if self.large_context_holdout is not None and not isinstance(self.large_context_policy, list):
+            raise ValueError("large_context_holdout is valid only with a large_context_policy list")
+        if isinstance(self.large_context_policy, list):
+            if not 1 <= len(self.large_context_policy) <= MAX_LARGE_CONTEXT_CANDIDATES:
+                raise ValueError(
+                    f"large_context_policy list must contain between 1 and {MAX_LARGE_CONTEXT_CANDIDATES} names"
+                )
+            if any(not item.strip() for item in self.large_context_policy):
+                raise ValueError("every large_context_policy list item must be non-empty")
         return self
 
     def to_wire(self) -> Dict[str, Any]:

--- a/libs/synthefy/src/synthefy/nori_client.py
+++ b/libs/synthefy/src/synthefy/nori_client.py
@@ -42,13 +42,16 @@ from synthefy.featurize import (
 )
 from synthefy.data_models import NoriPredictRequest, NoriPredictResponse
 from synthefy.nori_data_models import (
+    DEFAULT_LARGE_CONTEXT_HOLDOUT,
     DEFAULT_LARGE_CONTEXT_SEED,
     DEFAULT_LARGE_CONTEXT_THRESHOLD,
     DEFAULT_MULTI_TARGET_PREDICTION_STRATEGY,
     LargeContextPolicy,
+    LargeContextHoldout,
     LargeContextReport,
     MAX_LARGE_CONTEXT_SEED,
     MAX_LARGE_CONTEXT_THRESHOLD,
+    MAX_LARGE_CONTEXT_CANDIDATES,
     MAX_MULTI_TARGET_AUTOREGRESSIVE_ORDERS,
     MAX_MULTI_TARGET_COPULA_CV,
     MAX_MULTI_TARGET_COPULA_PIT_JITTER,
@@ -354,6 +357,7 @@ def _build_nori_request(
     large_context_policy: Optional[LargeContextPolicy] = None,
     large_context_threshold: Optional[int] = None,
     large_context_seed: Optional[int] = None,
+    large_context_holdout: Optional[LargeContextHoldout] = None,
     multi_target_prediction_strategy: Optional[MultiTargetPredictionStrategy] = None,
     multi_target_prediction_policy: Optional[MultiTargetPredictionPolicy] = None,
 ) -> NoriPredictRequest:
@@ -424,6 +428,7 @@ def _build_nori_request(
         large_context_policy=large_context_policy,
         large_context_threshold=large_context_threshold,
         large_context_seed=large_context_seed,
+        large_context_holdout=large_context_holdout,
         multi_target_prediction_strategy=multi_target_prediction_strategy,
         multi_target_prediction_policy=multi_target_prediction_policy,
     )
@@ -686,6 +691,7 @@ def _validate_large_context_controls(
     policy: Optional[LargeContextPolicy],
     threshold: Optional[int],
     seed: Optional[int],
+    holdout: Optional[LargeContextHoldout],
     output_type: str,
     model: Optional[str],
     mode: str,
@@ -698,23 +704,38 @@ def _validate_large_context_controls(
     distinguishable from "omitted" here, unlike comparing against the default value.
     """
     if policy is None:
-        if threshold is not None or seed is not None:
+        if threshold is not None or seed is not None or holdout is not None:
             # Both are otherwise silently dropped from the wire request: the caller
             # almost certainly meant to also pass large_context_policy=. Same rule,
             # same wording, as NoriPredictRequest's own model_validator and the
             # server's _parse_large_context, so the client fails exactly where the
             # request would have anyway -- before a paid hosted round-trip.
             raise ValueError(
-                "large_context_threshold/large_context_seed require "
-                f"large_context_policy; got threshold={threshold!r}, seed={seed!r} "
+                "large_context_threshold/large_context_seed/large_context_holdout require "
+                f"large_context_policy; got threshold={threshold!r}, seed={seed!r}, "
+                f"holdout={holdout!r} "
                 "with no policy selected. Pass large_context_policy=..., or omit "
-                "both large_context_threshold and large_context_seed."
+                "the large-context controls."
             )
         return
-    if not isinstance(policy, str) and (mode != "local" or not callable(policy)):
+    if isinstance(policy, list):
+        if not policy or len(policy) > MAX_LARGE_CONTEXT_CANDIDATES:
+            raise ValueError(
+                "large_context_policy list must contain between 1 and "
+                f"{MAX_LARGE_CONTEXT_CANDIDATES} built-in policy names"
+            )
+        if any(not isinstance(item, str) or not item.strip() for item in policy):
+            raise ValueError("every large_context_policy list item must be a non-empty string")
+    elif not isinstance(policy, str) and (mode != "local" or not callable(policy)):
         raise ValueError(
-            "large_context_policy must be a policy name string; custom callables are supported only in local mode."
+            "large_context_policy must be a policy name string or list of names; "
+            "custom callables are supported only in local mode."
         )
+    if holdout is not None:
+        if not isinstance(policy, list):
+            raise ValueError("large_context_holdout is valid only with a large_context_policy list")
+        if holdout not in ("random", "tail"):
+            raise ValueError("large_context_holdout must be 'random' or 'tail'")
     if threshold is not None and (
         isinstance(threshold, bool)
         or not isinstance(threshold, Integral)
@@ -758,11 +779,12 @@ def _normalized_large_context_report(request: NoriPredictRequest, report: Option
     )
     seed = request.large_context_seed if request.large_context_seed is not None else DEFAULT_LARGE_CONTEXT_SEED
     if report is None:
-        return LargeContextReport(
+        resolved = LargeContextReport(
             applied=False,
-            policy=(policy if isinstance(policy, str) else getattr(policy, "__name__", repr(policy))),
+            policy=_large_context_policy_label(policy),
             threshold=threshold,
             seed=seed,
+            holdout_strategy=request.large_context_holdout,
             reason="below_threshold",
             window=None,
             n_train=len(request.X_train),
@@ -771,16 +793,28 @@ def _normalized_large_context_report(request: NoriPredictRequest, report: Option
             nori_calls=0,
             full_context=None,
             reused_train_state=False,
-        ).model_dump()
-    return LargeContextReport.model_validate(
-        {
-            **report,
-            "applied": True,
-            "threshold": threshold,
-            "seed": seed,
-            "reason": None,
-        }
-    ).model_dump()
+        )
+    else:
+        resolved = LargeContextReport.model_validate(
+            {
+                **report,
+                "applied": True,
+                "threshold": threshold,
+                "seed": seed,
+                "reason": None,
+            }
+        )
+    exclude = {"holdout_strategy"} if resolved.holdout_strategy is None else set()
+    return resolved.model_dump(exclude=exclude)
+
+
+def _large_context_policy_label(policy: LargeContextPolicy) -> str:
+    """Canonical display label shared by local and hosted capability checks."""
+    if isinstance(policy, list):
+        return f"gate[{','.join(item.strip() for item in policy)}]"
+    if isinstance(policy, str):
+        return policy.strip()
+    return getattr(policy, "__name__", repr(policy))
 
 
 # The one discretization strategy computable from the hosted endpoint's
@@ -1321,6 +1355,7 @@ class SynthefyNoriClient:
         large_context_policy: Optional[LargeContextPolicy] = None,
         large_context_threshold: Optional[int] = None,
         large_context_seed: Optional[int] = None,
+        large_context_holdout: Optional[LargeContextHoldout] = None,
         multi_target_prediction_strategy: Optional[MultiTargetPredictionStrategy] = None,
         multi_target_prediction_policy: Optional[MultiTargetPredictionPolicy] = None,
         timeout: Optional[float] = None,
@@ -1490,10 +1525,12 @@ class SynthefyNoriClient:
             settings needs far more query rows than the hosted request-body limit allows
             (~64 MiB) -- so lowering ``elements_budget`` is what lets a hosted caller reach
             the cached path at all.
-        large_context_policy : str, callable, or None
+        large_context_policy : str, list of str, callable, or None
             Select context rows explicitly when `len(X_train)` exceeds
             `large_context_threshold`. Off by default. Remote and SageMaker
-            modes forward a policy-name string unchanged; the server accepts
+            modes forward one policy-name string or a list of up to eight names;
+            a list is scored on a train holdout and deploys its per-table winner.
+            The server accepts
             every built-in in its installed Nori registry, including `random`,
             `cluster_route`, `cluster_route_g4`, `safeboost`, and `boost`.
             Parameter strings such as `safeboost[nu=0.25]` are supported.
@@ -1513,6 +1550,10 @@ class SynthefyNoriClient:
             Deterministic policy seed in the range 0 through 2**32 - 1. `None` (the
             default) resolves to 0 once `large_context_policy` is set; passing it
             without a policy raises, rather than being silently dropped.
+        large_context_holdout : {"random", "tail"} or None, optional
+            Validation split for a policy list. `random` is the default for IID
+            rows. `tail` holds out the final rows and keeps future chronological
+            rows out of every candidate context. Invalid with a single policy.
 
             Client calls are one-shot: every call supplies and fits `X_train`
             again. No hidden local or hosted cross-request context cache is
@@ -1641,6 +1682,7 @@ class SynthefyNoriClient:
             policy=large_context_policy,
             threshold=large_context_threshold,
             seed=large_context_seed,
+            holdout=large_context_holdout,
             output_type=output_type,
             model=self.model,
             mode=self.mode,
@@ -1680,9 +1722,15 @@ class SynthefyNoriClient:
             resolved_large_context_seed = (
                 DEFAULT_LARGE_CONTEXT_SEED if large_context_seed is None else int(large_context_seed)
             )
+            resolved_large_context_holdout = (
+                (large_context_holdout or DEFAULT_LARGE_CONTEXT_HOLDOUT)
+                if isinstance(large_context_policy, list)
+                else None
+            )
         else:
             resolved_large_context_threshold = None
             resolved_large_context_seed = None
+            resolved_large_context_holdout = None
         request = _build_nori_request(
             X_train,
             y_train,
@@ -1697,6 +1745,7 @@ class SynthefyNoriClient:
             large_context_policy=large_context_policy,
             large_context_threshold=resolved_large_context_threshold,
             large_context_seed=resolved_large_context_seed,
+            large_context_holdout=resolved_large_context_holdout,
             multi_target_prediction_strategy=multi_target_prediction_strategy,
             multi_target_prediction_policy=multi_target_prediction_policy,
         )
@@ -1893,6 +1942,11 @@ class SynthefyNoriClient:
                         if request.large_context_seed is not None
                         else DEFAULT_LARGE_CONTEXT_SEED
                     ),
+                    **(
+                        {"large_context_holdout": request.large_context_holdout or DEFAULT_LARGE_CONTEXT_HOLDOUT}
+                        if isinstance(request.large_context_policy, list)
+                        else {}
+                    ),
                     # The client API is one-shot: every call fits again. A
                     # caller that needs fit-once/predict-many cache control
                     # should use NoriRegressor directly.
@@ -1934,6 +1988,10 @@ class SynthefyNoriClient:
                         if request.large_context_seed is not None
                         else DEFAULT_LARGE_CONTEXT_SEED
                     )
+                    if isinstance(request.large_context_policy, list):
+                        regressor.large_context_holdout = request.large_context_holdout or DEFAULT_LARGE_CONTEXT_HOLDOUT
+                    elif hasattr(regressor, "large_context_holdout"):
+                        regressor.large_context_holdout = DEFAULT_LARGE_CONTEXT_HOLDOUT
                     regressor.large_context_cache_entries = 1
                 except AttributeError as exc:
                     raise ImportError(
@@ -2154,7 +2212,7 @@ class SynthefyNoriClient:
                 request.large_context_seed if request.large_context_seed is not None else DEFAULT_LARGE_CONTEXT_SEED
             )
             mismatches = []
-            expected_policy = request.large_context_policy.strip()
+            expected_policy = _large_context_policy_label(request.large_context_policy)
             if report.policy != expected_policy:
                 mismatches.append(f"policy={report.policy!r}, expected {expected_policy!r}")
 
@@ -2162,13 +2220,21 @@ class SynthefyNoriClient:
                 mismatches.append(f"threshold={report.threshold}, expected {expected_threshold}")
             if report.seed != expected_seed:
                 mismatches.append(f"seed={report.seed}, expected {expected_seed}")
+            expected_holdout = (
+                request.large_context_holdout or DEFAULT_LARGE_CONTEXT_HOLDOUT
+                if isinstance(request.large_context_policy, list)
+                else None
+            )
+            if report.holdout_strategy != expected_holdout:
+                mismatches.append(f"holdout_strategy={report.holdout_strategy!r}, expected {expected_holdout!r}")
             if mismatches:
                 raise ValueError(
                     "The deployment returned a mismatched "
                     "large_context_report (" + "; ".join(mismatches) + "). "
                     "The client cannot prove the requested policy was honored."
                 )
-            self.last_large_context_report = report.model_dump()
+            exclude = {"holdout_strategy"} if report.holdout_strategy is None else set()
+            self.last_large_context_report = report.model_dump(exclude=exclude)
         if is_multi_target:
             expected_strategy = request.multi_target_prediction_strategy or DEFAULT_MULTI_TARGET_PREDICTION_STRATEGY
             if parsed.multi_target_prediction_strategy != expected_strategy:

--- a/libs/synthefy/src/synthefy/nori_data_models.py
+++ b/libs/synthefy/src/synthefy/nori_data_models.py
@@ -61,6 +61,8 @@ MEMORY_RUNGS = (
 #: without importing the heavyweight synthefy-nori package.
 DEFAULT_LARGE_CONTEXT_THRESHOLD = 50_000
 DEFAULT_LARGE_CONTEXT_SEED = 0
+DEFAULT_LARGE_CONTEXT_HOLDOUT = "random"
+MAX_LARGE_CONTEXT_CANDIDATES = 8
 
 #: Hosted serving owns its work bounds; these cap the two integer controls before
 #: a request is sent.
@@ -68,9 +70,10 @@ MAX_LARGE_CONTEXT_THRESHOLD = 10_000_000
 MAX_LARGE_CONTEXT_SEED = 2**32 - 1
 
 MemoryPreset = Literal["exact", "max_context", "off"]
-#: Local mode also accepts callables; hosted modes require a policy-name string and
-#: let the server's installed synthefy-nori resolver decide whether it is valid.
-LargeContextPolicy = Union[str, Callable[..., Any]]
+#: Local mode also accepts a callable; hosted modes accept one built-in name or a
+#: bounded list of names for the per-table holdout gate.
+LargeContextPolicy = Union[str, List[str], Callable[..., Any]]
+LargeContextHoldout = Literal["random", "tail"]
 MultiTargetPredictionStrategy = Literal["independent", "copula", "autoregressive"]
 DEFAULT_MULTI_TARGET_PREDICTION_STRATEGY: MultiTargetPredictionStrategy = "copula"
 MAX_MULTI_TARGET_RANDOM_STATE = 2**32 - 1
@@ -475,6 +478,13 @@ class LargeContextReport(BaseModel):
         ge=0,
         le=MAX_LARGE_CONTEXT_SEED,
         description="Deterministic policy seed honored for this request.",
+    )
+    holdout_strategy: Optional[LargeContextHoldout] = Field(
+        None,
+        description=(
+            "Validation split used by a policy-list gate: random for IID rows or "
+            "tail for chronologically ordered rows. Null for a single policy."
+        ),
     )
     reason: Optional[str] = Field(
         None,

--- a/libs/synthefy/tests/test_nori_client.py
+++ b/libs/synthefy/tests/test_nori_client.py
@@ -1388,6 +1388,7 @@ def test_request_model_roundtrip():
         "large_context_policy": None,
         "large_context_threshold": None,
         "large_context_seed": None,
+        "large_context_holdout": None,
         "multi_target_prediction_strategy": None,
         "multi_target_prediction_policy": None,
     }
@@ -2901,22 +2902,34 @@ def test_remote_client_rejects_callable_large_context_policy_before_network():
     assert calls["count"] == 0
 
 
-def test_remote_client_rejects_non_string_policy_before_network():
-    calls = {"count": 0}
+def test_remote_client_forwards_a_tail_gated_policy_list_and_verifies_report():
+    capture: Dict = {}
+    policies = ["target_rank[cap=32768]", "target_rank[cap=65536]"]
+    report = {
+        **_LARGE_CONTEXT_REPORT,
+        "policy": "gate[target_rank[cap=32768],target_rank[cap=65536]]",
+        "threshold": 50_000,
+        "seed": 0,
+        "holdout_strategy": "tail",
+    }
+    client = _client_with(_large_context_handler(capture, report))
+    client.predict(
+        _X_TRAIN,
+        _Y_TRAIN,
+        _X_TEST,
+        large_context_policy=policies,
+        large_context_holdout="tail",
+    )
+    assert capture["body"]["large_context_policy"] == policies
+    assert capture["body"]["large_context_holdout"] == "tail"
+    assert client.last_large_context_report == report
 
-    def handler(_request):
-        calls["count"] += 1
-        return httpx.Response(500)
 
-    client = _client_with(handler)
-    with pytest.raises(ValueError, match="policy name string"):
-        client.predict(
-            _X_TRAIN,
-            _Y_TRAIN,
-            _X_TEST,
-            large_context_policy=["random", "cluster_route"],
-        )
-    assert calls["count"] == 0
+@pytest.mark.parametrize("policy", [[], [""], ["random", 1], ["random"] * 9])
+def test_remote_client_rejects_invalid_policy_lists_before_network(policy):
+    client = _client_with(lambda _request: pytest.fail("network called"))
+    with pytest.raises(ValueError, match="large_context_policy"):
+        client.predict(_X_TRAIN, _Y_TRAIN, _X_TEST, large_context_policy=policy)
 
 
 @pytest.mark.parametrize("output_type", ["quantiles", "full"])
@@ -2988,6 +3001,15 @@ def test_large_context_request_model_is_bounded_and_omits_unset_fields():
         NoriPredictRequest(**base, large_context_threshold=123)
     for policy in ("boost", "safeboost", "cluster_route[groups=16]"):
         assert NoriPredictRequest(**base, large_context_policy=policy).to_wire()["large_context_policy"] == policy
+    gated = NoriPredictRequest(
+        **base,
+        large_context_policy=["random", "target_rank[cap=32768]"],
+        large_context_holdout="tail",
+    )
+    assert gated.to_wire()["large_context_policy"] == ["random", "target_rank[cap=32768]"]
+    assert gated.to_wire()["large_context_holdout"] == "tail"
+    with pytest.raises(ValueError, match="valid only with.*list"):
+        NoriPredictRequest(**base, large_context_policy="random", large_context_holdout="tail")
     with pytest.raises(ValueError):
         NoriPredictRequest(
             **base,

--- a/src/synthefy_nori/api.py
+++ b/src/synthefy_nori/api.py
@@ -196,6 +196,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         large_context_policy=None,
         large_context_threshold: int = DEFAULT_LARGE_CONTEXT_THRESHOLD,
         large_context_seed: int = 0,
+        large_context_holdout: str = "random",
         large_context_cache_entries: int = 1,
         svd_dim: int | None = 128,
         embedder="minilm",
@@ -279,7 +280,8 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 ``large_context_threshold`` rows. ``None`` (default) keeps the existing
                 behavior — full context, trimmed by ``memory_policy`` if it does not
                 fit. Otherwise a policy name (``"cluster_route"``,
-                ``"cluster_route_g4"``, ``"safeboost"``, ``"boost"``, ``"random"``),
+                ``"cluster_route_g4"``, ``"safeboost"``, ``"boost"``, ``"random"``,
+                ``"target_rank"``),
                 ``True`` for the default (``"cluster_route"``), a
                 ``"pkg.mod:fn"``/``"file.py:fn"`` path, a callable, or a LIST of any of
                 those (scored on a train holdout, per-table winner deployed). Append
@@ -291,6 +293,11 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
 
                 * ``"random"`` — **1** Nori call. One shared context window, chosen at
                   random. The cheapest fallback; no routing, no accuracy upside.
+                * ``"target_rank"`` — **1** Nori call. Equal-frequency target-rank
+                  midpoints form one shared context. Use ``[cap=32768]`` or
+                  ``[cap=65536]`` to compare sizes inside a list/holdout gate. The 64k
+                  global screen lost on temporal tables, so it is opt-in and should be
+                  gated rather than selected globally.
                 * ``"cluster_route"`` — up to ``groups`` (default 8) Nori calls. Clusters
                   the query rows into groups, each scored against its own local context
                   pool. **The recommended default when a policy is used**: the only one
@@ -304,6 +311,10 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
                 Default 50,000. Inert when ``large_context_policy`` is ``None``.
             large_context_seed: seeds the policies' row draws, so two identical predicts
                 agree. Default 0.
+            large_context_holdout: validation split used when ``large_context_policy`` is
+                a list. ``"random"`` (default) is appropriate for IID tables;
+                ``"tail"`` holds out the final rows and should be used when input order
+                is chronological. Non-default values are invalid for a single policy.
             large_context_cache_entries: how many distinct encoded contexts to retain across
                 ``predict`` calls. Default 1 (the historical behavior). A policy that
                 rotates between pools — ``cluster_route`` builds ``groups`` of them —
@@ -372,6 +383,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         self.large_context_policy = large_context_policy
         self.large_context_threshold = int(large_context_threshold)
         self.large_context_seed = int(large_context_seed)
+        self.large_context_holdout = str(large_context_holdout)
         self.large_context_cache_entries = int(large_context_cache_entries)
         if large_context_max_calls is not None and (
             isinstance(large_context_max_calls, bool)
@@ -444,7 +456,16 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
         # Same reason, for large_context_policy=: an unknown policy name or a bad parameter
         # should fail at fit(), not minutes into a job on a million-row table.
         if self.large_context_policy is not None:
-            resolve_large_context_policy(self.large_context_policy)
+            if self.large_context_holdout not in ("random", "tail"):
+                raise ValueError(
+                    f"large_context_holdout must be 'random' or 'tail'; got {self.large_context_holdout!r}"
+                )
+            if self.large_context_holdout != "random" and not isinstance(self.large_context_policy, (list, tuple)):
+                raise ValueError("large_context_holdout is valid only with a large_context_policy list")
+            resolve_large_context_policy(
+                self.large_context_policy,
+                holdout_strategy=self.large_context_holdout,
+            )
             # large_context_applies() only ever compares n_train > threshold, so a
             # non-positive threshold silently makes the policy apply to EVERY table
             # regardless of size -- almost certainly a typo (a stray minus sign, or a
@@ -1149,6 +1170,7 @@ class NoriRegressor(RegressorMixin, BaseEstimator):
             policy_spec=self.large_context_policy,
             seed=self.large_context_seed,
             cache_scope=("decoder", decoder, "memory_policy", memory_scope),
+            holdout_strategy=getattr(self, "large_context_holdout", "random"),
         )
         return pred
 

--- a/src/synthefy_nori/inference/large_context.py
+++ b/src/synthefy_nori/inference/large_context.py
@@ -15,7 +15,7 @@ already within the window.
 
 ``cluster_route`` is the default because it is the only arm measured across all 15
 benchmark tables without a regression. ``safeboost``, ``boost``, ``random``,
-``cluster_route_g4``, a ``holdout_gate`` over any of them, and custom callables
+``target_rank``, ``cluster_route_g4``, a ``holdout_gate`` over any of them, and custom callables
 are all selectable. **The menu, each arm's measured cost and its tail risk live in**
 ``policies.py`` — one home per number, so they cannot drift apart. ``boost``'s tail is
 severe; read it there before selecting it.
@@ -70,7 +70,7 @@ DEFAULT_LARGE_CONTEXT_POLICY = "cluster_route"
 """The policy used when one is requested without naming which."""
 
 
-def resolve_large_context_policy(spec) -> tuple[str, Policy]:
+def resolve_large_context_policy(spec, *, holdout_strategy: str = "random") -> tuple[str, Policy]:
     """Turn ``large_context_policy=`` into ``(name, callable)``.
 
     Accepts everything :func:`~synthefy_nori.inference.policies.resolve_policy` does --
@@ -94,7 +94,7 @@ def resolve_large_context_policy(spec) -> tuple[str, Policy]:
                 "leave large-table handling to the memory policy as before."
             )
         names = [resolve_policy(c)[0] for c in candidates]
-        return f"gate[{','.join(names)}]", holdout_gate(candidates)
+        return f"gate[{','.join(names)}]", holdout_gate(candidates, strategy=holdout_strategy)
     return resolve_policy(spec)
 
 
@@ -162,6 +162,7 @@ def run_policy(
     policy_spec,
     seed: int = 0,
     cache_scope: tuple = (),
+    holdout_strategy: str = "random",
 ) -> tuple[np.ndarray, dict]:
     """Run one large-context policy over ``X_test`` and return ``(predictions, report)``.
 
@@ -182,7 +183,7 @@ def run_policy(
         the policy to a single ``predict`` is paying. A second call on the same
         estimator reports fewer, because the chain it replays was already built.
     """
-    name, policy = resolve_large_context_policy(policy_spec)
+    name, policy = resolve_large_context_policy(policy_spec, holdout_strategy=holdout_strategy)
     # run_seed travels with the query view because the rng below is drawn from it and a
     # boosting chain's shards come from that rng -- so it keys the train cache.
     problem = base.with_queries(X_test, run_seed=seed, cache_scope=cache_scope)
@@ -193,13 +194,15 @@ def run_policy(
             name, problem, problem.window, full_context=False, reused_train_state=False
         )
     window = problem.window
-    if problem.n_train <= window:
+    policy_cap = getattr(policy, "context_cap", None)
+    if problem.n_train <= window and (policy_cap is None or problem.n_train <= policy_cap):
         # Nothing to select: the whole table already fits one call. Every policy would
         # degenerate to it, and cluster_route would waste `groups` calls re-predicting
         # partitions of a context it could take whole.
         warnings.warn(
             f"large_context_policy={name!r} was requested for a table of {problem.n_train} "
-            f"rows, but all of them fit the {window}-row window, so no policy is needed; "
+            f"rows, but all of them fit the {window}-row window and the policy does not "
+            f"request a smaller cap, so no policy is needed; "
             f"predicting from full context in one call. Raise large_context_threshold above "
             f"{problem.n_train} to silence this.",
             LargeContextPolicyWarning,
@@ -226,6 +229,7 @@ def run_policy(
     winner = getattr(policy, "last_winner", None)
     if winner is not None:
         report["gate_winner"] = winner
+        report["holdout_strategy"] = getattr(policy, "holdout_strategy", holdout_strategy)
     return preds, report
 
 

--- a/src/synthefy_nori/inference/policies.py
+++ b/src/synthefy_nori/inference/policies.py
@@ -13,12 +13,18 @@ Keeping one implementation for both roles prevents benchmark and production beha
 from drifting apart: a policy measured in the harness is the exact policy that
 deploys.
 
-Five policies are registered. `cluster_route` is the only one with full benchmark
+Six policies are registered. `cluster_route` is the only one with full benchmark
 coverage and is the default when the feature is enabled; the rest are opt-in. The
 numbers below are from the recorded within-checkpoint policy benchmark:
 
   random             one random window. The baseline, and the cheapest thing that works:
                      a shared 8k window is within 0.013 R² of full context (median 0.004).
+  target_rank        one target-stratified window, selected at equal-frequency rank
+                     midpoints. ``cap=`` may make it smaller than the hardware window,
+                     so a holdout gate can compare 32k with 64k on the same fitted table.
+                     At 64k versus 32k it lost -0.0035 mean R² over nine extreme tables,
+                     including -0.0129 on all four LaDe tables, at 3.02x latency. It is
+                     a gateable specialist, not a default.
   cluster_route      cluster the QUERIES into `groups` groups, build one shared local pool
                      per group, route each query to its group's cache. Best policy of the
                      nine benchmarked (+0.017 mean Δ vs `random`, best on 7 of 15 tables,
@@ -39,9 +45,12 @@ Both boosting arms shard the table into `n_train // window` disjoint shards. The
 observed failures were at 4–6 shards, so they warn below `MIN_BOOST_SHARDS` (8) and
 fall back to `random` below two.
 
-Other evaluated approaches (coreset, stratified-y, per-cluster boosting) either lost
-or had severe regressions and are deliberately not shipped. Use this module's
-extension point to evaluate a new approach without expanding the built-in menu.
+Other evaluated approaches (feature-diversity coresets and per-cluster boosting)
+either lost or had severe regressions and are deliberately not shipped. Target-rank
+selection is the exception: it is shipped opt-in so its exact 32k/64k variants can be
+compared inside the existing train-holdout gate, not because its global 64k result won.
+Use this module's extension point to evaluate other approaches without expanding the
+built-in menu.
 
 ## Writing your own policy
 
@@ -83,7 +92,7 @@ import sys
 import warnings
 from functools import partial
 from pathlib import Path
-from typing import Callable, Optional, Sequence
+from typing import Callable, Literal, Optional, Sequence
 
 import numpy as np
 from sklearn.cluster import MiniBatchKMeans
@@ -637,6 +646,47 @@ def random_window(problem: Problem, rng: np.random.Generator) -> np.ndarray:
     return problem.predict(pool)
 
 
+@register_policy("target_rank")
+def target_rank(problem: Problem, rng: np.random.Generator, cap: Optional[int] = None) -> np.ndarray:
+    """One shared target-stratified context, selected at rank midpoints.
+
+    ``cap=None`` fills the hardware-derived ``problem.window``. A smaller explicit cap
+    lets a holdout gate compare context sizes without changing the fitted estimator::
+
+        large_context_policy=["target_rank[cap=32768]", "target_rank[cap=65536]"]
+
+    An explicit cap may not exceed ``problem.window``: doing so would make the
+    predictor silently subsample the selected rows and invalidate both the method name
+    and its holdout score. Ties are stable by original row order, and the chosen row
+    indices are sorted before prediction so selection does not reorder the context.
+
+    This is opt-in. On nine frozen extreme tables, 64k versus 32k changed mean R² by
+    -0.0035, lost on every LaDe table, and cost 3.02x inference latency. Its purpose is
+    to be a cheap one-call specialist that the existing holdout gate may accept on a
+    fitted IID table and reject elsewhere, not to replace ``cluster_route``.
+    """
+    del rng  # deterministic by construction; the protocol seed cannot change the pool
+    cap = problem.window if cap is None else int(cap)
+    if cap < 1:
+        raise ValueError(f"target_rank cap must be >= 1, got {cap}")
+    if cap > problem.window:
+        raise ValueError(
+            f"target_rank cap={cap} exceeds the hardware-safe window={problem.window}; "
+            "raise memory_policy.elements_budget or choose a smaller cap"
+        )
+    if not np.isfinite(problem.y_train).all():
+        raise ValueError("target_rank requires finite context targets")
+    if problem.n_train <= cap:
+        return problem.predict(np.arange(problem.n_train, dtype=np.int64))
+
+    order = np.argsort(problem.y_train, kind="stable")
+    ranks = np.floor((np.arange(cap, dtype=np.float64) + 0.5) * problem.n_train / cap).astype(np.int64)
+    pool = np.sort(order[ranks])
+    if len(pool) != cap or len(np.unique(pool)) != cap:
+        raise AssertionError("target_rank selection produced duplicate context rows")
+    return problem.predict(pool)
+
+
 @register_policy("cluster_route")
 def cluster_route(problem: Problem, rng: np.random.Generator, groups: int = 8) -> np.ndarray:
     """Clustered shared pools: `groups` query clusters, one shared local pool each.
@@ -899,12 +949,20 @@ def boost(
 
 
 # ----------------------------------------------------------------------- combinator
-def holdout_gate(candidates: Sequence[str | Policy], holdout: int = 2000) -> Policy:
+HoldoutStrategy = Literal["random", "tail"]
+
+
+def holdout_gate(
+    candidates: Sequence[str | Policy],
+    holdout: int = 2000,
+    strategy: HoldoutStrategy = "random",
+) -> Policy:
     """Build a meta-policy that picks the per-table winner on a train holdout.
 
-    Carves up to `holdout` rows out of train — capped so at least one full `window`
-    remains behind for the candidates to build a context from — scores every candidate
-    on them, then re-runs the winner on the real test set. This is how a custom policy
+    Carves up to `holdout` rows out of train, scores every candidate on them, then
+    re-runs the winner on the real test set. ``strategy="random"`` is the ordinary
+    IID split. ``strategy="tail"`` holds out the final rows and is the leak-safe choice
+    when input order is chronological. This is how a custom policy
     earns its way into production without a global claim: on the 15-table run the gate scored +0.0166,
     matching the best single policy, because it deployed the strong arm where it won
     and fell back where it would have blown up (diamonds: 0.947 not 0.717).
@@ -922,6 +980,8 @@ def holdout_gate(candidates: Sequence[str | Policy], holdout: int = 2000) -> Pol
 
     The winner is recorded on the returned function as `.last_winner`.
     """
+    if strategy not in ("random", "tail"):
+        raise ValueError(f"holdout strategy must be 'random' or 'tail', got {strategy!r}")
     resolved = [resolve_policy(c) for c in candidates]
 
     def gate(problem: Problem, rng: np.random.Generator) -> np.ndarray:
@@ -929,35 +989,58 @@ def holdout_gate(candidates: Sequence[str | Policy], holdout: int = 2000) -> Pol
         # the fitted table alone -- exactly like a boosting chain, and cached the same
         # way. Without this the sweep re-runs on every predict and the gate costs its
         # whole menu forever instead of once (measured: 33.8s cold, 32.4s warm).
-        key = ("gate", tuple(name for name, _ in resolved), holdout, problem.run_seed)
+        key = ("gate", tuple(name for name, _ in resolved), holdout, strategy, problem.run_seed)
         by_name = dict(resolved)
         cached = problem.train_cache.get(key)
         if cached is not None:
             gate.last_winner = cached
             return by_name[cached](problem, rng)
 
-        # Never hold out so much that the candidates are left without a full window to
-        # fill their context from. At n_train <= holdout the uncapped draw takes every
-        # row, and each candidate is then scored on an EMPTY context -- a real predictor
-        # raises there, and one that tolerates it picks a winner off noise.
-        n_held = min(holdout, problem.n_train - problem.window)
-        if n_held < 1:
+        # Never hold out so much that a candidate is left without the context it
+        # requested. Ordinary candidates need the full hardware window; explicitly
+        # capped target_rank candidates need only their cap. This distinction lets a
+        # gate compare 32k and 64k even when the hardware window is larger than both.
+        desired_context = max(problem.window if cap is None else min(int(cap), problem.window) for cap in caps)
+        if problem.n_train < 3:
             raise ValueError(
-                f"holdout_gate needs more than window={problem.window} train rows to "
-                f"carve a holdout from, but this table has {problem.n_train}. At that "
-                "size the whole table fits one call and no policy is needed."
+                "holdout_gate needs at least three train rows: one context row and "
+                f"two rows for an R² holdout, but this table has {problem.n_train}"
+            )
+        # When the table is only just above the activation threshold, an explicit cap
+        # can exceed the rows available after carving a holdout (50,001 rows versus a
+        # 65,536 cap is the production case). A cap is a maximum, not a minimum: score
+        # that candidate on the largest context the fold affords instead of crashing.
+        if problem.n_train <= desired_context:
+            n_held = min(holdout, max(2, int(np.ceil(problem.n_train * 0.05))))
+        else:
+            n_held = min(holdout, problem.n_train - desired_context)
+        n_held = max(2, min(n_held, problem.n_train - 1))
+        available_context = problem.n_train - n_held
+        requirement = f"desired_context={desired_context}" if finite_caps else f"window={problem.window}"
+        if available_context < desired_context:
+            warnings.warn(
+                f"holdout_gate: {requirement}, but this table leaves only "
+                f"{available_context} context rows after its {n_held}-row holdout; "
+                "capped candidates are scored on that available context and deployed "
+                "with up to their requested cap.",
+                LargeContextPolicyWarning,
+                stacklevel=2,
             )
         if n_held < holdout:
             warnings.warn(
-                f"holdout_gate: {problem.n_train} train rows at window="
-                f"{problem.window} leaves only {n_held} for the holdout, not "
+                f"holdout_gate: {problem.n_train} train rows with {requirement} "
+                f"leaves only {n_held} for the holdout, not "
                 f"{holdout}; the winner is chosen on that much evidence. Lower "
                 "`window`, or select a policy directly instead of gating.",
                 LargeContextPolicyWarning,
                 stacklevel=2,
             )
-        held = problem.rng(7).permutation(problem.n_train)[:n_held]
-        keep = np.setdiff1d(np.arange(problem.n_train), held, assume_unique=False)
+        if strategy == "tail":
+            held = np.arange(problem.n_train - n_held, problem.n_train)
+            keep = np.arange(problem.n_train - n_held)
+        else:
+            held = problem.rng(7).permutation(problem.n_train)[:n_held]
+            keep = np.setdiff1d(np.arange(problem.n_train), held, assume_unique=False)
         sub = problem.subproblem(keep, held)
         best_name, best_fn, best_score = None, None, -np.inf
         for name, fn in resolved:
@@ -978,6 +1061,10 @@ def holdout_gate(candidates: Sequence[str | Policy], holdout: int = 2000) -> Pol
         return best_fn(problem, rng)
 
     gate.last_winner = None
+    caps = [getattr(fn, "context_cap", None) for _, fn in resolved]
+    finite_caps = [int(cap) for cap in caps if cap is not None]
+    gate.context_cap = min(finite_caps) if finite_caps else None
+    gate.holdout_strategy = strategy
     return gate
 
 
@@ -1064,10 +1151,13 @@ def resolve_policy(spec: str | Policy) -> tuple[str, Policy]:
         )
 
     if params:
+        raw_fn = fn
         signature = inspect.signature(fn)
         takes_kwargs = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values())
         unknown = set() if takes_kwargs else set(params) - set(signature.parameters)
         if unknown:
             raise ValueError(f"policy {text!r} has no parameter(s) {sorted(unknown)}")
         fn = partial(fn, **params)
+        if raw_fn is target_rank and "cap" in params:
+            fn.context_cap = int(params["cap"])
     return (f"{label}[{raw}]" if params else label), fn

--- a/tests/test_large_context_policy.py
+++ b/tests/test_large_context_policy.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 import torch
 
+from synthefy_nori.api import NoriRegressor
 from synthefy_nori.inference import large_context
 from synthefy_nori.inference import policies as pol
 from synthefy_nori.inference.memory_policy import MemoryPolicy
@@ -115,6 +116,76 @@ def test_parameters_bind_through_the_spec():
     assert report["nori_calls"] == 3
 
 
+def test_target_rank_selects_stable_midpoint_rows_without_reordering_context():
+    seen = []
+
+    def recording_predict(X_ctx, y_ctx, X_query):
+        seen.append((X_ctx.copy(), np.asarray(y_ctx).copy()))
+        return np.zeros(len(X_query))
+
+    X_train = np.arange(8, dtype=np.float32)[:, None]
+    y_train = np.arange(8, 0, -1, dtype=np.float64)
+    base = large_context.build_problem(recording_predict, X_train, y_train, window=4)
+    X_test = np.zeros((3, 1), dtype=np.float32)
+
+    _, report = large_context.run_policy(base, X_test, policy_spec="target_rank")
+
+    assert report["nori_calls"] == 1
+    assert seen[0][0][:, 0].tolist() == [0.0, 2.0, 4.0, 6.0]
+    assert seen[0][1].tolist() == [8.0, 6.0, 4.0, 2.0]
+
+
+def test_target_rank_cap_can_compare_smaller_contexts_inside_one_window():
+    seen = []
+
+    def recording_predict(X_ctx, y_ctx, X_query):
+        seen.append(len(X_ctx))
+        return np.zeros(len(X_query))
+
+    X_train, y_train, X_test = make_table(n_train=400, n_test=10)
+    base = large_context.build_problem(recording_predict, X_train, y_train, window=64)
+    _, report = large_context.run_policy(base, X_test, policy_spec="target_rank[cap=32]")
+    assert seen == [32]
+    assert report["policy"] == "target_rank[cap=32]"
+
+
+def test_target_rank_cap_is_honored_even_when_the_whole_table_fits_the_window():
+    seen = []
+
+    def recording_predict(X_ctx, y_ctx, X_query):
+        seen.append(len(X_ctx))
+        return np.zeros(len(X_query))
+
+    X_train, y_train, X_test = make_table(n_train=50, n_test=10)
+    base = large_context.build_problem(recording_predict, X_train, y_train, window=64)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _, report = large_context.run_policy(base, X_test, policy_spec="target_rank[cap=32]")
+    assert seen == [32]
+    assert report["full_context"] is False
+
+
+def test_target_rank_rejects_a_cap_above_the_hardware_safe_window():
+    base = make_base(window=40, n_train=400)
+    _, _, X_test = make_table(n_test=10)
+    with pytest.raises(ValueError, match="exceeds the hardware-safe window=40"):
+        large_context.run_policy(base, X_test, policy_spec="target_rank[cap=64]")
+
+
+def test_gate_can_compare_two_target_rank_caps_below_the_hardware_window():
+    X_train, y_train, X_test = make_table(n_train=50, n_test=10)
+    base = large_context.build_problem(ridge_predict, X_train, y_train, window=64)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
+        preds, report = large_context.run_policy(
+            base,
+            X_test,
+            policy_spec=["target_rank[cap=16]", "target_rank[cap=32]"],
+        )
+    assert preds.shape == (10,)
+    assert report["gate_winner"] in ("target_rank[cap=16]", "target_rank[cap=32]")
+
+
 # -------------------------------------------------------------------- run_policy
 def test_run_policy_returns_one_prediction_per_query_row():
     base = make_base()
@@ -189,7 +260,7 @@ def test_y_test_raises_on_an_inference_problem_instead_of_returning_zeros():
 def test_the_shipped_policies_never_read_y_test():
     base = make_base(window=40, n_train=400)
     _, _, X_test = make_table(n_test=60)
-    for name in ("random", "cluster_route", "cluster_route_g4", "safeboost", "boost"):
+    for name in ("random", "target_rank", "cluster_route", "cluster_route_g4", "safeboost", "boost"):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", pol.LargeContextPolicyWarning)
             preds, _ = large_context.run_policy(base, X_test, policy_spec=name)
@@ -931,15 +1002,50 @@ def test_a_squeezed_holdout_says_so():
         large_context.run_policy(base, X_test, policy_spec=["random", "cluster_route"])
 
 
-def test_the_gate_refuses_a_table_it_cannot_carve_a_holdout_from():
-    """Unreachable through `run_policy`, which serves full context below the window --
-    but `holdout_gate` is public, and silently scoring on nothing is the failure this
-    replaces."""
-    X_train, y_train, X_test = make_table(n_train=40, n_test=10)
-    base = large_context.build_problem(ridge_predict, X_train, y_train, window=50, seed=1)
-    gate = pol.holdout_gate(["random"])
-    with pytest.raises(ValueError, match="needs more than window=50 train rows"):
-        gate(base.with_queries(X_test), np.random.default_rng(0))
+def test_the_gate_shortens_a_capped_candidate_instead_of_crashing_near_its_cap():
+    """Production analogue: default threshold 50k, candidates capped 32k/64k."""
+    X_train, y_train, X_test = make_table(n_train=55, n_test=10)
+    base = large_context.build_problem(ridge_predict, X_train, y_train, window=64, seed=1)
+    with pytest.warns(pol.LargeContextPolicyWarning, match="leaves only 52 context rows"):
+        preds, report = large_context.run_policy(
+            base,
+            X_test,
+            policy_spec=["target_rank[cap=32]", "target_rank[cap=64]"],
+        )
+    assert preds.shape == (10,)
+    assert report["gate_winner"] in ("target_rank[cap=32]", "target_rank[cap=64]")
+
+
+def test_tail_holdout_keeps_future_rows_out_of_candidate_context():
+    seen = []
+
+    def observe(problem, rng):
+        del rng
+        seen.append((problem.X_train[:, 0].tolist(), problem.X_test[:, 0].tolist()))
+        return np.zeros(problem.n_test)
+
+    X_train = np.arange(10, dtype=np.float32)[:, None]
+    y_train = np.arange(10, dtype=np.float64)
+    X_test = np.zeros((2, 1), dtype=np.float32)
+    base = large_context.build_problem(ridge_predict, X_train, y_train, window=4)
+    gate = pol.holdout_gate([observe], holdout=2, strategy="tail")
+    gate(base.with_queries(X_test), np.random.default_rng(0))
+    assert seen[0] == (list(range(8)), [8.0, 9.0])
+
+
+def test_unknown_holdout_strategy_is_rejected():
+    with pytest.raises(ValueError, match="random.*tail"):
+        pol.holdout_gate(["random"], strategy="future")
+
+
+def test_the_estimator_rejects_tail_holdout_for_a_single_policy():
+    regressor = NoriRegressor(
+        large_context_policy="target_rank[cap=32]",
+        large_context_holdout="tail",
+    )
+
+    with pytest.raises(ValueError, match="valid only with a large_context_policy list"):
+        regressor.fit(np.zeros((8, 2)), np.arange(8, dtype=float))
 
 
 # ------------------------------------------- review: what `reused_train_state` records


### PR DESCRIPTION
## Summary

Promotes the validated target-rank context-policy patch from staging.

- adds opt-in `target_rank[cap=N]` context selection
- adds random/tail holdout gating for bounded policy lists
- exposes the typed controls through the local estimator and hosted client
- documents the measured 32k/64k trade-off and keeps the gate non-default

The 11-file patch is byte-identical to the shared files merged in staging.

## Validation

Staging PR #41 passed:

- 897 core tests
- 324 AWS-enabled targeted client/policy tests
- Python 3.9/3.11 package tests and package cutover rehearsal
- Torch 2.8–2.13 compatibility
- locked and Torch 2.13 Modal GPU tests
- slow inference, MPS, embeddings, train-step, distribution, lint, and build gates

Sources:

- Internal: https://github.com/Synthefy/synthefy-nori-internal/pull/555
- Staging: https://github.com/Synthefy/synthefy-nori-staging/pull/41
