### PR TITLE
chore(release): prepare synthefy-nori 0.20.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.1.2';
-          assert synthefy_nori.__version__ == '0.20.1'"
+          assert synthefy_nori.__version__ == '0.20.2'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.20.1"
+version = "0.20.2"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -24,7 +24,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.20.1"
+__version__ = "0.20.2"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -99,7 +99,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.20.1"
+    assert root["project"]["version"] == "0.20.2"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -6540,7 +6540,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.20.1"
+version = "0.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
## Scope

Prepare `synthefy-nori` 0.20.2 after the persistence fixes in #151. Five one-line updates only, matching `RELEASING.md`: project version, module version, workspace lock entry, CI import assertion, and workspace test assertion.

`synthefy` remains 7.1.2. No dependency versions, inference code, checkpoint weights, API contracts, deployment configuration, or publisher workflows change. No tag, GitHub Release, or PyPI upload is created by this PR.

## Proposed Release Notes

### synthefy-nori 0.20.2

#### Fixes

- Fix pickling and deep copying fitted large-context regressors by making the retained predictor adapter serializable. (#151)
- Fix restoration of populated policy caches while preserving cached values, hit accounting, warm-state reuse, and predictions. (#151)

#### Repository Examples

- Add 2026 fantasy-football and NFL passing-yard example notebooks, including a companion feature-building helper. (#149, #150)

#### Compatibility

- Prediction algorithms, public API signatures, model weights, and dependencies are unchanged. The persistence verification preserved all 96 tested predictions exactly.
- Newly saved large-context estimators require the fixed runtime to load; older releases cannot resolve the new adapter reference. Before downgrading, load saved estimators with the fixed runtime and preserve their data/configuration for refitting. Only load trusted pickle files.
- The lightweight `synthefy` client is unchanged; no corresponding client release is needed.

## Validation

- Structured lockfile comparison confirms that only the heavy workspace package version changes; all resolved dependencies are identical.
- Fresh full fast suite: **918 passed**, 23 skipped, 56 deselected, 17 warnings, 25.80 seconds. Correctness lint and diff whitespace checks pass.
- Both distributions build as wheels and source distributions; all four artifacts pass strict Twine validation. The unchanged client is built for validation only, not publication.
- Clean environment: candidate heavy wheel **0.20.2** with registry-installed **synthefy 7.1.2**; version/import checks and `uv pip check` pass. All **20 persistence tests pass against the installed wheel**, with a collection-time assertion that the estimator comes from site-packages rather than the checkout.
- Generated transfer sidecars were removed before final validation; archive inspection confirms none are present in the four artifacts. No sidecars are committed.
- Scope/code review: five coordinated version lines; no unrelated cleanup or release automation changes.
- Public post-merge CPU and GPU CI for #151 passed. This PR's CI must also pass before merge/tagging.

## Publication Gates

This PR only prepares the version and reviewable release notes. Before publication:

- Finish public post-merge and release-PR CI, obtain review approval, and merge the version PR.
- Satisfy the documented rebase-sync/drop-check gate; it is not waived by preparing this draft.
- Obtain approval to tag and publish, then use `synthefy-nori-v0.20.2` on the validated public-main commit and the protected `publish-synthefy-nori.yml` trusted-publishing workflow.
- Verify the published package in a clean environment afterward. Do not publish the unchanged client or deploy a service as part of this patch release.

## Rollback

Before publication, close the draft or revert the version-only commit through review. After PyPI publication, do not reuse 0.20.2; fix forward with a new patch version. Downgrading also requires the saved-estimator compatibility precautions above.
