### PR TITLE
fix: restore large-context estimator persistence

### DIFF
--- a/src/synthefy_nori/inference/large_context.py
+++ b/src/synthefy_nori/inference/large_context.py
@@ -29,6 +29,7 @@ Opt in, and read :attr:`NoriRegressor.large_context_report_` to see what actuall
 from __future__ import annotations
 
 import warnings
+from functools import partial
 from typing import Callable, Optional
 
 import numpy as np
@@ -246,6 +247,13 @@ def _report(name: str, problem: Problem, window: int, *, full_context: bool, reu
     }
 
 
+def _predictor_call(predictor, X_context, y_context, X_query) -> np.ndarray:
+    out = predictor.predict(X_context, y_context, X_query)
+    if hasattr(out, "detach"):  # a torch tensor: np.asarray() would raise on CUDA
+        out = out.detach().cpu().numpy()
+    return np.asarray(out, dtype=np.float64).reshape(-1)
+
+
 def predictor_call_fn(predictor) -> Callable[..., np.ndarray]:
     """Adapt a predictor into the one primitive a policy calls.
 
@@ -254,17 +262,10 @@ def predictor_call_fn(predictor) -> Callable[..., np.ndarray]:
     device. Bridging the two is this module's job — it is what makes ``policies.py``
     numpy-only and testable without a checkpoint.
 
-    Kept as a closure over the predictor alone (not the surrounding predict call) so a
-    long-lived :class:`Problem` holding this does not pin a query block alive.
+    Bind only the predictor so a long-lived :class:`Problem` does not pin a query
+    block alive. A module-level callable also keeps fitted estimators pickleable.
     """
-
-    def one_call(X_context, y_context, X_query) -> np.ndarray:
-        out = predictor.predict(X_context, y_context, X_query)
-        if hasattr(out, "detach"):  # a torch tensor: np.asarray() would raise on CUDA
-            out = out.detach().cpu().numpy()
-        return np.asarray(out, dtype=np.float64).reshape(-1)
-
-    return one_call
+    return partial(_predictor_call, predictor)
 
 
 __all__ = [

--- a/src/synthefy_nori/inference/policies.py
+++ b/src/synthefy_nori/inference/policies.py
@@ -206,10 +206,13 @@ class SharedTrainState(dict):
       hit on an entry a microsecond old.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.hits = 0
-        self._derived_this_call: set = set()
+    def __new__(cls, *args, **kwargs):
+        # Unpickling inserts dict entries before restoring attributes and skips
+        # __init__, so __setitem__ needs its accounting state at allocation time.
+        state = super().__new__(cls)
+        state.hits = 0
+        state._derived_this_call = set()
+        return state
 
     def begin_call(self) -> None:
         """Start a fresh accounting window: everything stored so far now counts as

--- a/tests/test_large_context_pickle.py
+++ b/tests/test_large_context_pickle.py
@@ -1,0 +1,49 @@
+"""Large-context fitted state survives persistence and sklearn-style copying."""
+
+from __future__ import annotations
+
+import copy
+import pickle
+
+import numpy as np
+import pytest
+import torch
+
+from synthefy_nori.api import NoriRegressor
+from synthefy_nori.inference.large_context import predictor_call_fn
+from synthefy_nori.inference.policies import SharedTrainState
+
+
+class _PicklePredictor:
+    quantile_collapse = "mean"
+    bar_point_estimator = "mean"
+
+    def budget_n_features(self, X):
+        return X.shape[1]
+
+    def max_context_rows(self, X, *, budget_n_features):
+        return 16
+
+    def predict(self, X_context, y_context, X_query):
+        context = np.column_stack((X_context, np.ones(len(X_context))))
+        query = np.column_stack((X_query, np.ones(len(X_query))))
+        coefficients = np.linalg.solve(context.T @ context + 1e-3 * np.eye(context.shape[1]), context.T @ y_context)
+        return torch.tensor(query @ coefficients).reshape(-1, 1).requires_grad_()
+
+
+def _pickle_roundtrip(value):
+    return pickle.loads(pickle.dumps(value))
+
+
+@pytest.mark.parametrize("roundtrip", [_pickle_roundtrip, copy.deepcopy], ids=["pickle", "deepcopy"])
+def test_predictor_adapter_roundtrip_preserves_tensor_conversion(roundtrip):
+    X = np.arange(12, dtype=np.float32).reshape(6, 2)
+    y = np.arange(6, dtype=np.float64)
+    call = predictor_call_fn(_PicklePredictor())
+    expected = call(X, y, X[:1])
+
+    actual = roundtrip(call)(X, y, X[:1])
+
+    assert actual.shape == (1,)
+    assert actual.dtype == np.float64
+    np.testing.assert_array_equal(actual, expected)

--- a/tests/test_large_context_pickle.py
+++ b/tests/test_large_context_pickle.py
@@ -47,3 +47,64 @@ def test_predictor_adapter_roundtrip_preserves_tensor_conversion(roundtrip):
     assert actual.shape == (1,)
     assert actual.dtype == np.float64
     np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize("protocol", [4, 5])
+def test_populated_train_state_roundtrip_preserves_hit_accounting(protocol):
+    state = SharedTrainState()
+    state["earlier"] = np.arange(4)
+    state.begin_call()
+    state.get("earlier")
+    state["current"] = np.arange(2)
+
+    restored = pickle.loads(pickle.dumps(state, protocol=protocol))
+
+    assert restored.hits == 1
+    np.testing.assert_array_equal(restored["current"], [0, 1])
+    assert restored.hits == 1
+    np.testing.assert_array_equal(restored["earlier"], [0, 1, 2, 3])
+    assert restored.hits == 2
+    restored.begin_call()
+    restored.get("current")
+    assert restored.hits == 1
+    assert state.hits == 1
+
+
+@pytest.mark.parametrize("roundtrip", [_pickle_roundtrip, copy.deepcopy], ids=["pickle", "deepcopy"])
+@pytest.mark.parametrize(
+    "policy,reuses_state",
+    [
+        (None, False),
+        ("random", False),
+        ("target_rank[cap=8]", False),
+        ("cluster_route", True),
+        ("cluster_route_g4", True),
+        ("safeboost", True),
+        ("boost", True),
+        (["random", "target_rank[cap=8]"], True),
+    ],
+)
+def test_fitted_policy_roundtrip_preserves_predictions_and_warm_cache(policy, reuses_state, roundtrip):
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(192, 4)).astype(np.float32)
+    y = X[:, 0] - 2 * X[:, 1] + 0.3 * X[:, 2] ** 2
+    query = rng.normal(size=(12, 4)).astype(np.float32)
+    estimator = NoriRegressor(
+        model_path="unused", device="cpu", large_context_policy=policy, large_context_threshold=16
+    )
+    estimator._predictor = _PicklePredictor()
+    estimator.fit(X, y)
+    estimator.predict(query)
+    expected = estimator.predict(query)
+    expected_report = copy.deepcopy(estimator.large_context_report_)
+
+    restored = roundtrip(estimator)
+
+    np.testing.assert_array_equal(restored.predict(query), expected)
+    assert restored.large_context_report_ == expected_report
+    if policy is not None:
+        assert restored.large_context_report_["reused_train_state"] is reuses_state
+    new_query = query[::-1].copy()
+    np.testing.assert_array_equal(restored.predict(new_query), estimator.predict(new_query))
+    restored.fit(X, y + 10)
+    np.testing.assert_allclose(restored.predict(query), expected + 10, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
## Summary

Fix two independent persistence failures in fitted large-context `NoriRegressor` estimators. Keep the fixes in two reviewable commits:

| Commit | Change |
| --- | --- |
| `78d03b5` | Replace the local predictor closure with a partial of a module-level function. |
| `b5b1965` | Initialize policy-cache accounting before pickle restores dictionary entries. |

Based on public `main` at `a0e751299c998182b1f7ec066794c4f589e705f0`. Three files only: `src/synthefy_nori/inference/large_context.py`, `src/synthefy_nori/inference/policies.py`, and `tests/test_large_context_pickle.py` (128 insertions, 14 deletions).

No unrelated cleanup, dependency changes, version bumps, checkpoint changes, or deployment changes. This is a draft for review, not a release.

## Root Causes and Affected Paths

1. **Saving a fitted large-context estimator fails.** The documented `NoriRegressor(..., large_context_policy=...)` prediction path retains a `Problem` whose predictor adapter is a local closure. Once the policy path runs, `pickle.dumps(estimator)` raises `AttributeError: Can't pickle local object 'predictor_call_fn.<locals>.one_call'`. A partial of a module-level callable makes that adapter pickleable while preserving tensor detachment, CPU conversion, float64 output, and shape. Only the predictor is bound; query arrays are not retained by the adapter.
2. **Restoring a populated policy cache fails independently.** Pickle restores dictionary entries before instance attributes and skips `__init__`. `SharedTrainState.__setitem__` therefore accesses `_derived_this_call` before it exists. Initializing accounting in `__new__` permits entry restoration, after which pickle restores the original cache-accounting attributes. Cached values, hit counts, and warm-state behavior are preserved.

These paths are reached by ordinary persistence and deep copying after a user opts into a large-context policy. They do not require malformed inputs or an unusual checkpoint. User-supplied local/lambda policy functions remain subject to normal Python pickle limitations.

## Reproduction and Tests

```bash
uv sync --locked --extra dev
uv run pytest -q tests/test_large_context_pickle.py
```

The regression file was run against the public baseline during the audit: **10 failed / 10 passed**. Isolating the adapter fix left **7 failures / 13 passes**, demonstrating the second defect. With both fixes, all **20** cases pass.

Coverage includes pickle protocols 4 and 5, deepcopy, tensor conversion, all built-in policies, a holdout gate, cache accounting, warm-state reuse, exact restored predictions, a different query batch, and refitting.

The real-checkpoint baseline fails to serialize all seven policy-enabled configurations; the ordinary policy-disabled control passes. The baseline source, configuration, and locked dependencies were verified identical to public `main` for the runtime under test. Fresh public candidate probe results are recorded below.

Probe configuration: released 6M checkpoint SHA-256 `a13b2bc31d8db24d17bae6d04844e0adf669e446087b0b7a34c7b05045d61323`, NumPy seed 0, 192x4 training inputs, target `x0 - 2*x1 + 0.3*x2**2`, 12 query rows, CPU, no augmentations, `large_context_threshold=32`, and `memory_policy={"elements_budget": 256}`. Cases: ordinary, random, target-rank cap 16, cluster-route, g4, safeboost, boost, and a random/target-rank gate.

## Validation

- Fresh public fast suite: **918 passed**, 23 skipped, 56 deselected, 17 warnings, 26.65 seconds. Audit baseline: 898 passed with the same skips/deselections.
- Fresh lightweight client suite with sockets disabled: **284 passed**, 2 skipped, 3 deselected, 1 warning, 10.74 seconds.
- Fresh public CPU checkpoint persistence probe: **8/8 passed**; baseline 7/8 failed to serialize. Maximum absolute prediction difference is **0.0** both before/after and after restoration, across 96 predictions. Cache reports and API signatures also match exactly.
- Import smoke, correctness lint, changed-file formatting, and diff whitespace checks: pass.
- Wheels and source distributions for both packages: all four artifacts build and pass strict Twine validation. No artifacts are published.
- The exact source/test changes were reviewed for correctness, serialization order, copying, retained references, and regression coverage; no additional change-specific findings.
- GitHub CI will run on this draft. Keep it unmerged until checks and review are complete.

## Compatibility and Risks

Estimator constructor/fit/predict signatures, tensor conversion, cache accounting, checkpoint tensors, serving schemas, dependencies, and package versions are unchanged. This changes the representation of the retained adapter, not the numerical inference algorithm.

The adapter microbenchmark measured approximately 570 -> 606 ns/call with unchanged 176-byte peak traced allocation and no additional input-array copies. Whole-estimator persistence now creates restored copies where the old implementation failed, so whole-process peak RSS is not a controlled inference-only memory comparison. Shared-host wall times do not establish performance equivalence or a speedup.

Observed warm median seconds, baseline -> public candidate (three repetitions per case): ordinary 1.368 -> 1.690; random 1.391 -> 1.706; target-rank 1.074 -> 1.260; cluster-route 6.130 -> 7.925; g4 3.313 -> 4.943; safeboost 4.593 -> 4.709; boost 5.419 -> 5.715; gate 0.982 -> 1.339. The untouched ordinary path also varies on this shared host, so these measurements do not isolate the performance effect of this patch. Full-probe peak RSS was 1,210,852 -> 1,278,800 KiB, including the newly working estimator restoration path.

Newly saved large-context estimators reference the new module-level adapter and require the fixed code to load. Before downgrading, load those estimators with the fixed package and preserve their data/configuration for refitting. Only deserialize trusted pickle files.

## Rollback

Before merge, close the draft. After merge, revert the two commits through a reviewed PR. There are no migrations, checkpoint changes, or deployment-state changes to undo. Reverting reintroduces both persistence defects and requires the downgrade precautions above.

No release, tag, PyPI publication, weights publication, or deployment is requested by this PR.
