### PR TITLE
fix(attention): support streamed 30M/100M heads

### DIFF
--- a/src/synthefy_nori/model/layer.py
+++ b/src/synthefy_nori/model/layer.py
@@ -687,6 +687,15 @@ class MultiheadAttention(torch.nn.Module):
         batch_groups, n_query, n_heads, head_dim = q.shape
         scale = (1.0 / math.sqrt(float(head_dim))) if sdpa_scale is None else sdpa_scale
         q_flex = q.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
+        # FlexAttention's Triton kernel reshapes the value head width with a
+        # power-of-two block. Released models use widths such as 44 and 56, so
+        # pad Q/K/V with zeros for the kernel and slice the output back. Zero
+        # padding preserves both QK logits and V aggregation; keep ``scale``
+        # based on the original width so the attention math stays unchanged.
+        flex_head_dim = 1 << (head_dim - 1).bit_length()
+        head_dim_padding = flex_head_dim - head_dim
+        if head_dim_padding:
+            q_flex = nn.functional.pad(q_flex, (0, head_dim_padding))
         running_lse = torch.full(
             (batch_groups, n_heads, n_query),
             float("-inf"),
@@ -702,9 +711,16 @@ class MultiheadAttention(torch.nn.Module):
         for kv_block in kv_cache.iter_kv_blocks():
             if kv_block.ndim != 5 or kv_block.shape[0] != batch_groups:
                 raise ValueError(f"streamed K/V block must be [BG, K, 2, Hkv, D], got {tuple(kv_block.shape)}")
+            if kv_block.shape[-1] != head_dim:
+                raise ValueError(
+                    f"streamed K/V head width must match query head width {head_dim}, got {kv_block.shape[-1]}"
+                )
             k, v = kv_block.unbind(dim=2)
             k_flex = k.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
             v_flex = v.to(FLASH_ATTN_DTYPE).permute(0, 2, 1, 3).contiguous()
+            if head_dim_padding:
+                k_flex = nn.functional.pad(k_flex, (0, head_dim_padding))
+                v_flex = nn.functional.pad(v_flex, (0, head_dim_padding))
             block_output, block_lse = _flex_attention_with_lse(
                 q_flex,
                 k_flex,
@@ -723,7 +739,7 @@ class MultiheadAttention(torch.nn.Module):
             old_weight = torch.exp(running_lse - new_lse).unsqueeze(-1)
             block_weight = torch.exp(block_lse - new_lse).unsqueeze(-1)
             running_output.mul_(old_weight)
-            running_output.add_(block_output.to(torch.float32) * block_weight)
+            running_output.add_(block_output[..., :head_dim].to(torch.float32) * block_weight)
             running_lse = new_lse
             del (
                 kv_block,

--- a/tests/test_blockwise_context_attention.py
+++ b/tests/test_blockwise_context_attention.py
@@ -313,6 +313,56 @@ def test_flex_block_lse_merge_matches_one_full_softmax(monkeypatch, kv_heads):
     assert cache.max_staged_rows == 6
 
 
+@pytest.mark.parametrize(("head_dim", "flex_head_dim"), [(8, 8), (44, 64), (56, 64)])
+def test_flex_blockwise_pads_non_power_of_two_head_widths(monkeypatch, head_dim, flex_head_dim):
+    torch.manual_seed(7)
+    n_heads = 4
+    q = torch.randn(1, 5, n_heads, head_dim)
+    kv = torch.randn(1, 9, 2, n_heads, head_dim)
+    cache = BlockwiseSeqKV.from_row_slices(
+        _row_slices(kv, (4, 5)),
+        1,
+        2,
+        quantize=False,
+        device=torch.device("cpu"),
+        dtype=kv.dtype,
+    )
+    calls = []
+
+    def fake_flex(q_block, k_block, v_block, *, scale, enable_gqa):
+        calls.append((q_block.shape[-1], k_block.shape[-1], v_block.shape[-1], scale, enable_gqa))
+        logits = torch.einsum("bhqd,bhkd->bhqk", q_block.float(), k_block.float()) * scale
+        lse = torch.logsumexp(logits, dim=-1)
+        output = torch.einsum("bhqk,bhkd->bhqd", torch.softmax(logits, dim=-1), v_block.float())
+        return output, lse
+
+    monkeypatch.setattr(layer_module, "_flex_attention_with_lse", fake_flex)
+    attn = MultiheadAttention(
+        embed_dim=n_heads * head_dim,
+        num_heads=n_heads,
+        qkv_combined=False,
+        dropout=0.0,
+    ).eval()
+    with torch.inference_mode():
+        got = attn._compute_attention_blockwise_flex(q, cache)
+
+    q_full = q.to(torch.bfloat16).permute(0, 2, 1, 3)
+    k_full, v_full = kv.to(torch.bfloat16).unbind(dim=2)
+    logits = torch.einsum("bhqd,bhkd->bhqk", q_full.float(), k_full.permute(0, 2, 1, 3).float()) * head_dim**-0.5
+    expected = torch.einsum(
+        "bhqk,bhkd->bhqd",
+        torch.softmax(logits, dim=-1),
+        v_full.permute(0, 2, 1, 3).float(),
+    ).permute(0, 2, 1, 3)
+
+    torch.testing.assert_close(got, expected, rtol=2e-5, atol=2e-5)
+    assert [(q_dim, k_dim, v_dim, enable_gqa) for q_dim, k_dim, v_dim, _, enable_gqa in calls] == [
+        (flex_head_dim, flex_head_dim, flex_head_dim, False),
+        (flex_head_dim, flex_head_dim, flex_head_dim, False),
+    ]
+    assert [scale for _, _, _, scale, _ in calls] == pytest.approx([head_dim**-0.5] * 2)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 @pytest.mark.parametrize("kv_heads", [1, 4])
 def test_cuda_flex_blockwise_matches_full_sdpa(kv_heads):


### PR DESCRIPTION
## Promotion

Promotes [staging #42](https://github.com/Synthefy/synthefy-nori-staging/pull/42)
and [internal #556](https://github.com/Synthefy/synthefy-nori-internal/pull/556)
unchanged to public.

## Result

| Model | Head width | Before live fix | Patched H100 kernel |
|---|---:|---:|---:|
| 6M | 64 | PASS | PASS |
| 30M | 56 | `stream_context` returned 500 | PASS |
| 100M | 44 | `stream_context` returned 500 | PASS |

FlexAttention receives zero-padded power-of-two Q/K/V heads, keeps the original
softmax scale, and slices the output back. Width 64 stays unpadded.

- Internal: 197 focused tests and all PR checks green.
- Staging: all 18 checks green, including locked/latest Modal GPU checks and
  the full inference suite.
- H100 widths 44/56 match the unchanged width-64 BF16-vs-SDPA envelope (max
  absolute error `0.0078125`):
  [Modal run](https://modal.com/apps/synthefy/main/ap-2g9oHTy8oUkKTyUDYrTVOz).

After merge, redeploy 30M/100M and rerun the full released-client live suites.
