### PR TITLE
chore(release): prepare 7.1.2 and 0.20.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: >-
           uv run python -c
           "import synthefy, synthefy_nori;
-          assert synthefy.__version__ == '7.1.1';
+          assert synthefy.__version__ == '7.1.2';
           assert synthefy_nori.__version__ == '0.20.1'"
       - run: uv run pytest
       - run: >-
@@ -42,13 +42,13 @@ jobs:
         include:
           - python_version: "3.9"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.1.1-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.1.2-py3-none-any.whl
           - python_version: "3.9"
             kind: sdist
-            artifact_file: dist/synthefy/synthefy-7.1.1.tar.gz
+            artifact_file: dist/synthefy/synthefy-7.1.2.tar.gz
           - python_version: "3.11"
             kind: wheel
-            artifact_file: dist/synthefy/synthefy-7.1.1-py3-none-any.whl
+            artifact_file: dist/synthefy/synthefy-7.1.2-py3-none-any.whl
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -72,7 +72,7 @@ jobs:
 
           uv pip install --python "$CLIENT_TEST_PY" --strict "$CLIENT_TEST_ARTIFACT"
           uv pip check --python "$CLIENT_TEST_PY"
-          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.1.1"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
+          "$CLIENT_TEST_PY" -c 'import importlib.util; import synthefy; from importlib.metadata import metadata; assert "site-packages" in synthefy.__file__; assert synthefy.__version__ == "7.1.2"; assert metadata("synthefy")["Requires-Python"] == ">=3.9"; assert all(importlib.util.find_spec(name) is None for name in ("boto3", "joblib", "scipy", "sentence_transformers", "sklearn", "synthefy_nori", "torch"))'
 
           uv pip install --python "$CLIENT_TEST_PY" --strict \
             "boto3>=1.34,<2" \

--- a/libs/synthefy/CHANGELOG.md
+++ b/libs/synthefy/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.2] - 2026-09-02
+
+### Added
+
+- Added the opt-in `target_rank[cap=N]` large-context policy to local, Baseten,
+  and SageMaker requests. Policy lists can use bounded random or tail holdouts
+  to select a per-table winner, and capability reports verify the honored
+  policy and holdout strategy.
+
 ## [7.1.1] - 2026-08-29
 
 ### Fixed

--- a/libs/synthefy/pyproject.toml
+++ b/libs/synthefy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synthefy"
-version = "7.1.1"
+version = "7.1.2"
 description = "Lightweight client and workflow SDK for Synthefy Nori regression and forecasting"
 readme = "README.md"
 license = "Apache-2.0"

--- a/libs/synthefy/src/synthefy/__init__.py
+++ b/libs/synthefy/src/synthefy/__init__.py
@@ -17,7 +17,7 @@ from synthefy.data_models import (
 )
 from synthefy.nori_client import SynthefyNoriClient
 
-__version__ = "7.1.1"
+__version__ = "7.1.2"
 
 __all__ = [
     "DEFAULT_LARGE_CONTEXT_SEED",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -102,8 +102,8 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     assert root["project"]["version"] == "0.20.1"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
-    assert client["project"]["version"] == "7.1.1"
-    assert _declared_version() == "7.1.1"
+    assert client["project"]["version"] == "7.1.2"
+    assert _declared_version() == "7.1.2"
     assert client["build-system"] == {
         "requires": ["hatchling==1.27.0"],
         "build-backend": "hatchling.build",
@@ -343,7 +343,7 @@ def test_the_root_lock_is_the_only_lock_and_contains_both_editable_projects():
     assert len(root_entries) == len(client_entries) == 1
     assert root_entries[0]["source"] == {"editable": "."}
     assert client_entries[0]["source"] == {"editable": "libs/synthefy"}
-    assert client_entries[0]["version"] == "7.1.1"
+    assert client_entries[0]["version"] == "7.1.2"
     assert "synthefy" in {dep["name"] for dep in root_entries[0]["dependencies"]}
 
     hatchling = [item for item in packages if item["name"] == "hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6457,7 +6457,7 @@ wheels = [
 
 [[package]]
 name = "synthefy"
-version = "7.1.1"
+version = "7.1.2"
 source = { editable = "libs/synthefy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare the public package releases for the target-rank context policy and the
streamed-attention head-width fix.

- bump `synthefy` from 7.1.1 to 7.1.2
- keep the already-prepared `synthefy-nori` 0.20.1 version
- update the client changelog, lockfile, artifact paths, and version assertions

## Release notes

### synthefy 7.1.2

Adds opt-in `target_rank[cap=N]` context selection and bounded random/tail
holdout selection for policy lists across local, Baseten, and SageMaker modes.

### synthefy-nori 0.20.1

Includes the target-rank runtime, the existing single-row point-shape fix, and
the FlexAttention padding fix for streamed context on the 30M/100M head widths.

## Validation

- 275 targeted workspace/client/context tests passed with the AWS extra
- ruff lint and formatting passed
- both wheels and sdists pass strict Twine checks
- clean lightweight-only install: 7.1.2, Torch absent
- clean mixed install: `synthefy 7.1.2` + released `synthefy-nori 0.20.0`
- clean paired install: 7.1.2 + 0.20.1, `pip check` green
- candidate 0.20.1 completed a clean CPU local-regression prediction
- production 30M and 100M released-client suites: 63 passed, 3 skipped each

Production runs:

- https://github.com/Synthefy/synthefy-nori-internal/actions/runs/33669006345
- https://github.com/Synthefy/synthefy-nori-internal/actions/runs/33669009148

Source promotions:

- target-rank policy: #146
- streamed-attention fix: #147

No checkpoint, dependency range, model slug, pricing, billing, limit, or
entitlement change.
