### PR TITLE
Promote: transductive fit for the wide-table SVD selector + release 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           uv run python -c
           "import synthefy, synthefy_nori;
           assert synthefy.__version__ == '7.1.2';
-          assert synthefy_nori.__version__ == '0.20.2'"
+          assert synthefy_nori.__version__ == '0.21.0'"
       - run: uv run pytest
       - run: >-
           uv run ruff check src scripts tests

--- a/README.md
+++ b/README.md
@@ -570,6 +570,8 @@ ensemble math but can reassociate mixed-precision GEMMs at the last few bits.
 | Env var | Default | What it does |
 |---|---|---|
 | `SYNTHEFY_GPU_SVD` | `1` (on) | Run the high-dimensional feature SVD on the GPU (exact, not randomized). Acts when features ≥256; set `0` for the CPU/randomized path. |
+
+On tables with more than 256 features the SVD projection is fitted on the context **and** the query rows' features (labels are never used) since 0.21.0 — `"fit_on_test": true` in the bundled inference config. This keeps query rows whose features drift outside the context's range (a later time period, another instrument batch) inside the fitted subspace; on random splits the two fits coincide. Set it to `false` in a custom `inference_config` to recover the context-only fit.
 | `SYNTHEFY_CAP_QUANTILES` | `1` (on) | Cap quantile-transform resolution + subsample its fit. Acts on large context (>2000 rows); set `0` to disable. |
 | `SYNTHEFY_QUANTILE_MAX` / `SYNTHEFY_QUANTILE_SUBSAMPLE` | — | Tune the cap above (max quantiles / fit-subsample size). |
 | `SYNTHEFY_ADAPTIVE_FIT_SUBSAMPLE` | `2000` | Fit preprocessing on at most this many rows, apply to all rows. Acts on large context; set `0` to fit on all rows. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synthefy-nori"
-version = "0.20.2"
+version = "0.21.0"
 description = "Nori foundation model training, inference, and evaluation"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/synthefy_nori/__init__.py
+++ b/src/synthefy_nori/__init__.py
@@ -24,7 +24,7 @@ from synthefy_nori.api import (
 from synthefy_nori.embedding import NoriEmbedding
 from synthefy_nori.pricing import billable_price
 
-__version__ = "0.20.2"
+__version__ = "0.21.0"
 
 __all__ = [
     "ContextSubsampledWarning",

--- a/src/synthefy_nori/configs/default_inference.json
+++ b/src/synthefy_nori/configs/default_inference.json
@@ -26,7 +26,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -56,7 +56,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -86,7 +86,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -116,7 +116,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -146,7 +146,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -176,7 +176,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -206,7 +206,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   },
   {
@@ -236,7 +236,7 @@
       "svd_components": 512,
       "n_features_threshold": 256,
       "binary_threshold": 1.01,
-      "svd_rows_per_component": 3
+      "svd_rows_per_component": 3, "fit_on_test": true
     }
   }
 ]

--- a/src/synthefy_nori/inference/policies.py
+++ b/src/synthefy_nori/inference/policies.py
@@ -809,7 +809,11 @@ def replay_chain(problem: Problem, stages) -> np.ndarray:
     Equivalent to the fused build, not an approximation: preprocessing is inductive
     (fitted on the context, never on the query block — `_fit_transform_step_inductive`),
     so a query row scores the same whether it shared its call with the later train rows
-    or not, exactly as the existing `query_chunk` splitting already relies on.
+    or not, exactly as the existing `query_chunk` splitting already relies on. The one
+    exception is the wide-table projection when ``HighDimFeatureSelector.fit_on_test`` is
+    on (the default): above 256 features its basis also sees the query block's features,
+    so replay is equivalent up to that basis' dependence on the block — negligible when the
+    context dominates the block, which the `query_chunk` sizing guarantees.
     """
     preds = np.zeros(problem.n_test, dtype=np.float64)
     for shard, labels, weight in stages:

--- a/src/synthefy_nori/inference/predictor.py
+++ b/src/synthefy_nori/inference/predictor.py
@@ -517,7 +517,16 @@ class NoriPredictor:
         # `y_train` is forwarded to selectors that require it (e.g.
         # HighDimFeatureSelector with corr / mi / extratrees). Steps that don't
         # accept a y= kwarg simply ignore it via **kwargs.
-        categorical_idx = step.fit(x_train, categorical_idx, seed, y=y_train)
+        if (
+            isinstance(step, HighDimFeatureSelector)
+            and getattr(step, "fit_on_test", False)
+            and x_test is not None
+            and len(x_test)
+        ):
+            # Experimental transductive fit: the projection sees the test rows' feature distribution (no labels).
+            categorical_idx = step.fit(np.vstack([x_train, x_test]), categorical_idx, seed, y=None)
+        else:
+            categorical_idx = step.fit(x_train, categorical_idx, seed, y=y_train)
         if isinstance(step, FingerprintFeatureEncoder):
             x_train_out, categorical_idx = step.transform(x_train, is_test=False)
             x_test_out, categorical_idx = step.transform(x_test, is_test=True)

--- a/src/synthefy_nori/inference/preprocess.py
+++ b/src/synthefy_nori/inference/preprocess.py
@@ -1390,9 +1390,11 @@ class HighDimFeatureSelector(BasePreprocess):
         svd_rows_per_component: int = 1,
         extratrees_n_estimators: int = 100,
         subsample_rows: int = 5000,
+        fit_on_test: bool = False,
     ):
         super().__init__()
         self.strategy = strategy
+        self.fit_on_test = bool(fit_on_test)  # experimental: fit the projection on context + test features
         self.top_k = int(top_k)
         self.n_features_threshold = int(n_features_threshold)
         self.binary_threshold = float(binary_threshold)

--- a/tests/test_hdf_selector_transductive_fit.py
+++ b/tests/test_hdf_selector_transductive_fit.py
@@ -1,0 +1,91 @@
+"""HighDimFeatureSelector.fit_on_test: the projection is fitted on context + test features (no labels)."""
+
+import numpy as np
+import pytest
+
+from synthefy_nori.inference.predictor import NoriPredictor
+from synthefy_nori.inference.preprocess import HighDimFeatureSelector
+
+
+def _shifted_split(seed=0, n_train=400, n_test=100, n_features=40, n_shifted=10, shift=8.0):
+    rng = np.random.default_rng(seed)
+    x_train = rng.standard_normal((n_train, n_features))
+    x_test = rng.standard_normal((n_test, n_features))
+    # A block of features whose test values lie far outside the context range (time-varying covariates).
+    x_test[:, :n_shifted] += shift
+    return x_train.astype(np.float32), x_test.astype(np.float32)
+
+
+def _selector(**kw):
+    return HighDimFeatureSelector(strategy="svd_all", svd_components=8, n_features_threshold=16, **kw)
+
+
+def test_flag_defaults_off_and_is_stored():
+    assert _selector().fit_on_test is False
+    assert _selector(fit_on_test=True).fit_on_test is True
+
+
+def test_inductive_helper_fits_on_context_plus_test_when_enabled(monkeypatch):
+    x_train, x_test = _shifted_split()
+    seen = {}
+    orig_fit = HighDimFeatureSelector.fit
+
+    def recording_fit(self, x, categorical_features, seed, *, y=None, **kwargs):
+        seen["rows"] = len(x)
+        seen["y"] = y
+        return orig_fit(self, x, categorical_features, seed, y=y, **kwargs)
+
+    monkeypatch.setattr(HighDimFeatureSelector, "fit", recording_fit)
+    step = _selector(fit_on_test=True)
+    NoriPredictor._fit_transform_step_inductive(None, step, x_train, x_test, [], 0, y_train=np.zeros(len(x_train)))
+    assert seen["rows"] == len(x_train) + len(x_test)
+    assert seen["y"] is None  # labels are never part of the transductive fit
+
+    seen.clear()
+    step = _selector(fit_on_test=False)
+    NoriPredictor._fit_transform_step_inductive(None, step, x_train, x_test, [], 0, y_train=np.zeros(len(x_train)))
+    assert seen["rows"] == len(x_train)
+
+
+def test_transductive_projection_reconstructs_shifted_test_rows_better():
+    x_train, x_test = _shifted_split()
+    ctx_only, both = _selector(), _selector()
+    ctx_only.fit(x_train, [], 0)
+    both.fit(np.vstack([x_train, x_test]), [], 0)
+    assert not ctx_only.passthrough_ and not both.passthrough_
+
+    def recon_error(sel):
+        comps = np.asarray(sel.svd_model_.components_, dtype=np.float64)
+        x = x_test.astype(np.float64)
+        proj = x @ comps.T @ comps
+        return float(np.mean((x - proj) ** 2))
+
+    # The context-only basis cannot represent the shifted block; the joint basis can.
+    assert recon_error(both) < 0.5 * recon_error(ctx_only)
+
+
+def test_disabled_flag_is_byte_identical_to_previous_behaviour():
+    x_train, x_test = _shifted_split()
+    a, b = _selector(), _selector(fit_on_test=False)
+    a.fit(x_train, [], 0)
+    b.fit(x_train, [], 0)
+    xa, _ = a.transform(x_test)
+    xb, _ = b.transform(x_test)
+    np.testing.assert_array_equal(xa, xb)
+
+
+def test_shipped_configs_enable_transductive_fit():
+    """Every shipped inference config that carries the selector turns the transductive fit on."""
+    import json
+    from pathlib import Path
+
+    cfg_dir = Path(__file__).resolve().parents[1] / "src" / "synthefy_nori" / "configs"
+    checked = 0
+    for path in sorted(cfg_dir.glob("*.json")):
+        data = json.loads(path.read_text())
+        members = data if isinstance(data, list) else [data]
+        for m in members:
+            if isinstance(m, dict) and "HighDimFeatureSelector" in m:
+                assert m["HighDimFeatureSelector"].get("fit_on_test") is True, f"{path.name} lacks fit_on_test"
+                checked += 1
+    assert checked >= 8  # at least the 8 default ensemble members

--- a/tests/test_synthefy_workspace.py
+++ b/tests/test_synthefy_workspace.py
@@ -99,7 +99,7 @@ def test_project_identities_versions_and_build_backends_are_disjoint():
     client = _toml(_CLIENT / "pyproject.toml")
 
     assert root["project"]["name"] == "synthefy-nori"
-    assert root["project"]["version"] == "0.20.2"
+    assert root["project"]["version"] == "0.21.0"
     assert root["build-system"]["build-backend"] == "setuptools.build_meta"
     assert client["project"]["name"] == "synthefy"
     assert client["project"]["version"] == "7.1.2"

--- a/uv.lock
+++ b/uv.lock
@@ -6540,7 +6540,7 @@ package = [
 
 [[package]]
 name = "synthefy-nori"
-version = "0.20.2"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "einops" },


### PR DESCRIPTION
Promotes Synthefy/synthefy-nori-internal#583 (merged on internal main as d0cdb716) to public, and prepares the 0.21.0 release.

## What changes

`HighDimFeatureSelector` (active above 256 features) gains a `fit_on_test` knob and the bundled `default_inference.json` turns it on for all 8 ensemble members: the SVD projection is fitted on the context **plus the query rows' features** (never labels), so query rows whose features drift outside the context's range stay inside the fitted subspace. On random splits the two fits coincide, so the headline benchmarks are unaffected; `fit_on_test: false` in a custom config restores the context-only fit.

## Evidence (Nori-100M, internal report §19)

- BeyondArena `sberbank` (time-ordered splits): R² −0.35 → +0.54 (fold 3), +0.17 → +0.64 (fold 0), matching TabPFN-3 / TabFM / EXAONE on the same context.
- All 168 ledger units where the selector acts: +0.028 mean R², 109 wins / 58 losses, neutral on no-loss datasets; RamanBench wide tables +0.057 (11/4). Disabling the selector instead wrecks the spectra (−0.25), so the projection stays.
- TabArena: only QSAR-TID-11 qualifies (+0.003, 7/2); TALENT: only topo_2_1 (+0.003); no CTR23 dataset qualifies.

## Differences from the internal commit

The internal-only single-member research config is not in this tier, so the config guard test asserts the 8 default members (internal follow-up Synthefy/synthefy-nori-internal#589 makes the test identical across tiers so the cascade rebases cleanly).

## Release

Second commit bumps `pyproject.toml` and `__version__` to 0.21.0 (minor: default behaviour change above 256 features) and documents the knob in the README. After merge: `gh release create v0.21.0 --target main --title "v0.21.0" --generate-notes`, approve the `pypi` environment gate, then `pip install synthefy-nori==0.21.0` sanity check.

Known interaction (documented on #583): with context-cache reuse on wide tables, a different query batch changes the transformed context and forces a cache rebuild — correct, without the fit-once/serve-many speedup; follow-up to freeze the basis with the cached context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhMPCbKqMwLadrMwDneoGT